### PR TITLE
fix(content-manager): redirect to content-manager 403 page instead of /403

### DIFF
--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -53,7 +53,7 @@ const Layout = () => {
     supportedModelsToDisplay.length > 0 &&
     pathname !== '/content-manager/403'
   ) {
-    return <Navigate to="/403" />;
+    return <Navigate to="/content-manager/403" />;
   }
 
   // Redirect the user to the create content type page

--- a/packages/core/content-manager/admin/src/tests/layout.test.tsx
+++ b/packages/core/content-manager/admin/src/tests/layout.test.tsx
@@ -1,0 +1,67 @@
+/* eslint-disable check-file/filename-naming-convention */
+import { render, screen, waitFor } from '@tests/utils';
+import { Routes, Route } from 'react-router-dom';
+
+import { useContentManagerInitData } from '../hooks/useContentManagerInitData';
+import { Layout } from '../layout';
+
+import type { AppState } from '../modules/app';
+
+jest.mock('../hooks/useContentManagerInitData');
+
+const mockedUseContentManagerInitData = jest.mocked(useContentManagerInitData);
+
+const setInitData = (data: Partial<AppState>) => {
+  mockedUseContentManagerInitData.mockReturnValue({
+    isLoading: false,
+    collectionTypeLinks: [],
+    singleTypeLinks: [],
+    components: [],
+    fieldSizes: {},
+    models: [],
+    ...data,
+  });
+};
+
+const renderLayout = () =>
+  render(
+    <Routes>
+      <Route path="/content-manager/*" element={<Layout />} />
+      <Route path="/content-manager/403" element={<div>no-permissions-page</div>} />
+      <Route path="/403" element={<div>admin-catch-all</div>} />
+    </Routes>,
+    { initialEntries: ['/content-manager'] }
+  );
+
+describe('Content Manager | Layout', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Regression test for https://github.com/strapi/strapi/issues/26707:
+   * when the user has no authorised models for the active locale, the layout must
+   * redirect to the Content Manager's own NoPermissions route (`/content-manager/403`)
+   * and not to `/403`, which is not a registered route and renders "Page not found".
+   */
+  it('redirects to the content-manager 403 page when there are no authorised models', async () => {
+    setInitData({
+      collectionTypeLinks: [],
+      singleTypeLinks: [],
+      // The layout only inspects `isDisplayed`, so a minimal model is enough here.
+      models: [
+        {
+          uid: 'api::article.article',
+          isDisplayed: true,
+        } as unknown as AppState['models'][number],
+      ],
+    });
+
+    renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByText('no-permissions-page')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('admin-catch-all')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### What does it do?

In the Content Manager layout, when a user has no authorised models for the
active locale, the redirect target is changed from `/403` to
`/content-manager/403`.

```diff
- return <Navigate to="/403" />;
+ return <Navigate to="/content-manager/403" />;
```

A regression test is added that mocks `useContentManagerInitData` to simulate
a user with no authorised models and asserts that the layout renders the
Content Manager `NoPermissions` route (`/content-manager/403`) rather than the
admin catch-all.

### Why is it needed?

When an admin user's role is restricted to specific i18n locales, switching to
a locale the role can't access left the user on a generic **"Page not found"**
screen instead of a permissions message.

The cause is purely front-end routing: the `NoPermissions` page is registered
at `/content-manager/403` (see `packages/core/content-manager/admin/src/router.tsx`),
but the layout redirected to `/403`, which resolves to `/admin/403` — a path
with no registered route — so the admin catch-all (`path: '*'`) rendered the
global `NotFoundPage`.

The condition guarding the redirect already references `'/content-manager/403'`
(`pathname !== '/content-manager/403'`), so redirecting to that same path is the
consistent, minimal fix. Server-side RBAC (returning `403` for the unauthorized
locale) is correct and untouched.

### How to test it?

1. Enable i18n and create two locales, e.g. **en** (default) and **fr**.
2. Create a localized collection type (e.g. `Article`) with `draftAndPublish`
   and an entry that has both `en` and `fr` localizations.
3. In **Settings → Roles**, create a role whose Content Manager permissions on
   `Article` are scoped to **English** only (the "Locales" property).
4. Create a user with that role and log in as them.
5. Open the entry and switch to the **French** locale, e.g.
   `/admin/content-manager/collection-types/api::article.article/<documentId>?plugins[i18n][locale]=fr`

**Before:** the app navigates to `/admin/403` and shows "Page not found".
**After:** the user is shown the **NoPermissions** ("You don't have the
permissions to access that content") page.

Automated: `yarn test:front packages/core/content-manager/admin/src/tests/layout.test.tsx`

### Related issue(s)/PR(s)

Closes #26707
