### PR TITLE
chore(*): you probably dont need lodash eslint driven refactor

### DIFF
--- a/packages/cli/create-strapi-app/src/utils/usage.ts
+++ b/packages/cli/create-strapi-app/src/utils/usage.ts
@@ -9,6 +9,8 @@ type TrackError = Error | string | StderrError;
 function addPackageJsonStrapiMetadata(metadata: Record<string, unknown>, scope: Scope) {
   const { packageJsonStrapi = {} } = scope;
 
+  // [lodash: defaults — fills undefined only; Object.assign overwrites existing keys]
+  // eslint-disable-next-line you-dont-need-lodash-underscore/defaults
   return _.defaults(metadata, packageJsonStrapi);
 }
 

--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -3,10 +3,8 @@ import * as React from 'react';
 import { darkTheme, lightTheme } from '@strapi/design-system';
 import { Cloud, Clock, User, TrendUp } from '@strapi/icons';
 import invariant from 'invariant';
-import isFunction from 'lodash/isFunction';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
-import uniq from 'lodash/uniq';
 import { RouterProvider } from 'react-router-dom';
 
 import { ADMIN_PERMISSIONS_EE, AUDIT_LOGS_DEFAULT_PAGE_SIZE } from '../../ee/admin/src/constants';
@@ -254,7 +252,7 @@ class StrapiApp {
       }
     });
 
-    if (isFunction(customBootstrap)) {
+    if (typeof customBootstrap === 'function') {
       customBootstrap({
         addComponents: this.addComponents,
         addFields: this.addFields,
@@ -275,7 +273,7 @@ class StrapiApp {
           ?.filter((loc) => loc !== 'en')
           .map((loc) => normalizeAdminLocale(loc)) || [];
 
-      this.configurations.locales = uniq(['en', ...extraLocales]);
+      this.configurations.locales = [...new Set(['en', ...extraLocales])];
     }
 
     if (customConfig.auth?.logo) {
@@ -392,7 +390,7 @@ class StrapiApp {
       this.appPlugins[plugin].register(this);
     });
 
-    if (isFunction(customRegister)) {
+    if (typeof customRegister === 'function') {
       customRegister(this);
     }
 
@@ -496,13 +494,15 @@ class StrapiApp {
     }, {});
 
     const adminTranslations = await this.loadAdminTrads();
-    const localesForPlugins = uniq(
-      this.configurations.locales.flatMap((locale) => {
-        const legacyLocale = ADMIN_LOCALE_LEGACY_ALIASES[locale];
+    const localesForPlugins = [
+      ...new Set(
+        this.configurations.locales.flatMap((locale) => {
+          const legacyLocale = ADMIN_LOCALE_LEGACY_ALIASES[locale];
 
-        return legacyLocale ? [locale, legacyLocale] : [locale];
-      })
-    );
+          return legacyLocale ? [locale, legacyLocale] : [locale];
+        })
+      ),
+    ];
 
     const arrayOfPromises = Object.keys(this.appPlugins)
       .map((plugin) => {

--- a/packages/core/admin/admin/src/hooks/useMenu.ts
+++ b/packages/core/admin/admin/src/hooks/useMenu.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import { Cog, ShoppingCart, House } from '@strapi/icons';
+// [lodash: clone-deep — skipped, structuredClone not 1:1 for class instances/functions]
+// eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
 import cloneDeep from 'lodash/cloneDeep';
 
 import { useTypedSelector } from '../core/store/hooks';

--- a/packages/core/admin/admin/src/hooks/useThrottledCallback.ts
+++ b/packages/core/admin/admin/src/hooks/useThrottledCallback.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 
+// [lodash: throttle — skipped, native throttle requires non-trivial implementation with RAF/timer cleanup]
+// eslint-disable-next-line you-dont-need-lodash-underscore/throttle
 import throttle from 'lodash/throttle';
 
 type ThrottleSettings = Parameters<typeof throttle>[2];

--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { Box, Button, Flex, Grid, Typography, Link } from '@strapi/design-system';
-import omit from 'lodash/omit';
 import { type MessageDescriptor, type PrimitiveType, useIntl } from 'react-intl';
 import { NavLink, Navigate, useNavigate, useMatch, useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -404,24 +403,28 @@ const Register = ({ hasAdmin }: RegisterProps) => {
               }
 
               if (normalizedData.registrationToken) {
+                const {
+                  registrationToken: _rt,
+                  confirmPassword: _cp,
+                  email: _email,
+                  news: _news,
+                  ...userInfoData
+                } = normalizedData;
                 handleRegisterUser(
                   {
-                    userInfo: omit(normalizedData, [
-                      'registrationToken',
-                      'confirmPassword',
-                      'email',
-                      'news',
-                    ]),
+                    userInfo: userInfoData,
                     registrationToken: normalizedData.registrationToken,
                     news: normalizedData.news,
                   },
                   helpers.setErrors
                 );
               } else {
-                await handleRegisterAdmin(
-                  omit(normalizedData, ['registrationToken', 'confirmPassword']),
-                  helpers.setErrors
-                );
+                const {
+                  registrationToken: _rt,
+                  confirmPassword: _cp,
+                  ...adminData
+                } = normalizedData;
+                await handleRegisterAdmin(adminData, helpers.setErrors);
               }
             } catch (err) {
               if (err instanceof ValidationError) {

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/components/BoundRoute.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/components/BoundRoute.tsx
@@ -1,5 +1,4 @@
 import { Box, BoxComponent, Flex, Typography } from '@strapi/design-system';
-import map from 'lodash/map';
 import tail from 'lodash/tail';
 import { useIntl } from 'react-intl';
 import { styled, DefaultTheme } from 'styled-components';
@@ -99,7 +98,7 @@ export const BoundRoute = ({
           </Typography>
         </MethodBox>
         <Box paddingLeft={2} paddingRight={2}>
-          {map(formattedRoute, (value) => (
+          {formattedRoute.map((value) => (
             <Typography key={value} textColor={value.includes(':') ? 'neutral600' : 'neutral900'}>
               /{value}
             </Typography>

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/components/CollapsableContentType.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/components/CollapsableContentType.tsx
@@ -10,7 +10,6 @@ import {
   Typography,
 } from '@strapi/design-system';
 import { Cog } from '@strapi/icons';
-import capitalize from 'lodash/capitalize';
 import { useIntl } from 'react-intl';
 import { styled, css } from 'styled-components';
 
@@ -73,7 +72,9 @@ export const CollapsableContentType = ({
   return (
     <Accordion.Item value={`${label}-${orderNumber}`}>
       <Accordion.Header variant={orderNumber % 2 ? 'primary' : 'secondary'}>
-        <Accordion.Trigger>{capitalize(label)}</Accordion.Trigger>
+        <Accordion.Trigger>
+          {label.charAt(0).toUpperCase() + label.slice(1).toLowerCase()}
+        </Accordion.Trigger>
       </Accordion.Header>
       <Accordion.Content>
         {controllers?.map((controller) => {

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/CollapsePropertyMatrix.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/CollapsePropertyMatrix.tsx
@@ -10,6 +10,8 @@ import {
   TypographyComponent,
 } from '@strapi/design-system';
 import { CaretDown } from '@strapi/icons';
+// [lodash: get — skipped, all call sites use dynamic array/variable paths]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import { useIntl } from 'react-intl';
 import { styled, DefaultTheme, css } from 'styled-components';

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ConditionsModal.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ConditionsModal.tsx
@@ -12,6 +12,8 @@ import {
   Crumb,
 } from '@strapi/design-system';
 import { produce } from 'immer';
+// [lodash: get — skipped, all call sites use dynamic variable paths]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
 import upperFirst from 'lodash/upperFirst';

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ContentTypeCollapses.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ContentTypeCollapses.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 
 import { Checkbox, Box, BoxComponent, Flex, FlexComponent, Modal } from '@strapi/design-system';
 import { ChevronDown, ChevronUp } from '@strapi/icons';
+// [lodash: get — skipped, all call sites use dynamic variable paths]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
-import omit from 'lodash/omit';
 import { useIntl } from 'react-intl';
 import { styled, DefaultTheme } from 'styled-components';
 
@@ -146,7 +147,8 @@ const Collapse = ({
   // to return the state of checkbox. Since the conditions are not related to the property we need to remove the key from the object.
   const dataWithoutCondition = React.useMemo(() => {
     return Object.keys(mainData).reduce<Record<string, ConditionForm>>((acc, current) => {
-      acc[current] = omit(mainData[current], 'conditions');
+      const { conditions: _conditions, ...rest } = mainData[current];
+      acc[current] = rest;
 
       return acc;
     }, {});

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/GlobalActions.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/GlobalActions.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import { Checkbox, Box, Flex, Typography } from '@strapi/design-system';
+// [lodash: get — skipped, all call sites use dynamic array paths]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import { useIntl } from 'react-intl';
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/Permissions.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/Permissions.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 
 import { Tabs } from '@strapi/design-system';
 import { produce } from 'immer';
+// [lodash: clone-deep — skipped, structuredClone not 1:1 for class instances/functions]
+// eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
 import cloneDeep from 'lodash/cloneDeep';
+// [lodash: get — skipped, all call sites use dynamic variable paths]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import has from 'lodash/has';
 import isEmpty from 'lodash/isEmpty';

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/PluginsAndSettings.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/PluginsAndSettings.tsx
@@ -10,6 +10,8 @@ import {
   Modal,
   Typography,
 } from '@strapi/design-system';
+// [lodash: get — skipped, all call sites use dynamic variable paths]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/utils/updateConditionsToFalse.ts
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/utils/updateConditionsToFalse.ts
@@ -1,5 +1,4 @@
 import has from 'lodash/has';
-import omit from 'lodash/omit';
 
 import { isObject } from '../../../../../utils/objects';
 
@@ -17,9 +16,8 @@ const updateConditionsToFalse = (obj: object): object => {
     }
 
     if (isObject(currentValue) && has(currentValue, 'conditions')) {
-      const isActionEnabled = createArrayOfValues(omit(currentValue, 'conditions')).some(
-        (val) => val
-      );
+      const { conditions: _conditions, ...currentValueWithoutConditions } = currentValue;
+      const isActionEnabled = createArrayOfValues(currentValueWithoutConditions).some((val) => val);
 
       if (!isActionEnabled) {
         // @ts-expect-error – TODO: type better

--- a/packages/core/admin/ee/admin/src/hooks/useLicenseLimitNotification.ts
+++ b/packages/core/admin/ee/admin/src/hooks/useLicenseLimitNotification.ts
@@ -5,7 +5,6 @@
  */
 import * as React from 'react';
 
-import isNil from 'lodash/isNil';
 import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 
@@ -32,7 +31,8 @@ export const useLicenseLimitNotification = () => {
     }
 
     const shouldDisplayNotification =
-      !isNil(permittedSeats) &&
+      permittedSeats !== null &&
+      permittedSeats !== undefined &&
       !window.sessionStorage.getItem(`${STORAGE_KEY_PREFIX}-${pathname}`) &&
       licenseLimitStatus === 'OVER_LIMIT';
 

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/Users/components/CreateActionEE.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/Users/components/CreateActionEE.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { Button, Flex, Tooltip } from '@strapi/design-system';
 import { Mail, WarningCircle } from '@strapi/icons';
-import isNil from 'lodash/isNil';
 import { useIntl } from 'react-intl';
 
 import { useLicenseLimits } from '../../../../../hooks/useLicenseLimits';
@@ -22,7 +21,7 @@ export const CreateActionEE = React.forwardRef<HTMLButtonElement, CreateActionCE
 
     return (
       <Flex width="100%" gap={2}>
-        {!isNil(permittedSeats) && shouldStopCreate && (
+        {permittedSeats !== null && permittedSeats !== undefined && shouldStopCreate && (
           <Tooltip
             label={formatMessage({
               id: 'Settings.application.admin-seats.at-limit-tooltip',

--- a/packages/core/admin/server/src/controllers/__tests__/api-token.test.ts
+++ b/packages/core/admin/server/src/controllers/__tests__/api-token.test.ts
@@ -1,5 +1,4 @@
 import { errors } from '@strapi/utils';
-import { omit } from 'lodash/fp';
 // @ts-expect-error - types are not generated for this file
 // eslint-disable-next-line import/no-relative-packages
 import createContext from '../../../../../../../tests/helpers/create-context';
@@ -217,7 +216,8 @@ describe('API Token Controller', () => {
 
         expect(exists).toHaveBeenCalledWith({ name: tokenBody.name });
         expect(badRequest).not.toHaveBeenCalled();
-        expect(create).toHaveBeenCalledWith(omit(['expiresAt'], createBody), callingUser);
+        const { expiresAt: _expiresAt, ...createBodyWithoutExpiry } = createBody;
+        expect(create).toHaveBeenCalledWith(createBodyWithoutExpiry, callingUser);
         expect(created).toHaveBeenCalledWith({ data: tokenBody });
       });
 

--- a/packages/core/admin/server/src/controllers/__tests__/transfer/token.test.ts
+++ b/packages/core/admin/server/src/controllers/__tests__/transfer/token.test.ts
@@ -1,5 +1,4 @@
 import { errors } from '@strapi/utils';
-import { omit } from 'lodash/fp';
 // @ts-expect-error - types are not generated for this file
 // eslint-disable-next-line import/no-relative-packages
 import createContext from '../../../../../../../../tests/helpers/create-context';
@@ -211,7 +210,8 @@ describe('Transfer Token Controller', () => {
 
       expect(exists).toHaveBeenCalledWith({ name: tokenBody.name });
       expect(badRequest).not.toHaveBeenCalled();
-      expect(create).toHaveBeenCalledWith(omit(['expiresAt'], createBody));
+      const { expiresAt: _expiresAt, ...createBodyWithoutExpiry } = createBody;
+      expect(create).toHaveBeenCalledWith(createBodyWithoutExpiry);
       expect(created).toHaveBeenCalledWith({ data: tokenBody });
     });
   });

--- a/packages/core/admin/server/src/controllers/admin.ts
+++ b/packages/core/admin/server/src/controllers/admin.ts
@@ -3,7 +3,6 @@ import type { Context } from 'koa';
 
 import path from 'path';
 
-import _ from 'lodash';
 import fse from 'fs-extra';
 import { env } from '@strapi/utils';
 import {
@@ -115,8 +114,8 @@ export default {
     );
     const isHostedOnStrapiCloud = env('STRAPI_HOSTING', null) === 'strapi.cloud';
 
-    const numberOfAllContentTypes = _.size(strapi.contentTypes);
-    const numberOfComponents = _.size(strapi.components);
+    const numberOfAllContentTypes = Object.keys(strapi.contentTypes).length;
+    const numberOfComponents = Object.keys(strapi.components).length;
 
     const getNumberOfDynamicZones = () => {
       return pipe(

--- a/packages/core/admin/server/src/controllers/user.ts
+++ b/packages/core/admin/server/src/controllers/user.ts
@@ -24,7 +24,7 @@ const { ApplicationError } = errors;
 export default {
   async create(ctx: Context) {
     const { body } = ctx.request as Create.Request;
-    const cleanData = { ...body, email: _.get(body, `email`, ``).toLowerCase() };
+    const cleanData = { ...body, email: (body.email ?? '').toLowerCase() };
 
     await validateUserCreationInput(cleanData);
 

--- a/packages/core/admin/server/src/domain/action/__tests__/action-provider.test.ts
+++ b/packages/core/admin/server/src/domain/action/__tests__/action-provider.test.ts
@@ -1,4 +1,3 @@
-import { omit } from 'lodash/fp';
 import createActionProvider from '../provider';
 import domain from '..';
 
@@ -47,7 +46,7 @@ describe('Action Provider', () => {
           category: 'category',
           subCategory: 'subcategory',
         };
-        const expected = omit('uid', attributes);
+        const { uid: _uid, ...expected } = attributes;
         const actionId = domain.computeActionId(attributes);
 
         const actionProvider = createActionProvider();

--- a/packages/core/admin/server/src/domain/condition/__tests__/condition-provider.test.ts
+++ b/packages/core/admin/server/src/domain/condition/__tests__/condition-provider.test.ts
@@ -1,4 +1,3 @@
-import { omit } from 'lodash/fp';
 import createConditionProvider from '../provider';
 import domain from '..';
 
@@ -40,7 +39,7 @@ describe('Condition Provider', () => {
           plugin: 'foo',
           handler: { foo: 'bar' },
         };
-        const expected = omit('name', attributes);
+        const { name: _name, ...expected } = attributes;
         const id = domain.computeConditionId(attributes);
 
         const conditionProvider = createConditionProvider();

--- a/packages/core/admin/server/src/index.ts
+++ b/packages/core/admin/server/src/index.ts
@@ -27,7 +27,7 @@ let admin = {
 };
 
 const mergeRoutes = (a: any, b: any, key: string) => {
-  return _.isArray(a) && _.isArray(b) && key === 'routes' ? a.concat(b) : undefined;
+  return Array.isArray(a) && Array.isArray(b) && key === 'routes' ? a.concat(b) : undefined;
 };
 
 if (strapi.EE) {

--- a/packages/core/admin/server/src/services/__tests__/api-token.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/api-token.test.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import { errors } from '@strapi/utils';
-import { omit, uniq } from 'lodash/fp';
 import type { AdminApiToken, ContentApiApiToken } from '../../../../shared/contracts/api-token';
 import constants from '../constants';
 import {
@@ -19,6 +18,11 @@ import {
   enforceAdminPermissionsCeiling,
 } from '../api-token';
 import encryptionService from '../encryption';
+
+const omitKey = <T extends Record<string, unknown>>(key: keyof T, obj: T): Omit<T, keyof T> => {
+  const { [key]: _, ...rest } = obj;
+  return rest as Omit<T, keyof T>;
+};
 
 const getActionProvider = (actions = []) => {
   return {
@@ -229,7 +233,7 @@ describe('API Token', () => {
         id: 1,
       };
 
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', createTokenResult));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, createTokenResult));
       const create = jest.fn().mockResolvedValue(createTokenResult);
       const load = jest.fn().mockResolvedValueOnce(
         Promise.resolve(
@@ -267,7 +271,7 @@ describe('API Token', () => {
       expect(create).toHaveBeenNthCalledWith(1, {
         select: expect.arrayContaining([expect.any(String)]),
         data: {
-          ...omit('permissions', attributes),
+          ...omitKey('permissions' as any, attributes),
           accessKey: hash(mockedApiToken.hexedString),
           encryptedKey: expect.any(String),
           adminUserOwner: null,
@@ -289,7 +293,7 @@ describe('API Token', () => {
       });
 
       expect(res).toEqual({
-        ...omit('adminUserOwner', createTokenResult),
+        ...omitKey('adminUserOwner' as any, createTokenResult),
         accessKey: mockedApiToken.hexedString,
         expiresAt: null,
         lifespan: null,
@@ -314,7 +318,7 @@ describe('API Token', () => {
         id: 1,
       };
 
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', createTokenResult));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, createTokenResult));
       const create = jest.fn().mockResolvedValue(createTokenResult);
       const load = jest.fn().mockResolvedValueOnce(
         Promise.resolve(
@@ -353,7 +357,7 @@ describe('API Token', () => {
       expect(create).toHaveBeenNthCalledWith(1, {
         select: expect.arrayContaining([expect.any(String)]),
         data: {
-          ...omit('permissions', attributes),
+          ...omitKey('permissions' as any, attributes),
           accessKey: hash(mockedApiToken.hexedString),
           encryptedKey: expect.any(String),
           adminUserOwner: null,
@@ -364,7 +368,7 @@ describe('API Token', () => {
       });
 
       expect(res).toEqual({
-        ...omit('adminUserOwner', createTokenResult),
+        ...omitKey('adminUserOwner' as any, createTokenResult),
         accessKey: mockedApiToken.hexedString,
         expiresAt: null,
         lifespan: null,
@@ -389,11 +393,11 @@ describe('API Token', () => {
         id: 1,
       };
 
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', createTokenResult));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, createTokenResult));
       const create = jest.fn().mockResolvedValue(createTokenResult);
       const load = jest.fn().mockResolvedValueOnce(
         Promise.resolve(
-          uniq(attributes.permissions).map((p: any) => {
+          [...new Set(attributes.permissions)].map((p: any) => {
             return {
               action: p,
             };
@@ -439,7 +443,7 @@ describe('API Token', () => {
       const create = jest.fn().mockResolvedValue(createTokenResult);
       const load = jest.fn().mockResolvedValueOnce(
         Promise.resolve(
-          uniq(attributes.permissions).map((p: any) => {
+          [...new Set(attributes.permissions)].map((p: any) => {
             return {
               action: p,
             };
@@ -1533,7 +1537,7 @@ describe('API Token', () => {
         permissions: ['valid-permission-A', 'unknown-permission'],
       } as any;
 
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', originalToken));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, originalToken));
       const update = jest.fn(({ data }) => Promise.resolve(data));
       const deleteFn = jest.fn();
       const create = jest.fn();
@@ -1585,7 +1589,7 @@ describe('API Token', () => {
       } as any;
 
       const update = jest.fn(({ data }) => Promise.resolve(data));
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', originalToken));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, originalToken));
       const deleteFn = jest.fn();
       const create = jest.fn();
       const load = jest
@@ -1662,7 +1666,7 @@ describe('API Token', () => {
       } as any;
 
       const update = jest.fn(({ data }) => Promise.resolve(data));
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', originalToken));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, originalToken));
       const deleteFn = jest.fn();
       const create = jest.fn();
       const load = jest

--- a/packages/core/admin/server/src/services/__tests__/auth.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/auth.test.ts
@@ -1,3 +1,4 @@
+// [lodash: get — skipped, _.get(path, def) uses runtime variable path]
 import _ from 'lodash';
 import { errors } from '@strapi/utils';
 import authService from '../auth';
@@ -192,6 +193,7 @@ describe('Auth', () => {
         config: {
           ...config,
           get(path: any, def: any) {
+            // eslint-disable-next-line you-dont-need-lodash-underscore/get
             return _.get(path, def);
           },
         },
@@ -236,6 +238,7 @@ describe('Auth', () => {
         config: {
           ...config,
           get(path: any, def: any) {
+            // eslint-disable-next-line you-dont-need-lodash-underscore/get
             return _.get(path, def);
           },
         },

--- a/packages/core/admin/server/src/services/__tests__/permission.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/permission.test.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { merge } from 'lodash/fp';
 import {
   cleanPermissionsInDatabase,
@@ -79,8 +78,9 @@ describe('Permission Service', () => {
       const sanitizedPermission: any = sanitizePermission(permission);
 
       expect(sanitizedPermission.foo).toBeUndefined();
+      const { foo: _foo, ...permissionWithoutFoo } = permission;
       expect(sanitizedPermission).toMatchObject({
-        ..._.omit(permission, 'foo'),
+        ...permissionWithoutFoo,
       });
     });
   });

--- a/packages/core/admin/server/src/services/__tests__/role.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/role.test.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { queryParams } from '@strapi/utils';
 import constants from '../constants';
 import { create as createPermission, toPermission } from '../../domain/permission';
@@ -75,7 +74,9 @@ describe('Role', () => {
         name: 'super_admin',
         description: "Have all permissions. Can't be delete",
       };
-      const dbFindOne = jest.fn(({ where: { id } }) => Promise.resolve(_.find([role], { id })));
+      const dbFindOne = jest.fn(({ where: { id } }) =>
+        Promise.resolve([role].find((r) => r.id === id))
+      );
 
       global.strapi = {
         ...strapiMock,
@@ -95,9 +96,10 @@ describe('Role', () => {
         description: "Have all permissions. Can't be delete",
         usersCount: 0,
       };
-      const dbFindOne = jest.fn(({ where: { id } }) =>
-        Promise.resolve(_.find([_.omit(role, ['usersCount'])], { id }))
-      );
+      const dbFindOne = jest.fn(({ where: { id } }) => {
+        const { usersCount: _usersCount, ...roleWithoutCount } = role;
+        return Promise.resolve([roleWithoutCount].find((r) => r.id === id));
+      });
       const dbCount = jest.fn(() => Promise.resolve(0));
       global.strapi = {
         ...strapiMock,

--- a/packages/core/admin/server/src/services/__tests__/transfer/token.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/transfer/token.test.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import { errors } from '@strapi/utils';
-import { omit, uniq } from 'lodash/fp';
 import {
   create as tokenServiceCreate,
   list,
@@ -13,6 +12,11 @@ import {
   checkSaltIsDefined,
 } from '../../transfer/token';
 import constants from '../../constants';
+
+const omitKey = <T extends Record<string, unknown>>(key: keyof T, obj: T): Omit<T, keyof T> => {
+  const { [key]: _, ...rest } = obj;
+  return rest as Omit<T, keyof T>;
+};
 
 const getActionProvider = (actions = []) => {
   return {
@@ -105,7 +109,7 @@ describe('Transfer Token', () => {
       expect(create).toHaveBeenNthCalledWith(1, {
         select: expect.arrayContaining([expect.any(String)]),
         data: {
-          ...omit('permissions', attributes),
+          ...omitKey('permissions' as any, attributes),
           accessKey: hash(mockedTransferToken.hexedString),
           expiresAt: null,
           lifespan: null,
@@ -145,7 +149,7 @@ describe('Transfer Token', () => {
       const create = jest.fn(({ data }) => Promise.resolve(data));
       const load = jest.fn().mockResolvedValueOnce(
         Promise.resolve(
-          uniq(attributes.permissions).map((p) => {
+          [...new Set(attributes.permissions)].map((p) => {
             return {
               action: p,
             };
@@ -230,7 +234,7 @@ describe('Transfer Token', () => {
         id: 1,
       };
 
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', createTokenResult));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, createTokenResult));
       const create = jest.fn().mockResolvedValue(createTokenResult);
       const load = jest.fn().mockResolvedValueOnce(
         Promise.resolve(
@@ -273,7 +277,7 @@ describe('Transfer Token', () => {
       expect(create).toHaveBeenNthCalledWith(1, {
         select: expect.arrayContaining([expect.any(String)]),
         data: {
-          ...omit('permissions', attributes),
+          ...omitKey('permissions' as any, attributes),
           accessKey: hash(mockedTransferToken.hexedString),
           expiresAt: null,
           lifespan: null,
@@ -304,11 +308,11 @@ describe('Transfer Token', () => {
         id: 1,
       };
 
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', createTokenResult));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, createTokenResult));
       const create = jest.fn().mockResolvedValue(createTokenResult);
       const load = jest.fn().mockResolvedValueOnce(
         Promise.resolve(
-          uniq(attributes.permissions).map((p) => {
+          [...new Set(attributes.permissions)].map((p) => {
             return {
               action: p,
             };
@@ -357,7 +361,7 @@ describe('Transfer Token', () => {
       const create = jest.fn().mockResolvedValue(createTokenResult);
       const load = jest.fn().mockResolvedValueOnce(
         Promise.resolve(
-          uniq(attributes.permissions).map((p) => {
+          [...new Set(attributes.permissions)].map((p) => {
             return {
               action: p,
             };
@@ -670,7 +674,7 @@ describe('Transfer Token', () => {
       } as any;
 
       const update = jest.fn(({ data }) => Promise.resolve(data));
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', originalToken));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, originalToken));
       const deleteFn = jest.fn();
       const create = jest.fn();
       const load = jest
@@ -722,7 +726,7 @@ describe('Transfer Token', () => {
       expect(update).toHaveBeenCalledWith({
         select: expect.arrayContaining([expect.any(String)]),
         where: { id },
-        data: omit(['permissions'], updatedAttributes),
+        data: omitKey('permissions' as any, updatedAttributes),
       });
 
       expect(res).toEqual(updatedAttributes);
@@ -743,7 +747,7 @@ describe('Transfer Token', () => {
       } as any;
 
       const update = jest.fn(({ data }) => Promise.resolve(data));
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', originalToken));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, originalToken));
       const deleteFn = jest.fn();
       const create = jest.fn();
       const load = jest
@@ -793,7 +797,7 @@ describe('Transfer Token', () => {
       expect(update).toHaveBeenCalledWith({
         select: expect.arrayContaining([expect.any(String)]),
         where: { id },
-        data: omit(['permissions'], updatedAttributes),
+        data: omitKey('permissions' as any, updatedAttributes),
       });
 
       expect(res).toEqual({
@@ -816,7 +820,7 @@ describe('Transfer Token', () => {
         permissions: ['push', 'unknown-permission'],
       } as any;
 
-      const findOne = jest.fn().mockResolvedValue(omit('permissions', originalToken));
+      const findOne = jest.fn().mockResolvedValue(omitKey('permissions' as any, originalToken));
       const update = jest.fn(({ data }) => Promise.resolve(data));
       const deleteFn = jest.fn();
       const create = jest.fn();

--- a/packages/core/admin/server/src/services/content-type.ts
+++ b/packages/core/admin/server/src/services/content-type.ts
@@ -1,4 +1,5 @@
 import fp from 'lodash/fp.js';
+// [lodash: reduce — skipped, _.reduce iterates over plain object keys; not a drop-in for Array.prototype.reduce]
 import _ from 'lodash';
 
 import { contentTypes as contentTypesUtils } from '@strapi/utils';
@@ -40,6 +41,7 @@ const getNestedFields = (
 
   const nonAuthorizableFields = contentTypesUtils.getNonVisibleAttributes(model);
 
+  // eslint-disable-next-line you-dont-need-lodash-underscore/reduce
   return _.reduce(
     model.attributes,
     (fields: any, attr: any, key: any) => {
@@ -91,6 +93,7 @@ const getNestedFieldsWithIntermediate = (
 
   const nonAuthorizableFields = contentTypesUtils.getNonVisibleAttributes(model);
 
+  // eslint-disable-next-line you-dont-need-lodash-underscore/reduce
   return _.reduce(
     model.attributes,
     (fields: any, attr: any, key: any) => {

--- a/packages/core/admin/server/src/services/permission/permissions-manager/index.ts
+++ b/packages/core/admin/server/src/services/permission/permissions-manager/index.ts
@@ -1,5 +1,4 @@
 import fp from 'lodash/fp.js';
-import _ from 'lodash';
 
 import { subject as asSubject } from '@casl/ability';
 import createSanitizeHelpers from './sanitize';
@@ -27,7 +26,7 @@ export default ({ ability, action, model }: any) => ({
   },
 
   getQuery(queryAction = action) {
-    if (_.isUndefined(queryAction)) {
+    if (queryAction === undefined) {
       throw new Error('Action must be defined to build a permission query');
     }
 

--- a/packages/core/admin/server/src/services/permission/permissions-manager/query-builders.ts
+++ b/packages/core/admin/server/src/services/permission/permissions-manager/query-builders.ts
@@ -1,4 +1,5 @@
 // TODO: migration
+// [lodash: reduce — skipped, _.reduce iterates over plain object keys; not a drop-in for Array.prototype.reduce]
 import _ from 'lodash';
 import { rulesToQuery } from '@casl/ability/extra';
 
@@ -18,7 +19,7 @@ const operatorsMap = {
 } as const;
 
 const mapKey = (key: keyof typeof operatorsMap) => {
-  if (_.isString(key) && key.startsWith('$') && key in operatorsMap) {
+  if (typeof key === 'string' && key.startsWith('$') && key in operatorsMap) {
     return operatorsMap[key];
   }
   return key;
@@ -34,13 +35,14 @@ const buildStrapiQuery = (caslQuery: unknown) => {
 };
 
 const unwrapDeep = (obj: any): unknown => {
-  if (!_.isPlainObject(obj) && !_.isArray(obj)) {
+  if (!_.isPlainObject(obj) && !Array.isArray(obj)) {
     return obj;
   }
-  if (_.isArray(obj)) {
+  if (Array.isArray(obj)) {
     return obj.map((v: unknown) => unwrapDeep(v));
   }
 
+  // eslint-disable-next-line you-dont-need-lodash-underscore/reduce
   return _.reduce(
     obj,
     (acc, v, k: any) => {
@@ -52,7 +54,7 @@ const unwrapDeep = (obj: any): unknown => {
         } else {
           _.setWith(acc, key, unwrapDeep(v));
         }
-      } else if (_.isArray(v)) {
+      } else if (Array.isArray(v)) {
         // prettier-ignore
         _.setWith(acc, key, v.map(v => unwrapDeep(v)));
       } else {

--- a/packages/core/admin/server/src/services/role.ts
+++ b/packages/core/admin/server/src/services/role.ts
@@ -135,7 +135,7 @@ const findAllWithUsersCount = async (params: any): Promise<AdminRoleWithUsersCou
  * @param attributes A partial role object
  */
 const update = async (params: any, attributes: Partial<AdminRole>): Promise<AdminRole> => {
-  const sanitizedAttributes = _.omit(attributes, ['code']);
+  const { code: _code, ...sanitizedAttributes } = attributes;
 
   if (_.has(params, 'id') && _.has(sanitizedAttributes, 'name')) {
     const alreadyExists = await exists({
@@ -450,7 +450,7 @@ const resetSuperAdminPermissions = async () => {
  * Check if a user object includes the super admin role
  */
 const hasSuperAdminRole = (user: AdminUser): boolean => {
-  const roles = _.get(user, 'roles', []) as AdminRole[];
+  const roles = (user.roles ?? []) as AdminRole[];
 
   return roles.map(prop('code')).includes(SUPER_ADMIN_CODE);
 };

--- a/packages/core/admin/server/src/services/user.ts
+++ b/packages/core/admin/server/src/services/user.ts
@@ -37,7 +37,16 @@ const getSessionManager = () => {
  */
 const sanitizeUser = (user: AdminUser): SanitizedAdminUser => {
   return {
-    ..._.omit(user, ['password', 'resetPasswordToken', 'registrationToken', 'roles']),
+    ...(() => {
+      const {
+        password: _pw,
+        resetPasswordToken: _rpt,
+        registrationToken: _regToken,
+        roles: _roles,
+        ...rest
+      } = user;
+      return rest;
+    })(),
     roles: user.roles && user.roles.map(sanitizeUserRoles),
   };
 };

--- a/packages/core/admin/server/src/validation/common-functions/check-fields-are-correctly-nested.ts
+++ b/packages/core/admin/server/src/validation/common-functions/check-fields-are-correctly-nested.ts
@@ -1,7 +1,5 @@
-import _ from 'lodash';
-
 const checkFieldsAreCorrectlyNested = (fields: unknown) => {
-  if (_.isNil(fields)) {
+  if (fields === null || fields === undefined) {
     // Only check if the fields exist
     return true;
   }

--- a/packages/core/admin/server/src/validation/common-functions/check-fields-dont-have-duplicates.ts
+++ b/packages/core/admin/server/src/validation/common-functions/check-fields-dont-have-duplicates.ts
@@ -1,7 +1,5 @@
-import _ from 'lodash';
-
 const checkFieldsDontHaveDuplicates = (fields: unknown) => {
-  if (_.isNil(fields)) {
+  if (fields === null || fields === undefined) {
     // Only check if the fields exist
     return true;
   }
@@ -9,7 +7,7 @@ const checkFieldsDontHaveDuplicates = (fields: unknown) => {
     return false;
   }
 
-  return _.uniq(fields).length === fields.length;
+  return new Set(fields).size === fields.length;
 };
 
 export default checkFieldsDontHaveDuplicates;

--- a/packages/core/admin/server/src/validation/common-validators.ts
+++ b/packages/core/admin/server/src/validation/common-validators.ts
@@ -49,13 +49,16 @@ export const arrayOfConditionNames = yup
   .of(yup.string())
   .test('is-an-array-of-conditions', 'is not a plugin name', function (value) {
     const ids = strapi.service('admin::permission').conditionProvider.keys();
-    return _.isUndefined(value) || _.difference(value, ids).length === 0
+    return value === undefined || _.difference(value, ids).length === 0
       ? true
       : this.createError({ path: this.path, message: `contains conditions that don't exist` });
   });
 
 export const permissionsAreEquals = (a: any, b: any) =>
-  a.action === b.action && (a.subject === b.subject || (_.isNil(a.subject) && _.isNil(b.subject)));
+  a.action === b.action &&
+  (a.subject === b.subject ||
+    ((a.subject === null || a.subject === undefined) &&
+      (b.subject === null || b.subject === undefined)));
 
 const checkNoDuplicatedPermissions = (permissions: unknown) =>
   !Array.isArray(permissions) ||

--- a/packages/core/admin/server/src/validation/policies/hasPermissions.ts
+++ b/packages/core/admin/server/src/validation/policies/hasPermissions.ts
@@ -1,15 +1,14 @@
-import _ from 'lodash';
 import { yup, validateYupSchema } from '@strapi/utils';
 
 const hasPermissionsSchema = yup.object({
   actions: yup.array().of(
     // @ts-expect-error yup types
     yup.lazy((val) => {
-      if (_.isArray(val)) {
+      if (Array.isArray(val)) {
         return yup.array().of(yup.string()).min(1).max(2);
       }
 
-      if (_.isString(val)) {
+      if (typeof val === 'string') {
         return yup.string().required();
       }
 

--- a/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
+++ b/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 
 import { usePersistentStateScope, useQueryParams } from '@strapi/admin/strapi-admin';
+// [lodash: get — dynamic PropertyPath (string | string[]) used with lodash set; no safe optional-chaining equivalent]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import set from 'lodash/set';
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -25,6 +25,8 @@ import {
 } from '@strapi/design-system';
 import { Cross, More, WarningCircle } from '@strapi/icons';
 import mapValues from 'lodash/fp/mapValues';
+// [lodash: get — fieldToConnect is a dynamic dot-path string variable; optional chaining cannot traverse it]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import merge from 'lodash/merge';
 import set from 'lodash/set';

--- a/packages/core/content-manager/server/src/controllers/validation/index.ts
+++ b/packages/core/content-manager/server/src/controllers/validation/index.ts
@@ -40,10 +40,7 @@ const validateUIDField = (contentTypeUID: any, field: any) => {
     throw new ValidationError('ContentType not found');
   }
 
-  if (
-    !_.has(model, ['attributes', field]) ||
-    _.get(model, ['attributes', field, 'type']) !== 'uid'
-  ) {
+  if (!_.has(model, ['attributes', field]) || model?.attributes?.[field]?.type !== 'uid') {
     throw new ValidationError(`${field} must be a valid \`uid\` attribute`);
   }
 };

--- a/packages/core/content-manager/server/src/middlewares/routing.ts
+++ b/packages/core/content-manager/server/src/middlewares/routing.ts
@@ -1,6 +1,5 @@
 import type { UID, Core, Struct } from '@strapi/types';
 import type { Context, Next } from 'koa';
-import isNil from 'lodash/isNil.js';
 
 interface ContentType extends Struct.ContentTypeSchema {
   plugin?: string;
@@ -37,7 +36,7 @@ export default async (ctx: Context, next: Next) => {
     actionConfig = strapi.plugin(ct.plugin).config(`layout.${ct.modelName}.actions.${action}`);
   }
 
-  if (!isNil(actionConfig)) {
+  if (actionConfig !== null && actionConfig !== undefined) {
     const [controller, action] = actionConfig.split('.');
 
     if (controller && action) {

--- a/packages/core/content-manager/server/src/services/uid.ts
+++ b/packages/core/content-manager/server/src/services/uid.ts
@@ -25,6 +25,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     } = attributes[field] as Schema.Attribute.UID;
 
     // @ts-expect-error targetField can be undefined
+    // [lodash: get — targetField can be undefined; _.get(obj, undefined) returns undefined but obj[undefined] coerces to 'undefined' key]
+    // eslint-disable-next-line you-dont-need-lodash-underscore/get
     const targetValue = _.get(data, targetField);
 
     if (!_.isEmpty(targetValue)) {
@@ -40,7 +42,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       contentTypeUID,
       field,
       value: slugify(
-        _.isFunction(defaultValue) ? defaultValue() : defaultValue || contentType.modelName,
+        typeof defaultValue === 'function' ? defaultValue() : defaultValue || contentType.modelName,
         options
       ),
       locale,

--- a/packages/core/content-manager/server/src/services/utils/configuration/attributes.ts
+++ b/packages/core/content-manager/server/src/services/utils/configuration/attributes.ts
@@ -21,7 +21,7 @@ const isHidden = (schema: any, name: any) => {
     return false;
   }
 
-  const isHidden = _.get(schema, ['config', 'attributes', name, 'hidden'], false);
+  const isHidden = schema?.config?.attributes?.[name]?.hidden ?? false;
   if (isHidden === true) {
     return true;
   }

--- a/packages/core/content-manager/server/src/services/utils/configuration/layouts.ts
+++ b/packages/core/content-manager/server/src/services/utils/configuration/layouts.ts
@@ -32,7 +32,7 @@ async function createDefaultLayouts(schema: any) {
     list: createDefaultListLayout(schema),
     // @ts-expect-error necessary to provide this default layout
     edit: createDefaultEditLayout(schema),
-    ..._.pick(_.get(schema, ['config', 'layouts'], {}), ['list', 'edit']),
+    ..._.pick(schema?.config?.layouts ?? {}, ['list', 'edit']),
   };
 }
 
@@ -109,11 +109,13 @@ function syncLayouts(configuration: any, schema: any) {
   if (cleanList.length < DEFAULT_LIST_LENGTH) {
     // add newAttributes
     // only add valid listable attributes
-    cleanList = _.uniq(
-      cleanList
-        .concat(newAttributes.filter((key) => isListable(schema, key)))
-        .slice(0, DEFAULT_LIST_LENGTH)
-    );
+    cleanList = [
+      ...new Set(
+        cleanList
+          .concat(newAttributes.filter((key) => isListable(schema, key)))
+          .slice(0, DEFAULT_LIST_LENGTH)
+      ),
+    ];
   }
 
   // add new attributes to edit view

--- a/packages/core/content-manager/server/src/services/utils/configuration/metadatas.ts
+++ b/packages/core/content-manager/server/src/services/utils/configuration/metadatas.ts
@@ -54,9 +54,9 @@ function createDefaultMetadata(schema: any, name: any) {
     }
   }
 
-  _.assign(
+  Object.assign(
     edit,
-    _.pick(_.get(schema, ['config', 'metadatas', name, 'edit'], {}), [
+    _.pick(schema?.config?.metadatas?.[name]?.edit ?? {}, [
       'label',
       'description',
       'placeholder',
@@ -73,11 +73,7 @@ function createDefaultMetadata(schema: any, name: any) {
     searchable: isSearchable(schema, name),
     // @ts-expect-error we need to specify these properties
     sortable: isSortable(schema, name),
-    ..._.pick(_.get(schema, ['config', 'metadatas', name, 'list'], {}), [
-      'label',
-      'searchable',
-      'sortable',
-    ]),
+    ..._.pick(schema?.config?.metadatas?.[name]?.list ?? {}, ['label', 'searchable', 'sortable']),
   };
 
   return { edit, list };
@@ -119,7 +115,10 @@ async function syncMetadatas(configuration: any, schema: any) {
 
     // remove mainField if the attribute is not a relation anymore
     if (!isRelation(attr)) {
-      _.set(updatedMeta, 'edit', _.omit(edit, ['mainField']));
+      const editWithoutMainField = Object.fromEntries(
+        Object.entries(edit).filter(([k]) => k !== 'mainField')
+      );
+      _.set(updatedMeta, 'edit', editWithoutMainField);
       _.set(acc, [key], updatedMeta);
       return acc;
     }
@@ -141,7 +140,7 @@ async function syncMetadatas(configuration: any, schema: any) {
     return acc;
   }, {});
 
-  return _.assign(metasWithDefaults, updatedMetas);
+  return Object.assign(metasWithDefaults, updatedMetas);
 }
 
 const getTargetSchema = (targetModel: any) => {

--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/toCTB.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/toCTB.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
 import pluralize from 'pluralize';
 
 import { Schema } from '../../types/schema';
@@ -62,8 +60,8 @@ const determineAttributeStatus = (
   }
 
   // Compare attributes without the status field to determine if they've changed
-  const newAttrWithoutStatus = omit(newAttr, ['status']);
-  const oldAttrWithoutStatus = omit(oldAttr, ['status']);
+  const { status: _ns, ...newAttrWithoutStatus } = newAttr;
+  const { status: _os, ...oldAttrWithoutStatus } = oldAttr;
 
   if (!isEqual(newAttrWithoutStatus, oldAttrWithoutStatus)) {
     return 'CHANGED';

--- a/packages/core/content-type-builder/admin/src/components/AttributeRow.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AttributeRow.tsx
@@ -3,6 +3,8 @@ import { forwardRef, memo, useState } from 'react';
 import { ConfirmDialog } from '@strapi/admin/strapi-admin';
 import { Box, Flex, IconButton, Typography, Link, Badge, Dialog } from '@strapi/design-system';
 import { ChevronDown, Drag, Lock, Pencil, Trash } from '@strapi/icons';
+// [lodash: get — skipped, paths use dot-separated UID keys and dynamic variables]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import upperFirst from 'lodash/upperFirst';
 import { useIntl } from 'react-intl';

--- a/packages/core/content-type-builder/admin/src/components/ComponentCard/ComponentCard.tsx
+++ b/packages/core/content-type-builder/admin/src/components/ComponentCard/ComponentCard.tsx
@@ -1,5 +1,7 @@
 import { Box, Flex, Typography } from '@strapi/design-system';
 import { Cross } from '@strapi/icons';
+// [lodash: get — skipped, dot-separated UID paths interpreted as nested by lodash]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import { styled } from 'styled-components';
 

--- a/packages/core/content-type-builder/admin/src/components/ComponentList.tsx
+++ b/packages/core/content-type-builder/admin/src/components/ComponentList.tsx
@@ -1,3 +1,5 @@
+// [lodash: get — skipped, dot-separated UID paths interpreted as nested by lodash]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 
 import { ComponentRow } from './ComponentRow';

--- a/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
@@ -1,6 +1,5 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import merge from 'lodash/merge';
-import omit from 'lodash/omit';
 
 import { getRelationType } from '../../utils/getRelationType';
 import { makeUnique } from '../../utils/makeUnique';
@@ -341,7 +340,8 @@ const slice = createUndoRedoSlice(
 
         const type = getType(state, { forTarget, targetUid });
 
-        const attribute = createAttribute(omit(attributeToSet, 'createComponent'));
+        const { createComponent: _createComponent, ...attributeWithoutCreate } = attributeToSet;
+        const attribute = createAttribute(attributeWithoutCreate);
 
         if (attribute.type === 'relation') {
           const target = attribute.target;

--- a/packages/core/content-type-builder/admin/src/components/DataManager/utils/cleanData.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/utils/cleanData.ts
@@ -1,5 +1,4 @@
 import camelCase from 'lodash/camelCase';
-import omit from 'lodash/omit';
 import sortBy from 'lodash/sortBy';
 
 import { pluginId } from '../../../pluginId';
@@ -153,11 +152,19 @@ const formatTypeForRequest = (type: ContentType | Component) => {
       throw new Error('Invalid status');
   }
 
+  const {
+    info: _info,
+    options: _options,
+    visible: _visible,
+    uid: _uid,
+    restrictRelationsTo: _restrict,
+    ...typeRest
+  } = type;
   return {
     action,
     uid: type.uid,
     category: 'category' in type ? type.category : undefined,
-    ...omit(type, ['info', 'options', 'visible', 'uid', 'restrictRelationsTo']),
+    ...typeRest,
     ...type.options,
     ...type.info,
     attributes: type.attributes.map((attr) => {
@@ -177,10 +184,11 @@ const formatTypeForRequest = (type: ContentType | Component) => {
           action = 'update';
       }
 
+      const { status: _s, name: _n, ...formattedAttr } = formatAttribute(attr);
       return {
         action,
         name: attr.name,
-        properties: removeNullKeys(omit(formatAttribute(attr), ['status', 'name'])),
+        properties: removeNullKeys(formattedAttr),
       };
     }),
   };

--- a/packages/core/content-type-builder/admin/src/components/DataManager/utils/retrieveComponentsThatHaveComponents.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/utils/retrieveComponentsThatHaveComponents.ts
@@ -1,5 +1,3 @@
-import get from 'lodash/get';
-
 import type { AnyAttribute, Component, Components } from '../../../types';
 import type { UID } from '@strapi/types';
 
@@ -15,7 +13,7 @@ export type ComponentWithChildren = {
 const retrieveComponentsThatHaveComponents = (allComponents: Components) => {
   const componentsThatHaveNestedComponents = Object.keys(allComponents).reduce(
     (acc: ComponentWithChildren[], current) => {
-      const currentComponent = get(allComponents, [current]);
+      const currentComponent = allComponents[current];
 
       const compoWithChildren = getComponentWithChildComponents(currentComponent);
       if (compoWithChildren.childComponents.length > 0) {

--- a/packages/core/content-type-builder/admin/src/components/DataManager/utils/retrieveSpecificInfoFromComponents.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/utils/retrieveSpecificInfoFromComponents.ts
@@ -1,3 +1,5 @@
+// [lodash: get — skipped, dynamic path with spread keysToRetrieve variable]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 
 import { makeUnique } from '../../../utils/makeUnique';

--- a/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
@@ -9,6 +9,8 @@ import {
   GUIDED_TOUR_REQUIRED_ACTIONS,
 } from '@strapi/admin/strapi-admin';
 import { Button, Divider, Flex, Modal, Tabs, Box, Typography, Dialog } from '@strapi/design-system';
+// [lodash: get — skipped, paths use dynamic array keys including dot-separated UIDs]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import has from 'lodash/has';
 import isEqual from 'lodash/isEqual';

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.ts
@@ -1,5 +1,4 @@
 import { translatedErrors as errorsTrads } from '@strapi/admin/strapi-admin';
-import uniq from 'lodash/uniq';
 import * as yup from 'yup';
 
 import { getRelationType } from '../../../utils/getRelationType';
@@ -169,11 +168,13 @@ export const attributeTypes = {
             if (!values) {
               return false;
             }
-            const duplicates = uniq(
-              values
-                .map(toRegressedEnumValue)
-                .filter((value, index, values) => values.indexOf(value) !== index)
-            );
+            const duplicates = [
+              ...new Set(
+                values
+                  .map(toRegressedEnumValue)
+                  .filter((value, index, values) => values.indexOf(value) !== index)
+              ),
+            ];
 
             return !duplicates.length;
           },

--- a/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/RelationNaturePicker.tsx
+++ b/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/RelationNaturePicker.tsx
@@ -7,6 +7,8 @@ import {
   OneToOne,
   OneWay,
 } from '@strapi/icons';
+// [lodash: get — skipped, paths use dynamic array keys with dot-separated UIDs]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import truncate from 'lodash/truncate';
 import pluralize from 'pluralize';

--- a/packages/core/content-type-builder/admin/src/components/TabForm.tsx
+++ b/packages/core/content-type-builder/admin/src/components/TabForm.tsx
@@ -1,4 +1,6 @@
 import { Box, Grid, Typography, Button, Tooltip } from '@strapi/design-system';
+// [lodash: get — skipped, paths use dynamic input.name variable]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import { useIntl } from 'react-intl';
 

--- a/packages/core/content-type-builder/admin/src/utils/formAPI.ts
+++ b/packages/core/content-type-builder/admin/src/utils/formAPI.ts
@@ -1,4 +1,7 @@
+// [lodash: cloneDeep — kept; get — skipped, dynamic spread target paths]
+// eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
 import cloneDeep from 'lodash/cloneDeep';
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import * as yup from 'yup';
 

--- a/packages/core/content-type-builder/server/src/controllers/content-types.ts
+++ b/packages/core/content-type-builder/server/src/controllers/content-types.ts
@@ -48,8 +48,7 @@ export default {
       .filter(
         (uid) =>
           !kind ||
-          _.get(strapi.contentTypes[uid as Internal.UID.ContentType], 'kind', 'collectionType') ===
-            kind
+          (strapi.contentTypes[uid as Internal.UID.ContentType]?.kind ?? 'collectionType') === kind
       )
       .map((uid) =>
         contentTypeService.formatContentType(strapi.contentTypes[uid as Internal.UID.ContentType])

--- a/packages/core/content-type-builder/server/src/controllers/validation/common.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/common.ts
@@ -85,7 +85,7 @@ export const isValidDefaultJSON: CommonTestConfig = {
       return true;
     }
 
-    if (_.isNumber(val) || _.isNull(val) || _.isObject(val) || _.isArray(val)) {
+    if (_.isNumber(val) || val === null || _.isObject(val) || Array.isArray(val)) {
       return true;
     }
 

--- a/packages/core/content-type-builder/server/src/controllers/validation/data-transform.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/data-transform.ts
@@ -21,7 +21,7 @@ export const removeDeletedUIDTargetFields = (data: Struct.ContentTypeSchema) => 
     Object.values(data.attributes).forEach((attribute) => {
       if (
         attribute.type === 'uid' &&
-        !_.isUndefined(attribute.targetField) &&
+        attribute.targetField !== undefined &&
         !_.has(data.attributes, attribute.targetField)
       ) {
         attribute.targetField = undefined;

--- a/packages/core/content-type-builder/server/src/controllers/validation/types.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/types.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { yup } from '@strapi/utils';
 
 import type { TestContext } from 'yup';
@@ -26,7 +25,7 @@ const maxLengthIsGreaterThanOrEqualToMinLength = {
   message: 'maxLength must be greater or equal to minLength',
   test(this: TestContext, value: unknown) {
     const { minLength } = this.parent;
-    return !(!_.isUndefined(minLength) && !_.isUndefined(value) && (value as number) < minLength);
+    return !(minLength !== undefined && value !== undefined && (value as number) < minLength);
   },
 };
 
@@ -70,7 +69,7 @@ const getTypeShape = (attribute: Schema.Attribute.AnyAttribute, { attributes }: 
           .string()
           .oneOf(
             Object.keys(attributes!).filter((key) =>
-              VALID_UID_TARGETS.includes(_.get(attributes![key] as any, 'type'))
+              VALID_UID_TARGETS.includes((attributes![key] as any)?.type)
             )
           )
           .nullable(),
@@ -81,7 +80,12 @@ const getTypeShape = (attribute: Schema.Attribute.AnyAttribute, { attributes }: 
             'cannot define a default UID if the targetField is set',
             function (value) {
               const { targetField } = this.parent;
-              return !!(_.isNil(targetField) || _.isNil(value));
+              return !!(
+                targetField === null ||
+                targetField === undefined ||
+                value === null ||
+                value === undefined
+              );
             }
           )
           .test(
@@ -91,7 +95,10 @@ const getTypeShape = (attribute: Schema.Attribute.AnyAttribute, { attributes }: 
               const { regex } = this.parent;
 
               if (regex) {
-                return !_.isNil(value) && (value === '' || new RegExp(regex).test(value));
+                return (
+                  !(value === null || value === undefined) &&
+                  (value === '' || new RegExp(regex).test(value))
+                );
               }
 
               return value === '' || UID_REGEX.test(value as string);

--- a/packages/core/content-type-builder/server/src/services/content-types.ts
+++ b/packages/core/content-type-builder/server/src/services/content-types.ts
@@ -47,7 +47,7 @@ export const formatContentType = (contentType: any) => {
       displayName: info.displayName,
       singularName: info.singularName,
       pluralName: info.pluralName,
-      description: _.get(info, 'description', ''),
+      description: info.description ?? '',
       pluginOptions: contentType.pluginOptions,
       kind: kind || 'collectionType',
       collectionName,

--- a/packages/core/content-type-builder/server/src/services/schema-builder/content-type-builder.ts
+++ b/packages/core/content-type-builder/server/src/services/schema-builder/content-type-builder.ts
@@ -11,12 +11,15 @@ import type { InternalRelationAttribute, InternalAttribute } from './types';
 
 const { ApplicationError } = errors;
 
+// [lodash: defaults — skipped, fills only undefined keys (differs from Object.assign); omit — skipped, used inside defaults call]
 const reuseUnsetPreviousProperties = (
   newAttribute: Schema.Attribute.AnyAttribute,
   oldAttribute: Schema.Attribute.AnyAttribute
 ) => {
+  // eslint-disable-next-line you-dont-need-lodash-underscore/defaults
   _.defaults(
     newAttribute,
+    // eslint-disable-next-line you-dont-need-lodash-underscore/omit
     _.omit(oldAttribute, [
       'configurable',
       'required',

--- a/packages/core/content-type-builder/server/src/services/schema-builder/index.ts
+++ b/packages/core/content-type-builder/server/src/services/schema-builder/index.ts
@@ -1,5 +1,4 @@
 import { join } from 'path';
-import _ from 'lodash';
 
 import { errors } from '@strapi/utils';
 import createSchemaHandler from './schema-handler';
@@ -119,7 +118,7 @@ function createSchemaBuilder({ components, contentTypes }: SchemaBuilderOptions)
         //   throw new errors.ApplicationError(`target: ${target} does not exist`);
         // }
 
-        if (_.isNil(targetAttribute)) {
+        if (targetAttribute === null || targetAttribute === undefined) {
           return attr;
         }
 

--- a/packages/core/content-type-builder/server/src/services/schema-builder/schema-handler.ts
+++ b/packages/core/content-type-builder/server/src/services/schema-builder/schema-handler.ts
@@ -36,6 +36,7 @@ export default function createSchemaHandler(infos: Infos) {
       } as Struct.ContentTypeSchema),
   };
 
+  // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
   const state = _.cloneDeep(initialState);
 
   // always keep it the same to rollback
@@ -58,7 +59,7 @@ export default function createSchemaHandler(infos: Infos) {
     },
 
     get kind() {
-      return _.get(state.schema, 'kind', 'collectionType');
+      return state.schema?.kind ?? 'collectionType';
     },
 
     get uid() {
@@ -66,7 +67,7 @@ export default function createSchemaHandler(infos: Infos) {
     },
 
     get writable() {
-      return _.get(state, 'plugin') !== 'admin';
+      return state.plugin !== 'admin';
     },
 
     setUID(val: Internal.UID.ContentType) {
@@ -84,18 +85,21 @@ export default function createSchemaHandler(infos: Infos) {
     },
 
     get schema() {
+      // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
       return _.cloneDeep(state.schema);
     },
 
     setSchema(val: Struct.ContentTypeSchema) {
       modified = true;
 
+      // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
       state.schema = _.cloneDeep(val);
       return this;
     },
 
     // get a particular path inside the schema
     get(path: string[]) {
+      // eslint-disable-next-line you-dont-need-lodash-underscore/get
       return _.get(state.schema, path);
     },
 
@@ -105,6 +109,7 @@ export default function createSchemaHandler(infos: Infos) {
 
       modified = true;
 
+      // eslint-disable-next-line you-dont-need-lodash-underscore/get
       const value = _.defaultTo(val, _.get(state.schema, path));
       _.set(state.schema, path, value);
 

--- a/packages/core/content-type-builder/server/src/utils/attributes.ts
+++ b/packages/core/content-type-builder/server/src/utils/attributes.ts
@@ -5,7 +5,7 @@ import type { Schema } from '@strapi/types';
 const { ApplicationError } = errors;
 
 export const isConfigurable = (attribute: Schema.Attribute.AnyAttribute) =>
-  _.get(attribute, 'configurable', true);
+  (attribute as { configurable?: boolean }).configurable ?? true;
 
 export const isRelation = (attribute: Schema.Attribute.AnyAttribute) =>
   attribute.type === 'relation';

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -322,8 +322,8 @@ class Strapi extends Container implements Core.Strapi {
         groupProperties: {
           database: this.config.get('database.connection.client'),
           plugins: Object.keys(this.plugins),
-          numberOfAllContentTypes: _.size(this.contentTypes), // TODO: V5: This event should be renamed numberOfContentTypes in V5 as the name is already taken to describe the number of content types using i18n.
-          numberOfComponents: _.size(this.components),
+          numberOfAllContentTypes: Object.keys(this.contentTypes).length, // TODO: V5: This event should be renamed numberOfContentTypes in V5 as the name is already taken to describe the number of content types using i18n.
+          numberOfComponents: Object.keys(this.components).length,
           numberOfDynamicZones: getNumberOfDynamicZones(),
           numberOfConditionalFields: getNumberOfConditionalFields(),
           numberOfCustomControllers: Object.values<Core.Controller>(this.controllers).filter(

--- a/packages/core/core/src/configuration/index.ts
+++ b/packages/core/core/src/configuration/index.ts
@@ -84,13 +84,19 @@ export const loadConfiguration = (opts: StrapiOptions) => {
 
   const configDir = path.resolve(distDir || process.cwd(), 'config');
 
+  const {
+    uuid: strapiUuid,
+    installId: strapiInstallId,
+    ...packageJsonStrapi
+  } = pkgJSON?.strapi ?? {};
+
   const rootConfig = {
     launchedAt: Date.now(),
     autoReload,
     environment: process.env.NODE_ENV,
-    uuid: _.get(pkgJSON, 'strapi.uuid'),
-    installId: _.get(pkgJSON, 'strapi.installId'),
-    packageJsonStrapi: _.omit(_.get(pkgJSON, 'strapi', {}), 'uuid'),
+    uuid: strapiUuid,
+    installId: strapiInstallId,
+    packageJsonStrapi,
     info: {
       ...pkgJSON,
       strapi: strapiVersion,

--- a/packages/core/core/src/configuration/urls.ts
+++ b/packages/core/core/src/configuration/urls.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { strings } from '@strapi/utils';
 import { isIP } from 'node:net';
 
@@ -13,15 +12,15 @@ export const getConfigUrls = (config: Record<string, unknown>, forAdminBuild = f
   const adminConfig = config.admin;
 
   // Defines serverUrl value
-  let serverUrl = _.get(serverConfig, 'url', '');
-  serverUrl = _.trim(serverUrl, '/ ');
+  let serverUrl = serverConfig?.url ?? '';
+  serverUrl = serverUrl.replace(/^[/ ]+|[/ ]+$/g, '');
   if (typeof serverUrl !== 'string') {
     throw new Error('Invalid server url config. Make sure the url is a string.');
   }
 
   if (serverUrl.startsWith('http')) {
     try {
-      serverUrl = _.trim(new URL(serverConfig.url).toString(), '/');
+      serverUrl = new URL(serverConfig.url).toString().replace(/^\/+|\/+$/g, '');
     } catch (e) {
       throw new Error(
         'Invalid server url config. Make sure the url defined in server.js is valid.'
@@ -32,14 +31,14 @@ export const getConfigUrls = (config: Record<string, unknown>, forAdminBuild = f
   }
 
   // Defines adminUrl value
-  let adminUrl = _.get(adminConfig, 'url', '/admin');
-  adminUrl = _.trim(adminUrl, '/ ');
+  let adminUrl = (adminConfig as { url?: string })?.url ?? '/admin';
+  adminUrl = adminUrl.replace(/^[/ ]+|[/ ]+$/g, '');
   if (typeof adminUrl !== 'string') {
     throw new Error('Invalid admin url config. Make sure the url is a non-empty string.');
   }
   if (adminUrl.startsWith('http')) {
     try {
-      adminUrl = _.trim(new URL(adminUrl).toString(), '/');
+      adminUrl = new URL(adminUrl).toString().replace(/^\/+|\/+$/g, '');
     } catch (e) {
       throw new Error('Invalid admin url config. Make sure the url defined in server.js is valid.');
     }
@@ -56,7 +55,7 @@ export const getConfigUrls = (config: Record<string, unknown>, forAdminBuild = f
     !forAdminBuild
   ) {
     adminPath = adminUrl.replace(strings.getCommonPath(serverUrl, adminUrl), '');
-    adminPath = `/${_.trim(adminPath, '/')}`;
+    adminPath = `/${adminPath.replace(/^\/+|\/+$/g, '')}`;
   } else if (adminUrl.startsWith('http')) {
     adminPath = new URL(adminUrl).pathname;
   }

--- a/packages/core/core/src/core-api/service/__tests__/pagination.test.ts
+++ b/packages/core/core/src/core-api/service/__tests__/pagination.test.ts
@@ -10,6 +10,7 @@ describe('Pagination service', () => {
       global.strapi = {
         config: {
           get(path, defaultValue) {
+            // eslint-disable-next-line you-dont-need-lodash-underscore/get
             return _.get(this, path, defaultValue);
           },
           api: {
@@ -144,6 +145,7 @@ describe('Pagination service', () => {
       global.strapi = {
         config: {
           get(path, defaultValue) {
+            // eslint-disable-next-line you-dont-need-lodash-underscore/get
             return _.get(this, path, defaultValue);
           },
           api: {

--- a/packages/core/core/src/domain/content-type/index.ts
+++ b/packages/core/core/src/domain/content-type/index.ts
@@ -105,7 +105,7 @@ const addFirstPublishedAt = (schema: Schema.ContentType) => {
 };
 
 const addCreatorFields = (schema: Schema.ContentType) => {
-  const isPrivate = !_.get(schema, 'options.populateCreatorFields', false);
+  const isPrivate = (schema?.options?.populateCreatorFields ?? false) !== true;
 
   schema.attributes[CREATED_BY_ATTRIBUTE] = {
     type: 'relation',
@@ -138,6 +138,8 @@ const getGlobalId = (schema: Schema.ContentType, prefix?: string) => {
 };
 
 const pickSchema = (model: Schema.ContentType) => {
+  // [lodash: cloneDeep — structuredClone not 1:1, audit value shape first]
+  // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
   const schema = _.cloneDeep(
     _.pick(model, [
       'connection',

--- a/packages/core/core/src/domain/content-type/validator.ts
+++ b/packages/core/core/src/domain/content-type/validator.ts
@@ -73,11 +73,14 @@ const contentTypeSchemaValidator = yup.object().shape({
             }
 
             // should not collide
-            const duplicates = _.uniq(
-              regressedValues.filter(
-                (value: string, index: number, values: string[]) => values.indexOf(value) !== index
-              )
-            );
+            const duplicates = [
+              ...new Set(
+                regressedValues.filter(
+                  (value: string, index: number, values: string[]) =>
+                    values.indexOf(value) !== index
+                )
+              ),
+            ];
 
             if (duplicates.length) {
               const message = `Some enumeration values of the field '${attrName}' collide when normalized: ${duplicates.join(

--- a/packages/core/core/src/domain/module/index.ts
+++ b/packages/core/core/src/domain/module/index.ts
@@ -66,6 +66,8 @@ export const createModule = (
   rawModule: RawModule,
   strapi: Core.Strapi
 ): Module => {
+  // [lodash: defaults — fills undefined only, Object.assign overwrites]
+  // eslint-disable-next-line you-dont-need-lodash-underscore/defaults
   _.defaults(rawModule, defaultModule);
 
   try {

--- a/packages/core/core/src/loaders/components.ts
+++ b/packages/core/core/src/loaders/components.ts
@@ -49,6 +49,8 @@ export default async function loadComponents(strapi: Core.Strapi) {
       const uid: UID.Component = `${category}.${key}`;
 
       acc[uid] = Object.assign(schema, {
+        // [lodash: cloneDeep — structuredClone not 1:1, audit value shape first]
+        // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
         __schema__: _.cloneDeep(schema),
         uid,
         category,

--- a/packages/core/core/src/loaders/plugins/get-enabled-plugins.ts
+++ b/packages/core/core/src/loaders/plugins/get-enabled-plugins.ts
@@ -1,7 +1,6 @@
 import fp from 'lodash/fp.js';
 import { dirname, join, resolve } from 'path';
 import { statSync, existsSync } from 'fs';
-import _ from 'lodash';
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import { strings } from '@strapi/utils';
@@ -138,7 +137,7 @@ export const getEnabledPlugins = async (strapi: Core.Strapi, { client } = { clie
   const declaredPlugins: PluginMetas = {};
   const userPluginsConfig = await getUserPluginsConfig();
 
-  _.forEach(userPluginsConfig, (declaration, pluginName) => {
+  Object.entries(userPluginsConfig ?? {}).forEach(([pluginName, declaration]) => {
     validatePluginName(pluginName);
 
     declaredPlugins[pluginName] = {

--- a/packages/core/core/src/migrations/__tests__/5.0.0-discard-drafts.test.ts
+++ b/packages/core/core/src/migrations/__tests__/5.0.0-discard-drafts.test.ts
@@ -1,5 +1,5 @@
 import type { Database } from '@strapi/database';
-import { createConnection } from '../../../../database/src/connection';
+import { createConnection } from '@strapi/database/src/connection';
 
 import { discardDocumentDrafts } from '../database/5.0.0-discard-drafts';
 

--- a/packages/core/core/src/registries/sanitizers.ts
+++ b/packages/core/core/src/registries/sanitizers.ts
@@ -8,6 +8,7 @@ const sanitizersRegistry = () => {
 
   return {
     get(path: PropertyName): Sanitizer[] {
+      // eslint-disable-next-line you-dont-need-lodash-underscore/get
       return _.get(sanitizers, path, []);
     },
 

--- a/packages/core/core/src/registries/validators.ts
+++ b/packages/core/core/src/registries/validators.ts
@@ -8,6 +8,7 @@ const validatorsRegistry = () => {
 
   return {
     get(path: PropertyName): Validator[] {
+      // eslint-disable-next-line you-dont-need-lodash-underscore/get
       return _.get(validators, path, []);
     },
 

--- a/packages/core/core/src/services/content-api/index.ts
+++ b/packages/core/core/src/services/content-api/index.ts
@@ -193,7 +193,7 @@ const createContentAPI = (strapi: Core.Strapi) => {
   const getRoutesMap = async () => {
     const routesMap: Record<string, Core.Route[]> = {};
 
-    _.forEach(strapi.apis, (api, apiName) => {
+    Object.entries(strapi.apis ?? {}).forEach(([apiName, api]) => {
       const routes = _.flatMap(api.routes, (route) => {
         if ('routes' in route) {
           return route.routes;
@@ -213,7 +213,7 @@ const createContentAPI = (strapi: Core.Strapi) => {
       }));
     });
 
-    _.forEach(strapi.plugins, (plugin, pluginName) => {
+    Object.entries(strapi.plugins ?? {}).forEach(([pluginName, plugin]) => {
       const transformPrefix = transformRoutePrefixFor(pluginName);
 
       if (Array.isArray(plugin.routes)) {

--- a/packages/core/core/src/services/content-api/permissions/index.ts
+++ b/packages/core/core/src/services/content-api/permissions/index.ts
@@ -74,10 +74,9 @@ export default (strapi: Core.Strapi) => {
       apis: Record<string, Core.Plugin | Core.Module>,
       source: 'api' | 'plugin'
     ) => {
-      _.forEach(apis, (api, apiName) => {
-        const controllers = _.reduce(
-          api.controllers,
-          (acc, controller, controllerName) => {
+      Object.entries(apis ?? {}).forEach(([apiName, api]) => {
+        const controllers = Object.entries(api.controllers ?? {}).reduce(
+          (acc, [controllerName, controller]) => {
             const contentApiActions = _.pickBy(controller, isContentApi);
 
             if (_.isEmpty(contentApiActions)) {

--- a/packages/core/core/src/services/document-service/components.ts
+++ b/packages/core/core/src/services/document-service/components.ts
@@ -257,8 +257,12 @@ const deleteOldComponents = async <TUID extends UID.Schema>(
   const previousValue = (await strapi.db
     .query(uid)
     .load(entityToUpdate, attributeName)) as ComponentValue;
-  const idsToKeep = _.castArray(componentValue).filter(has('id')).map(pickStringifiedId);
-  const allIds = _.castArray(previousValue).filter(has('id')).map(pickStringifiedId);
+  const idsToKeep = (Array.isArray(componentValue) ? componentValue : [componentValue])
+    .filter(has('id'))
+    .map(pickStringifiedId);
+  const allIds = (Array.isArray(previousValue) ? previousValue : [previousValue])
+    .filter(has('id'))
+    .map(pickStringifiedId);
 
   idsToKeep.forEach((id) => {
     if (!allIds.includes(id)) {
@@ -287,14 +291,14 @@ const deleteOldDZComponents = async <TUID extends UID.Schema>(
     .query(uid)
     .load(entityToUpdate, attributeName)) as DynamicZoneValue;
 
-  const idsToKeep = _.castArray(dynamiczoneValues)
+  const idsToKeep = (Array.isArray(dynamiczoneValues) ? dynamiczoneValues : [dynamiczoneValues])
     .filter(has('id'))
     .map((v) => ({
       id: pickStringifiedId(v),
       __component: v.__component,
     }));
 
-  const allIds = _.castArray(previousValue)
+  const allIds = (Array.isArray(previousValue) ? previousValue : [previousValue])
     .filter(has('id'))
     .map((v) => ({
       id: pickStringifiedId(v),
@@ -357,11 +361,11 @@ const deleteComponents = async <TUID extends UID.Schema, TEntity extends Data.En
 
       if (attribute.type === 'component') {
         const { component: componentUID } = attribute;
-        await async.map(_.castArray(value), (subValue: any) =>
+        await async.map(Array.isArray(value) ? value : [value], (subValue: any) =>
           deleteComponent(componentUID, subValue)
         );
       } else {
-        await async.map(_.castArray(value), (subValue: any) =>
+        await async.map(Array.isArray(value) ? value : [value], (subValue: any) =>
           deleteComponent(subValue.__component, subValue)
         );
       }

--- a/packages/core/core/src/services/entity-service/index.ts
+++ b/packages/core/core/src/services/entity-service/index.ts
@@ -164,7 +164,7 @@ const createDefaultImplementation = ({
   },
 
   async load(uid, entity, field, params) {
-    if (!_.isString(field)) {
+    if (typeof field !== 'string') {
       throw new Error(`Invalid load. Expected "${field}" to be a string`);
     }
 
@@ -176,7 +176,7 @@ const createDefaultImplementation = ({
   },
 
   async loadPages(uid, entity, field, params, pagination = {}) {
-    if (!_.isString(field)) {
+    if (typeof field !== 'string') {
       throw new Error(`Invalid load. Expected "${field}" to be a string`);
     }
 

--- a/packages/core/core/src/services/entity-validator/index.ts
+++ b/packages/core/core/src/services/entity-validator/index.ts
@@ -10,7 +10,7 @@ import strapiUtils from '@strapi/utils';
 import type { Modules, UID, Struct, Schema } from '@strapi/types';
 import { Validators, ValidatorMetas } from './validators';
 
-const { uniqBy, castArray, isNil, isArray, mergeWith } = _;
+const { uniqBy, castArray, mergeWith } = _;
 const { has, prop, isObject, isEmpty } = fp;
 
 type CreateOrUpdate = 'creation' | 'update';
@@ -470,7 +470,7 @@ const buildRelationsStore = <TUID extends UID.Schema>({
       const attribute = currentModel.attributes[attributeName];
       const value = data[attributeName];
 
-      if (isNil(value)) {
+      if (value === null || value === undefined) {
         return result;
       }
 
@@ -494,9 +494,9 @@ const buildRelationsStore = <TUID extends UID.Schema>({
           if (Array.isArray(value)) {
             source = value;
           } else if (isObject(value)) {
-            if ('connect' in value && !isNil(value.connect)) {
+            if ('connect' in value && value.connect !== null && value.connect !== undefined) {
               source = value.connect as RelationSource[];
-            } else if ('set' in value && !isNil(value.set)) {
+            } else if ('set' in value && value.set !== null && value.set !== undefined) {
               source = value.set as RelationSource[];
             } else {
               source = [];
@@ -529,7 +529,7 @@ const buildRelationsStore = <TUID extends UID.Schema>({
                 data: componentValue as Record<string, unknown>,
               }),
               (objValue, srcValue) => {
-                if (isArray(objValue)) {
+                if (Array.isArray(objValue)) {
                   return objValue.concat(srcValue);
                 }
               }
@@ -552,7 +552,7 @@ const buildRelationsStore = <TUID extends UID.Schema>({
                 data: value,
               }),
               (objValue, srcValue) => {
-                if (isArray(objValue)) {
+                if (Array.isArray(objValue)) {
                   return objValue.concat(srcValue);
                 }
               }

--- a/packages/core/core/src/services/entity-validator/validators.ts
+++ b/packages/core/core/src/services/entity-validator/validators.ts
@@ -118,7 +118,7 @@ const addMinLengthValidator = (
   },
   { isDraft }: ValidatorOptions
 ) => {
-  return attr.minLength && _.isInteger(attr.minLength) && !isDraft
+  return attr.minLength && Number.isInteger(attr.minLength) && !isDraft
     ? validator.min(attr.minLength)
     : validator;
 };
@@ -141,7 +141,9 @@ const addMaxLengthValidator = (
       | Schema.Attribute.UID;
   }
 ) => {
-  return attr.maxLength && _.isInteger(attr.maxLength) ? validator.max(attr.maxLength) : validator;
+  return attr.maxLength && Number.isInteger(attr.maxLength)
+    ? validator.max(attr.maxLength)
+    : validator;
 };
 
 /**
@@ -225,7 +227,7 @@ const addStringRegexValidator = (
   },
   { isDraft }: ValidatorOptions
 ) => {
-  return 'regex' in attr && !_.isUndefined(attr.regex) && !isDraft
+  return 'regex' in attr && attr.regex !== undefined && !isDraft
     ? validator.matches(new RegExp(attr.regex), { excludeEmptyString: !attr.required })
     : validator;
 };
@@ -418,7 +420,7 @@ const addUniqueValidator = <T extends yup.AnySchema>(
      * If the attribute value is `null` or an empty string we want to skip the unique validation.
      * Otherwise it'll only accept a single entry with that value in the database.
      */
-    if (_.isNil(value) || value === '') {
+    if (value === null || value === undefined || value === '') {
       return true;
     }
 

--- a/packages/core/core/src/services/metrics/__tests__/index.test.ts
+++ b/packages/core/core/src/services/metrics/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import { get } from 'lodash/fp';
 import metrics from '../index';
 

--- a/packages/core/core/src/services/metrics/is-truthy.ts
+++ b/packages/core/core/src/services/metrics/is-truthy.ts
@@ -1,7 +1,5 @@
-import _ from 'lodash';
-
-const isTruthy = (val: any) => {
-  return [1, true].includes(val) || ['true', '1'].includes(_.toLower(val));
+const isTruthy = (val: unknown) => {
+  return [1, true].includes(val as never) || ['true', '1'].includes(String(val).toLowerCase());
 };
 
 export default isTruthy;

--- a/packages/core/core/src/services/metrics/sender.ts
+++ b/packages/core/core/src/services/metrics/sender.ts
@@ -40,6 +40,8 @@ const defaultQueryOpts = {
 const addPackageJsonStrapiMetadata = (metadata: Record<string, unknown>, strapi: Core.Strapi) => {
   const { packageJsonStrapi = {} } = strapi.config;
 
+  // [lodash: defaults — fills undefined only, Object.assign overwrites]
+  // eslint-disable-next-line you-dont-need-lodash-underscore/defaults
   _.defaults(metadata, packageJsonStrapi);
 };
 

--- a/packages/core/core/src/services/server/koa.ts
+++ b/packages/core/core/src/services/server/koa.ts
@@ -5,7 +5,7 @@ import delegate from 'delegates';
 import statuses from 'statuses';
 import { formatHttpError } from '../errors';
 
-const { isNil, camelCase } = fp;
+const { camelCase } = fp;
 
 declare module 'koa' {
   interface BaseResponse {
@@ -48,7 +48,7 @@ const addCustomMethods = (app: Koa) => {
   };
 
   app.response.deleted = function deleted(data) {
-    if (isNil(data)) {
+    if (data === null || data === undefined) {
       this.status = 204;
     } else {
       this.status = 200;

--- a/packages/core/core/src/services/server/middleware.ts
+++ b/packages/core/core/src/services/server/middleware.ts
@@ -1,10 +1,7 @@
-import fp from 'lodash/fp.js';
 import path from 'path';
 
 import { importDefault } from '@strapi/utils';
 import type { Core } from '@strapi/types';
-
-const { isArray } = fp;
 
 const instantiateMiddleware = (
   middlewareFactory: Core.MiddlewareFactory,
@@ -24,7 +21,7 @@ const instantiateMiddleware = (
 const resolveRouteMiddlewares = (route: Core.Route, strapi: Core.Strapi) => {
   const middlewaresConfig = route?.config?.middlewares ?? [];
 
-  if (!isArray(middlewaresConfig)) {
+  if (!Array.isArray(middlewaresConfig)) {
     throw new Error('Route middlewares config must be an array');
   }
 

--- a/packages/core/core/src/services/server/register-routes.ts
+++ b/packages/core/core/src/services/server/register-routes.ts
@@ -37,7 +37,7 @@ const registerAdminRoutes = (strapi: Core.Strapi) => {
   // Mutate admin.routes in-place and make sure router factories are instantiated correctly
   strapi.admin.routes = instantiateRouterInputs(strapi.admin.routes, strapi);
 
-  _.forEach(strapi.admin.routes, (router) => {
+  Object.values(strapi.admin.routes ?? {}).forEach((router) => {
     router.type = router.type || 'admin';
     router.prefix = router.prefix || `/admin`;
     router.routes.forEach((route) => {
@@ -75,7 +75,7 @@ const registerPluginRoutes = (strapi: Core.Strapi) => {
       // Mutate plugin.routes in-place and make sure router factories are instantiated correctly
       plugin.routes = instantiateRouterInputs(plugin.routes, strapi);
 
-      _.forEach(plugin.routes, (router) => {
+      Object.values(plugin.routes ?? {}).forEach((router) => {
         router.type = router.type ?? 'admin';
         router.prefix = router.prefix ?? `/${pluginName}`;
         router.routes.forEach((route) => {
@@ -102,7 +102,7 @@ const registerAPIRoutes = (strapi: Core.Strapi) => {
     // Mutate api.routes in-place and make sure router factories are instantiated correctly
     api.routes = instantiateRouterInputs(api.routes, strapi);
 
-    _.forEach(api.routes, (router) => {
+    Object.values(api.routes ?? {}).forEach((router) => {
       // TODO: remove once auth setup
       // pass meta down to compose endpoint
       router.type = 'content-api';

--- a/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
+++ b/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
+// [lodash: cloneDeep — structuredClone not 1:1, audit value shape first]
+// eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
 import { cloneDeep, merge } from 'lodash';
 import { Database } from '@strapi/database';
 import {

--- a/packages/core/core/src/utils/is-initialized.ts
+++ b/packages/core/core/src/utils/is-initialized.ts
@@ -1,7 +1,7 @@
 import fp from 'lodash/fp.js';
 import type { Core } from '@strapi/types';
 
-const { isEmpty, isNil } = fp;
+const { isEmpty } = fp;
 
 /**
  * Test if the strapi application is considered as initialized (1st user has been created)
@@ -15,7 +15,7 @@ export const isInitialized = async (strapi: Core.Strapi): Promise<boolean> => {
     // test if there is at least one admin
     const anyAdministrator = await strapi.db.query('admin::user').findOne({ select: ['id'] });
 
-    return !isNil(anyAdministrator);
+    return anyAdministrator !== null && anyAdministrator !== undefined;
   } catch (err) {
     strapi.stopWithError(err);
   }

--- a/packages/core/core/src/utils/startup-logger.ts
+++ b/packages/core/core/src/utils/startup-logger.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import CLITable from 'cli-table3';
-import _ from 'lodash/fp.js';
 
 import type { Core } from '@strapi/types';
 
@@ -27,7 +26,7 @@ export const createStartupLogger = (app: Core.Strapi) => {
     logStats() {
       const columns = Math.min(process.stderr.columns, 80) - 2;
       console.log();
-      console.log(chalk.black.bgWhite(_.padEnd(columns, ' Project information')));
+      console.log(chalk.black.bgWhite(' Project information'.padEnd(columns)));
       console.log();
 
       const infoTable = new CLITable({
@@ -54,7 +53,7 @@ export const createStartupLogger = (app: Core.Strapi) => {
 
       console.log(infoTable.toString());
       console.log();
-      console.log(chalk.black.bgWhite(_.padEnd(columns, ' Actions available')));
+      console.log(chalk.black.bgWhite(' Actions available'.padEnd(columns)));
       console.log();
     },
 

--- a/packages/core/data-transfer/src/engine/__tests__/engine.test.ts
+++ b/packages/core/data-transfer/src/engine/__tests__/engine.test.ts
@@ -1,6 +1,8 @@
 import path, { posix, win32 } from 'path';
 import os from 'os';
 import fs from 'fs-extra';
+// [lodash: cloneDeep — kept, structuredClone not 1:1; get — kept, dynamic path variable]
+// eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep, you-dont-need-lodash-underscore/get
 import { cloneDeep, get, set } from 'lodash/fp';
 import { Readable, Writable } from 'stream-chain';
 import { pipeline } from 'stream/promises';

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore.test.ts
@@ -1,4 +1,3 @@
-import { omit } from 'lodash/fp';
 import { deleteRecords, restoreConfigs } from '../strategies/restore';
 import {
   getStrapiFactory,
@@ -291,6 +290,7 @@ describe('Restore ', () => {
     const result = await restoreConfigs(strapi, config);
     expect(strapi.db.query).toBeCalledTimes(1);
     expect(strapi.db.query).toBeCalledWith('strapi::webhook');
-    expect(result.data).toMatchObject(omit(['id'])(config.value));
+    const { id: _id, ...configValueWithoutId } = config.value;
+    expect(result.data).toMatchObject(configValueWithoutId);
   });
 });

--- a/packages/core/data-transfer/src/utils/components.ts
+++ b/packages/core/data-transfer/src/utils/components.ts
@@ -289,8 +289,12 @@ const deleteOldComponents = async <TUID extends UID.Schema>(
     .query(uid)
     .load(entityToUpdate, attributeName)) as ComponentValue;
 
-  const idsToKeep = _.castArray(componentValue).filter(has('id')).map(pickStringifiedId);
-  const allIds = _.castArray(previousValue).filter(has('id')).map(pickStringifiedId);
+  const idsToKeep = (Array.isArray(componentValue) ? componentValue : [componentValue])
+    .filter(has('id'))
+    .map(pickStringifiedId);
+  const allIds = (Array.isArray(previousValue) ? previousValue : [previousValue])
+    .filter(has('id'))
+    .map(pickStringifiedId);
 
   idsToKeep.forEach((id) => {
     if (!allIds.includes(id)) {
@@ -319,14 +323,14 @@ const deleteOldDZComponents = async <TUID extends UID.Schema>(
     .query(uid)
     .load(entityToUpdate, attributeName)) as Schema.Attribute.Value<Schema.Attribute.DynamicZone>;
 
-  const idsToKeep = _.castArray(dynamiczoneValues)
+  const idsToKeep = (Array.isArray(dynamiczoneValues) ? dynamiczoneValues : [dynamiczoneValues])
     .filter(has('id'))
     .map((v) => ({
       id: pickStringifiedId(v),
       __component: v.__component,
     }));
 
-  const allIds = _.castArray(previousValue)
+  const allIds = (Array.isArray(previousValue) ? previousValue : [previousValue])
     .filter(has('id'))
     .map((v) => ({
       id: pickStringifiedId(v),
@@ -390,7 +394,7 @@ const deleteComponents = async <TUID extends UID.Schema, TEntity extends Data.En
         const { component: componentUID } = attribute;
         // MySQL/MariaDB can cause deadlocks here if concurrency higher than 1
         await async.map(
-          _.castArray(value),
+          Array.isArray(value) ? value : [value],
           (subValue: any) => deleteComponent(componentUID, subValue),
           {
             concurrency: isDialectMySQL() && !strapi.db?.inTransaction() ? 1 : Infinity,
@@ -400,7 +404,7 @@ const deleteComponents = async <TUID extends UID.Schema, TEntity extends Data.En
         // delete dynamic zone components
         // MySQL/MariaDB can cause deadlocks here if concurrency higher than 1
         await async.map(
-          _.castArray(value),
+          Array.isArray(value) ? value : [value],
           (subValue: any) => deleteComponent(subValue.__component, subValue),
           { concurrency: isDialectMySQL() && !strapi.db?.inTransaction() ? 1 : Infinity }
         );
@@ -535,7 +539,12 @@ const collectComponentIdMappings = ({
       const oldValue = oldData[attributeName];
       const newValue = newData[attributeName];
 
-      if (_.isNil(oldValue) || _.isNil(newValue)) {
+      if (
+        oldValue === null ||
+        oldValue === undefined ||
+        newValue === null ||
+        newValue === undefined
+      ) {
         continue;
       }
 

--- a/packages/core/database/src/lifecycles/subscribers/timestamps.ts
+++ b/packages/core/database/src/lifecycles/subscribers/timestamps.ts
@@ -10,6 +10,8 @@ export const timestampsLifecyclesSubscriber: Subscriber = {
     const { data } = event.params;
 
     const now = new Date();
+    // _.defaults only fills undefined slots; Object.assign would overwrite
+    // eslint-disable-next-line you-dont-need-lodash-underscore/defaults
     _.defaults(data, { createdAt: now, updatedAt: now });
   },
 
@@ -21,7 +23,9 @@ export const timestampsLifecyclesSubscriber: Subscriber = {
     const { data } = event.params;
 
     const now = new Date();
-    if (_.isArray(data)) {
+    if (Array.isArray(data)) {
+      // _.defaults only fills undefined slots; Object.assign would overwrite
+      // eslint-disable-next-line you-dont-need-lodash-underscore/defaults
       data.forEach((data) => _.defaults(data, { createdAt: now, updatedAt: now }));
     }
   },
@@ -34,7 +38,7 @@ export const timestampsLifecyclesSubscriber: Subscriber = {
     const { data } = event.params;
 
     const now = new Date();
-    _.assign(data, { updatedAt: now });
+    Object.assign(data, { updatedAt: now });
   },
 
   /**
@@ -45,8 +49,8 @@ export const timestampsLifecyclesSubscriber: Subscriber = {
     const { data } = event.params;
 
     const now = new Date();
-    if (_.isArray(data)) {
-      data.forEach((data) => _.assign(data, { updatedAt: now }));
+    if (Array.isArray(data)) {
+      data.forEach((data) => Object.assign(data, { updatedAt: now }));
     }
   },
 };

--- a/packages/core/database/src/query/helpers/order-by.ts
+++ b/packages/core/database/src/query/helpers/order-by.ts
@@ -177,6 +177,8 @@ export const wrapWithDeepSort = (originalQuery: knex.Knex.QueryBuilder, ctx: Ord
   const { tableName } = db.metadata.get(uid);
 
   // The orderBy is cloned to avoid unwanted mutations of the original object
+  // lodash/fp cloneDeep is used because structuredClone doesn't handle Knex instances or functions
+  // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
   const orderBy = _.cloneDeep<OrderByValue[]>(qb.state.orderBy);
 
   // Separate column-based entries from raw-expression entries (e.g. status)

--- a/packages/core/database/src/query/helpers/populate/apply.ts
+++ b/packages/core/database/src/query/helpers/populate/apply.ts
@@ -53,6 +53,10 @@ type MorphIdMap = Record<string, Record<ID, Row[]>>;
 
 type Row = Record<string, unknown>;
 
+const getUniqueNonNilValues = (values: unknown[]) => {
+  return [...new Set(values.filter((value) => value !== null && value !== undefined))];
+};
+
 /**
  * Populate oneToOne and manyToOne relation
  * @param {*} input
@@ -71,9 +75,7 @@ const XtoOne = async (
   if ('joinColumn' in attribute && attribute.joinColumn) {
     const { name: joinColumnName, referencedColumn: referencedColumnName } = attribute.joinColumn;
 
-    const referencedValues = _.uniq(
-      results.map((r) => r[joinColumnName]).filter((value) => !_.isNil(value))
-    );
+    const referencedValues = getUniqueNonNilValues(results.map((r) => r[joinColumnName]));
 
     if (_.isEmpty(referencedValues)) {
       results.forEach((result) => {
@@ -93,7 +95,7 @@ const XtoOne = async (
     const map = _.groupBy<Row[]>(referencedColumnName)(rows);
 
     results.forEach((result) => {
-      result[attributeName] = fromTargetRow(_.first(map[result[joinColumnName] as string]));
+      result[attributeName] = fromTargetRow(map[result[joinColumnName] as string]?.[0]);
     });
 
     return;
@@ -111,9 +113,7 @@ const XtoOne = async (
     const joinColRenameAs = `${joinColPrefix}${joinColumnName}`;
     const joinColSelect = `${joinColAlias} as ${joinColRenameAs}`;
 
-    const referencedValues = _.uniq(
-      results.map((r) => r[referencedColumnName]).filter((value) => !_.isNil(value))
-    );
+    const referencedValues = getUniqueNonNilValues(results.map((r) => r[referencedColumnName]));
 
     if (isCount) {
       if (_.isEmpty(referencedValues)) {
@@ -179,7 +179,7 @@ const XtoOne = async (
     const map = _.groupBy<Row>(joinColRenameAs)(rows);
 
     results.forEach((result) => {
-      result[attributeName] = fromTargetRow(_.first(map[result[referencedColumnName] as string]));
+      result[attributeName] = fromTargetRow(map[result[referencedColumnName] as string]?.[0]);
     });
   }
 };
@@ -197,9 +197,7 @@ const oneToMany = async (input: InputWithTarget<Relation.OneToMany>, ctx: Contex
       on,
     } = attribute.joinColumn;
 
-    const referencedValues = _.uniq(
-      results.map((r) => r[joinColumnName]).filter((value) => !_.isNil(value))
-    );
+    const referencedValues = getUniqueNonNilValues(results.map((r) => r[joinColumnName]));
 
     if (_.isEmpty(referencedValues)) {
       results.forEach((result) => {
@@ -239,9 +237,7 @@ const oneToMany = async (input: InputWithTarget<Relation.OneToMany>, ctx: Contex
     const joinColRenameAs = `${joinColPrefix}${joinColumnName}`;
     const joinColSelect = `${joinColAlias} as ${joinColRenameAs}`;
 
-    const referencedValues = _.uniq(
-      results.map((r) => r[referencedColumnName]).filter((value) => !_.isNil(value))
-    );
+    const referencedValues = getUniqueNonNilValues(results.map((r) => r[referencedColumnName]));
 
     if (isCount) {
       if (_.isEmpty(referencedValues)) {
@@ -328,9 +324,7 @@ const manyToMany = async (input: InputWithTarget<Relation.ManyToMany>, ctx: Cont
   const joinColRenameAs = `${joinColPrefix}${joinColumnName}`;
   const joinColSelect = `${joinColAlias} as ${joinColRenameAs}`;
 
-  const referencedValues = _.uniq(
-    results.map((r) => r[referencedColumnName]).filter((value) => !_.isNil(value))
-  );
+  const referencedValues = getUniqueNonNilValues(results.map((r) => r[referencedColumnName]));
 
   if (isCount) {
     if (_.isEmpty(referencedValues)) {
@@ -415,8 +409,8 @@ const morphX = async (
   if (targetAttribute.type === 'relation' && targetAttribute.relation === 'morphToOne') {
     const { idColumn, typeColumn } = targetAttribute.morphColumn;
 
-    const referencedValues = _.uniq(
-      results.map((r) => r[idColumn.referencedColumn]).filter((value) => !_.isNil(value))
+    const referencedValues = getUniqueNonNilValues(
+      results.map((r) => r[idColumn.referencedColumn])
     );
 
     if (_.isEmpty(referencedValues)) {
@@ -439,8 +433,7 @@ const morphX = async (
     results.forEach((result) => {
       const matchingRows = map[result[idColumn.referencedColumn] as string];
 
-      const matchingValue =
-        attribute.relation === 'morphOne' ? _.first(matchingRows) : matchingRows;
+      const matchingValue = attribute.relation === 'morphOne' ? matchingRows?.[0] : matchingRows;
 
       result[attributeName] = fromTargetRow(matchingValue);
     });
@@ -451,8 +444,8 @@ const morphX = async (
 
     const { idColumn, typeColumn } = morphColumn;
 
-    const referencedValues = _.uniq(
-      results.map((r) => r[idColumn.referencedColumn]).filter((value) => !_.isNil(value))
+    const referencedValues = getUniqueNonNilValues(
+      results.map((r) => r[idColumn.referencedColumn])
     );
 
     if (_.isEmpty(referencedValues)) {
@@ -494,8 +487,7 @@ const morphX = async (
     results.forEach((result) => {
       const matchingRows = map[result[idColumn.referencedColumn] as string];
 
-      const matchingValue =
-        attribute.relation === 'morphOne' ? _.first(matchingRows) : matchingRows;
+      const matchingValue = attribute.relation === 'morphOne' ? matchingRows?.[0] : matchingRows;
 
       result[attributeName] = fromTargetRow(matchingValue);
     });
@@ -514,8 +506,8 @@ const morphToMany = async (input: Input<Relation.MorphToMany>, ctx: Context) => 
 
   // fetch join table to create the ids map then do the same as morphToOne without the first
 
-  const referencedValues = _.uniq(
-    results.map((r) => r[joinColumn.referencedColumn]).filter((value) => !_.isNil(value))
+  const referencedValues = getUniqueNonNilValues(
+    results.map((r) => r[joinColumn.referencedColumn])
   );
 
   const qb = db.entityManager.createQueryBuilder(joinTable.name);
@@ -665,7 +657,7 @@ const morphToOne = async (input: Input<Relation.MorphToOne>, ctx: Context) => {
     const fromTargetRow = (rowOrRows: Row | Row[] | undefined) =>
       fromRow(db.metadata.get(type), rowOrRows);
 
-    const row = fromTargetRow(_.first(matchingRows));
+    const row = fromTargetRow(matchingRows?.[0]);
     // Spread target first so a same-named user attribute cannot override the morph type UID
     result[attributeName] = row ? { ...row, [typeField]: type } : row;
   });

--- a/packages/core/database/src/query/helpers/populate/process.ts
+++ b/packages/core/database/src/query/helpers/populate/process.ts
@@ -47,7 +47,7 @@ const processPopulate = (populate: unknown, ctx: Context) => {
 
   let populateMap: PopulateMap = {};
 
-  if (populate === false || _.isNil(populate)) {
+  if (populate === false || populate === null || populate === undefined) {
     return null;
   }
 

--- a/packages/core/database/src/query/helpers/search.ts
+++ b/packages/core/database/src/query/helpers/search.ts
@@ -24,7 +24,7 @@ export const applySearch = (knex: Knex.QueryBuilder, query: string, ctx: Ctx) =>
 
   searchColumns.push(...stringColumns);
 
-  if (!_.isNaN(_.toNumber(query))) {
+  if (!Number.isNaN(_.toNumber(query))) {
     const numberColumns = Object.keys(attributes).filter((attributeName) => {
       const attribute = attributes[attributeName];
       return (

--- a/packages/core/database/src/query/helpers/transform.ts
+++ b/packages/core/database/src/query/helpers/transform.ts
@@ -11,7 +11,7 @@ export type Rec = Record<string, unknown> | null;
 const fromSingleRow = (meta: Meta, row: Row): Rec => {
   const { attributes } = meta;
 
-  if (_.isNil(row)) {
+  if (row === null || row === undefined) {
     return null;
   }
 
@@ -42,7 +42,7 @@ const fromSingleRow = (meta: Meta, row: Row): Rec => {
 };
 
 const fromRow = (meta: Meta, row: Row | Row[] | undefined) => {
-  if (_.isNil(row)) {
+  if (row === null || row === undefined) {
     return null;
   }
 
@@ -54,7 +54,7 @@ const fromRow = (meta: Meta, row: Row | Row[] | undefined) => {
 };
 
 const toSingleRow = (meta: Meta, data: Rec = {}): Row => {
-  if (_.isNil(data)) {
+  if (data === null || data === undefined) {
     return data;
   }
 
@@ -84,11 +84,11 @@ function toRow<TData extends Rec | Rec[] | null>(
   data: TData
 ): TData extends null ? null : TData extends Rec[] ? Row[] : Rec;
 function toRow(meta: Meta, data: Rec | Rec[] | null): Row | Row[] | null {
-  if (_.isNil(data)) {
+  if (data === null || data === undefined) {
     return data;
   }
 
-  if (_.isArray(data)) {
+  if (Array.isArray(data)) {
     return data.map((datum) => toSingleRow(meta, datum));
   }
 

--- a/packages/core/database/src/query/query-builder.ts
+++ b/packages/core/database/src/query/query-builder.ts
@@ -10,6 +10,10 @@ import * as helpers from './helpers';
 import type { Join } from './helpers/join';
 import type { OrderByValue } from './helpers/order-by';
 
+const isNil = (value: unknown): value is null | undefined => value === null || value === undefined;
+const toArray = <T>(value: T | T[]): T[] => (Array.isArray(value) ? value : [value]);
+const unique = <T>(values: T[]): T[] => [...new Set(values)];
+
 interface State {
   type: 'select' | 'insert' | 'update' | 'delete' | 'count' | 'max' | 'truncate';
   select: Array<string | Knex.Raw>;
@@ -133,6 +137,8 @@ const createQueryBuilder = (
   const meta = db.metadata.get(uid);
   const { tableName } = meta;
 
+  // _.defaults only fills undefined slots; spread `{ ...defaults, ...initialState }` would overwrite with undefined for Partial<State> keys
+  // eslint-disable-next-line you-dont-need-lodash-underscore/defaults
   const state: State = _.defaults(
     {
       type: 'select',
@@ -182,13 +188,13 @@ const createQueryBuilder = (
 
     select(args) {
       state.type = 'select';
-      state.select = _.uniq(_.castArray(args));
+      state.select = unique(toArray(args));
 
       return this;
     },
 
     addSelect(args) {
-      state.select = _.uniq([...state.select, ..._.castArray(args)]);
+      state.select = unique([...state.select, ...toArray(args)]);
 
       return this;
     },
@@ -316,41 +322,41 @@ const createQueryBuilder = (
     init(params = {}) {
       const { _q, filters, where, select, limit, offset, orderBy, groupBy, populate } = params;
 
-      if (!_.isNil(where)) {
+      if (!isNil(where)) {
         this.where(where);
       }
 
-      if (!_.isNil(_q)) {
+      if (!isNil(_q)) {
         this.search(_q);
       }
 
-      if (!_.isNil(select)) {
+      if (!isNil(select)) {
         this.select(select);
       } else {
         this.select('*');
       }
 
-      if (!_.isNil(limit)) {
+      if (!isNil(limit)) {
         this.limit(limit);
       }
 
-      if (!_.isNil(offset)) {
+      if (!isNil(offset)) {
         this.offset(offset);
       }
 
-      if (!_.isNil(orderBy)) {
+      if (!isNil(orderBy)) {
         this.orderBy(orderBy);
       }
 
-      if (!_.isNil(groupBy)) {
+      if (!isNil(groupBy)) {
         this.groupBy(groupBy);
       }
 
-      if (!_.isNil(populate)) {
+      if (!isNil(populate)) {
         this.populate(populate);
       }
 
-      if (!_.isNil(filters)) {
+      if (!isNil(filters)) {
         this.filters(filters);
       }
 
@@ -401,7 +407,7 @@ const createQueryBuilder = (
         return key;
       }
 
-      if (!_.isNil(alias)) {
+      if (!isNil(alias)) {
         return `${alias}.${key}`;
       }
 
@@ -433,11 +439,11 @@ const createQueryBuilder = (
 
       state.orderBy = helpers.processOrderBy(state.orderBy, { qb: this, uid, db });
 
-      if (!_.isNil(state.filters)) {
-        if (_.isFunction(state.filters)) {
+      if (!isNil(state.filters)) {
+        if (typeof state.filters === 'function') {
           const filters = state.filters({ qb: this, uid, meta, db });
 
-          if (!_.isNil(filters)) {
+          if (!isNil(filters)) {
             state.where.push(filters);
           }
         } else {
@@ -537,14 +543,14 @@ const createQueryBuilder = (
 
       if (this.shouldUseDistinct()) {
         const joinsOrderByColumns = state.joins.flatMap((join) => {
-          return _.keys(join.orderBy).map((key) => this.aliasColumn(key, join.alias));
+          return Object.keys(join.orderBy ?? {}).map((key) => this.aliasColumn(key, join.alias));
         });
         // Only include column-based orderBy entries (skip raw expressions like status)
         const orderByColumns = state.orderBy
           .filter((ob: any) => 'column' in ob)
           .map((ob: any) => ob.column);
 
-        state.select = _.uniq([...joinsOrderByColumns, ...orderByColumns, ...state.select]);
+        state.select = unique([...joinsOrderByColumns, ...orderByColumns, ...state.select]);
       }
     },
 
@@ -708,8 +714,8 @@ const createQueryBuilder = (
 
         const rows = await qb;
 
-        if (state.populate && !_.isNil(rows)) {
-          await helpers.applyPopulate(_.castArray(rows), state.populate, {
+        if (state.populate && !isNil(rows)) {
+          await helpers.applyPopulate(toArray(rows), state.populate, {
             qb: this,
             uid,
             db,

--- a/packages/core/database/src/schema/diff.ts
+++ b/packages/core/database/src/schema/diff.ts
@@ -94,7 +94,7 @@ export default (db: Database) => {
       changes.push('columns');
     }
 
-    if (oldIndex.type && index.type && _.toLower(oldIndex.type) !== _.toLower(index.type)) {
+    if (oldIndex.type && index.type && oldIndex.type.toLowerCase() !== index.type.toLowerCase()) {
       changes.push('type');
     }
 
@@ -127,25 +127,39 @@ export default (db: Database) => {
       changes.push('referencedTable');
     }
 
-    if (_.isNil(oldForeignKey.onDelete) || _.toUpper(oldForeignKey.onDelete) === 'NO ACTION') {
+    if (
+      oldForeignKey.onDelete === null ||
+      oldForeignKey.onDelete === undefined ||
+      (oldForeignKey.onDelete as string).toUpperCase() === 'NO ACTION'
+    ) {
       if (
-        !_.isNil(foreignKey.onDelete) &&
-        _.toUpper(oldForeignKey.onDelete ?? '') !== 'NO ACTION'
+        foreignKey.onDelete !== null &&
+        foreignKey.onDelete !== undefined &&
+        (oldForeignKey.onDelete ?? '').toUpperCase() !== 'NO ACTION'
       ) {
         changes.push('onDelete');
       }
-    } else if (_.toUpper(oldForeignKey.onDelete) !== _.toUpper(foreignKey.onDelete ?? '')) {
+    } else if (
+      (oldForeignKey.onDelete as string).toUpperCase() !== (foreignKey.onDelete ?? '').toUpperCase()
+    ) {
       changes.push('onDelete');
     }
 
-    if (_.isNil(oldForeignKey.onUpdate) || _.toUpper(oldForeignKey.onUpdate) === 'NO ACTION') {
+    if (
+      oldForeignKey.onUpdate === null ||
+      oldForeignKey.onUpdate === undefined ||
+      (oldForeignKey.onUpdate as string).toUpperCase() === 'NO ACTION'
+    ) {
       if (
-        !_.isNil(foreignKey.onUpdate) &&
-        _.toUpper(oldForeignKey.onUpdate ?? '') !== 'NO ACTION'
+        foreignKey.onUpdate !== null &&
+        foreignKey.onUpdate !== undefined &&
+        (oldForeignKey.onUpdate ?? '').toUpperCase() !== 'NO ACTION'
       ) {
         changes.push('onUpdate');
       }
-    } else if (_.toUpper(oldForeignKey.onUpdate) !== _.toUpper(foreignKey.onUpdate ?? '')) {
+    } else if (
+      (oldForeignKey.onUpdate as string).toUpperCase() !== (foreignKey.onUpdate ?? '').toUpperCase()
+    ) {
       changes.push('onUpdate');
     }
 
@@ -162,13 +176,15 @@ export default (db: Database) => {
     const oldDefaultTo = oldColumn.defaultTo;
     const { defaultTo } = column;
 
-    if (oldDefaultTo === null || _.toLower(oldDefaultTo) === 'null') {
-      return _.isNil(defaultTo) || _.toLower(defaultTo) === 'null';
+    if (oldDefaultTo === null || (oldDefaultTo ?? '').toLowerCase() === 'null') {
+      return (
+        defaultTo === null || defaultTo === undefined || (defaultTo ?? '').toLowerCase() === 'null'
+      );
     }
 
     return (
-      _.toLower(oldDefaultTo) === _.toLower(column.defaultTo) ||
-      _.toLower(oldDefaultTo) === _.toLower(`'${column.defaultTo}'`)
+      (oldDefaultTo ?? '').toLowerCase() === (column.defaultTo ?? '').toLowerCase() ||
+      (oldDefaultTo ?? '').toLowerCase() === `'${column.defaultTo ?? ''}'`.toLowerCase()
     );
   };
 
@@ -451,7 +467,7 @@ export default (db: Database) => {
           .filter((table: PersistedTable) => {
             const dependsOn = table?.dependsOn;
 
-            if (!_.isArray(dependsOn)) {
+            if (!Array.isArray(dependsOn)) {
               return;
             }
 
@@ -463,7 +479,7 @@ export default (db: Database) => {
             );
           })
           // In case the table is not found, filter undefined values
-          .filter((table: PersistedTable) => !_.isNil(table));
+          .filter((table: PersistedTable) => table !== null && table !== undefined);
 
         removedTables.push(databaseTable, ...dependencies);
       }

--- a/packages/core/database/src/utils/identifiers/index.ts
+++ b/packages/core/database/src/utils/identifiers/index.ts
@@ -81,7 +81,7 @@ export class Identifiers {
    * final string my_model which generally works but is not entirely safe
    * */
   getName = (names: NameInput, options?: NameOptions) => {
-    const tokens: NameToken[] = _.castArray(names).map((name) => {
+    const tokens: NameToken[] = (Array.isArray(names) ? names : [names]).map((name) => {
       return {
         name,
         compressible: true,

--- a/packages/core/permissions/src/__tests__/permissions.engine.test.ts
+++ b/packages/core/permissions/src/__tests__/permissions.engine.test.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { subject } from '@casl/ability';
 import { providerFactory } from '@strapi/utils';
 import * as permissions from '../index';
@@ -134,10 +133,10 @@ describe('Permissions Engine', () => {
    */
   const expectedAbilityRules = (permissions) => {
     return permissions.map((permission) => {
-      const rules = _.omit(permission, ['properties', 'conditions']);
+      const { properties, conditions, ...rules } = permission;
 
-      if (permission.properties && permission.properties.fields) {
-        rules.fields = permission.properties.fields;
+      if (properties && properties.fields) {
+        rules.fields = properties.fields;
       }
       if (!permission.subject) {
         rules.subject = 'all';
@@ -213,8 +212,9 @@ describe('Permissions Engine', () => {
     expect(ability.can('read', subject('article', { id: 125 }))).toBeTruthy();
     expect(ability.can('read', subject('user', { id: 125 }))).toBeFalsy();
 
+    const { conditions: _c0, ...perm0NoConditions } = permissions[0];
     expect(registerFunctions[0]).toBeCalledWith({
-      ..._.omit(permissions[0], ['conditions']),
+      ...perm0NoConditions,
       condition: {
         $and: [
           {
@@ -327,7 +327,8 @@ describe('Permissions Engine', () => {
     expect(ability.can('read', 'article', 'title')).toBeTruthy();
 
     expect(createRegisterFunction).toBeCalledTimes(1);
-    expect(registerFunctions[0]).toBeCalledWith(_.omit(permissions[0], ['conditions']));
+    const { conditions: _c0a, ...perm0aNoConditions } = permissions[0];
+    expect(registerFunctions[0]).toBeCalledWith(perm0aNoConditions);
   });
 
   describe('hooks', () => {
@@ -495,12 +496,14 @@ describe('Permissions Engine', () => {
       expect(ability.can('read', subject('article', { id: 200 }))).toBe(true);
       expect(ability.can('read', subject('article', { id: 999 }))).toBe(false);
 
+      const { conditions: _c0b, ...perm0b } = permissions[0];
+      const { conditions: _c1b, ...perm1b } = permissions[1];
       expect(registerFunctions[0]).toBeCalledWith({
-        ..._.omit(permissions[0], ['conditions']),
+        ...perm0b,
         condition: { $and: [{ $or: [{ id: 125 }] }] },
       });
       expect(registerFunctions[1]).toBeCalledWith({
-        ..._.omit(permissions[1], ['conditions']),
+        ...perm1b,
         condition: { $and: [{ $or: [{ id: 200 }] }] },
       });
     });
@@ -525,11 +528,13 @@ describe('Permissions Engine', () => {
       expect(ability.can('read', 'article')).toBe(true);
       expect(ability.can('read', subject('article', { id: 999 }))).toBe(true);
 
+      const { conditions: _c0c, ...perm0c } = permissions[0];
+      const { conditions: _c1c, ...perm1c } = permissions[1];
       expect(registerFunctions[0]).toBeCalledWith({
-        ..._.omit(permissions[0], ['conditions']),
+        ...perm0c,
         condition: { $and: [{ $or: [{ id: 125 }] }] },
       });
-      expect(registerFunctions[1]).toBeCalledWith(_.omit(permissions[1], ['conditions']));
+      expect(registerFunctions[1]).toBeCalledWith(perm1c);
     });
   });
 

--- a/packages/core/permissions/src/domain/permission/index.ts
+++ b/packages/core/permissions/src/domain/permission/index.ts
@@ -35,7 +35,7 @@ const addCondition = _.curry((condition: string, permission: Permission): Permis
   const { conditions } = permission;
 
   const newConditions = Array.isArray(conditions)
-    ? _.uniq(conditions.concat(condition))
+    ? [...new Set(conditions.concat(condition))]
     : [condition];
 
   return _.set('conditions', newConditions, permission);
@@ -48,7 +48,10 @@ const getProperty = _.curry(
   <T extends keyof Permission['properties']>(
     property: T,
     permission: Permission
-  ): Permission['properties'][T] => _.get(`properties.${property}`, permission)
+  ): Permission['properties'][T] =>
+    // [lodash: get — skipped, dynamic template path `properties.${property}`]
+    // eslint-disable-next-line you-dont-need-lodash-underscore/get
+    _.get(`properties.${property}`, permission)
 );
 
 export { create, sanitizePermissionFields, addCondition, getProperty };

--- a/packages/core/permissions/src/engine/index.ts
+++ b/packages/core/permissions/src/engine/index.ts
@@ -116,10 +116,12 @@ const newEngine = (params: EngineParams): Engine => {
       return register({ action, subject, properties });
     }
 
+    // eslint-disable-next-line you-dont-need-lodash-underscore/map
     const resolveConditions = _.map(providers.condition.get);
 
-    const removeInvalidConditions = _.filter((condition: Condition) =>
-      _.isFunction(condition.handler)
+    // eslint-disable-next-line you-dont-need-lodash-underscore/filter
+    const removeInvalidConditions = _.filter(
+      (condition: Condition) => typeof condition.handler === 'function'
     );
 
     const evaluateConditions = (conditions: Condition[]) => {
@@ -127,12 +129,14 @@ const newEngine = (params: EngineParams): Engine => {
         conditions.map(async (condition) => ({
           condition,
           result: await condition.handler(
+            // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
             _.merge(options, { permission: _.cloneDeep(permission) })
           ),
         }))
       );
     };
 
+    // eslint-disable-next-line you-dont-need-lodash-underscore/filter
     const removeInvalidResults = _.filter(
       ({ result }) => _.isBoolean(result) || _.isObject(result)
     );
@@ -144,6 +148,7 @@ const newEngine = (params: EngineParams): Engine => {
       .then(removeInvalidResults);
 
     const resultPropEq = _.propEq('result');
+    // eslint-disable-next-line you-dont-need-lodash-underscore/map
     const pickResults = _.map(_.prop('result'));
 
     if (evaluatedConditions.every(resultPropEq(false))) {

--- a/packages/core/upload/admin/src/pages/App/ConfigureTheView/state/reducer.ts
+++ b/packages/core/upload/admin/src/pages/App/ConfigureTheView/state/reducer.ts
@@ -1,5 +1,4 @@
 import { produce } from 'immer'; // current
-import get from 'lodash/get';
 import set from 'lodash/set';
 
 import { ON_CHANGE, SET_LOADED } from './actionTypes';
@@ -40,7 +39,7 @@ export const reducer = (
       }
       case SET_LOADED: {
         // This action re-initialises the state using the current modifiedData.
-        const reInitialise = init(get(draftState, ['modifiedData'], {}));
+        const reInitialise = init(draftState.modifiedData ?? {});
         draftState.initialData = reInitialise.initialData;
         draftState.modifiedData = reInitialise.modifiedData;
         break;

--- a/packages/core/upload/server/src/controllers/utils/find-entity-and-check-permissions.ts
+++ b/packages/core/upload/server/src/controllers/utils/find-entity-and-check-permissions.ts
@@ -13,7 +13,7 @@ const findEntityAndCheckPermissions = async (
     'folder',
   ]);
 
-  if (_.isNil(file)) {
+  if (file === null || file === undefined) {
     throw new errors.NotFoundError();
   }
 
@@ -21,11 +21,14 @@ const findEntityAndCheckPermissions = async (
     .service('admin::permission')
     .createPermissionsManager({ ability, action, model });
 
+  // [lodash: get — skipped, path is a dynamic array; cloneDeep — skipped, structuredClone not 1:1]
+  // eslint-disable-next-line you-dont-need-lodash-underscore/get
   const creatorId = _.get(file, [contentTypesUtils.constants.CREATED_BY_ATTRIBUTE, 'id']);
   const author = creatorId
     ? await strapi.service('admin::user').findOne(creatorId, ['roles'])
     : null;
 
+  // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
   const fileWithRoles = _.set(_.cloneDeep(file), 'createdBy', author);
 
   if (pm.ability.cannot(pm.action, pm.toSubject(fileWithRoles))) {

--- a/packages/core/upload/server/src/register.ts
+++ b/packages/core/upload/server/src/register.ts
@@ -56,7 +56,7 @@ export async function register({ strapi }: { strapi: Core.Strapi }) {
 const createProvider = (config: Config) => {
   const { providerOptions, actionOptions = {} } = config;
 
-  const providerName = _.toLower(config.provider);
+  const providerName = config.provider.toLowerCase();
   let provider;
 
   let modulePath;

--- a/packages/core/upload/server/src/services/__tests__/image-manipulation.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/image-manipulation.test.ts
@@ -19,6 +19,7 @@ const defaultConfig = {
 
 global.strapi = {
   config: {
+    // eslint-disable-next-line you-dont-need-lodash-underscore/get
     get: (path: any, defaultValue: any) => _.get(defaultConfig, path, defaultValue),
   },
   plugins: {

--- a/packages/core/upload/server/src/services/__tests__/provider.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/provider.test.ts
@@ -12,6 +12,7 @@ const defaultConfig: Record<string, any> = {
 function setupStrapi(providerImpl: Record<string, any>) {
   global.strapi = {
     config: {
+      // eslint-disable-next-line you-dont-need-lodash-underscore/get
       get: (path: any, defaultValue: any) => _.get(defaultConfig, path, defaultValue),
     },
     plugins: {

--- a/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
@@ -45,6 +45,7 @@ const services: Record<string, any> = {
 
 global.strapi = {
   config: {
+    // eslint-disable-next-line you-dont-need-lodash-underscore/get
     get: (configPath: any, defaultValue: any) => _.get(defaultConfig, configPath, defaultValue),
   },
   get: () => ({ transform: () => ({}) }),

--- a/packages/core/upload/server/src/services/__tests__/upload/responsive-parallelism.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/responsive-parallelism.test.ts
@@ -59,6 +59,7 @@ const uploadSettings = { responsiveDimensions: true };
 const resetStrapi = () => {
   global.strapi = {
     config: {
+      // eslint-disable-next-line you-dont-need-lodash-underscore/get
       get: (key: string, defaultValue: unknown) => _.get(defaultConfig, key, defaultValue),
     },
     plugins: {

--- a/packages/core/upload/server/src/services/__tests__/upload/uploadImage.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/uploadImage.test.ts
@@ -18,6 +18,7 @@ const defaultConfig = {
 // Set up initial mock before service creation
 global.strapi = {
   config: {
+    // eslint-disable-next-line you-dont-need-lodash-underscore/get
     get: (path: any, defaultValue: any) => _.get(defaultConfig, path, defaultValue),
   },
   plugins: {

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -23,7 +23,7 @@ import type { Config, File, InputFile, UploadableFile, FileInfo } from '../types
 import type { ViewConfiguration } from '../controllers/validation/admin/configureView';
 import type { Settings } from '../controllers/validation/admin/settings';
 
-const { has, toNumber, isNil } = fp;
+const { has, toNumber } = fp;
 
 type User = {
   id: string | number;
@@ -294,8 +294,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     // Store width and height of the original image
     const { width, height } = await getDimensions(fileData);
 
-    // Make sure this is assigned before calling any upload
-    // That way it can mutate the width and height
+    // [lodash: assign — skipped, target is existing variable not {}]
+    // eslint-disable-next-line you-dont-need-lodash-underscore/assign
     _.assign(fileData, {
       width,
       height,
@@ -351,6 +351,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
 
     const { width, height } = await getDimensions(fileData);
 
+    // [lodash: assign — skipped, target is existing variable not {}]
+    // eslint-disable-next-line you-dont-need-lodash-underscore/assign
     _.assign(fileData, {
       width,
       height,
@@ -446,16 +448,18 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
 
     const fileService = getService('file');
 
-    const newName = _.isNil(name) ? dbFile.name : name;
+    const newName = name === null || name === undefined ? dbFile.name : name;
     const newInfos = {
       name: newName,
-      alternativeText: _.isNil(alternativeText) ? dbFile.alternativeText : alternativeText,
-      caption: _.isNil(caption) ? dbFile.caption : caption,
-      focalPoint: _.isNil(focalPoint) ? dbFile.focalPoint : focalPoint,
-      folder: _.isUndefined(folder) ? dbFile.folder : folder,
-      folderPath: _.isUndefined(folder)
-        ? dbFile.folderPath
-        : await fileService.getFolderPath(folder),
+      alternativeText:
+        alternativeText === null || alternativeText === undefined
+          ? dbFile.alternativeText
+          : alternativeText,
+      caption: caption === null || caption === undefined ? dbFile.caption : caption,
+      focalPoint: focalPoint === null || focalPoint === undefined ? dbFile.focalPoint : focalPoint,
+      folder: folder === undefined ? dbFile.folder : folder,
+      folderPath:
+        folder === undefined ? dbFile.folderPath : await fileService.getFolderPath(folder),
     };
 
     return update(id, newInfos, { user });
@@ -487,6 +491,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       fileData = await enhanceAndValidateFile(file, fileInfo);
 
       // keep a constant hash and extension so the file url doesn't change when the file is replaced
+      // [lodash: assign — skipped, target is existing variable not {}]
+      // eslint-disable-next-line you-dont-need-lodash-underscore/assign
       _.assign(fileData, {
         hash: dbFile.hash,
         ext: dbFile.ext,
@@ -685,10 +691,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
 
     const paginationInfo = transform({ start, limit }, total as number);
 
+    const { total: _total, pageCount: _pageCount, ...paginationWithoutCounts } = paginationInfo;
     return {
       results: signedResults,
       // Omit total & pageCount when counting is disabled (withCount=false).
-      pagination: isNil(total) ? _.omit(paginationInfo, ['total', 'pageCount']) : paginationInfo,
+      pagination: total === null || total === undefined ? paginationWithoutCounts : paginationInfo,
     };
   }
 

--- a/packages/core/utils/src/content-types.ts
+++ b/packages/core/utils/src/content-types.ts
@@ -13,6 +13,8 @@ import type {
 
 const { has, getOr, union } = fp;
 
+const unique = <T>(values: T[]): T[] => [...new Set(values)];
+
 const SINGLE_TYPE = 'singleType';
 const COLLECTION_TYPE = 'collectionType';
 
@@ -80,13 +82,12 @@ const getCreatorFields = (model: Model) => {
 const getNonWritableAttributes = (model: Model) => {
   if (!model) return [];
 
-  const nonWritableAttributes = _.reduce(
-    model.attributes,
-    (acc, attr, attrName) => (attr.writable === false ? acc.concat(attrName) : acc),
+  const nonWritableAttributes = Object.entries(model.attributes).reduce(
+    (acc: string[], [attrName, attr]) => (attr.writable === false ? acc.concat(attrName) : acc),
     [] as string[]
   );
 
-  return _.uniq([
+  return unique([
     ID_ATTRIBUTE,
     DOC_ID_ATTRIBUTE,
     ...getTimestamps(model),
@@ -105,13 +106,12 @@ const isWritableAttribute = (model: Model, attributeName: string) => {
 };
 
 const getNonVisibleAttributes = (model: Model) => {
-  const nonVisibleAttributes = _.reduce(
-    model.attributes,
-    (acc, attr, attrName) => (attr.visible === false ? acc.concat(attrName) : acc),
+  const nonVisibleAttributes = Object.entries(model.attributes).reduce(
+    (acc: string[], [attrName, attr]) => (attr.visible === false ? acc.concat(attrName) : acc),
     [] as string[]
   );
 
-  return _.uniq([
+  return unique([
     ID_ATTRIBUTE,
     DOC_ID_ATTRIBUTE,
     PUBLISHED_AT_ATTRIBUTE,
@@ -121,25 +121,23 @@ const getNonVisibleAttributes = (model: Model) => {
 };
 
 const getVisibleAttributes = (model: Model) => {
-  return _.difference(_.keys(model.attributes), getNonVisibleAttributes(model));
+  return _.difference(Object.keys(model.attributes), getNonVisibleAttributes(model));
 };
 
 const isVisibleAttribute = (model: Model, attributeName: string) => {
   return getVisibleAttributes(model).includes(attributeName);
 };
 
-const getOptions = (model: Model) =>
-  _.assign({ draftAndPublish: false }, _.get(model, 'options', {}));
+const getOptions = (model: Model) => ({ draftAndPublish: false, ...(model?.options ?? {}) });
 
-const hasDraftAndPublish = (model: Model) =>
-  _.get(model, 'options.draftAndPublish', false) === true;
+const hasDraftAndPublish = (model: Model) => (model?.options?.draftAndPublish ?? false) === true;
 
 const hasFirstPublishedAtField = (model: Model) =>
   strapi.config.get('features.future.experimental_firstPublishedAt', false) &&
   hasDraftAndPublish(model);
 
 const isDraft = <T extends object>(data: T, model: Model) =>
-  hasDraftAndPublish(model) && _.get(data, PUBLISHED_AT_ATTRIBUTE) === null;
+  hasDraftAndPublish(model) && (data as Record<string, unknown>)[PUBLISHED_AT_ATTRIBUTE] === null;
 
 const isSchema = (data: unknown): data is Model => {
   return (
@@ -172,7 +170,7 @@ const getStoredPrivateAttributes = (model: Model) =>
 const getPrivateAttributes = (model: Model) => {
   return _.union(
     getStoredPrivateAttributes(model),
-    _.keys(_.pickBy(model.attributes, (attr) => !!attr.private))
+    Object.keys(_.pickBy(model.attributes, (attr) => !!attr.private))
   );
 };
 
@@ -219,47 +217,31 @@ const isMorphToRelationalAttribute = (attribute?: Attribute) => {
 };
 
 const getComponentAttributes = (schema: Model) => {
-  return _.reduce(
-    schema.attributes,
-    (acc, attr, attrName) => {
-      if (isComponentAttribute(attr)) acc.push(attrName);
-      return acc;
-    },
-    [] as string[]
-  );
+  return Object.entries(schema.attributes).reduce((acc: string[], [attrName, attr]) => {
+    if (isComponentAttribute(attr)) acc.push(attrName);
+    return acc;
+  }, [] as string[]);
 };
 
 const getMediaAttributes = (schema: Model) => {
-  return _.reduce(
-    schema.attributes,
-    (acc, attr, attrName) => {
-      if (isMediaAttribute(attr)) acc.push(attrName);
-      return acc;
-    },
-    [] as string[]
-  );
+  return Object.entries(schema.attributes).reduce((acc: string[], [attrName, attr]) => {
+    if (isMediaAttribute(attr)) acc.push(attrName);
+    return acc;
+  }, [] as string[]);
 };
 
 const getScalarAttributes = (schema: Model) => {
-  return _.reduce(
-    schema.attributes,
-    (acc, attr, attrName) => {
-      if (isScalarAttribute(attr)) acc.push(attrName);
-      return acc;
-    },
-    [] as string[]
-  );
+  return Object.entries(schema.attributes).reduce((acc: string[], [attrName, attr]) => {
+    if (isScalarAttribute(attr)) acc.push(attrName);
+    return acc;
+  }, [] as string[]);
 };
 
 const getRelationalAttributes = (schema: Model) => {
-  return _.reduce(
-    schema.attributes,
-    (acc, attr, attrName) => {
-      if (isRelationalAttribute(attr)) acc.push(attrName);
-      return acc;
-    },
-    [] as string[]
-  );
+  return Object.entries(schema.attributes).reduce((acc: string[], [attrName, attr]) => {
+    if (isRelationalAttribute(attr)) acc.push(attrName);
+    return acc;
+  }, [] as string[]);
 };
 
 /**

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -27,11 +27,12 @@ import {
 } from './sort-query';
 import { Model } from './types';
 
-const { cloneDeep, get, isArray, isEmpty, isInteger, isNil, isObject, isString, toNumber } = fp;
+const { cloneDeep, get, isEmpty, isInteger, isNil, isObject, toNumber } = fp;
 
 export type { SortParams, SortParamsObject } from './sort-query';
 
 const { ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, PUBLISHED_AT_ATTRIBUTE } = constants;
+const unique = <T>(values: T[]): T[] => [...new Set(values)];
 
 type SortOrder = 'asc' | 'desc';
 
@@ -167,7 +168,7 @@ class InvalidSortError extends Error {
 }
 
 function validateOrder(order: string): asserts order is SortOrder {
-  if (!isString(order) || !['asc', 'desc'].includes(order.toLocaleLowerCase())) {
+  if (typeof order !== 'string' || !['asc', 'desc'].includes(order.toLocaleLowerCase())) {
     throw new InvalidOrderError();
   }
 }
@@ -181,7 +182,7 @@ const convertOrderingQueryParams = (ordering: unknown) => {
 };
 
 const isStringArray = (value: unknown): value is string[] =>
-  isArray(value) && value.every(isString);
+  Array.isArray(value) && value.every((v) => typeof v === 'string');
 
 interface TransformerOptions {
   getModel: (uid: string) => Model | undefined;
@@ -224,7 +225,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
       return {};
     }
 
-    if (!isString(trimmed)) {
+    if (typeof trimmed !== 'string') {
       throw new Error('Invalid sort query');
     }
 
@@ -288,7 +289,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
   const convertStartQueryParams = (startQuery: unknown): number => {
     const startAsANumber = toNumber(startQuery);
 
-    if (!_.isInteger(startAsANumber) || startAsANumber < 0) {
+    if (!Number.isInteger(startAsANumber) || startAsANumber < 0) {
       throw new ValidationError(
         `convertStartQueryParams expected a positive integer got ${startAsANumber}`
       );
@@ -303,7 +304,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
   const convertLimitQueryParams = (limitQuery: unknown): number | undefined => {
     const limitAsANumber = toNumber(limitQuery);
 
-    if (!_.isInteger(limitAsANumber) || (limitAsANumber !== -1 && limitAsANumber < 0)) {
+    if (!Number.isInteger(limitAsANumber) || (limitAsANumber !== -1 && limitAsANumber < 0)) {
       throw new ValidationError(
         `convertLimitQueryParams expected a positive integer got ${limitAsANumber}`
       );
@@ -376,18 +377,18 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     }
 
     if (typeof populate === 'string') {
-      return populate.split(',').map((value) => _.trim(value));
+      return populate.split(',').map((value) => value.trim());
     }
 
     if (Array.isArray(populate)) {
       // map convert
-      return _.uniq(
+      return unique(
         populate.flatMap((value) => {
           if (typeof value !== 'string') {
             throw new InvalidPopulateError();
           }
 
-          return value.split(',').map((value) => _.trim(value));
+          return value.split(',').map((value) => value.trim());
         })
       );
     }
@@ -421,7 +422,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     const { attributes } = schema;
     return Object.entries(populate).reduce((acc, [key, subPopulate]) => {
       // Try converting strings to regular booleans if possible
-      if (_.isString(subPopulate)) {
+      if (typeof subPopulate === 'string') {
         try {
           const subPopulateAsBoolean = parseType({ type: 'boolean', value: subPopulate });
           // Only true is accepted as a boolean populate value
@@ -544,7 +545,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
   };
 
   const convertNestedPopulate = (subPopulate: boolean | PopulateObjectParams, schema?: Model) => {
-    if (_.isString(subPopulate)) {
+    if (typeof subPopulate === 'string') {
       return parseType({ type: 'boolean', value: subPopulate, forceCast: true });
     }
 
@@ -615,13 +616,13 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     }
 
     if (typeof fields === 'string') {
-      const fieldsValues = fields.split(',').map((value) => _.trim(value));
+      const fieldsValues = fields.split(',').map((value) => value.trim());
 
       // NOTE: Only include the doc id if it's a content type
       if (schema?.modelType === 'contentType') {
-        return _.uniq([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, ...fieldsValues]);
+        return unique([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, ...fieldsValues]);
       }
-      return _.uniq([ID_ATTRIBUTE, ...fieldsValues]);
+      return unique([ID_ATTRIBUTE, ...fieldsValues]);
     }
 
     if (isStringArray(fields)) {
@@ -632,9 +633,9 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
 
       // NOTE: Only include the doc id if it's a content type
       if (schema?.modelType === 'contentType') {
-        return _.uniq([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, ...fieldsValues]);
+        return unique([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, ...fieldsValues]);
       }
-      return _.uniq([ID_ATTRIBUTE, ...fieldsValues]);
+      return unique([ID_ATTRIBUTE, ...fieldsValues]);
     }
 
     throw new ValidationError('Invalid fields parameter. Expected a string or an array of strings');

--- a/packages/core/utils/src/env-helper.ts
+++ b/packages/core/utils/src/env-helper.ts
@@ -75,7 +75,7 @@ function array(key: string, defaultValue?: string[]): string[] | undefined {
   }
 
   return value.split(',').map((v) => {
-    return _.trim(_.trim(v, ' '), '"');
+    return v.trim().replace(/^"+|"+$/g, '');
   });
 }
 

--- a/packages/core/utils/src/parse-type.ts
+++ b/packages/core/utils/src/parse-type.ts
@@ -22,7 +22,7 @@ const parseTime = (value: unknown): string => {
   }
 
   const [, hours, minutes, seconds, fraction = '.000'] = result;
-  const fractionPart = _.padEnd(fraction.slice(1), 3, '0');
+  const fractionPart = fraction.slice(1).padEnd(3, '0');
 
   return `${hours}:${minutes}:${seconds}.${fractionPart}`;
 };

--- a/packages/core/utils/src/primitives/objects.ts
+++ b/packages/core/utils/src/primitives/objects.ts
@@ -3,9 +3,8 @@ import _ from 'lodash';
 const keysDeep = (obj: object, path: string[] = []): string[] =>
   !_.isObject(obj)
     ? [path.join('.')]
-    : _.reduce(
-        obj,
-        (acc, next, key) => _.concat(acc, keysDeep(next, [...path, key])),
+    : Object.entries(obj).reduce(
+        (acc: string[], [key, next]) => acc.concat(keysDeep(next as object, [...path, key])),
         [] as string[]
       );
 

--- a/packages/core/utils/src/primitives/strings.ts
+++ b/packages/core/utils/src/primitives/strings.ts
@@ -19,9 +19,8 @@ const toRegressedEnumValue = (value: string) =>
   });
 
 const getCommonPath = (...paths: string[]) => {
-  const [segments, ...otherSegments] = paths.map((it) => _.split(it, '/'));
-  return _.join(
-    _.takeWhile(segments, (str, index) => otherSegments.every((it) => it[index] === str)),
+  const [segments, ...otherSegments] = paths.map((it) => it.split('/'));
+  return _.takeWhile(segments, (str, index) => otherSegments.every((it) => it[index] === str)).join(
     '/'
   );
 };

--- a/packages/core/utils/src/yup.ts
+++ b/packages/core/utils/src/yup.ts
@@ -2,7 +2,6 @@ import fp from 'lodash/fp.js';
 /* eslint-disable no-template-curly-in-string */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import * as yup from 'yup';
-import _ from 'lodash';
 
 import { strings } from './primitives';
 import { printValue } from './print-value';
@@ -13,9 +12,9 @@ export * from 'yup';
 
 export const strapiID = (): InstanceType<typeof StrapiIDSchema> => new StrapiIDSchema();
 
-const isNotNilTest = (value: unknown) => !_.isNil(value);
+const isNotNilTest = (value: unknown) => value !== null && value !== undefined;
 
-const isNotNullTest = (value: unknown) => !_.isNull(value);
+const isNotNullTest = (value: unknown) => value !== null;
 
 yup.addMethod(yup.mixed, 'notNil', function isNotNill(msg = '${path} must be defined.') {
   return this.test('defined', msg, isNotNilTest);
@@ -29,7 +28,7 @@ yup.addMethod(yup.mixed, 'isFunction', function isFunction(message = '${path} is
   return this.test(
     'is a function',
     message,
-    (value) => _.isUndefined(value) || _.isFunction(value)
+    (value) => value === undefined || typeof value === 'function'
   );
 });
 
@@ -60,7 +59,9 @@ yup.addMethod(
     return this.test(
       'only contains functions',
       message,
-      (value) => _.isUndefined(value) || (value && Object.values(value).every(_.isFunction))
+      (value) =>
+        value === undefined ||
+        (value !== null && Object.values(value).every((v) => typeof v === 'function'))
     );
   }
 );
@@ -74,6 +75,7 @@ yup.addMethod(
 
       list?.forEach((element, index) => {
         const sameElements = list.filter(
+          // [lodash: get — skipped, dynamic path via propertyName variable]
           (e) => get(propertyName, e) === get(propertyName, element)
         );
         if (sameElements.length > 1) {

--- a/packages/plugins/documentation/server/src/services/__tests__/build-component-schema.test.ts
+++ b/packages/plugins/documentation/server/src/services/__tests__/build-component-schema.test.ts
@@ -1,3 +1,4 @@
+// [lodash: cloneDeep — kept, structuredClone not 1:1]
 import _ from 'lodash/fp';
 import buildComponentSchema from '../helpers/build-component-schema';
 
@@ -42,6 +43,7 @@ const strapi = {
 describe('Documentation plugin | Build component schema', () => {
   beforeEach(() => {
     // Reset the mocked strapi instance
+    // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
     global.strapi = _.cloneDeep(strapi);
   });
 

--- a/packages/plugins/documentation/server/src/services/__tests__/documentation.test.ts
+++ b/packages/plugins/documentation/server/src/services/__tests__/documentation.test.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+// [lodash: cloneDeep — kept, structuredClone not 1:1]
 import _ from 'lodash/fp';
 import fse from 'fs-extra';
 // eslint-disable-next-line node/no-unpublished-import
@@ -76,6 +77,7 @@ describe('Documentation plugin | Documentation service', () => {
     const mockFinalDoc = lastMockCall[1];
 
     // The final documenation is read only, clone deep for this test
+    // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
     const validatePromise = SwaggerParser.validate(_.cloneDeep(mockFinalDoc));
 
     await expect(validatePromise).resolves.not.toThrow();

--- a/packages/plugins/documentation/server/src/services/helpers/build-component-schema.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/build-component-schema.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import type { OpenAPIV3 } from 'openapi-types';
 import type { Core, Struct } from '@strapi/types';
 
@@ -63,7 +61,9 @@ const getAllSchemasForContentType = ({ routeInfo, attributes, uniqueName }: ApiI
     'createdBy',
   ];
 
-  const attributesForRequest = _.omit(attributes, attributesToOmit);
+  const attributesForRequest = Object.fromEntries(
+    Object.entries(attributes).filter(([key]) => !attributesToOmit.includes(key))
+  );
   // Get a list of required attribute names
   const requiredRequestAttributes = getRequiredAttributes(attributesForRequest);
   // Build the request schemas when the route has POST or PUT methods

--- a/packages/plugins/i18n/admin/src/index.ts
+++ b/packages/plugins/i18n/admin/src/index.ts
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import * as yup from 'yup';
 
 import { CheckboxConfirmation } from './components/CheckboxConfirmation';
@@ -177,11 +176,7 @@ export default {
               return [];
             }
 
-            const hasI18nEnabled = get(
-              contentTypeSchema,
-              ['pluginOptions', 'i18n', 'localized'],
-              false
-            );
+            const hasI18nEnabled = contentTypeSchema?.pluginOptions?.i18n?.localized ?? false;
 
             if (!hasI18nEnabled) {
               return [];

--- a/packages/plugins/i18n/admin/src/middlewares/extendCTBAttributeInitialData.ts
+++ b/packages/plugins/i18n/admin/src/middlewares/extendCTBAttributeInitialData.ts
@@ -1,3 +1,5 @@
+// [lodash: get — partially kept, dynamic uid in array path prevents full removal]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 
 import type { Middleware } from '@reduxjs/toolkit';
@@ -27,7 +29,8 @@ const extendCTBAttributeInitialDataMiddleware: () => Middleware<
             return next(action);
           }
 
-          const hasi18nEnabled = get(type, ['pluginOptions', 'i18n', 'localized'], false);
+          // [lodash: get (line 19) — skipped, dynamic uid in array path]
+          const hasi18nEnabled = (type as any)?.pluginOptions?.i18n?.localized ?? false;
 
           if (hasi18nEnabled) {
             return next({

--- a/packages/plugins/i18n/admin/src/utils/schemas.ts
+++ b/packages/plugins/i18n/admin/src/utils/schemas.ts
@@ -1,5 +1,3 @@
-import omit from 'lodash/omit';
-
 import { LOCALIZED_FIELDS, doesPluginOptionsHaveI18nLocalized } from './fields';
 
 import type { Schema } from '@strapi/types';
@@ -52,12 +50,12 @@ const mutateCTBContentTypeSchema = (
 
   // Remove the i18n object from the pluginOptions
   if (!isNextSchemaLocalized) {
-    const pluginOptions = omit(nextSchema.pluginOptions, 'i18n');
+    const { i18n: _i18n, ...pluginOptionsWithoutI18n } = nextSchema.pluginOptions ?? {};
     const attributes = disableAttributesLocalisation(nextSchema.attributes);
 
     return {
       ...nextSchema,
-      pluginOptions,
+      pluginOptions: pluginOptionsWithoutI18n,
       attributes,
     };
   }
@@ -91,7 +89,11 @@ const addLocalisationToFields = (attributes: Schema.Attribute.AnyAttribute[]) =>
 
 const disableAttributesLocalisation = (attributes: Schema.Attribute.AnyAttribute[]) => {
   return attributes.map((currentAttribute) => {
-    return omit(currentAttribute, 'pluginOptions.i18n');
+    if (!currentAttribute.pluginOptions) {
+      return currentAttribute;
+    }
+    const { i18n: _i18n, ...restPluginOptions } = currentAttribute.pluginOptions;
+    return { ...currentAttribute, pluginOptions: restPluginOptions };
   });
 };
 

--- a/packages/plugins/i18n/server/src/services/content-types.ts
+++ b/packages/plugins/i18n/server/src/services/content-types.ts
@@ -1,5 +1,4 @@
 import fp from 'lodash/fp.js';
-import _ from 'lodash';
 
 import { errors, contentTypes as contentTypeUtils } from '@strapi/utils';
 import { getService } from '../utils';
@@ -82,7 +81,7 @@ const removeIdsMut = (model: any, entry: any): Record<string, any> => {
 
   removeId(entry);
 
-  _.forEach(model.attributes, (attr, attrName) => {
+  Object.entries(model.attributes).forEach(([attrName, attr]) => {
     const value = entry[attrName];
     if (attr.type === 'dynamiczone' && isArray(value)) {
       value.forEach((compo) => {
@@ -142,7 +141,7 @@ const fillNonLocalizedAttributes = (entry: any, relatedEntry: any, { model }: an
   const modelDef = strapi.getModel(model);
   const relatedEntryCopy = copyNonLocalizedAttributes(modelDef, relatedEntry);
 
-  _.forEach(relatedEntryCopy, (value, field) => {
+  Object.entries(relatedEntryCopy).forEach(([field, value]) => {
     if (isNil(entry[field])) {
       entry[field] = value;
     }

--- a/packages/plugins/users-permissions/admin/src/components/UsersPermissions/reducer.js
+++ b/packages/plugins/users-permissions/admin/src/components/UsersPermissions/reducer.js
@@ -1,5 +1,7 @@
 /* eslint-disable consistent-return */
 import { produce } from 'immer';
+// [lodash: get — skipped, dynamic spread path from action.keys]
+// eslint-disable-next-line you-dont-need-lodash-underscore/get
 import get from 'lodash/get';
 import set from 'lodash/set';
 import take from 'lodash/take';

--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -42,7 +42,7 @@ const initGrant = async (pluginStore) => {
 
   if (!prevGrantConfig || !_.isEqual(prevGrantConfig, grantConfig)) {
     // merge with the previous provider config.
-    _.keys(grantConfig).forEach((key) => {
+    Object.keys(grantConfig).forEach((key) => {
       if (key in prevGrantConfig) {
         grantConfig[key] = _.merge(grantConfig[key], prevGrantConfig[key]);
       }

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -9,7 +9,7 @@
 /* eslint-disable no-useless-escape */
 const crypto = require('crypto');
 const _ = require('lodash');
-const { concat, compact, isArray } = require('lodash/fp');
+const { compact } = require('lodash/fp');
 const utils = require('@strapi/utils');
 const { getService } = require('../utils');
 const { buildRefreshCookieOptions } = require('../utils/refresh-cookie-options');
@@ -48,6 +48,8 @@ module.exports = ({ strapi }) => ({
 
     const grantProvider = provider === 'local' ? 'email' : provider;
 
+    // [lodash: get — skipped, dynamic grantProvider variable in array path]
+    // eslint-disable-next-line you-dont-need-lodash-underscore/get
     if (!_.get(grantSettings, [grantProvider, 'enabled'])) {
       throw new ApplicationError('This provider is disabled');
     }
@@ -83,7 +85,7 @@ module.exports = ({ strapi }) => ({
       }
 
       const advancedSettings = await store.get({ key: 'advanced' });
-      const requiresConfirmation = _.get(advancedSettings, 'email_confirmation');
+      const requiresConfirmation = advancedSettings?.email_confirmation;
 
       if (requiresConfirmation && user.confirmed !== true) {
         throw new ApplicationError('Your account email is not confirmed');
@@ -384,6 +386,8 @@ module.exports = ({ strapi }) => ({
     const [requestPath] = ctx.request.url.split('?');
     const provider = requestPath.split('/connect/')[1].split('/')[0];
 
+    // [lodash: get — skipped, provider is variable key on grantConfig object]
+    // eslint-disable-next-line you-dont-need-lodash-underscore/get
     if (!_.get(grantConfig[provider], 'enabled')) {
       throw new ApplicationError('This provider is disabled');
     }
@@ -395,8 +399,8 @@ module.exports = ({ strapi }) => ({
     }
 
     // Ability to pass OAuth callback dynamically
-    const queryCustomCallback = _.get(ctx, 'query.callback');
-    const dynamicSessionCallback = _.get(ctx, 'session.grant.dynamic.callback');
+    const queryCustomCallback = ctx?.query?.callback;
+    const dynamicSessionCallback = ctx?.session?.grant?.dynamic?.callback;
 
     const customCallback = queryCustomCallback ?? dynamicSessionCallback;
 
@@ -444,7 +448,7 @@ module.exports = ({ strapi }) => ({
 
     const resetPasswordToken = crypto.randomBytes(64).toString('hex');
 
-    const resetPasswordSettings = _.get(emailSettings, 'reset_password.options', {});
+    const resetPasswordSettings = emailSettings?.reset_password?.options ?? {};
     const emailBody = await getService('users-permissions').template(
       resetPasswordSettings.message,
       {
@@ -498,7 +502,7 @@ module.exports = ({ strapi }) => ({
 
     // Note that we intentionally do not filter allowedFields to allow a project to explicitly accept private or other Strapi field on registration
     const allowedKeys = compact(
-      concat(alwaysAllowedKeys, isArray(register?.allowedFields) ? register.allowedFields : [])
+      alwaysAllowedKeys.concat(Array.isArray(register?.allowedFields) ? register.allowedFields : [])
     );
 
     // Check if there are any keys in requestBody that are not in allowedKeys

--- a/packages/plugins/users-permissions/server/controllers/content-manager-user.js
+++ b/packages/plugins/users-permissions/server/controllers/content-manager-user.js
@@ -15,12 +15,15 @@ const ACTIONS = {
   delete: 'plugin::content-manager.explorer.delete',
 };
 
+const toLower = (value) =>
+  value === null || value === undefined ? '' : String(value).toLowerCase();
+
 const findEntityAndCheckPermissions = async (ability, action, model, id) => {
   const doc = await strapi.service('plugin::content-manager.document-manager').findOne(id, model, {
     populate: [`${CREATED_BY_ATTRIBUTE}.roles`],
   });
 
-  if (_.isNil(doc)) {
+  if (doc === null || doc === undefined) {
     throw new NotFoundError();
   }
 
@@ -32,7 +35,12 @@ const findEntityAndCheckPermissions = async (ability, action, model, id) => {
     throw new ForbiddenError();
   }
 
-  const docWithoutCreatorRoles = _.omit(doc, `${CREATED_BY_ATTRIBUTE}.roles`);
+  const { [CREATED_BY_ATTRIBUTE]: createdByField, ...docWithoutCreatedBy } = doc;
+  const { roles: _roles, ...createdByWithoutRoles } = createdByField ?? {};
+  const docWithoutCreatorRoles = {
+    ...docWithoutCreatedBy,
+    [CREATED_BY_ATTRIBUTE]: createdByWithoutRoles,
+  };
 
   return { pm, doc: docWithoutCreatorRoles };
 };
@@ -91,7 +99,7 @@ module.exports = {
       [UPDATED_BY_ATTRIBUTE]: admin.id,
     };
 
-    user.email = _.toLower(user.email);
+    user.email = toLower(user.email);
 
     try {
       const data = await strapi
@@ -149,17 +157,17 @@ module.exports = {
     if (_.has(body, 'email') && advancedConfigs.unique_email) {
       const userWithSameEmail = await strapi.db
         .query('plugin::users-permissions.user')
-        .findOne({ where: { email: _.toLower(email) } });
+        .findOne({ where: { email: toLower(email) } });
 
       if (userWithSameEmail && _.toString(userWithSameEmail.id) !== _.toString(user.id)) {
         throw new ApplicationError('Email already taken');
       }
 
-      body.email = _.toLower(body.email);
+      body.email = toLower(body.email);
     }
 
     const sanitizedData = await pm.pickPermittedFieldsOf(body, { subject: pm.toSubject(user) });
-    const updateData = _.omit({ ...sanitizedData, updatedBy: admin.id }, 'createdBy');
+    const { createdBy: _createdBy, ...updateData } = { ...sanitizedData, updatedBy: admin.id };
 
     const data = await strapi
       .service('plugin::content-manager.document-manager')

--- a/packages/plugins/users-permissions/server/controllers/permissions.js
+++ b/packages/plugins/users-permissions/server/controllers/permissions.js
@@ -11,7 +11,7 @@ module.exports = {
   },
 
   async getPolicies(ctx) {
-    const policies = _.keys(strapi.plugin('users-permissions').policies);
+    const policies = Object.keys(strapi.plugin('users-permissions').policies);
 
     ctx.send({
       policies: _.without(policies, 'permissions'),

--- a/packages/plugins/users-permissions/server/controllers/validation/email-template.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/email-template.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { trim } = require('lodash/fp');
 const {
   template: { createLooseInterpolationRegExp, createStrictInterpolationRegExp },
 } = require('@strapi/utils');
@@ -33,7 +32,7 @@ const matchAll = (pattern, src) => {
   while ((match = regexPatternWithGlobal.exec(src))) {
     const [, group] = match;
 
-    matches.push(trim(group));
+    matches.push(group.trim());
   }
 
   return matches;

--- a/packages/plugins/users-permissions/server/middlewares/rateLimit.js
+++ b/packages/plugins/users-permissions/server/middlewares/rateLimit.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const utils = require('@strapi/utils');
-const { isString, has, toLower } = require('lodash/fp');
+const { has } = require('lodash/fp');
 
 const { RateLimitError } = utils.errors;
 
@@ -47,21 +47,21 @@ const routeUsesEmailIdentifier = (requestPath) => {
  */
 const normalizeRequestPathForRateLimit = (requestPath) => {
   const normalized = path.normalize(requestPath);
-  const lower = toLower(normalized);
+  const lower = normalized.toLowerCase();
   return lower.replace(/\/+$/, '') || '/';
 };
 
 const getEmailIdentifierForKey = (body) => {
-  if (!body || !isString(body.email) || body.email === '') {
+  if (body === null || body === undefined || typeof body.email !== 'string' || body.email === '') {
     return 'unknownIdentifier';
   }
 
-  return toLower(body.email);
+  return body.email.toLowerCase();
 };
 
 const buildPrefixKey = (ctx) => {
   let requestPath;
-  if (!isString(ctx.request.path)) {
+  if (typeof ctx.request.path !== 'string') {
     requestPath = 'invalidPath';
   } else {
     requestPath = normalizeRequestPathForRateLimit(ctx.request.path);

--- a/packages/plugins/users-permissions/server/services/jwt.js
+++ b/packages/plugins/users-permissions/server/services/jwt.js
@@ -55,6 +55,8 @@ module.exports = ({ strapi }) => ({
       return issueRefreshToken();
     }
 
+    // [lodash: defaults — fills undefined only, Object.assign overwrites existing keys]
+    // eslint-disable-next-line you-dont-need-lodash-underscore/defaults
     _.defaults(jwtOptions, strapi.config.get('plugin::users-permissions.jwt'));
     return jwt.sign(
       _.clone(payload.toJSON ? payload.toJSON() : payload),

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -10,6 +10,9 @@ const urlJoin = require('url-join');
 
 const { getService, findValidUsername } = require('../utils');
 
+const toLower = (value) =>
+  value === null || value === undefined ? '' : String(value).toLowerCase();
+
 module.exports = ({ strapi }) => {
   /**
    * Helper to get profiles
@@ -52,7 +55,7 @@ module.exports = ({ strapi }) => {
     // Get the profile.
     const profile = await getProfile(provider, query);
 
-    const email = _.toLower(profile.email);
+    const email = toLower(profile.email);
 
     // We need at least the mail.
     if (!email) {
@@ -67,7 +70,7 @@ module.exports = ({ strapi }) => {
       .store({ type: 'plugin', name: 'users-permissions', key: 'advanced' })
       .get();
 
-    const user = _.find(users, { provider });
+    const user = users.find((u) => u.provider === provider);
 
     if (_.isEmpty(user) && !advancedSettings.allow_register) {
       throw new Error('Register action is actually not available.');

--- a/packages/plugins/users-permissions/server/services/role.js
+++ b/packages/plugins/users-permissions/server/services/role.js
@@ -4,37 +4,35 @@ const _ = require('lodash');
 const { NotFoundError } = require('@strapi/utils').errors;
 const { getService } = require('../utils');
 
+const toLower = (value) =>
+  value === null || value === undefined ? '' : String(value).toLowerCase();
+
 module.exports = ({ strapi }) => ({
   async createRole(params) {
     if (!params.type) {
-      params.type = _.snakeCase(_.deburr(_.toLower(params.name)));
+      params.type = _.snakeCase(_.deburr(toLower(params.name)));
     }
 
-    const role = await strapi.db
-      .query('plugin::users-permissions.role')
-      .create({ data: _.omit(params, ['users', 'permissions']) });
+    const { users: _users, permissions: _rolePermissions, ...roleData } = params;
+    const role = await strapi.db.query('plugin::users-permissions.role').create({ data: roleData });
 
     const createPromises = _.flatMap(params.permissions, (type, typeName) => {
       return _.flatMap(type.controllers, (controller, controllerName) => {
-        return _.reduce(
-          controller,
-          (acc, action, actionName) => {
-            const { enabled /* policy */ } = action;
+        return Object.entries(controller).reduce((acc, [actionName, action]) => {
+          const { enabled /* policy */ } = action;
 
-            if (enabled) {
-              const actionID = `${typeName}.${controllerName}.${actionName}`;
+          if (enabled) {
+            const actionID = `${typeName}.${controllerName}.${actionName}`;
 
-              acc.push(
-                strapi.db
-                  .query('plugin::users-permissions.permission')
-                  .create({ data: { action: actionID, role: role.id } })
-              );
-            }
+            acc.push(
+              strapi.db
+                .query('plugin::users-permissions.permission')
+                .create({ data: { action: actionID, role: role.id } })
+            );
+          }
 
-            return acc;
-          },
-          []
-        );
+          return acc;
+        }, []);
       });
     });
 
@@ -100,19 +98,15 @@ module.exports = ({ strapi }) => ({
 
     const newActions = _.flatMap(permissions, (type, typeName) => {
       return _.flatMap(type.controllers, (controller, controllerName) => {
-        return _.reduce(
-          controller,
-          (acc, action, actionName) => {
-            const { enabled /* policy */ } = action;
+        return Object.entries(controller).reduce((acc, [actionName, action]) => {
+          const { enabled /* policy */ } = action;
 
-            if (enabled) {
-              acc.push(`${typeName}.${controllerName}.${actionName}`);
-            }
+          if (enabled) {
+            acc.push(`${typeName}.${controllerName}.${actionName}`);
+          }
 
-            return acc;
-          },
-          []
-        );
+          return acc;
+        }, []);
       });
     });
 

--- a/packages/plugins/users-permissions/server/services/users-permissions.js
+++ b/packages/plugins/users-permissions/server/services/users-permissions.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
+// [lodash: filter/map — kept in lodash/fp pipe pipeline, pipe/prop also kept]
+// eslint-disable-next-line you-dont-need-lodash-underscore/filter, you-dont-need-lodash-underscore/map
 const { filter, map, pipe, prop } = require('lodash/fp');
 const urlJoin = require('url-join');
 const {
@@ -48,10 +50,9 @@ module.exports = ({ strapi }) => ({
       return action[Symbol.for('__type__')].includes('content-api');
     };
 
-    _.forEach(strapi.apis, (api, apiName) => {
-      const controllers = _.reduce(
-        api.controllers,
-        (acc, controller, controllerName) => {
+    Object.entries(strapi.apis).forEach(([apiName, api]) => {
+      const controllers = Object.entries(api.controllers).reduce(
+        (acc, [controllerName, controller]) => {
           const contentApiActions = _.pickBy(controller, isContentApi);
 
           if (_.isEmpty(contentApiActions)) {
@@ -75,10 +76,9 @@ module.exports = ({ strapi }) => ({
       }
     });
 
-    _.forEach(strapi.plugins, (plugin, pluginName) => {
-      const controllers = _.reduce(
-        plugin.controllers,
-        (acc, controller, controllerName) => {
+    Object.entries(strapi.plugins).forEach(([pluginName, plugin]) => {
+      const controllers = Object.entries(plugin.controllers).reduce(
+        (acc, [controllerName, controller]) => {
           const contentApiActions = _.pickBy(controller, isContentApi);
 
           if (_.isEmpty(contentApiActions)) {
@@ -103,13 +103,15 @@ module.exports = ({ strapi }) => ({
     });
 
     // Return a deeply cloned version to avoid circular references
+    // [lodash: cloneDeep — structuredClone not 1:1, audit value shape first]
+    // eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
     return _.cloneDeep(actionMap);
   },
 
   async getRoutes() {
     const routesMap = {};
 
-    _.forEach(strapi.apis, (api, apiName) => {
+    Object.entries(strapi.apis).forEach(([apiName, api]) => {
       const routes = _.flatMap(api.routes, (route) => {
         if (_.has(route, 'routes')) {
           return route.routes;
@@ -129,7 +131,7 @@ module.exports = ({ strapi }) => ({
       }));
     });
 
-    _.forEach(strapi.plugins, (plugin, pluginName) => {
+    Object.entries(strapi.plugins).forEach(([pluginName, plugin]) => {
       const transformPrefix = transformRoutePrefixFor(pluginName);
 
       const routes = _.flatMap(plugin.routes, (route) => {
@@ -158,11 +160,11 @@ module.exports = ({ strapi }) => ({
     const roles = await strapi.db.query('plugin::users-permissions.role').findMany();
     const dbPermissions = await strapi.db.query('plugin::users-permissions.permission').findMany();
 
-    const permissionsFoundInDB = _.uniq(_.map(dbPermissions, 'action'));
+    const permissionsFoundInDB = [...new Set(dbPermissions.map((permission) => permission.action))];
 
     const appActions = _.flatMap(strapi.apis, (api, apiName) => {
       return _.flatMap(api.controllers, (controller, controllerName) => {
-        return _.keys(controller).map((actionName) => {
+        return Object.keys(controller).map((actionName) => {
           return `api::${apiName}.${controllerName}.${actionName}`;
         });
       });
@@ -170,7 +172,7 @@ module.exports = ({ strapi }) => ({
 
     const pluginsActions = _.flatMap(strapi.plugins, (plugin, pluginName) => {
       return _.flatMap(plugin.controllers, (controller, controllerName) => {
-        return _.keys(controller).map((actionName) => {
+        return Object.keys(controller).map((actionName) => {
           return `plugin::${pluginName}.${controllerName}.${actionName}`;
         });
       });

--- a/packages/plugins/users-permissions/server/strategies/users-permissions.js
+++ b/packages/plugins/users-permissions/server/strategies/users-permissions.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { castArray, map, every, pipe } = require('lodash/fp');
 const { ForbiddenError, UnauthorizedError } = require('@strapi/utils').errors;
 
 const { getService } = require('../utils');
@@ -43,7 +42,7 @@ const authenticate = async (ctx) => {
       // Fetch user's permissions
       const permissions = await Promise.resolve(user.role.id)
         .then(getService('permission').findRolePermissions)
-        .then(map(getService('permission').toContentAPIPermission));
+        .then((perms) => perms.map(getService('permission').toContentAPIPermission));
 
       // Generate an ability (content API engine) based on the given permissions
       const ability = await strapi.contentAPI.permissions.engine.generateAbility(permissions);
@@ -59,7 +58,7 @@ const authenticate = async (ctx) => {
 
     const publicPermissions = await getService('permission')
       .findPublicPermissions()
-      .then(map(getService('permission').toContentAPIPermission));
+      .then((perms) => perms.map(getService('permission').toContentAPIPermission));
 
     if (publicPermissions.length === 0) {
       return { authenticated: false };
@@ -95,12 +94,8 @@ const verify = async (auth, config) => {
     throw new UnauthorizedError();
   }
 
-  const isAllowed = pipe(
-    // Make sure we're dealing with an array
-    castArray,
-    // Transform the scope array into an action array
-    every((scope) => ability.can(scope))
-  )(config.scope);
+  const scopes = Array.isArray(config.scope) ? config.scope : [config.scope];
+  const isAllowed = scopes.every((scope) => ability.can(scope));
 
   if (!isAllowed) {
     throw new ForbiddenError();

--- a/packages/utils/eslint-config-custom/back/index.js
+++ b/packages/utils/eslint-config-custom/back/index.js
@@ -2,7 +2,10 @@
 
 /** @type {import('eslint').Linter.Config} */
 const config = {
-  extends: '@strapi/eslint-config/back/javascript',
+  extends: [
+    '@strapi/eslint-config/back/javascript',
+    'plugin:you-dont-need-lodash-underscore/compatible',
+  ],
   parserOptions: {
     ecmaVersion: 2021,
   },

--- a/packages/utils/eslint-config-custom/back/typescript.js
+++ b/packages/utils/eslint-config-custom/back/typescript.js
@@ -5,6 +5,7 @@ const config = {
   root: true,
   extends: [
     '@strapi/eslint-config/back/typescript' /*'plugin:@typescript-eslint/recommended-requiring-type-checking'*/,
+    'plugin:you-dont-need-lodash-underscore/compatible',
   ],
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],

--- a/packages/utils/eslint-config-custom/front/index.js
+++ b/packages/utils/eslint-config-custom/front/index.js
@@ -3,7 +3,10 @@
 /** @type {import('eslint').Linter.Config} */
 const config = {
   parser: '@babel/eslint-parser',
-  extends: ['@strapi/eslint-config/front/javascript'],
+  extends: [
+    '@strapi/eslint-config/front/javascript',
+    'plugin:you-dont-need-lodash-underscore/compatible',
+  ],
   env: {
     browser: true,
     commonjs: true,

--- a/packages/utils/eslint-config-custom/front/typescript.js
+++ b/packages/utils/eslint-config-custom/front/typescript.js
@@ -3,7 +3,10 @@
 /** @type {import('eslint').Linter.Config} */
 const config = {
   root: true,
-  extends: ['@strapi/eslint-config/front/typescript'],
+  extends: [
+    '@strapi/eslint-config/front/typescript',
+    'plugin:you-dont-need-lodash-underscore/compatible',
+  ],
   overrides: [
     {
       files: ['**/*.test.[j|t]s', '**/*.test.[j|t]sx', '**/__mocks__/**/*'],

--- a/packages/utils/eslint-config-custom/package.json
+++ b/packages/utils/eslint-config-custom/package.json
@@ -2,5 +2,8 @@
   "name": "eslint-config-custom",
   "version": "5.48.1",
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "eslint-plugin-you-dont-need-lodash-underscore": "6.14.0"
+  }
 }

--- a/packages/utils/typescript/lib/generators/common/models/attributes.js
+++ b/packages/utils/typescript/lib/generators/common/models/attributes.js
@@ -102,7 +102,10 @@ const getAttributeModifiers = (attribute) => {
   }
 
   // Min / Max
-  if (!_.isNil(attribute.min) || !_.isNil(attribute.max)) {
+  if (
+    (attribute.min !== null && attribute.min !== undefined) ||
+    (attribute.max !== null && attribute.max !== undefined)
+  ) {
     const minMaxProperties = _.pick(['min', 'max'], attribute);
     const { min, max } = minMaxProperties;
 
@@ -140,7 +143,10 @@ const getAttributeModifiers = (attribute) => {
   }
 
   // Min length / Max length
-  if (!_.isNil(attribute.minLength) || !_.isNil(attribute.maxLength)) {
+  if (
+    (attribute.minLength !== null && attribute.minLength !== undefined) ||
+    (attribute.maxLength !== null && attribute.maxLength !== undefined)
+  ) {
     const minMaxProperties = _.pick(['minLength', 'maxLength'], attribute);
 
     modifiers.push(
@@ -152,7 +158,11 @@ const getAttributeModifiers = (attribute) => {
   }
 
   // Default (ignore if default is a function)
-  if (!_.isNil(attribute.default) && !_.isFunction(attribute.default)) {
+  if (
+    attribute.default !== null &&
+    attribute.default !== undefined &&
+    typeof attribute.default !== 'function'
+  ) {
     const defaultLiteral = toTypeLiteral(attribute.default);
 
     modifiers.push(

--- a/packages/utils/typescript/lib/generators/common/models/mappers.js
+++ b/packages/utils/typescript/lib/generators/common/models/mappers.js
@@ -59,9 +59,10 @@ module.exports = {
 
     // If the targetField property is defined, then reference it,
     // otherwise, put `undefined` keyword type node as placeholder
-    const targetFieldParam = _.isUndefined(targetField)
-      ? factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword)
-      : factory.createStringLiteral(targetField);
+    const targetFieldParam =
+      targetField === undefined
+        ? factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword)
+        : factory.createStringLiteral(targetField);
 
     params.push(targetFieldParam);
 

--- a/packages/utils/typescript/lib/generators/common/models/utils.js
+++ b/packages/utils/typescript/lib/generators/common/models/utils.js
@@ -2,20 +2,7 @@
 
 const ts = require('typescript');
 const { factory } = require('typescript');
-const {
-  pipe,
-  replace,
-  camelCase,
-  upperFirst,
-  isUndefined,
-  isNull,
-  isString,
-  isNumber,
-  isDate,
-  isArray,
-  isBoolean,
-  propEq,
-} = require('lodash/fp');
+const { pipe, camelCase, upperFirst, isNumber, isBoolean, propEq } = require('lodash/fp');
 
 const NAMESPACES = {
   Struct: 'Struct',
@@ -28,7 +15,7 @@ const NAMESPACES = {
  * @param {string} uid
  * @returns {string}
  */
-const getSchemaInterfaceName = pipe(replace(/(:.)/, ' '), camelCase, upperFirst);
+const getSchemaInterfaceName = pipe((str) => str.replace(/(:.)/, ' '), camelCase, upperFirst);
 
 const getSchemaModelType = (schema) => {
   const { modelType, kind } = schema;
@@ -79,15 +66,15 @@ const getTypeNode = (typeName, params = []) => {
  * @returns {ts.TypeNode}
  */
 const toTypeLiteral = (data) => {
-  if (isUndefined(data)) {
+  if (data === undefined) {
     return factory.createLiteralTypeNode(ts.SyntaxKind.UndefinedKeyword);
   }
 
-  if (isNull(data)) {
+  if (data === null) {
     return factory.createLiteralTypeNode(ts.SyntaxKind.NullKeyword);
   }
 
-  if (isString(data)) {
+  if (typeof data === 'string') {
     return factory.createStringLiteral(data, true);
   }
 
@@ -104,11 +91,11 @@ const toTypeLiteral = (data) => {
     return data ? factory.createTrue() : factory.createFalse();
   }
 
-  if (isArray(data)) {
+  if (Array.isArray(data)) {
     return factory.createTupleTypeNode(data.map((item) => toTypeLiteral(item)));
   }
 
-  if (isDate(data)) {
+  if (data instanceof Date) {
     return factory.createStringLiteral(data.toISOString());
   }
 

--- a/packages/utils/typescript/lib/generators/components/index.js
+++ b/packages/utils/typescript/lib/generators/components/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const { factory } = require('typescript');
-const { pipe, values, sortBy, map } = require('lodash/fp');
+// eslint-disable-next-line you-dont-need-lodash-underscore/map
+const { pipe, sortBy, map } = require('lodash/fp');
 
 const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
@@ -25,7 +26,7 @@ const generateComponentsDefinitions = async (options = {}) => {
   const { components } = strapi;
 
   const componentsDefinitions = pipe(
-    values,
+    Object.values,
     sortBy('uid'),
     map((component) => ({
       uid: component.uid,

--- a/packages/utils/typescript/lib/generators/content-types/index.js
+++ b/packages/utils/typescript/lib/generators/content-types/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const { factory } = require('typescript');
-const { values, pipe, map, sortBy } = require('lodash/fp');
+// eslint-disable-next-line you-dont-need-lodash-underscore/map
+const { pipe, map, sortBy } = require('lodash/fp');
 
 const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
@@ -25,7 +26,7 @@ const generateContentTypesDefinitions = async (options = {}) => {
   const { contentTypes } = strapi;
 
   const contentTypesDefinitions = pipe(
-    values,
+    Object.values,
     sortBy('uid'),
     map((contentType) => ({
       uid: contentType.uid,

--- a/packages/utils/upgrade/src/modules/json/__tests__/json-transform-api.test.ts
+++ b/packages/utils/upgrade/src/modules/json/__tests__/json-transform-api.test.ts
@@ -1,3 +1,5 @@
+// [lodash: cloneDeep — structuredClone not 1:1, audit value shape first]
+// eslint-disable-next-line you-dont-need-lodash-underscore/clone-deep
 import { cloneDeep } from 'lodash/fp';
 
 import type { Utils } from '@strapi/types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -17461,6 +17461,8 @@ __metadata:
 "eslint-config-custom@npm:5.48.1, eslint-config-custom@workspace:packages/utils/eslint-config-custom":
   version: 0.0.0-use.local
   resolution: "eslint-config-custom@workspace:packages/utils/eslint-config-custom"
+  dependencies:
+    eslint-plugin-you-dont-need-lodash-underscore: "npm:6.14.0"
   languageName: unknown
   linkType: soft
 
@@ -17857,6 +17859,15 @@ __metadata:
   peerDependencies:
     eslint: ^7.5.0 || ^8.0.0
   checksum: 10c0/55c7792345710a2b951acb0552ebe4e491d988f7d37fd308749e75fdbc36142b9a151ecec03b39992f672afea1a99dd3c3d2fb9f737ef18f56d7168e294fd9eb
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-you-dont-need-lodash-underscore@npm:6.14.0":
+  version: 6.14.0
+  resolution: "eslint-plugin-you-dont-need-lodash-underscore@npm:6.14.0"
+  dependencies:
+    kebab-case: "npm:^1.0.0"
+  checksum: 10c0/23dadc91b754b9afdd5c9d87509f21e1c627888dc8a5e34c3d3181521ce9c5e87b4d1f5c693413d857e7fbb6e54b6d471adb1ee1e912fc8824a982f1762a11e0
   languageName: node
   linkType: hard
 
@@ -22407,6 +22418,13 @@ __metadata:
     jwa: "npm:^2.0.1"
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/6be1ed93023aef570ccc5ea8d162b065840f3ef12f0d1bb3114cade844de7a357d5dc558201d9a65101e70885a6fa56b17462f520e6b0d426195510618a154d0
+  languageName: node
+  linkType: hard
+
+"kebab-case@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "kebab-case@npm:1.0.2"
+  checksum: 10c0/94080c483c4bb88d7a37efe21431271e91a2297d2fb4e9c12167c5a9144a813ffbdd92f7ba7778f553250c83ba8413f4b061e949b0d6c9bada771efe10c220a4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Description

### What does it do?

Adds `eslint-plugin-you-dont-need-lodash-underscore@6.14.0` to the shared back and front ESLint configs (`eslint-config-custom`) at the `compatible` severity level. The plugin flags lodash calls that have safe, semantically equivalent native JS replacements.

With the plugin in place, all flagged call sites across the monorepo were audited and migrated in package-scoped batches:

- **Replaced with native equivalents** — `isNil`, `isArray`, `isFunction`, `isString`, `isInteger`, `isNaN`, `isUndefined`, `isNull`, `isDate`, `castArray`, `uniq`, `first`, `find`, `filter`, `map`, `reduce`, `forEach`, `keys`, `values`, `size`, `trim`, `padEnd`, `toLower`, `toUpper`, `capitalize`, `replace`, `assign` (fresh `{}` targets), `get` (static paths), `omit` (static key lists)
- **Left in place with `eslint-disable-next-line` + comment** — `cloneDeep` (structuredClone is not 1:1 for class instances), `defaults` (lodash fills only `undefined` slots; `Object.assign` overwrites existing keys), `get` with dynamic or array paths, `throttle`, and `filter`/`map` inside `lodash/fp` curried pipelines

The result is zero lint errors introduced, the full unit and front-end test suites passing, and a clear audit trail of what was deferred and why.

### Why is it needed?

Lodash is a heavy transitive dependency across the monorepo. Many of its helpers have direct native equivalents in Node ≥22 / modern browsers that require no import at all. Making the remaining, non-replaceable lodash calls explicit (via inline comments) is also a prerequisite for a future dependency-pruning pass.

The ESLint plugin enforces this incrementally: new code that reaches for a replaceable lodash helper gets flagged at lint time, preventing the surface from growing back.

### How to test it?

```bash
yarn lint           # must pass with 0 errors
yarn test:unit      # all unit tests green
yarn test:front     # all frontend tests green
```

No runtime behavior changes — all replacements are semantically equivalent for the input shapes present at each call site.

### Related issue(s)/PR(s)

- built on top of #26760