### PR TITLE
chore(deps): upgrade TypeScript to 5.9.3

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -55,7 +55,7 @@
     "docusaurus-plugin-typedoc": "1.4.2",
     "typedoc": "0.28.19",
     "typedoc-plugin-markdown": "4.11.0",
-    "typescript": "5.4.5",
+    "typescript": "5.9.3",
     "unist-util-visit": "5.0.0"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6851,7 +6851,7 @@ __metadata:
     react-dom: "npm:18.3.1"
     typedoc: "npm:0.28.19"
     typedoc-plugin-markdown: "npm:4.11.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
     unist-util-visit: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -13570,23 +13570,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
+"typescript@npm:5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
+"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/db2ad2a16ca829f50427eeb1da155e7a45e598eec7b086d8b4e8ba44e5a235f758e606d681c66992230d3fc3b8995865e5fd0b22a2c95486d0b3200f83072ec9
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "tar": "7.5.16",
     "ts-jest": "29.1.0",
     "tsx": "4.22.4",
-    "typescript": "5.4.5",
+    "typescript": "5.9.3",
     "vitest": "catalog:",
     "yalc": "1.0.0-pre.53",
     "yargs": "17.7.2"

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -142,7 +142,7 @@
     "semver": "7.7.4",
     "sift": "16.0.1",
     "sonner": "2.0.7",
-    "typescript": "5.4.5",
+    "typescript": "5.9.3",
     "use-context-selector": "1.4.1",
     "yup": "0.32.9",
     "zod": "3.25.67"

--- a/packages/core/admin/server/src/services/permission/permissions-manager/sanitize.ts
+++ b/packages/core/admin/server/src/services/permission/permissions-manager/sanitize.ts
@@ -201,9 +201,7 @@ export default ({ action, ability, model }: any) => {
   const wrapSanitize = (createSanitizeFunction: any) => {
     const { getPermissionFields } = createPermissionFieldsCache(ability);
 
-    // TODO
-    // @ts-expect-error define the correct return type
-    const wrappedSanitize = async (data: unknown, options = {} as any) => {
+    const wrappedSanitize = async (data: unknown, options = {} as any): Promise<unknown> => {
       if (isArray(data)) {
         return Promise.all(data.map((entity: unknown) => wrappedSanitize(entity, options)));
       }

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
@@ -21,8 +21,10 @@ const CellContent = ({ content, mainField, attribute, rowId, name }: CellContent
     return (
       <Typography
         textColor="neutral800"
-        paddingLeft={attribute.type === ('relation' || 'component') ? '1.6rem' : 0}
-        paddingRight={attribute.type === ('relation' || 'component') ? '1.6rem' : 0}
+        paddingLeft={attribute.type === 'relation' || attribute.type === 'component' ? '1.6rem' : 0}
+        paddingRight={
+          attribute.type === 'relation' || attribute.type === 'component' ? '1.6rem' : 0
+        }
       >
         -
       </Typography>

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -93,7 +93,7 @@
     "react-query": "3.39.3",
     "react-router-dom": "6.30.3",
     "styled-components": "6.4.1",
-    "typescript": "5.4.5"
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -111,7 +111,7 @@
     "resolve.exports": "2.0.2",
     "semver": "7.7.4",
     "statuses": "2.0.1",
-    "typescript": "5.4.5",
+    "typescript": "5.9.3",
     "undici": "6.27.0",
     "yup": "0.32.9",
     "zod": "3.25.67"

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -88,7 +88,7 @@
     "knex": "3.0.1",
     "koa": "2.16.4",
     "rimraf": "6.1.3",
-    "typescript": "5.4.5",
+    "typescript": "5.9.3",
     "vitest": "catalog:",
     "vitest-config": "5.49.0"
   },

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -163,7 +163,7 @@
     "resolve-from": "5.0.0",
     "semver": "7.7.4",
     "style-loader": "3.3.4",
-    "typescript": "5.4.5",
+    "typescript": "5.9.3",
     "vite": "5.4.21",
     "webpack": "5.106.2",
     "webpack-bundle-analyzer": "5.3.0",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -72,7 +72,7 @@
     "eslint-config-custom": "5.49.0",
     "lodash": "4.18.1",
     "tsconfig": "5.49.0",
-    "typescript": "5.4.5",
+    "typescript": "5.9.3",
     "undici": "6.27.0"
   },
   "engines": {

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -62,7 +62,7 @@
     "react-router-dom": "6.30.3",
     "styled-components": "6.4.1",
     "tsconfig": "5.49.0",
-    "typescript": "5.4.5"
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -76,7 +76,7 @@
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
     "styled-components": "6.4.1",
-    "typescript": "5.4.5",
+    "typescript": "5.9.3",
     "vitest": "catalog:",
     "vitest-config": "5.49.0"
   },

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -90,7 +90,7 @@
     "react-router-dom": "6.30.3",
     "styled-components": "6.4.1",
     "tsconfig": "5.49.0",
-    "typescript": "5.4.5"
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "11.3.4",
     "lodash": "4.18.1",
     "prettier": "3.3.3",
-    "typescript": "5.4.5"
+    "typescript": "5.9.3"
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8951,7 +8951,7 @@ __metadata:
     sift: "npm:16.0.1"
     sonner: "npm:2.0.7"
     styled-components: "npm:6.4.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
     use-context-selector: "npm:1.4.1"
     vite: "npm:5.4.21"
     vite-plugin-dts: "npm:^4.3.0"
@@ -9109,7 +9109,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/admin": ^5.0.0
@@ -9258,7 +9258,7 @@ __metadata:
     statuses: "npm:2.0.1"
     supertest: "npm:7.2.2"
     tsconfig: "npm:5.49.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
     undici: "npm:6.27.0"
     vitest: "catalog:"
     vitest-config: "npm:5.49.0"
@@ -9303,7 +9303,7 @@ __metadata:
     stream-json: "npm:1.9.1"
     tar: "npm:7.5.16"
     tar-stream: "npm:2.2.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
     vitest: "catalog:"
     vitest-config: "npm:5.49.0"
     ws: "npm:8.20.1"
@@ -9562,7 +9562,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
     tsconfig: "npm:5.49.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
@@ -9588,7 +9588,7 @@ __metadata:
     react-intl: "npm:6.6.2"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
     vitest: "catalog:"
     vitest-config: "npm:5.49.0"
   peerDependencies:
@@ -9682,7 +9682,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
     tsconfig: "npm:5.49.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -9961,7 +9961,7 @@ __metadata:
     semver: "npm:7.7.4"
     style-loader: "npm:3.3.4"
     tsconfig: "npm:5.49.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
     vite: "npm:5.4.21"
     webpack: "npm:5.106.2"
     webpack-bundle-analyzer: "npm:5.3.0"
@@ -10018,7 +10018,7 @@ __metadata:
     typedoc: "npm:0.28.19"
     typedoc-github-wiki-theme: "npm:2.1.0"
     typedoc-plugin-markdown: "npm:4.11.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
     undici: "npm:6.27.0"
     zod: "npm:3.25.67"
   languageName: unknown
@@ -10034,7 +10034,7 @@ __metadata:
     fs-extra: "npm:11.3.4"
     lodash: "npm:4.18.1"
     prettier: "npm:3.3.3"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -29449,7 +29449,7 @@ __metadata:
     tar: "npm:7.5.16"
     ts-jest: "npm:29.1.0"
     tsx: "npm:4.22.4"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.9.3"
     vitest: "catalog:"
     yalc: "npm:1.0.0-pre.53"
     yargs: "npm:17.7.2"
@@ -30995,16 +30995,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
-  languageName: node
-  linkType: hard
-
 "typescript@npm:5.8.2":
   version: 5.8.2
   resolution: "typescript@npm:5.8.2"
@@ -31015,23 +31005,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5, typescript@npm:^5.4.0":
+"typescript@npm:5.9.3, typescript@npm:^5, typescript@npm:^5.4.0":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/db2ad2a16ca829f50427eeb1da155e7a45e598eec7b086d8b4e8ba44e5a235f758e606d681c66992230d3fc3b8995865e5fd0b22a2c95486d0b3200f83072ec9
   languageName: node
   linkType: hard
 
@@ -31045,7 +31025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.0#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.0#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:


### PR DESCRIPTION
### What does it do?

Bumps the TypeScript compiler from **5.4.5 to 5.9.3** across the monorepo — the root `package.json` and all packages that declare a `typescript` devDependency. Two pre-existing type errors surfaced by the stricter 5.9 compiler are fixed as part of the upgrade:

- A always-truthy `|| 'component'` pattern in a ternary expression (`TS2872`) in the content-manager list view.
- A recursive `async` function missing an explicit return type annotation (`TS7024`) in the admin permissions-manager sanitize service. The existing `@ts-expect-error` TODO comment for that function is also resolved.

### Why is it needed?

TypeScript 5.4.5 cannot parse the `@tsconfig/node24` preset (requires `es2024` target and granular `ESNext.*` lib entries added in later TS versions). Reaching the latest 5.x release unblocks fully adopting `@tsconfig/node24` and other Node 24 / modernization work ([CMS-1286](https://linear.app/strapi/issue/CMS-1286)).

### How to test it?

```bash
yarn test:ts    # all back + front type checks
yarn build # full build
```

### Related issue(s)/PR(s)

- Closes CMS-1286 — Upgrade monorepo TypeScript to latest 5.x (this PR)
- Part of CMS-656 — Drop Node 20 support and move CI to Node 24 ([#26631](https://github.com/strapi/strapi/pull/26631))
- Unblocks CMS-1284 — shared tsconfig Node 24 alignment ([#26781](https://github.com/strapi/strapi/pull/26781))