### PR TITLE
fix(graphql): preserve M2M relation order with pagination (#26577)

### DIFF
--- a/packages/core/database/src/query/helpers/populate/apply.ts
+++ b/packages/core/database/src/query/helpers/populate/apply.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp';
+import { hasSort } from '@strapi/utils';
 
 import { fromRow } from '../transform';
 import type { QueryBuilder } from '../../query-builder';
@@ -20,7 +21,9 @@ const getJoinTableOrderBy = (
   populateValue: Record<string, unknown>,
   joinTable: { orderBy?: Record<string, 'asc' | 'desc'> }
 ) => {
-  if (!_.isEmpty(populateValue.orderBy) || !joinTable.orderBy) {
+  const explicitSort = populateValue.orderBy ?? populateValue.sort;
+
+  if (hasSort(explicitSort) || !joinTable.orderBy) {
     return undefined;
   }
 

--- a/packages/core/utils/src/__tests__/sanitize-query.test.ts
+++ b/packages/core/utils/src/__tests__/sanitize-query.test.ts
@@ -112,4 +112,26 @@ describe('sanitizeQuery', () => {
     });
     expect((result as any).filters.title).not.toHaveProperty('__invalidNestedFilterKey');
   });
+
+  describe('sort', () => {
+    it.each([
+      ['empty array (GraphQL default)', []],
+      ['empty string', ''],
+      ['comma-only string', ','],
+      ['empty object', {}],
+      ['array of empty strings', ['']],
+      ['array with null (qs sort[])', [null]],
+    ])('removes meaningless sort: %s', async (_label, sort) => {
+      const result = await sanitizers.query({ sort, filters: { id: 1 } }, schema);
+
+      expect(result).not.toHaveProperty('sort');
+      expect(result).toHaveProperty('filters');
+    });
+
+    it('keeps meaningful sort', async () => {
+      const result = await sanitizers.query({ sort: 'title:asc', filters: { id: 1 } }, schema);
+
+      expect(result).toHaveProperty('sort', 'title:asc');
+    });
+  });
 });

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -41,3 +41,4 @@ export * from './content-api-router';
 export * from './security';
 export * from './publication-filter';
 export * from './has-published-version-param';
+export { hasSort } from './sort-query';

--- a/packages/core/utils/src/sanitize/index.ts
+++ b/packages/core/utils/src/sanitize/index.ts
@@ -18,6 +18,7 @@ import traverseEntity from '../traverse-entity';
 import { traverseQueryFilters, traverseQuerySort, traverseQueryPopulate } from '../traverse';
 import type { Model, Data } from '../types';
 import { validatePublicationFilterQueryParam } from '../publication-filter';
+import { hasSort } from '../sort-query';
 
 export interface Options {
   auth?: unknown;
@@ -198,8 +199,10 @@ const createAPISanitizers = (opts: APIOptions) => {
       Object.assign(sanitizedQuery, { filters: await sanitizeFilters(filters, schema, { auth }) });
     }
 
-    if (sort) {
+    if (hasSort(sort)) {
       Object.assign(sanitizedQuery, { sort: await sanitizeSort(sort, schema, { auth }) });
+    } else if ('sort' in sanitizedQuery) {
+      delete sanitizedQuery.sort;
     }
 
     if (fields) {

--- a/packages/plugins/graphql/server/src/services/builders/utils.ts
+++ b/packages/plugins/graphql/server/src/services/builders/utils.ts
@@ -1,6 +1,6 @@
 import { entries, mapValues, omit } from 'lodash/fp';
 import { idArg, nonNull } from 'nexus';
-import { pagination } from '@strapi/utils';
+import { hasSort, pagination } from '@strapi/utils';
 import type { Core, Struct } from '@strapi/types';
 
 const { withDefaultPagination } = pagination;
@@ -157,6 +157,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         Object.assign(newArgs, {
           filters: mappers.graphQLFiltersToStrapiQuery(filters, contentType),
         });
+      }
+
+      // GraphQL SortArg defaults to `[]`; omit meaningless sort so join-table UI order is preserved.
+      if (!hasSort(newArgs.sort)) {
+        delete newArgs.sort;
       }
 
       return newArgs;

--- a/tests/api/plugins/graphql/collection-relation-order.test.api.js
+++ b/tests/api/plugins/graphql/collection-relation-order.test.api.js
@@ -2,6 +2,9 @@
 
 /**
  * GraphQL collection-type manyToMany relation order with pagination (issue #26577).
+ *
+ * GraphQL SortArg defaults to `[]`; meaningless sort must not override join-table connect order.
+ * Explicit meaningful sort must still win (no breaking change).
  */
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
@@ -24,7 +27,7 @@ const categoryModel = {
       type: 'relation',
       relation: 'manyToMany',
       target: 'api::article.article',
-      mappedBy: 'categories',
+      targetAttribute: 'categories',
     },
   },
 };
@@ -35,24 +38,21 @@ const articleModel = {
   singularName: 'article',
   pluralName: 'articles',
   displayName: 'Article',
-  draftAndPublish: true,
   attributes: {
     title: { type: 'string' },
-    categories: {
-      type: 'relation',
-      relation: 'manyToMany',
-      target: 'api::category.category',
-      inversedBy: 'articles',
-    },
   },
 };
+
+const CONNECT_ORDER = ['Gamma', 'Alpha', 'Beta'];
+
+const categoryNamesFromList = (items) => items.map((item) => item.name ?? item.attributes?.name);
 
 describe('GraphQL collection relation order (issue #26577)', () => {
   let articleDocumentId;
   const categoryIds = [];
 
   beforeAll(async () => {
-    await builder.addContentTypes([categoryModel, articleModel]).build();
+    await builder.addContentTypes([articleModel, categoryModel]).build();
 
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
@@ -87,6 +87,32 @@ describe('GraphQL collection relation order (issue #26577)', () => {
     await builder.cleanup();
   });
 
+  test('returns manyToMany relations in connect order without pagination', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          article(documentId: $documentId) {
+            data {
+              attributes {
+                categories {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: articleDocumentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const categories = res.body.data.article.data.attributes.categories;
+
+    expect(categoryNamesFromList(categories)).toEqual(CONNECT_ORDER);
+  });
+
   test('returns manyToMany relations in connect order with pagination', async () => {
     const res = await graphqlQuery({
       query: /* GraphQL */ `
@@ -109,9 +135,34 @@ describe('GraphQL collection relation order (issue #26577)', () => {
     expect(res.body.errors).toBeUndefined();
 
     const categories = res.body.data.article.data.attributes.categories;
-    const names = categories.map((item) => item.name ?? item.attributes?.name);
 
-    expect(names).toEqual(['Gamma', 'Alpha', 'Beta']);
+    expect(categoryNamesFromList(categories)).toEqual(CONNECT_ORDER);
+  });
+
+  test('returns manyToMany relations in connect order when sort is explicitly empty with pagination', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          article(documentId: $documentId) {
+            data {
+              attributes {
+                categories(sort: [], pagination: { page: 1, pageSize: 10 }) {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: articleDocumentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const categories = res.body.data.article.data.attributes.categories;
+
+    expect(categoryNamesFromList(categories)).toEqual(CONNECT_ORDER);
   });
 
   test('returns manyToMany relations in connect order via _connection with pagination', async () => {
@@ -138,8 +189,107 @@ describe('GraphQL collection relation order (issue #26577)', () => {
     expect(res.body.errors).toBeUndefined();
 
     const nodes = res.body.data.article.data.attributes.categories_connection.nodes;
-    const names = nodes.map((item) => item.name ?? item.attributes?.name);
 
-    expect(names).toEqual(['Gamma', 'Alpha', 'Beta']);
+    expect(categoryNamesFromList(nodes)).toEqual(CONNECT_ORDER);
+  });
+
+  test('paginates manyToMany relations in connect order across pages', async () => {
+    const page1 = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          article(documentId: $documentId) {
+            data {
+              attributes {
+                categories(pagination: { page: 1, pageSize: 2 }) {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: articleDocumentId },
+    });
+
+    const page2 = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          article(documentId: $documentId) {
+            data {
+              attributes {
+                categories(pagination: { page: 2, pageSize: 2 }) {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: articleDocumentId },
+    });
+
+    expect(page1.statusCode).toBe(200);
+    expect(page1.body.errors).toBeUndefined();
+    expect(page2.statusCode).toBe(200);
+    expect(page2.body.errors).toBeUndefined();
+
+    const page1Names = categoryNamesFromList(page1.body.data.article.data.attributes.categories);
+    const page2Names = categoryNamesFromList(page2.body.data.article.data.attributes.categories);
+
+    expect(page1Names).toEqual(['Gamma', 'Alpha']);
+    expect(page2Names).toEqual(['Beta']);
+    expect([...page1Names, ...page2Names]).toEqual(CONNECT_ORDER);
+  });
+
+  test('applies explicit sort on manyToMany relations with pagination', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          article(documentId: $documentId) {
+            data {
+              attributes {
+                categories(sort: ["name:asc"], pagination: { page: 1, pageSize: 10 }) {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: articleDocumentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const categories = res.body.data.article.data.attributes.categories;
+
+    expect(categoryNamesFromList(categories)).toEqual(['Alpha', 'Beta', 'Gamma']);
+  });
+
+  test('applies explicit descending sort on manyToMany relations with pagination', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          article(documentId: $documentId) {
+            data {
+              attributes {
+                categories(sort: ["name:desc"], pagination: { page: 1, pageSize: 10 }) {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: articleDocumentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const categories = res.body.data.article.data.attributes.categories;
+
+    expect(categoryNamesFromList(categories)).toEqual(['Gamma', 'Beta', 'Alpha']);
   });
 });

--- a/tests/api/plugins/graphql/collection-relation-order.test.api.js
+++ b/tests/api/plugins/graphql/collection-relation-order.test.api.js
@@ -1,0 +1,145 @@
+'use strict';
+
+/**
+ * GraphQL collection-type manyToMany relation order with pagination (issue #26577).
+ */
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let graphqlQuery;
+
+const categoryModel = {
+  kind: 'collectionType',
+  collectionName: 'categories',
+  singularName: 'category',
+  pluralName: 'categories',
+  displayName: 'Category',
+  attributes: {
+    name: { type: 'string' },
+    articles: {
+      type: 'relation',
+      relation: 'manyToMany',
+      target: 'api::article.article',
+      mappedBy: 'categories',
+    },
+  },
+};
+
+const articleModel = {
+  kind: 'collectionType',
+  collectionName: 'articles',
+  singularName: 'article',
+  pluralName: 'articles',
+  displayName: 'Article',
+  draftAndPublish: true,
+  attributes: {
+    title: { type: 'string' },
+    categories: {
+      type: 'relation',
+      relation: 'manyToMany',
+      target: 'api::category.category',
+      inversedBy: 'articles',
+    },
+  },
+};
+
+describe('GraphQL collection relation order (issue #26577)', () => {
+  let articleDocumentId;
+  const categoryIds = [];
+
+  beforeAll(async () => {
+    await builder.addContentTypes([categoryModel, articleModel]).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    graphqlQuery = (body) =>
+      rq({
+        url: '/graphql',
+        method: 'POST',
+        body,
+      });
+
+    for (const name of ['Alpha', 'Beta', 'Gamma']) {
+      const category = await strapi.documents('api::category.category').create({
+        data: { name },
+      });
+      categoryIds.push(category.documentId);
+    }
+
+    const article = await strapi.documents('api::article.article').create({
+      data: {
+        title: 'Order test article',
+        categories: [categoryIds[2], categoryIds[0], categoryIds[1]],
+      },
+      populate: { categories: true },
+    });
+
+    articleDocumentId = article.documentId;
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('returns manyToMany relations in connect order with pagination', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          article(documentId: $documentId) {
+            data {
+              attributes {
+                categories(pagination: { page: 1, pageSize: 10 }) {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: articleDocumentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const categories = res.body.data.article.data.attributes.categories;
+    const names = categories.map((item) => item.name ?? item.attributes?.name);
+
+    expect(names).toEqual(['Gamma', 'Alpha', 'Beta']);
+  });
+
+  test('returns manyToMany relations in connect order via _connection with pagination', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          article(documentId: $documentId) {
+            data {
+              attributes {
+                categories_connection(pagination: { page: 1, pageSize: 10 }) {
+                  nodes {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: articleDocumentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const nodes = res.body.data.article.data.attributes.categories_connection.nodes;
+    const names = nodes.map((item) => item.name ?? item.attributes?.name);
+
+    expect(names).toEqual(['Gamma', 'Alpha', 'Beta']);
+  });
+});


### PR DESCRIPTION
## Summary
- Strip GraphQL's default `sort: []` in transformArgs, sanitize, and populate so join-table connect order is preserved
- Complements #26427 and #26553 for collection-type M2M relations with pagination
- Adds regression test for #26577
## Test plan
- [ ] `yarn test:api tests/api/plugins/graphql/collection-relation-order.test.api.js`
- [ ] Manual: article with 3 categories in custom order, GraphQL query with `categories(pagination: { page: 1, pageSize: 10 })` matches admin order
Fixes #26577