### PR TITLE
fix(create-strapi-app): new TypeScript apps use TS strict mode

### DIFF
--- a/packages/cli/create-strapi-app/templates/example/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/admin.ts
@@ -2,18 +2,18 @@ import type { Core } from '@strapi/strapi';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET'),
+    secret: env('ADMIN_JWT_SECRET')!,
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT'),
+    salt: env('API_TOKEN_SALT')!,
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT'),
+      salt: env('TRANSFER_TOKEN_SALT')!,
     },
   },
   secrets: {
-    encryptionKey: env('ENCRYPTION_KEY'),
+    encryptionKey: env('ENCRYPTION_KEY')!,
   },
   flags: {
     nps: env.bool('FLAG_NPS', true),

--- a/packages/cli/create-strapi-app/templates/example/config/database.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/database.ts
@@ -51,13 +51,21 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     },
   };
 
+  if (!(client in connections)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  type DatabaseClient = keyof typeof connections;
+
   return {
     connection: {
-      client,
-      ...connections[client],
+      client: client as DatabaseClient,
+      ...connections[client as DatabaseClient],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  };
+  } as Core.Config.Database;
 };
 
 export default config;

--- a/packages/cli/create-strapi-app/templates/example/config/server.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/server.ts
@@ -4,7 +4,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server =>
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS'),
+    keys: env.array('APP_KEYS')!,
   },
 });
 

--- a/packages/cli/create-strapi-app/templates/example/tsconfig.json
+++ b/packages/cli/create-strapi-app/templates/example/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "Node",
     "lib": ["ES2020"],
     "target": "ES2019",
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,

--- a/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
@@ -2,18 +2,18 @@ import type { Core } from '@strapi/strapi';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET'),
+    secret: env('ADMIN_JWT_SECRET')!,
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT'),
+    salt: env('API_TOKEN_SALT')!,
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT'),
+      salt: env('TRANSFER_TOKEN_SALT')!,
     },
   },
   secrets: {
-    encryptionKey: env('ENCRYPTION_KEY'),
+    encryptionKey: env('ENCRYPTION_KEY')!,
   },
   flags: {
     nps: env.bool('FLAG_NPS', true),

--- a/packages/cli/create-strapi-app/templates/vanilla/config/database.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/database.ts
@@ -51,13 +51,21 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     },
   };
 
+  if (!(client in connections)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  type DatabaseClient = keyof typeof connections;
+
   return {
     connection: {
-      client,
-      ...connections[client],
+      client: client as DatabaseClient,
+      ...connections[client as DatabaseClient],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  };
+  } as Core.Config.Database;
 };
 
 export default config;

--- a/packages/cli/create-strapi-app/templates/vanilla/config/server.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/server.ts
@@ -4,7 +4,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server =>
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS'),
+    keys: env.array('APP_KEYS')!,
   },
 });
 

--- a/packages/cli/create-strapi-app/templates/vanilla/tsconfig.json
+++ b/packages/cli/create-strapi-app/templates/vanilla/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "Node",
     "lib": ["ES2020"],
     "target": "ES2019",
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,


### PR DESCRIPTION
### What does it do?

Aligns the `create-strapi-app` vanilla and example TypeScript scaffolds so the server-side compiler config uses strict mode, matching the admin panel config and the monorepo baseline.

Enabling strict mode surfaced a few config typing gaps in the generated templates. Admin and server configs now assert required environment-backed secrets (JWT, API token salts, encryption key, app keys) where those values are expected at runtime. Database config validates the `DATABASE_CLIENT` value before building the connection and narrows the client type so the scaffold typechecks cleanly under strict mode.

### Why is it needed?

Every new TypeScript Strapi app created via `create-strapi-app` shipped with strict mode disabled on the server while the admin config already used strict mode. That split meant custom controllers, services, policies, and lifecycle hooks were not checked as rigorously as admin code or framework packages, making it harder to catch type errors early in new projects.

### How to test it?

From the monorepo root, scaffold a fresh TypeScript app from the updated templates (vanilla or example) and confirm the project typechecks without errors:

```bash
cd packages/cli/create-strapi-app
yarn build
npx create-strapi-app /tmp/strict-scaffold-test --typescript --no-run --skip-cloud
cd /tmp/strict-scaffold-test
yarn install
yarn strapi ts:generate-types
```

Alternatively, run TypeScript against the template sources directly:

```bash
cd packages/cli/create-strapi-app/templates/vanilla
npx tsc --noEmit
```

Expected: no TypeScript errors. A misconfigured `DATABASE_CLIENT` should throw a clear runtime error at startup rather than silently producing an invalid connection config.

### Related issue(s)/PR(s)

- Companion PR: #26780 — same strict-mode alignment for dev sandboxes and the website template.
- Fixes #26778