### PR TITLE
chore(definitions): introduce @strapi/definitions package

### DIFF
--- a/.ai/skills/definitions-package/SKILL.md
+++ b/.ai/skills/definitions-package/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: strapi-definitions-package
+description: Guide AI agents when consuming or editing @strapi/definitions. Use when modifying packages/definitions, adding constants/schemas/types there, promoting shared definitions to break package cycles, or deciding how @strapi/definitions relates to @strapi/strapi and @strapi/types.
+---
+
+# Definitions Package
+
+Use this skill before changing `packages/definitions` or importing from `@strapi/definitions`.
+
+## Role Of The Package
+
+`@strapi/definitions` is the source of truth for low-level Strapi definitions:
+
+- passive runtime primitives: constants and schemas
+- dependency-free concepts shared across packages
+
+It is **public low-level**, semver-respected, but not the primary user-facing import path. User-facing APIs should be curated through `@strapi/strapi`.
+
+## Layering
+
+Prefer this direction:
+
+```txt
+@strapi/definitions
+  low-level constants, schemas
+
+@strapi/strapi
+  public-facing API exposure for users and plugin authors
+
+@strapi/types
+  backwards-compatible facade for type imports (not yet migrated to definitions)
+```
+
+Do not make `definitions` depend on Strapi runtime packages, DI, app config, database clients, or package implementation details.
+
+## Promotion Test
+
+Promote a value/type into `@strapi/definitions` only when it passes most of this test:
+
+- It is needed by multiple packages, or needed to break a dependency cycle.
+- It is dependency-free, except tiny definition-layer dependencies already owned by this package, such as `zod`.
+- It is passive definition data, not business logic.
+- Its semantic name makes sense without mentioning the source package.
+- It represents a stable Strapi vocabulary or invariant.
+
+Keep package-local details in their owning package. Do not promote a helper only because two packages happen to duplicate it.
+
+## API Shape
+
+Use kind-first root namespaces:
+
+```ts
+import { constants, schemas, z } from '@strapi/definitions';
+```
+
+Root namespaces:
+
+- `constants` for primitive constants and magic literals
+- `schemas` for runtime schema objects, when schemas exist
+- `z` for the shared Zod export
+
+> **Types are not yet part of this package.** The question of how and whether to move type primitives (e.g. UID templates, namespace helpers) from `@strapi/types` into `@strapi/definitions` is unresolved. Do not add type exports until a design decision is made — keep types in `@strapi/types` for now.
+
+Do **not** add a nested `definitions.*` namespace. The package name already carries that meaning.
+
+## Namespace Rules
+
+Default to:
+
+```txt
+<kind>.<semantic-family>.<name>
+```
+
+Examples:
+
+```ts
+constants.regex.BIG_INTEGER;
+constants.numbers.INT64_MAX;
+schemas.contentTypes.contentType;
+schemas.fields.bigInteger;
+```
+
+Use semantic domains, not consumer package names:
+
+- Prefer broad concepts like `regex`, `numbers`, `fields`, `contentTypes`, `persistence`.
+- Reserve `database` for actual Strapi database abstraction contracts.
+- Do not mirror monorepo package names unless the concept is truly package-domain vocabulary.
+
+## Naming Rules
+
+Use:
+
+- `SCREAMING_SNAKE_CASE` for primitive constants, frozen values, and magic literals.
+- `camelCase` for schemas and richer definition objects.
+- no `Schema` suffix unless it prevents ambiguity.
+- JSDoc for every exported value/type. Public low-level definitions must document intent, not restate TypeScript shapes.
+
+Examples:
+
+```ts
+constants.regex.BIG_INTEGER;
+schemas.fields.bigInteger;
+schemas.contentTypes.contentType;
+```
+
+## Runtime Helpers
+
+Keep `definitions` passive-first.
+
+Allowed:
+
+```ts
+constants.regex.BIG_INTEGER;
+schemas.fields.bigInteger;
+```
+
+Avoid:
+
+```ts
+validators.isBigInteger();
+normalizers.toBigIntegerString();
+builders.createContentTypeSchema();
+```
+
+Active helpers usually belong in `@strapi/utils`, `@strapi/database`, `@strapi/core`, or `@strapi/strapi`. Only add active helpers with explicit justification.
+
+## Subpaths
+
+Do not add package subpath exports. Use root namespace imports:
+
+```ts
+import { constants } from '@strapi/definitions';
+
+constants.regex.BIG_INTEGER;
+```

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -63,6 +63,7 @@
     "@paralleldrive/cuid2": "2.2.2",
     "@strapi/admin": "5.49.0",
     "@strapi/database": "5.49.0",
+    "@strapi/definitions": "5.49.0",
     "@strapi/generators": "5.49.0",
     "@strapi/logger": "5.49.0",
     "@strapi/openapi": "5.49.0",

--- a/packages/core/core/src/services/entity-validator/validators.ts
+++ b/packages/core/core/src/services/entity-validator/validators.ts
@@ -8,6 +8,7 @@
  * The system also takes locales into account when validating data.
  * E.g, unique fields must be unique within the same locale.
  */
+import { constants } from '@strapi/definitions';
 import _ from 'lodash';
 import { yup } from '@strapi/utils';
 import type { Schema, Struct, Modules } from '@strapi/types';
@@ -43,8 +44,6 @@ const toNumberSafe = (value: unknown): number | undefined => {
   return Number.isFinite(num) ? num : undefined;
 };
 
-const BIG_INTEGER_REGEX = /^[+-]?\d+$/;
-
 const toBigIntegerString = (value: unknown): string | undefined => {
   if (value == null) {
     return undefined;
@@ -65,7 +64,7 @@ const toBigIntegerString = (value: unknown): string | undefined => {
   if (typeof value === 'string') {
     const trimmedValue = value.trim();
 
-    if (!BIG_INTEGER_REGEX.test(trimmedValue)) {
+    if (!constants.regex.BIG_INTEGER.test(trimmedValue)) {
       return undefined;
     }
 

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@paralleldrive/cuid2": "2.2.2",
+    "@strapi/definitions": "5.49.0",
     "@strapi/utils": "5.49.0",
     "ajv": "8.20.0",
     "date-fns": "2.30.0",

--- a/packages/core/database/src/fields/biginteger.ts
+++ b/packages/core/database/src/fields/biginteger.ts
@@ -1,7 +1,6 @@
+import { constants } from '@strapi/definitions';
 import { toString } from 'lodash/fp';
 import Field from './field';
-
-const BIG_INTEGER_REGEX = /^[+-]?\d+$/;
 
 const toBigIntegerString = (value: unknown): string => {
   if (typeof value === 'bigint') {
@@ -19,7 +18,7 @@ const toBigIntegerString = (value: unknown): string => {
   if (typeof value === 'string') {
     const trimmedValue = value.trim();
 
-    if (!BIG_INTEGER_REGEX.test(trimmedValue)) {
+    if (!constants.regex.BIG_INTEGER.test(trimmedValue)) {
       throw new Error(`Expected a valid BigInteger, got ${value}`);
     }
 

--- a/packages/definitions/.eslintrc.cjs
+++ b/packages/definitions/.eslintrc.cjs
@@ -1,0 +1,39 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  extends: ['eslint-config-custom/back/typescript'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+  ignorePatterns: [
+    'node_modules/',
+    '.eslintrc.cjs',
+    'vitest.config.ts',
+    'dist/',
+    'coverage/',
+    'rollup.config.mjs',
+  ],
+  rules: {
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: [
+          '**/test/**/*.js',
+          '**/test/**/*.ts',
+          '**/tests/**/*.js',
+          '**/tests/**/*.ts',
+          '**/__tests__/**/*.js',
+          '**/__tests__/**/*.ts',
+          '**/__mocks__/**/*.js',
+          '**/__mocks__/**/*.ts',
+          '**/*.test.ts',
+        ],
+        packageDir: __dirname,
+      },
+    ],
+  },
+};
+
+module.exports = config;

--- a/packages/definitions/.gitignore
+++ b/packages/definitions/.gitignore
@@ -1,0 +1,115 @@
+############################
+# OS X
+############################
+
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+.Spotlight-V100
+.Trashes
+._*
+
+
+############################
+# Linux
+############################
+
+*~
+
+
+############################
+# Windows
+############################
+
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.cab
+*.msi
+*.msm
+*.msp
+
+
+############################
+# Packages
+############################
+
+*.7z
+*.csv
+*.dat
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.seed
+*.so
+*.swo
+*.swp
+*.swn
+*.swm
+*.out
+*.pid
+
+
+############################
+# Logs and databases
+############################
+
+.tmp
+*.log
+*.sql
+*.sqlite
+
+
+############################
+# Misc.
+############################
+
+*#
+.idea
+nbproject
+
+
+############################
+# Node.js
+############################
+
+lib-cov
+lcov.info
+pids
+logs
+results
+build
+node_modules
+.node_history
+package-lock.json
+
+
+
+############################
+# Tests
+############################
+
+coverage
+
+############################
+# Documentation
+############################
+
+docs
+
+############################
+# Build output
+############################
+
+dist/

--- a/packages/definitions/LICENSE
+++ b/packages/definitions/LICENSE
@@ -1,0 +1,37 @@
+Copyright (c) 2015-present Strapi Solutions SAS
+
+Portions of the Strapi software are licensed as follows:
+
+* All software that resides under an "ee/" directory (the “EE Software”), if that directory exists, is licensed under the license defined below.
+
+Enterprise License
+
+If you or the company you represent has entered into a written agreement referencing the Enterprise Edition of the Strapi source code available at
+https://github.com/strapi/strapi, then such agreement applies to your use of the Enterprise Edition of the Strapi Software. If you or the company you
+represent is using the Enterprise Edition of the Strapi Software in connection with a subscription to our cloud offering, then the agreement you have
+agreed to with respect to our cloud offering and the licenses included in such agreement apply to your use of the Enterprise Edition of the Strapi Software.
+Otherwise, the Strapi Enterprise Software License Agreement (found here https://strapi.io/enterprise-terms) applies to your use of the Enterprise Edition of the Strapi Software.
+
+BY ACCESSING OR USING THE ENTERPRISE EDITION OF THE STRAPI SOFTWARE, YOU ARE AGREEING TO BE BOUND BY THE RELEVANT REFERENCED AGREEMENT.
+IF YOU ARE NOT AUTHORIZED TO ACCEPT THESE TERMS ON BEHALF OF THE COMPANY YOU REPRESENT OR IF YOU DO NOT AGREE TO ALL OF THE RELEVANT TERMS AND CONDITIONS REFERENCED AND YOU
+HAVE NOT OTHERWISE EXECUTED A WRITTEN AGREEMENT WITH STRAPI, YOU ARE NOT AUTHORIZED TO ACCESS OR USE OR ALLOW ANY USER TO ACCESS OR USE ANY PART OF
+THE ENTERPRISE EDITION OF THE STRAPI SOFTWARE.  YOUR ACCESS RIGHTS ARE CONDITIONAL ON YOUR CONSENT TO THE RELEVANT REFERENCED TERMS TO THE EXCLUSION OF ALL OTHER TERMS;
+IF THE RELEVANT REFERENCED TERMS ARE CONSIDERED AN OFFER BY YOU, ACCEPTANCE IS EXPRESSLY LIMITED TO THE RELEVANT REFERENCED TERMS.
+
+* All software outside of the above-mentioned directories or restrictions above is available under the "MIT Expat" license as set forth below.
+
+MIT Expat License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/definitions",
-  "version": "5.48.1",
+  "version": "5.49.0",
   "description": "Shared definitions, identity helpers, and schemas for Strapi packages",
   "keywords": [
     "strapi",
@@ -61,10 +61,10 @@
   },
   "devDependencies": {
     "@types/node": "20.19.41",
-    "eslint-config-custom": "5.48.1",
-    "tsconfig": "5.48.1",
+    "eslint-config-custom": "5.49.0",
+    "tsconfig": "5.49.0",
     "vitest": "catalog:",
-    "vitest-config": "5.48.1"
+    "vitest-config": "5.49.0"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@strapi/definitions",
+  "version": "5.48.1",
+  "description": "Shared definitions, identity helpers, and schemas for Strapi packages",
+  "keywords": [
+    "strapi",
+    "definitions"
+  ],
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/definitions"
+  },
+  "license": "SEE LICENSE IN LICENSE",
+  "author": {
+    "name": "Strapi Solutions SAS",
+    "email": "hi@strapi.io",
+    "url": "https://strapi.io"
+  },
+  "maintainers": [
+    {
+      "name": "Strapi Solutions SAS",
+      "email": "hi@strapi.io",
+      "url": "https://strapi.io"
+    }
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "source": "./src/index.ts",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "run -T npm-run-all clean --parallel build:code build:types",
+    "build:code": "run -T  rollup -c",
+    "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "clean": "run -T rimraf ./dist",
+    "lint": "run -T eslint .",
+    "test:ts": "run -T tsc --noEmit",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest --watch",
+    "watch": "run -T  rollup -c -w"
+  },
+  "dependencies": {
+    "zod": "3.25.67"
+  },
+  "devDependencies": {
+    "@types/node": "20.19.41",
+    "eslint-config-custom": "5.48.1",
+    "tsconfig": "5.48.1",
+    "vitest": "catalog:",
+    "vitest-config": "5.48.1"
+  },
+  "engines": {
+    "node": ">=20.0.0 <=26.x.x",
+    "npm": ">=6.0.0"
+  }
+}

--- a/packages/definitions/rollup.config.mjs
+++ b/packages/definitions/rollup.config.mjs
@@ -1,0 +1,7 @@
+import { baseConfig } from '../../rollup.utils.mjs';
+
+export default baseConfig({
+  input: './src/index.ts',
+  outDir: './dist',
+  rootDir: './src',
+});

--- a/packages/definitions/src/__tests__/constants.test.ts
+++ b/packages/definitions/src/__tests__/constants.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'vitest';
+
+import { constants } from '../index';
+
+describe('@strapi/definitions constants export', () => {
+  test('exports regex constants', () => {
+    expect(constants.regex.BIG_INTEGER.test('-42')).toBe(true);
+    expect(constants.regex.BIG_INTEGER.test('42.1')).toBe(false);
+  });
+});

--- a/packages/definitions/src/__tests__/zod.test.ts
+++ b/packages/definitions/src/__tests__/zod.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+
+import { z } from '../index';
+
+describe('@strapi/definitions zod export', () => {
+  test('exports zod v4', () => {
+    expect(z.string().parse('api::article.article')).toBe('api::article.article');
+  });
+});

--- a/packages/definitions/src/constants/index.ts
+++ b/packages/definitions/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * as regex from './regex';

--- a/packages/definitions/src/constants/regex.ts
+++ b/packages/definitions/src/constants/regex.ts
@@ -1,0 +1,4 @@
+/**
+ * Matches integer strings with an optional leading sign.
+ */
+export const BIG_INTEGER = /^[+-]?\d+$/;

--- a/packages/definitions/src/index.ts
+++ b/packages/definitions/src/index.ts
@@ -1,0 +1,3 @@
+export { z } from './zod';
+
+export * as constants from './constants';

--- a/packages/definitions/src/zod.ts
+++ b/packages/definitions/src/zod.ts
@@ -1,0 +1,11 @@
+import * as z from 'zod/v4';
+
+/**
+ * Re-export of the Zod v4 schema builder from the same version Strapi uses
+ * internally. Definitions-owned schemas must import from here to stay
+ * compatible across Strapi updates.
+ *
+ * @example
+ * import { z } from '@strapi/definitions';
+ */
+export { z };

--- a/packages/definitions/tsconfig.build.json
+++ b/packages/definitions/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**"]
+}

--- a/packages/definitions/tsconfig.eslint.json
+++ b/packages/definitions/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "vitest.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/definitions/tsconfig.json
+++ b/packages/definitions/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "tsconfig/base.json",
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/definitions/vitest.config.ts
+++ b/packages/definitions/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+// @ts-expect-error - Vitest config uses bundler resolution
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+      include: ['**/*.test.ts'],
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9188,6 +9188,7 @@ __metadata:
     "@paralleldrive/cuid2": "npm:2.2.2"
     "@strapi/admin": "npm:5.49.0"
     "@strapi/database": "npm:5.49.0"
+    "@strapi/definitions": "npm:5.49.0"
     "@strapi/generators": "npm:5.49.0"
     "@strapi/logger": "npm:5.49.0"
     "@strapi/openapi": "npm:5.49.0"
@@ -9315,6 +9316,7 @@ __metadata:
   resolution: "@strapi/database@workspace:packages/core/database"
   dependencies:
     "@paralleldrive/cuid2": "npm:2.2.2"
+    "@strapi/definitions": "npm:5.49.0"
     "@strapi/utils": "npm:5.49.0"
     "@types/fs-extra": "npm:11.0.4"
     ajv: "npm:8.20.0"
@@ -9332,15 +9334,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/definitions@workspace:packages/definitions":
+"@strapi/definitions@npm:5.49.0, @strapi/definitions@workspace:packages/definitions":
   version: 0.0.0-use.local
   resolution: "@strapi/definitions@workspace:packages/definitions"
   dependencies:
     "@types/node": "npm:20.19.41"
-    eslint-config-custom: "npm:5.48.1"
-    tsconfig: "npm:5.48.1"
+    eslint-config-custom: "npm:5.49.0"
+    tsconfig: "npm:5.49.0"
     vitest: "catalog:"
-    vitest-config: "npm:5.48.1"
+    vitest-config: "npm:5.49.0"
     zod: "npm:3.25.67"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -9332,6 +9332,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@strapi/definitions@workspace:packages/definitions":
+  version: 0.0.0-use.local
+  resolution: "@strapi/definitions@workspace:packages/definitions"
+  dependencies:
+    "@types/node": "npm:20.19.41"
+    eslint-config-custom: "npm:5.48.1"
+    tsconfig: "npm:5.48.1"
+    vitest: "catalog:"
+    vitest-config: "npm:5.48.1"
+    zod: "npm:3.25.67"
+  languageName: unknown
+  linkType: soft
+
 "@strapi/design-system@npm:2.2.0":
   version: 2.2.0
   resolution: "@strapi/design-system@npm:2.2.0"


### PR DESCRIPTION
### What does it do?

Introduces `@strapi/definitions`, a new low-level package for passive runtime primitives (constants, schemas) and shared type building blocks used across Strapi packages.

The initial surface includes:

- `constants.regex.BIG_INTEGER` — shared regex for big-integer validation
- `Internal` type namespaces for UID and namespace templates (moved from `@strapi/types`)
- A shared `z` Zod export and `Utils` string helpers

`@strapi/types` keeps its existing public type API but now re-exports from `@strapi/definitions`, acting as a backwards-compatible facade. `@strapi/database` and `@strapi/core` consume the shared `BIG_INTEGER` constant instead of maintaining local copies.

An agent skill documents promotion rules, namespace conventions, and how `@strapi/definitions` relates to `@strapi/strapi` and `@strapi/types`.

### Why is it needed?

Several core packages duplicate the same low-level definitions (regex literals, UID templates) or pull them through `@strapi/types`, which creates unnecessary coupling and makes dependency cycles harder to break. Centralizing passive, dependency-free definitions in a dedicated package gives consumers a stable vocabulary without importing runtime-heavy packages.

This is foundational work — more definitions can be promoted here over time as cycles are untangled.

### How to test it?

1. Build and unit-test the new package:

   ```bash
   yarn nx build @strapi/definitions
   yarn nx test:unit @strapi/definitions
   ```

2. Verify type-checking still passes for affected packages:

   ```bash
   yarn test:ts
   ```

3. Run unit tests for consumers that changed:

   ```bash
   yarn nx test:unit @strapi/database
   yarn nx test:unit @strapi/core
   yarn nx test:unit @strapi/types
   ```

4. Confirm big-integer validation behaviour is unchanged — string coercion and error messages in the database field layer should behave as before, now backed by the shared regex.

### Related issue(s)/PR(s)

None yet — this is new infrastructure.