### PR TITLE
chore(ts): enable erasableSyntaxOnly and noUncheckedSideEffectImports

### DIFF
--- a/packages/core/admin/admin/src/hooks/tests/useElementOnScreen.test.tsx
+++ b/packages/core/admin/admin/src/hooks/tests/useElementOnScreen.test.tsx
@@ -13,7 +13,11 @@ class MockIntersectionObserver {
   disconnect = disconnectMock;
   unobserve = jest.fn();
   takeRecords = jest.fn();
-  constructor(public callback: IntersectionObserverCallback) {}
+  callback: IntersectionObserverCallback;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
 }
 
 Object.defineProperty(global, 'IntersectionObserver', {

--- a/packages/core/core/src/services/session-manager.ts
+++ b/packages/core/core/src/services/session-manager.ts
@@ -122,10 +122,14 @@ export interface SessionManagerConfig {
 }
 
 class OriginSessionManager {
-  constructor(
-    private sessionManager: SessionManager,
-    private origin: string
-  ) {}
+  private sessionManager: SessionManager;
+
+  private origin: string;
+
+  constructor(sessionManager: SessionManager, origin: string) {
+    this.sessionManager = sessionManager;
+    this.origin = origin;
+  }
 
   async generateRefreshToken(
     userId: string,

--- a/packages/core/data-transfer/src/types/remote/protocol/server/error.ts
+++ b/packages/core/data-transfer/src/types/remote/protocol/server/error.ts
@@ -1,18 +1,26 @@
-export enum ErrorKind {
+export const ErrorKind = {
   // Generic
-  Unknown = 0,
+  Unknown: 0,
   // Chunk transfer
-  DiscardChunk = 1,
-  InvalidChunkFormat = 2,
-}
+  DiscardChunk: 1,
+  InvalidChunkFormat: 2,
+} as const satisfies Record<string, ErrorKind>;
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type ErrorKind = 0 | 1 | 2;
 
 export class ServerError extends Error {
-  constructor(
-    public code: ErrorKind,
-    public message: string,
-    public details?: Record<string, unknown> | null
-  ) {
+  public code: ErrorKind;
+
+  public message: string;
+
+  public details?: Record<string, unknown> | null;
+
+  constructor(code: ErrorKind, message: string, details?: Record<string, unknown> | null) {
     super(message);
+    this.code = code;
+    this.message = message;
+    this.details = details;
   }
 }
 

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/tests/AssigneeSelect.test.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/tests/AssigneeSelect.test.tsx
@@ -84,7 +84,11 @@ describe('AssigneeSelect', () => {
       readonly scrollMargin = '';
       readonly thresholds = [];
 
-      constructor(private callback: IntersectionObserverCallback) {}
+      private callback: IntersectionObserverCallback;
+
+      constructor(callback: IntersectionObserverCallback) {
+        this.callback = callback;
+      }
 
       disconnect = jest.fn();
       takeRecords = jest.fn(() => []);

--- a/packages/core/upload/admin/src/constants.ts
+++ b/packages/core/upload/admin/src/constants.ts
@@ -1,9 +1,11 @@
 import { getTrad } from './utils';
 
-export enum AssetSource {
-  Url = 'url',
-  Computer = 'computer',
-}
+export const AssetSource = {
+  Url: 'url',
+  Computer: 'computer',
+} as const satisfies Record<Capitalize<AssetSource>, AssetSource>;
+
+export type AssetSource = 'url' | 'computer';
 
 export const PERMISSIONS = {
   // This permission regards the main component (App) and is used to tell

--- a/packages/core/upload/admin/src/enums.ts
+++ b/packages/core/upload/admin/src/enums.ts
@@ -1,13 +1,17 @@
-export enum DocType {
-  Pdf = 'pdf',
-  Csv = 'csv',
-  Xls = 'xls',
-  Zip = 'zip',
-}
+export const DocType = {
+  Pdf: 'pdf',
+  Csv: 'csv',
+  Xls: 'xls',
+  Zip: 'zip',
+} as const satisfies Record<Capitalize<DocType>, DocType>;
 
-export enum AssetType {
-  Video = 'video',
-  Image = 'image',
-  Document = 'doc',
-  Audio = 'audio',
-}
+export type DocType = 'pdf' | 'csv' | 'xls' | 'zip';
+
+export const AssetType = {
+  Video: 'video',
+  Image: 'image',
+  Document: 'doc',
+  Audio: 'audio',
+} as const satisfies Record<string, AssetType>;
+
+export type AssetType = 'video' | 'image' | 'doc' | 'audio';

--- a/packages/core/upload/admin/src/future/enums.ts
+++ b/packages/core/upload/admin/src/future/enums.ts
@@ -1,6 +1,8 @@
-export enum AssetType {
-  Video = 'video',
-  Image = 'image',
-  Document = 'doc',
-  Audio = 'audio',
-}
+export const AssetType = {
+  Video: 'video',
+  Image: 'image',
+  Document: 'doc',
+  Audio: 'audio',
+} as const satisfies Record<string, AssetType>;
+
+export type AssetType = 'video' | 'image' | 'doc' | 'audio';

--- a/packages/utils/tsconfig/base.json
+++ b/packages/utils/tsconfig/base.json
@@ -11,6 +11,8 @@
     "noImplicitAny": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUncheckedSideEffectImports": true,
+    "erasableSyntaxOnly": true
   }
 }

--- a/packages/utils/tsconfig/client.json
+++ b/packages/utils/tsconfig/client.json
@@ -17,6 +17,8 @@
     "noImplicitAny": true,
     "declaration": true,
     "jsx": "react-jsx",
-    "types": ["@testing-library/jest-dom"]
+    "types": ["@testing-library/jest-dom"],
+    "noUncheckedSideEffectImports": true,
+    "erasableSyntaxOnly": true
   }
 }

--- a/packages/utils/upgrade/src/modules/version/types.ts
+++ b/packages/utils/upgrade/src/modules/version/types.ts
@@ -9,11 +9,14 @@ export type LiteralSemVer = `${Version}.${Version}.${Version}`;
 
 export type { SemVer, Range } from 'semver';
 
-export enum ReleaseType {
+export const ReleaseType = {
   // Classic
-  Major = 'major',
-  Minor = 'minor',
-  Patch = 'patch',
+  Major: 'major',
+  Minor: 'minor',
+  Patch: 'patch',
   // Other
-  Latest = 'latest',
-}
+  Latest: 'latest',
+} as const satisfies Record<Capitalize<ReleaseType>, ReleaseType>;
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type ReleaseType = 'major' | 'minor' | 'patch' | 'latest';


### PR DESCRIPTION
### What does it do?

Enables two TypeScript compiler flags in the shared tsconfig presets (`packages/utils/tsconfig/base.json` and `client.json`) and migrates the existing violations so the whole monorepo type-checks cleanly:

- **`noUncheckedSideEffectImports`** ([TS 5.6](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#the---nouncheckedsideeffectimports-option)) — errors on side-effect-only imports (`import "./x"`) whose specifier resolves to nothing. Previously the compiler silently ignored unresolved side-effect imports, so typo'd or dead module paths went undetected.
- **`erasableSyntaxOnly`** ([TS 5.8](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/#the---erasablesyntaxonly-option)) — forbids TS-only runtime constructs that can't be removed by pure type-stripping: `enum`, constructor parameter properties, namespaces containing runtime values, and `import =`. Keeps the codebase compatible with Node's native type stripping (`--experimental-strip-types`) and other erase-only transpilers (esbuild/swc/Babel `isolatedModules`-style).

Migrations required to pass both flags repo-wide:

- `enum` → `as const` object + same-named union type:
  - `upload` `AssetSource`, `DocType`, `AssetType` (incl. `future/`)
  - `data-transfer` `ErrorKind`
  - `upgrade` `ReleaseType`
- constructor parameter properties → explicit field declarations + assignment:
  - `data-transfer` `ServerError`
  - `core` `session-manager`
  - `IntersectionObserver` mocks in `admin` and `review-workflows` tests

### Why is it needed?

We're at the very start of the TypeScript 5.x upgrade, which is the cheapest possible moment to tighten compiler settings:

- **Smallest blast radius now.** The number of violations only grows over time. Enabling the flags today means migrating a handful of files instead of hundreds later. The full migration here is ~10 files.
- **Prevents regressions for free.** Once enabled, CI rejects any new `enum` / parameter property / unresolved side-effect import, so the codebase can't drift back. Retrofitting later is a one-off cost *plus* whatever accumulated in the meantime.
- **Forward-compatibility.** `erasableSyntaxOnly` aligns the source with type-stripping runtimes (Node ≥22 native strip, Bun, ts-blank-space). `noUncheckedSideEffectImports` is a pure correctness win — it can only catch real bugs (broken import paths), never reject valid code.

If `erasableSyntaxOnly` is considered too opinionated to adopt right now, `noUncheckedSideEffectImports` stands on its own and should be enabled regardless — it has no stylistic trade-off, only catches mistakes.

#### On dropping `enum`

`erasableSyntaxOnly` forces the move away from TS `enum`, which is widely regarded as a misfeature — it emits runtime code (unlike the rest of the type system), has surprising semantics (numeric enums are bidirectional and not type-safe, `const enum` breaks under isolated modules), and an `as const` object + union type is a strictly simpler, fully-erasable replacement. Further reading:

- [TS Handbook — Objects vs Enums](https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums) (the docs themselves recommend `as const` objects)
- [Total TypeScript — Why I don't like TypeScript enums](https://www.totaltypescript.com/why-i-dont-like-typescript-enums)
- [LogRocket — Why TypeScript enums suck](https://blog.logrocket.com/why-typescript-enums-suck/)
- [Nine terrible ways to use TypeScript enums (and one good way)](https://bluepnume.medium.com/nine-terrible-ways-to-use-typescript-enums-and-one-good-way-f9c7ec68bf15)
- [youdontneedtsenums.com](https://www.youdontneedtsenums.com/)

This can land as a **follow-up PR** to the TypeScript 5.9.3 upgrade (#26782) — it targets that branch so it can be reviewed/merged together with or right after the upgrade, while the migration surface is still minimal.

### How to test it?

```bash
yarn test:ts   # passes across the monorepo with both flags enabled
```

### Related issue(s)/PR(s)

Follow-up to #26782 (chore(deps): upgrade TypeScript to 5.9.3). Targets that PR's branch.
