### PR TITLE
fix(types): tighten Core.Config typings with backward-compatible deprecations

### DIFF
--- a/docs/docs/docs/01-core/configuration/00-intro.md
+++ b/docs/docs/docs/01-core/configuration/00-intro.md
@@ -56,6 +56,10 @@ Content API configuration, for example the 'rest.maxLimit' option to set the max
 
 Feature flags for enabling and configuring future features that would be breaking changes and cannot be enabled by default, or experimental features that are not ready for public stable release.
 
+#### typescript
+
+Controls TypeScript tooling during development (for example `autogenerate` to emit types for JavaScript projects).
+
 #### plugins
 
 Contains plugin configurations, with each root-level value the id of a plugin, for example, 'users-permissions'
@@ -91,7 +95,7 @@ NOTE: This is the only configuration that is currently an array rather than an o
 
 ### Typings
 
-Most of the base configurations have been typed, although they are not currently publicly available. They can be found in: `packages/core/types/src/types/core/config`
+Most of the base configurations have been typed, although they are not currently publicly available. They can be found in: `packages/core/types/src/core/config`
 
 Any time a new configuration option is added to Strapi, it must also be added to the types for the appropriate config file (and once the env var loading feature is available, a parser for it such as string, integer, stringArray, etc must be defined)
 

--- a/examples/getstarted/config/server.js
+++ b/examples/getstarted/config/server.js
@@ -19,7 +19,9 @@ module.exports = ({ env }) => ({
     populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', true),
   },
   // ℹ️ http_proxy is the env var used by system to set proxy globally
-  globalProxy: env('http_proxy'),
+  proxy: {
+    global: env('http_proxy'),
+  },
   http: {
     serverOptions: {
       requestTimeout: 1000 * 60 * 10, // set request timeout to 600000ms (10 minutes)

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -8,6 +8,7 @@ import { Database } from '@strapi/database';
 import type { Core, Modules, UID, Schema } from '@strapi/types';
 
 import { loadConfiguration } from './configuration';
+import { getServerGlobalProxy, shouldOpenAdminOnDevelop } from './configuration/server-config';
 
 import * as factories from './factories';
 
@@ -338,8 +339,7 @@ class Strapi extends Container implements Core.Strapi {
 
   async openAdmin({ isInitialized }: { isInitialized: boolean }) {
     const shouldOpenAdmin =
-      this.config.get('environment') === 'development' &&
-      this.config.get('admin.autoOpen', true) !== false;
+      this.config.get('environment') === 'development' && shouldOpenAdminOnDevelop(this.config);
 
     if (shouldOpenAdmin && !isInitialized) {
       try {
@@ -520,7 +520,7 @@ class Strapi extends Container implements Core.Strapi {
   }
 
   configureGlobalProxy() {
-    const globalProxy = this.config.get('server.proxy.global');
+    const globalProxy = getServerGlobalProxy(this.config);
     const httpProxy = this.config.get('server.proxy.http') || globalProxy;
     const httpsProxy = this.config.get('server.proxy.https') || globalProxy;
 

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -8,7 +8,7 @@ import { Database } from '@strapi/database';
 import type { Core, Modules, UID, Schema } from '@strapi/types';
 
 import { loadConfiguration } from './configuration';
-import { getServerGlobalProxy, shouldOpenAdminOnDevelop } from './configuration/server-config';
+import { warnDeprecatedServerConfig } from './configuration/server-config';
 
 import * as factories from './factories';
 
@@ -275,6 +275,8 @@ class Strapi extends Container implements Core.Strapi {
       ...config.get('server.logger.config'),
     });
 
+    warnDeprecatedServerConfig(config, logger);
+
     // Instantiate the Strapi container
     this.add('config', () => config)
       .add('query-params', createQueryParamService(this))
@@ -339,7 +341,8 @@ class Strapi extends Container implements Core.Strapi {
 
   async openAdmin({ isInitialized }: { isInitialized: boolean }) {
     const shouldOpenAdmin =
-      this.config.get('environment') === 'development' && shouldOpenAdminOnDevelop(this.config);
+      this.config.get('environment') === 'development' &&
+      this.config.get('admin.autoOpen', true) !== false;
 
     if (shouldOpenAdmin && !isInitialized) {
       try {
@@ -520,7 +523,7 @@ class Strapi extends Container implements Core.Strapi {
   }
 
   configureGlobalProxy() {
-    const globalProxy = getServerGlobalProxy(this.config);
+    const globalProxy = this.config.get('server.proxy.global');
     const httpProxy = this.config.get('server.proxy.http') || globalProxy;
     const httpsProxy = this.config.get('server.proxy.https') || globalProxy;
 

--- a/packages/core/core/src/configuration/__tests__/server-config.test.ts
+++ b/packages/core/core/src/configuration/__tests__/server-config.test.ts
@@ -1,0 +1,69 @@
+import type { Core } from '@strapi/types';
+
+import { getServerGlobalProxy, shouldOpenAdminOnDevelop } from '../server-config';
+
+const createConfigProvider = (values: Record<string, unknown>): Core.ConfigProvider => ({
+  get(path, defaultValue) {
+    const key = Array.isArray(path) ? path.join('.') : path;
+    return Object.prototype.hasOwnProperty.call(values, key) ? values[key] : defaultValue;
+  },
+  set() {
+    throw new Error('not implemented');
+  },
+  has(path) {
+    const key = Array.isArray(path) ? path.join('.') : path;
+    return Object.prototype.hasOwnProperty.call(values, key);
+  },
+});
+
+describe('server-config helpers', () => {
+  describe('getServerGlobalProxy', () => {
+    it('prefers server.proxy.global over deprecated server.globalProxy', () => {
+      const config = createConfigProvider({
+        'server.proxy.global': 'http://proxy.example',
+        'server.globalProxy': 'http://legacy.example',
+      });
+
+      expect(getServerGlobalProxy(config)).toBe('http://proxy.example');
+    });
+
+    it('falls back to deprecated server.globalProxy', () => {
+      const config = createConfigProvider({
+        'server.globalProxy': 'http://legacy.example',
+      });
+
+      expect(getServerGlobalProxy(config)).toBe('http://legacy.example');
+    });
+  });
+
+  describe('shouldOpenAdminOnDevelop', () => {
+    it('prefers admin.autoOpen over deprecated server.admin.autoOpen', () => {
+      const config = createConfigProvider({
+        'admin.autoOpen': true,
+        'server.admin.autoOpen': false,
+      });
+
+      expect(shouldOpenAdminOnDevelop(config)).toBe(true);
+    });
+
+    it('uses deprecated server.admin.autoOpen when admin.autoOpen is unset', () => {
+      const config = createConfigProvider({
+        'server.admin.autoOpen': false,
+      });
+
+      expect(shouldOpenAdminOnDevelop(config)).toBe(false);
+    });
+
+    it('defaults to true when neither key is set', () => {
+      expect(shouldOpenAdminOnDevelop(createConfigProvider({}))).toBe(true);
+    });
+
+    it('treats explicit false on admin.autoOpen as disabled', () => {
+      const config = createConfigProvider({
+        'admin.autoOpen': false,
+      });
+
+      expect(shouldOpenAdminOnDevelop(config)).toBe(false);
+    });
+  });
+});

--- a/packages/core/core/src/configuration/__tests__/server-config.test.ts
+++ b/packages/core/core/src/configuration/__tests__/server-config.test.ts
@@ -1,6 +1,6 @@
 import type { Core } from '@strapi/types';
 
-import { getServerGlobalProxy, shouldOpenAdminOnDevelop } from '../server-config';
+import { warnDeprecatedServerConfig } from '../server-config';
 
 const createConfigProvider = (values: Record<string, unknown>): Core.ConfigProvider => ({
   get(path, defaultValue) {
@@ -16,54 +16,53 @@ const createConfigProvider = (values: Record<string, unknown>): Core.ConfigProvi
   },
 });
 
-describe('server-config helpers', () => {
-  describe('getServerGlobalProxy', () => {
-    it('prefers server.proxy.global over deprecated server.globalProxy', () => {
-      const config = createConfigProvider({
-        'server.proxy.global': 'http://proxy.example',
-        'server.globalProxy': 'http://legacy.example',
-      });
+describe('warnDeprecatedServerConfig', () => {
+  it('warns when server.globalProxy is set', () => {
+    const warnings: string[] = [];
 
-      expect(getServerGlobalProxy(config)).toBe('http://proxy.example');
-    });
+    warnDeprecatedServerConfig(
+      createConfigProvider({ 'server.globalProxy': 'http://legacy.example' }),
+      { warn: (message) => warnings.push(message) }
+    );
 
-    it('falls back to deprecated server.globalProxy', () => {
-      const config = createConfigProvider({
-        'server.globalProxy': 'http://legacy.example',
-      });
-
-      expect(getServerGlobalProxy(config)).toBe('http://legacy.example');
-    });
+    expect(warnings).toEqual([
+      'server.globalProxy is deprecated and ignored. Use server.proxy.global in config/server instead.',
+    ]);
   });
 
-  describe('shouldOpenAdminOnDevelop', () => {
-    it('prefers admin.autoOpen over deprecated server.admin.autoOpen', () => {
-      const config = createConfigProvider({
-        'admin.autoOpen': true,
-        'server.admin.autoOpen': false,
-      });
+  it('warns when server.admin.autoOpen is set', () => {
+    const warnings: string[] = [];
 
-      expect(shouldOpenAdminOnDevelop(config)).toBe(true);
+    warnDeprecatedServerConfig(createConfigProvider({ 'server.admin.autoOpen': false }), {
+      warn: (message) => warnings.push(message),
     });
 
-    it('uses deprecated server.admin.autoOpen when admin.autoOpen is unset', () => {
-      const config = createConfigProvider({
-        'server.admin.autoOpen': false,
-      });
+    expect(warnings).toEqual([
+      'server.admin.autoOpen is deprecated and ignored. Use admin.autoOpen in config/admin instead.',
+    ]);
+  });
 
-      expect(shouldOpenAdminOnDevelop(config)).toBe(false);
+  it('emits both warnings when both deprecated keys are set', () => {
+    const warnings: string[] = [];
+
+    warnDeprecatedServerConfig(
+      createConfigProvider({
+        'server.globalProxy': 'http://legacy.example',
+        'server.admin.autoOpen': true,
+      }),
+      { warn: (message) => warnings.push(message) }
+    );
+
+    expect(warnings).toHaveLength(2);
+  });
+
+  it('does not warn when deprecated keys are absent', () => {
+    const warnings: string[] = [];
+
+    warnDeprecatedServerConfig(createConfigProvider({}), {
+      warn: (message) => warnings.push(message),
     });
 
-    it('defaults to true when neither key is set', () => {
-      expect(shouldOpenAdminOnDevelop(createConfigProvider({}))).toBe(true);
-    });
-
-    it('treats explicit false on admin.autoOpen as disabled', () => {
-      const config = createConfigProvider({
-        'admin.autoOpen': false,
-      });
-
-      expect(shouldOpenAdminOnDevelop(config)).toBe(false);
-    });
+    expect(warnings).toEqual([]);
   });
 });

--- a/packages/core/core/src/configuration/index.ts
+++ b/packages/core/core/src/configuration/index.ts
@@ -23,7 +23,6 @@ const defaultServerConfig = {
   port: Number(process.env.PORT) || 1337,
   proxy: false,
   cron: { enabled: false },
-  admin: { autoOpen: false },
   dirs: { public: './public' },
   transfer: {
     remote: {

--- a/packages/core/core/src/configuration/server-config.ts
+++ b/packages/core/core/src/configuration/server-config.ts
@@ -1,0 +1,28 @@
+import type { Core } from '@strapi/types';
+
+/**
+ * Resolves the deprecated `server.globalProxy` key when `server.proxy.global` is unset.
+ */
+export const getServerGlobalProxy = (config: Core.ConfigProvider) =>
+  config.get<string>('server.proxy.global') ?? config.get<string>('server.globalProxy');
+
+/**
+ * Whether `strapi develop` should open the admin panel in a browser.
+ *
+ * Prefers `admin.autoOpen`, then deprecated `server.admin.autoOpen`, then defaults to `true`.
+ */
+export const shouldOpenAdminOnDevelop = (config: Core.ConfigProvider) => {
+  const adminAutoOpen = config.get<boolean | undefined>('admin.autoOpen');
+
+  if (adminAutoOpen !== undefined) {
+    return adminAutoOpen !== false;
+  }
+
+  const serverAdminAutoOpen = config.get<boolean | undefined>('server.admin.autoOpen');
+
+  if (serverAdminAutoOpen !== undefined) {
+    return serverAdminAutoOpen !== false;
+  }
+
+  return true;
+};

--- a/packages/core/core/src/configuration/server-config.ts
+++ b/packages/core/core/src/configuration/server-config.ts
@@ -1,28 +1,23 @@
 import type { Core } from '@strapi/types';
 
-/**
- * Resolves the deprecated `server.globalProxy` key when `server.proxy.global` is unset.
- */
-export const getServerGlobalProxy = (config: Core.ConfigProvider) =>
-  config.get<string>('server.proxy.global') ?? config.get<string>('server.globalProxy');
+interface ConfigLogger {
+  warn: (message: string) => void;
+}
 
 /**
- * Whether `strapi develop` should open the admin panel in a browser.
- *
- * Prefers `admin.autoOpen`, then deprecated `server.admin.autoOpen`, then defaults to `true`.
+ * Log once at startup when deprecated server config keys are present.
+ * These keys are not read; warnings point users to the supported alternatives.
  */
-export const shouldOpenAdminOnDevelop = (config: Core.ConfigProvider) => {
-  const adminAutoOpen = config.get<boolean | undefined>('admin.autoOpen');
-
-  if (adminAutoOpen !== undefined) {
-    return adminAutoOpen !== false;
+export const warnDeprecatedServerConfig = (config: Core.ConfigProvider, log: ConfigLogger) => {
+  if (config.get('server.globalProxy')) {
+    log.warn(
+      'server.globalProxy is deprecated and ignored. Use server.proxy.global in config/server instead.'
+    );
   }
 
-  const serverAdminAutoOpen = config.get<boolean | undefined>('server.admin.autoOpen');
-
-  if (serverAdminAutoOpen !== undefined) {
-    return serverAdminAutoOpen !== false;
+  if (config.get('server.admin.autoOpen') !== undefined) {
+    log.warn(
+      'server.admin.autoOpen is deprecated and ignored. Use admin.autoOpen in config/admin instead.'
+    );
   }
-
-  return true;
 };

--- a/packages/core/core/src/utils/fetch.ts
+++ b/packages/core/core/src/utils/fetch.ts
@@ -1,6 +1,8 @@
 import type { Core, Modules } from '@strapi/types';
 import { ProxyAgent } from 'undici';
 
+import { getServerGlobalProxy } from '../configuration/server-config';
+
 // TODO: once core Node exposes a stable way to create a ProxyAgent we will use that instead of undici
 
 interface StrapiFetchOptions {
@@ -29,7 +31,7 @@ export const createStrapiFetch = (
 
   const proxy =
     strapi.config.get<ConstructorParameters<typeof ProxyAgent>[0]>('server.proxy.fetch') ||
-    strapi.config.get<string>('server.proxy.global');
+    getServerGlobalProxy(strapi.config);
 
   if (proxy) {
     if (logs) {

--- a/packages/core/core/src/utils/fetch.ts
+++ b/packages/core/core/src/utils/fetch.ts
@@ -1,8 +1,6 @@
 import type { Core, Modules } from '@strapi/types';
 import { ProxyAgent } from 'undici';
 
-import { getServerGlobalProxy } from '../configuration/server-config';
-
 // TODO: once core Node exposes a stable way to create a ProxyAgent we will use that instead of undici
 
 interface StrapiFetchOptions {
@@ -31,7 +29,7 @@ export const createStrapiFetch = (
 
   const proxy =
     strapi.config.get<ConstructorParameters<typeof ProxyAgent>[0]>('server.proxy.fetch') ||
-    getServerGlobalProxy(strapi.config);
+    strapi.config.get<string>('server.proxy.global');
 
   if (proxy) {
     if (logs) {

--- a/packages/core/types/src/core/config/admin.ts
+++ b/packages/core/types/src/core/config/admin.ts
@@ -72,7 +72,7 @@ export interface RateLimit {
   max?: number;
   delayAfter?: number;
   timeWait?: number;
-  prefixKey?: number;
+  prefixKey?: string;
   whitelist?: string;
   store?: string;
 }
@@ -82,7 +82,18 @@ export interface Transfer {
 }
 
 export interface FirstPublisedAtField {
+  /**
+   * @deprecated Use `features.future.experimental_firstPublishedAt` in `config/features.ts` instead.
+   */
   enabled: boolean;
+}
+
+export interface AdminLayoutModel {
+  actions?: Record<string, string>;
+}
+
+export interface AdminLayout {
+  [modelName: string]: AdminLayoutModel | undefined;
 }
 
 export interface Flags {
@@ -121,7 +132,13 @@ export interface Admin {
   auth: Auth;
 
   // optional - server configuration
+  /**
+   * @deprecated Not read by Strapi. Reserved for backward compatibility in config files.
+   */
   host?: string;
+  /**
+   * @deprecated Not read by Strapi. Reserved for backward compatibility in config files.
+   */
   port?: number;
   serveAdminPanel?: boolean;
   autoOpen?: boolean;
@@ -138,7 +155,16 @@ export interface Admin {
   ai?: Ai;
   forgotPassword?: ForgotPassword;
   rateLimit?: RateLimit;
+  /**
+   * @deprecated Use `features.future.experimental_firstPublishedAt` in `config/features.ts` instead.
+   */
   firstPublishedAtField?: FirstPublisedAtField;
   flags?: Flags;
   transfer?: Transfer;
+  /**
+   * Override content-manager edit-view actions per model.
+   *
+   * Keys are content-type model names. Values map action names to `controller.action` handlers.
+   */
+  layout?: AdminLayout;
 }

--- a/packages/core/types/src/core/config/admin.ts
+++ b/packages/core/types/src/core/config/admin.ts
@@ -131,13 +131,21 @@ export interface Admin {
   apiToken: ApiToken;
   auth: Auth;
 
-  // optional - server configuration
+  // optional - admin panel URL and legacy dev-server settings
   /**
-   * @deprecated Not read by Strapi. Reserved for backward compatibility in config files.
+   * Legacy option from when the admin panel ran on a separate webpack dev server
+   * (pre–v5 admin build pipeline). Not read by Strapi v5.
+   *
+   * For split deployment, use `admin.url` with `server.url` and `serveAdminPanel: false`.
+   * For the API listen address, use `server.host` / `server.port` in `config/server.ts`.
    */
   host?: string;
   /**
-   * @deprecated Not read by Strapi. Reserved for backward compatibility in config files.
+   * Legacy option from when the admin panel ran on a separate webpack dev server
+   * (pre–v5 admin build pipeline). Not read by Strapi v5.
+   *
+   * For split deployment, use `admin.url` with `server.url` and `serveAdminPanel: false`.
+   * For the API listen address, use `server.host` / `server.port` in `config/server.ts`.
    */
   port?: number;
   serveAdminPanel?: boolean;

--- a/packages/core/types/src/core/config/api.ts
+++ b/packages/core/types/src/core/config/api.ts
@@ -4,6 +4,9 @@ export interface ResponsesProp {
 
 export interface RestProp {
   prefix?: string;
+  /**
+   * @deprecated Not read by Strapi. Reserved for backward compatibility in config files.
+   */
   port?: number;
   defaultLimit?: number;
   maxLimit?: number;

--- a/packages/core/types/src/core/config/features.ts
+++ b/packages/core/types/src/core/config/features.ts
@@ -1,0 +1,14 @@
+/**
+ * Feature flags for enabling experimental or upcoming breaking changes.
+ *
+ * @see docs/docs/docs/06-future-flags.md
+ */
+export interface FeaturesFutureFlags {
+  unstableMediaLibrary?: boolean;
+  experimental_firstPublishedAt?: boolean;
+  [futureFlagName: string]: boolean | undefined;
+}
+
+export interface Features {
+  future?: FeaturesFutureFlags;
+}

--- a/packages/core/types/src/core/config/index.ts
+++ b/packages/core/types/src/core/config/index.ts
@@ -6,3 +6,5 @@ export type { OpenAPI } from './openapi';
 export type { Plugin } from './plugin';
 export type { Database } from './database';
 export type { Middlewares } from './middlewares';
+export type { Features } from './features';
+export type { TypeScript } from './typescript';

--- a/packages/core/types/src/core/config/server.ts
+++ b/packages/core/types/src/core/config/server.ts
@@ -52,7 +52,7 @@ export interface ServerTransfer {
 
 export interface ServerAdmin {
   /**
-   * @deprecated Use `admin.autoOpen` in `config/admin.ts` instead.
+   * @deprecated Use `admin.autoOpen` in `config/admin.ts` instead. Ignored at runtime; a startup warning is logged if set.
    */
   autoOpen?: boolean;
 }
@@ -104,7 +104,7 @@ export interface Server {
   absoluteUrl?: string;
   proxy?: boolean | Proxy;
   /**
-   * @deprecated Use `server.proxy.global` instead.
+   * @deprecated Use `server.proxy.global` instead. Ignored at runtime; a startup warning is logged if set.
    */
   globalProxy?: string;
   cron?: Cron;

--- a/packages/core/types/src/core/config/server.ts
+++ b/packages/core/types/src/core/config/server.ts
@@ -1,4 +1,5 @@
 import type { OpenAPI } from './openapi';
+import type { CronTasks } from '../../modules/cron';
 
 export interface App {
   keys: string[];
@@ -6,14 +7,23 @@ export interface App {
 
 export interface Cron {
   enabled?: boolean;
-  tasks?: object;
+  tasks?: CronTasks;
 }
 
 export interface Dirs {
   public?: string;
 }
 
+export interface LoggerConfig {
+  level?: string;
+  [key: string]: unknown;
+}
+
 export interface Logger {
+  /**
+   * Winston logger options merged into the Strapi logger at startup.
+   */
+  config?: LoggerConfig;
   updates?:
     | {
         enabled?: boolean;
@@ -41,6 +51,9 @@ export interface ServerTransfer {
 }
 
 export interface ServerAdmin {
+  /**
+   * @deprecated Use `admin.autoOpen` in `config/admin.ts` instead.
+   */
   autoOpen?: boolean;
 }
 
@@ -68,7 +81,7 @@ export interface Http {
 }
 
 export interface McpConfig {
-  enabled: boolean;
+  enabled?: boolean;
   /** Maximum time (ms) to wait for the MCP transport connection. Defaults to 5 000. */
   connectTimeoutMs?: number;
   /** Maximum time (ms) to wait for a single MCP request to complete. Defaults to 60 000. */
@@ -83,15 +96,24 @@ export interface Server {
 
   // optional
   socket?: string | number;
+  /**
+   * @deprecated Not read by Strapi. Reserved for backward compatibility in config files.
+   */
   emitErrors?: boolean;
   url?: string;
   absoluteUrl?: string;
   proxy?: boolean | Proxy;
+  /**
+   * @deprecated Use `server.proxy.global` instead.
+   */
   globalProxy?: string;
   cron?: Cron;
   dirs?: Dirs;
   logger?: Logger;
   transfer?: ServerTransfer;
+  /**
+   * @deprecated Use `admin.autoOpen` in `config/admin.ts` instead.
+   */
   admin?: ServerAdmin;
   openapi?: OpenAPI;
   webhooks?: Webhooks;

--- a/packages/core/types/src/core/config/typescript.ts
+++ b/packages/core/types/src/core/config/typescript.ts
@@ -1,0 +1,9 @@
+export interface TypeScript {
+  /**
+   * When unset or `true`, Strapi generates TypeScript definitions during `strapi develop`
+   * for JavaScript projects without a `tsconfig.json`.
+   *
+   * Set to `false` to disable autogeneration.
+   */
+  autogenerate?: boolean;
+}

--- a/packages/core/types/src/modules/cron.ts
+++ b/packages/core/types/src/modules/cron.ts
@@ -10,19 +10,19 @@ interface JobSpec {
 
 type TaskFn = ({ strapi }: { strapi: Strapi }, ...args: unknown[]) => Promise<unknown>;
 
-type Task =
+export type CronTask =
   | TaskFn
   | {
       task: TaskFn;
       options: Spec;
     };
 
-interface Tasks {
-  [key: string]: Task;
+export interface CronTasks {
+  [key: string]: CronTask;
 }
 
 export interface CronService {
-  add(tasks: Tasks): CronService;
+  add(tasks: CronTasks): CronService;
   remove(name: string): CronService;
   start(): CronService;
   stop(): CronService;

--- a/packages/core/types/src/modules/features.ts
+++ b/packages/core/types/src/modules/features.ts
@@ -1,8 +1,6 @@
-export interface FeaturesConfig {
-  future?: {
-    unstableMediaLibrary?: boolean;
-  };
-}
+import type { Features } from '../core/config/features';
+
+export type FeaturesConfig = Features;
 
 export interface FeaturesService {
   /**

--- a/packages/core/upload/server/src/types.ts
+++ b/packages/core/upload/server/src/types.ts
@@ -70,6 +70,10 @@ export interface Config {
     concurrency?: number;
   };
   concurrentUploadSize?: number;
+  security?: {
+    allowedTypes?: string[];
+    deniedTypes?: string[];
+  };
 }
 
 export interface UploadableFile extends Omit<File, 'id'> {


### PR DESCRIPTION
## Summary

- Aligns `Core.Config` types with runtime usage: `server.logger.config`, `admin.layout`, `server.cron.tasks`, `Core.Config.Features`, and `Core.Config.TypeScript`
- Marks legacy keys in types with `@deprecated` / JSDoc (`server.globalProxy`, `server.admin.autoOpen`, `emitErrors`, `api.rest.port`, `firstPublishedAtField`, legacy `admin.host`/`port`)
- **No runtime behavior changes** for proxy or auto-open — deprecated keys remain ignored as today
- Adds **startup warnings** when deprecated keys are present:
  - `server.globalProxy` → use `server.proxy.global`
  - `server.admin.autoOpen` → use `admin.autoOpen` in `config/admin.ts`
- Removes the unused `server.admin.autoOpen: false` framework default (was never read)
- Fixes `examples/getstarted` proxy config (`proxy.global`); contributor docs path; upload plugin `security` typing

## Follow-up: config factories + runtime validation

This PR improves static types and adds lightweight deprecation warnings only. A follow-up will add **typed config factories** (for `config/server.ts`, `config/admin.ts`, etc.) that stay in sync with `Core.Config` and perform **runtime validation** at load time — catching invalid shapes, unknown keys, and deprecated options earlier than TypeScript alone can.

That follow-up is especially valuable for **pure JavaScript projects**: today they get no config validation at all (types are compile-time only and are skipped entirely in `.js` apps). Config factories with runtime checks would give JS users the same guardrails TS users get from the type system — invalid or deprecated config would fail fast at startup with a clear error instead of failing silently or misbehaving later.

## Documentation follow-up (separate PR on `strapi/documentation`)

Public docs still describe `admin.host` / `admin.port` as active admin panel server settings. In v5 core these are not read; split deployment uses `admin.url` + `server.url` + `serveAdminPanel`.

Also update server proxy docs to use `server.proxy.global` only (not `server.globalProxy`).

Suggested pages:

- [Admin panel configuration](https://docs.strapi.io/cms/configurations/admin-panel)
- [Host, port, and path customization](https://docs.strapi.io/cms/admin-panel-customization/host-port-path)

## Test plan

- [x] `yarn test:ts` in `packages/core/types`
- [x] `yarn jest packages/core/core/src/configuration/__tests__/server-config.test.ts`
- [ ] CI green
- [ ] Smoke: project with `server.globalProxy` logs a warning and proxy behavior is unchanged
- [ ] Smoke: project with `server.admin.autoOpen` in `config/server.ts` logs a warning; `admin.autoOpen` still controls develop auto-open