### PR TITLE
fix(ci): use allowlisted thollander action ref in experimental publish workflow

### DIFF
--- a/.github/workflows/publish-pr-experimental.yml
+++ b/.github/workflows/publish-pr-experimental.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Update experimental build comment
-        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
+        uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: experimental-pr-build
           message: |


### PR DESCRIPTION
## What does it do?

Changes `publish-pr-experimental.yml` to use `thollander/actions-comment-pull-request@v2` instead of a pinned commit SHA.

## Why is it needed?

Every run of the Publish PR Experimental workflow has failed with `startup_failure` since #26739 merged. GitHub rejects the workflow at startup because the pinned SHA (`fabd468…`) is not on the org Actions allowlist — only the `@v2` tag pattern is permitted (same ref already used in `changeFreeze.yml`).

## How to test it?

1. Merge this PR.
2. Add the `publish-experimental` label to a same-repo PR (or push a new commit to one that already has it).
3. Confirm the workflow run starts jobs instead of `startup_failure`, publishes to npm, and posts/updates the experimental build comment.

## Related issue(s)/PR(s)

Fixes regression introduced in #26739.