### PR TITLE
fix(examples): dev sandboxes use TS strict mode

### DIFF
--- a/examples/complex/config/admin.ts
+++ b/examples/complex/config/admin.ts
@@ -1,4 +1,6 @@
-const adminConfig = ({ env }) => ({
+import type { Core } from '@strapi/strapi';
+
+const adminConfig = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
   auth: {
     secret: env('ADMIN_JWT_SECRET', 'example-token'),
   },

--- a/examples/complex/config/database.ts
+++ b/examples/complex/config/database.ts
@@ -1,4 +1,6 @@
-export default ({ env }) => {
+import type { Core } from '@strapi/strapi';
+
+export default ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database => {
   const client = env('DATABASE_CLIENT', 'postgres');
 
   const connections = {
@@ -48,17 +50,19 @@ export default ({ env }) => {
     },
   };
 
-  if (!connections[client]) {
+  if (!(client in connections)) {
     throw new Error(
       `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
     );
   }
 
+  type DatabaseClient = keyof typeof connections;
+
   return {
     connection: {
-      client,
-      ...connections[client],
+      client: client as DatabaseClient,
+      ...connections[client as DatabaseClient],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  };
+  } as Core.Config.Database;
 };

--- a/examples/complex/config/server.ts
+++ b/examples/complex/config/server.ts
@@ -1,4 +1,6 @@
-const serverConfig = ({ env }) => ({
+import type { Core } from '@strapi/strapi';
+
+const serverConfig = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {

--- a/examples/complex/tsconfig.json
+++ b/examples/complex/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "Node",
     "lib": ["ES2020"],
     "target": "ES2019",
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,

--- a/examples/empty/config/database.ts
+++ b/examples/empty/config/database.ts
@@ -51,13 +51,21 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     },
   };
 
+  if (!(client in connections)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  type DatabaseClient = keyof typeof connections;
+
   return {
     connection: {
-      client,
-      ...connections[client],
+      client: client as DatabaseClient,
+      ...connections[client as DatabaseClient],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  };
+  } as Core.Config.Database;
 };
 
 export default config;

--- a/examples/empty/tsconfig.json
+++ b/examples/empty/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "Node",
     "lib": ["ES2020"],
     "target": "ES2019",
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,

--- a/examples/kitchensink-ts/tsconfig.json
+++ b/examples/kitchensink-ts/tsconfig.json
@@ -7,7 +7,7 @@
     "lib": ["ES2020"],
     "target": "ES2019",
 
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
 

--- a/templates/website/config/admin.ts
+++ b/templates/website/config/admin.ts
@@ -2,14 +2,14 @@ import type { Core } from '@strapi/strapi';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET'),
+    secret: env('ADMIN_JWT_SECRET')!,
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT'),
+    salt: env('API_TOKEN_SALT')!,
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT'),
+      salt: env('TRANSFER_TOKEN_SALT')!,
     },
   },
   flags: {

--- a/templates/website/config/database.ts
+++ b/templates/website/config/database.ts
@@ -51,13 +51,21 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     },
   };
 
+  if (!(client in connections)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  type DatabaseClient = keyof typeof connections;
+
   return {
     connection: {
-      client,
-      ...connections[client],
+      client: client as DatabaseClient,
+      ...connections[client as DatabaseClient],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  };
+  } as Core.Config.Database;
 };
 
 export default config;

--- a/templates/website/config/server.ts
+++ b/templates/website/config/server.ts
@@ -4,7 +4,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server =>
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS'),
+    keys: env.array('APP_KEYS')!,
   },
 });
 

--- a/templates/website/src/bootstrap.ts
+++ b/templates/website/src/bootstrap.ts
@@ -11,6 +11,25 @@ const data = {
   leadFormSubmissions,
 };
 
+type FileData = {
+  filepath: string;
+  originalFileName: string;
+  size: number;
+  mimetype: string;
+};
+
+type ContentSection = {
+  __component: string;
+  features?: Array<Record<string, unknown>>;
+  logos?: Array<Record<string, unknown>>;
+  testimonials?: Array<Record<string, unknown>>;
+};
+
+type Page = {
+  slug: string;
+  contentSections: ContentSection[];
+};
+
 /**
  * This function will be called when the app is boostrapped.
  */
@@ -39,7 +58,7 @@ async function isFirstRun() {
   return !initHasRun;
 }
 
-async function setPublicPermissions(newPermissions) {
+async function setPublicPermissions(newPermissions: Record<string, string[]>) {
   // Find the ID of the public role
   const publicRole = await strapi.query('plugin::users-permissions.role').findOne({
     where: {
@@ -48,7 +67,7 @@ async function setPublicPermissions(newPermissions) {
   });
 
   // Create the new permissions and link them to the public role
-  const allPermissionsToCreate = [];
+  const allPermissionsToCreate: Array<Promise<unknown>> = [];
   Object.keys(newPermissions).map((controller) => {
     const actions = newPermissions[controller];
     const permissionsToCreate = actions.map((action) => {
@@ -64,13 +83,13 @@ async function setPublicPermissions(newPermissions) {
   await Promise.all(allPermissionsToCreate);
 }
 
-function getFileSizeInBytes(filePath) {
+function getFileSizeInBytes(filePath: string) {
   const stats = fs.statSync(filePath);
   const fileSizeInBytes = stats['size'];
   return fileSizeInBytes;
 }
 
-function getFileData(fileName) {
+function getFileData(fileName: string): FileData {
   const filePath = `./data/uploads/${fileName}`;
 
   // Parse the file metadata
@@ -134,8 +153,8 @@ async function createEntry(
   }
 }
 
-async function importPages(pages) {
-  const getPageCover = (slug) => {
+async function importPages(pages: Page[]) {
+  const getPageCover = (slug: string): FileData | null => {
     switch (slug) {
       case '':
         return getFileData('undraw-content-team.png');
@@ -145,7 +164,7 @@ async function importPages(pages) {
   };
 
   return pages.map(async (page) => {
-    const files = {};
+    const files: Record<string, FileData | null> = {};
     const shareImage = getPageCover(page.slug);
     if (shareImage) {
       files['metadata.shareImage'] = shareImage;
@@ -155,7 +174,7 @@ async function importPages(pages) {
       if (section.__component === 'sections.hero') {
         files[`contentSections.${index}.picture`] = getFileData('undraw-content-team.svg');
       } else if (section.__component === 'sections.feature-rows-group') {
-        const getFeatureMedia = (featureIndex) => {
+        const getFeatureMedia = (featureIndex: number): FileData | null => {
           switch (featureIndex) {
             case 0:
               return getFileData('undraw-design-page.svg');
@@ -165,12 +184,12 @@ async function importPages(pages) {
               return null;
           }
         };
-        section.features.forEach((feature, featureIndex) => {
+        section.features?.forEach((_feature, featureIndex) => {
           files[`contentSections.${index}.features.${featureIndex}.media`] =
             getFeatureMedia(featureIndex);
         });
       } else if (section.__component === 'sections.feature-columns-group') {
-        const getFeatureMedia = (featureIndex) => {
+        const getFeatureMedia = (featureIndex: number): FileData | null => {
           switch (featureIndex) {
             case 0:
               return getFileData('preview.svg');
@@ -182,15 +201,15 @@ async function importPages(pages) {
               return null;
           }
         };
-        section.features.forEach((feature, featureIndex) => {
+        section.features?.forEach((_feature, featureIndex) => {
           files[`contentSections.${index}.features.${featureIndex}.icon`] =
             getFeatureMedia(featureIndex);
         });
       } else if (section.__component === 'sections.testimonials-group') {
-        section.logos.forEach((logo, logoIndex) => {
+        section.logos?.forEach((_logo, logoIndex) => {
           files[`contentSections.${index}.logos.${logoIndex}.logo`] = getFileData('logo.png');
         });
-        section.testimonials.forEach((testimonial, testimonialIndex) => {
+        section.testimonials?.forEach((_testimonial, testimonialIndex) => {
           files[`contentSections.${index}.testimonials.${testimonialIndex}.logo`] =
             getFileData('logo.png');
           files[`contentSections.${index}.testimonials.${testimonialIndex}.picture`] =
@@ -199,7 +218,13 @@ async function importPages(pages) {
       }
     });
 
-    await createEntry('page', page, files);
+    await createEntry(
+      'page',
+      page,
+      Object.fromEntries(
+        Object.entries(files).filter((entry): entry is [string, FileData] => entry[1] !== null)
+      )
+    );
   });
 }
 
@@ -241,6 +266,6 @@ async function importSeedData() {
 
   // Create all entries
   await importGlobal();
-  await importPages(data.pages);
+  await importPages(data.pages as Page[]);
   await importLeadFormSubmissionData();
 }

--- a/templates/website/tsconfig.json
+++ b/templates/website/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "Node",
     "lib": ["ES2020"],
     "target": "ES2019",
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,


### PR DESCRIPTION
### What does it do?

Brings strict TypeScript checking to the server-side compiler config for internal dev sandboxes and the website template, aligning them with the admin panel configs and the monorepo baseline.

Enabling strict mode required typing fixes in config and bootstrap code: database configs now validate and narrow the database client before building connections; the complex example adopts proper `Core.Config` types for its config exports; the website template adds minimal types to its seed bootstrap helpers so nullable file references are handled safely under strict checking.

### Why is it needed?

Several internal TypeScript sandboxes and the website template still ran with strict mode disabled on the server while admin code and framework packages already used strict checking. That inconsistency made it harder to catch type errors in example apps and the website template during development, and diverged from the baseline expected for new user projects after the create-strapi-app scaffold fix.

### How to test it?

From the monorepo root, run TypeScript against each affected sandbox:

```bash
cd examples/empty && npx tsc --noEmit
cd examples/complex && npx tsc --noEmit
cd examples/kitchensink-ts && npx tsc --noEmit
cd templates/website && npx tsc --noEmit
```

Expected: no TypeScript errors in any of the above.

Optionally smoke-test an example app:

```bash
cd examples/empty
yarn develop
```

### Related issue(s)/PR(s)

Companion PR: #26779 — same strict-mode alignment for `create-strapi-app` scaffolds (user-facing new apps).