### PR TITLE
ci: report bundle size changes for PRs from forks

### DIFF
--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -34,6 +34,7 @@ jobs:
         run: printf '#!/bin/sh\nset -e\nyarn install\nyarn nx reset\nyarn build\n' > /tmp/install-and-build.sh
 
       - uses: preactjs/compressed-size-action@v2
+        id: compressed-size
         with:
           install-script: 'sh /tmp/install-and-build.sh'
           build-script: 'build:size'
@@ -44,3 +45,30 @@ jobs:
           # FIXME: exclude unnamed webpack chunks - remove once webpack
           # does not create them anymore
           exclude: '{**/build/**/+([0-9]{,4})*,**/node_modules/**}'
+
+      - name: Save comment body
+        env:
+          COMMENT_BODY: ${{ steps.compressed-size.outputs.comment-body }}
+        run: |
+          printf '%s\n' "$COMMENT_BODY" > /tmp/admin-bundle-size-comment.md
+
+      - name: Save PR number
+        env:
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}
+        run: |
+          echo "$PULL_REQUEST_NUMBER" > /tmp/admin-bundle-size-pr-number
+
+      - name: Upload comment body
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: admin-bundle-size-comment
+          path: /tmp/admin-bundle-size-comment.md
+          retention-days: 1
+
+      - name: Upload PR number
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: admin-bundle-size-pr-number
+          path: /tmp/admin-bundle-size-pr-number
+          retention-days: 1

--- a/.github/workflows/adminBundleSizeComment.yml
+++ b/.github/workflows/adminBundleSizeComment.yml
@@ -1,0 +1,49 @@
+name: Admin bundle-size comment
+
+on:
+  workflow_run:
+    workflows: ['Admin bundle-size']
+    types: [completed]
+
+jobs:
+  comment:
+    name: Comment
+    # Only handle successful PR runs from forks.
+    # Same-repository PRs can be commented on by the original pull_request workflow if it has permission.
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      pull-requests: write
+
+    steps:
+      - name: Download comment body
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: admin-bundle-size-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp
+
+      - name: Download PR number
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: admin-bundle-size-pr-number
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp
+
+      - name: Get PR number
+        id: pr
+        run: echo "pr=$(</tmp/admin-bundle-size-pr-number)" >> "$GITHUB_OUTPUT"
+
+      - uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: /tmp/admin-bundle-size-comment.md
+          pr_number: ${{ steps.pr.outputs.pr }}
+          comment_tag: admin-bundle-size


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

The downstream workflow uses `workflow_run` to comment with base repository permissions, while the untrusted fork code is built only in the original `pull_request` workflow.

This follows [GitHub's recommended](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/#:~:text=Below%20is%20an%20example%20of%20the%20intended%20usage%20in%20which%20the%20results%20of%20an%20unprivileged%20pull_request%20workflow%20are%20combined%20with%20a%20privileged%20workflow%20to%20leave%20a%20comment%20in%20response%20to%20a%20received%20PR%3A) pattern for securely handling pull requests from forks.

Note: `workflow_run` only runs after the merge into the default branch, so this PR will not trigger comments.

### Why is it needed?

Previously, `compressed-size-action` could not add comments to PRs opened from forks, so we had to check the results from the workflow logs, which was inconvenient.

Starting from `2.10.0`, it exposes the full `comment-body`, so we can now publish comments for PRs from forks. I hope this helps with project maintenance.

https://github.com/preactjs/compressed-size-action/pull/148


### How to test it?

1. Merge this PR.
2. Create a PR from a forked repository, or merge the default branch into an existing PR to trigger a new workflow run.

### Related issue(s)/PR(s)

See my test here https://github.com/rzzf/strapi/pull/2


---
Fixes CPR-421