### PR TITLE
fix(core): preserve M2M relation order on published version after reo…

### DIFF
--- a/packages/core/core/src/services/document-service/utils/bidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/bidirectional-relations.ts
@@ -83,6 +83,15 @@ const captureJoinBatches = async (
     relatedHasDraftAndPublish: boolean;
     /** Model that owns this attribute; draft capture is skipped for components. */
     schemaUid: UID.ContentType;
+    /**
+     * True when the attribute being captured is the owning side of the relation and the entity
+     * being published owns it (e.g. publishing an Article for `Article.categories`). In that case
+     * the owning-side order is rebuilt from the draft by `entries.publish`, so capturing the old
+     * published rows would only let `sync()` overwrite the freshly published order with a stale
+     * one — silently reverting a reorder made in the draft. The inverse-side order still needs the
+     * old-published capture to be restored, so this only suppresses the owning-side capture.
+     */
+    isOwningSide: boolean;
     oldVersions: LoadContext['oldVersions'];
     newVersions: LoadContext['newVersions'];
   }
@@ -94,6 +103,7 @@ const captureJoinBatches = async (
     relatedUid,
     relatedHasDraftAndPublish,
     schemaUid,
+    isOwningSide,
     oldVersions,
     newVersions,
   } = opts;
@@ -101,7 +111,11 @@ const captureJoinBatches = async (
   const batches: RelationEntry[] = [];
   const { name: table } = joinTable;
 
-  const oldIds = oldVersions.map((e) => e.id);
+  // Skip the old-published capture for the owning side: those rows are recreated in draft order
+  // by `entries.publish`, so restoring their order from the old published version is at best a
+  // no-op and at worst reverts a draft reorder. The draftsOnly capture below is still needed
+  // (e.g. when a related entry is published after this one) and is not affected by this guard.
+  const oldIds = isOwningSide ? [] : oldVersions.map((e) => e.id);
   if (oldIds.length > 0) {
     const existing = await strapi.db
       .getConnection()
@@ -254,6 +268,7 @@ const load = async (uid: UID.ContentType, { oldVersions, newVersions }: LoadCont
             ? !!strapi.contentTypes[relatedUid]?.options?.draftAndPublish
             : !!model.options?.draftAndPublish,
           schemaUid: model.uid as UID.ContentType,
+          isOwningSide,
           oldVersions,
           newVersions,
         });

--- a/tests/api/core/strapi/document-service/relations/m2m-order-republish.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/m2m-order-republish.test.api.ts
@@ -1,0 +1,128 @@
+/**
+ * Reproduction: M2M relation order must be preserved on the PUBLISHED version
+ * after reordering relations in the draft and re-publishing.
+ *
+ * Scenario (from issue report):
+ * 1. Create categories Alpha, Beta, Gamma.
+ * 2. Create Article with categories [Beta, Alpha, Gamma] and publish.
+ *    -> draft and published both show [Beta, Alpha, Gamma].
+ * 3. Reorder the draft's categories to [Alpha, Gamma, Beta] and publish again.
+ *    -> EXPECTED: published version shows [Alpha, Gamma, Beta] (same as draft).
+ *    -> BUG: published version stays [Beta, Alpha, Gamma].
+ */
+import type { Core, UID } from '@strapi/types';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+let strapi: Core.Strapi;
+const builder = createTestBuilder();
+let rq;
+
+const ARTICLE_UID = 'api::article.article' as UID.ContentType;
+const CATEGORY_UID = 'api::category.category' as UID.ContentType;
+
+const categoryModel = {
+  attributes: {
+    name: { type: 'string' },
+  },
+  draftAndPublish: true,
+  displayName: 'Category',
+  singularName: 'category',
+  pluralName: 'categories',
+  description: '',
+  collectionName: '',
+};
+
+const articleModel = {
+  attributes: {
+    title: { type: 'string' },
+    categories: {
+      type: 'relation',
+      relation: 'manyToMany',
+      target: CATEGORY_UID,
+      targetAttribute: 'articles',
+    },
+  },
+  draftAndPublish: true,
+  displayName: 'Article',
+  singularName: 'article',
+  pluralName: 'articles',
+  description: '',
+  collectionName: '',
+};
+
+const getPublishedCategoryNames = async (documentId: string) => {
+  const published = await strapi.documents(ARTICLE_UID).findOne({
+    documentId,
+    status: 'published',
+    populate: { categories: true },
+  });
+  return (published as any).categories.map((c: any) => c.name);
+};
+
+const getDraftCategoryNames = async (documentId: string) => {
+  const draft = await strapi.documents(ARTICLE_UID).findOne({
+    documentId,
+    status: 'draft',
+    populate: { categories: true },
+  });
+  return (draft as any).categories.map((c: any) => c.name);
+};
+
+describe('M2M relation order preserved on re-publish after reorder', () => {
+  const categoryIds: Record<string, string> = {};
+  let articleId: string;
+
+  beforeAll(async () => {
+    await builder.addContentTypes([categoryModel, articleModel]).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    for (const name of ['Alpha', 'Beta', 'Gamma']) {
+      const category = await strapi.documents(CATEGORY_UID).create({ data: { name } });
+      await strapi.documents(CATEGORY_UID).publish({ documentId: category.documentId });
+      categoryIds[name] = category.documentId;
+    }
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('initial publish keeps connect order [Beta, Alpha, Gamma]', async () => {
+    const article = await strapi.documents(ARTICLE_UID).create({
+      data: {
+        title: 'Order test',
+        categories: [categoryIds.Beta, categoryIds.Alpha, categoryIds.Gamma],
+      },
+    });
+    articleId = article.documentId;
+
+    await strapi.documents(ARTICLE_UID).publish({ documentId: articleId });
+
+    expect(await getDraftCategoryNames(articleId)).toEqual(['Beta', 'Alpha', 'Gamma']);
+    expect(await getPublishedCategoryNames(articleId)).toEqual(['Beta', 'Alpha', 'Gamma']);
+  });
+
+  test('reorder draft to [Alpha, Gamma, Beta] then publish -> published matches draft', async () => {
+    await strapi.documents(ARTICLE_UID).update({
+      documentId: articleId,
+      data: {
+        categories: [categoryIds.Alpha, categoryIds.Gamma, categoryIds.Beta],
+      },
+    });
+
+    // Draft reflects the new order immediately
+    expect(await getDraftCategoryNames(articleId)).toEqual(['Alpha', 'Gamma', 'Beta']);
+
+    await strapi.documents(ARTICLE_UID).publish({ documentId: articleId });
+
+    // Published must now match the reordered draft
+    expect(await getPublishedCategoryNames(articleId)).toEqual(['Alpha', 'Gamma', 'Beta']);
+    expect(await getDraftCategoryNames(articleId)).toEqual(['Alpha', 'Gamma', 'Beta']);
+  });
+});

--- a/tests/api/core/strapi/document-service/relations/m2m-order-republish.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/m2m-order-republish.test.api.ts
@@ -1,24 +1,16 @@
 /**
- * Reproduction: M2M relation order must be preserved on the PUBLISHED version
- * after reordering relations in the draft and re-publishing.
- *
- * Scenario (from issue report):
- * 1. Create categories Alpha, Beta, Gamma.
- * 2. Create Article with categories [Beta, Alpha, Gamma] and publish.
- *    -> draft and published both show [Beta, Alpha, Gamma].
- * 3. Reorder the draft's categories to [Alpha, Gamma, Beta] and publish again.
- *    -> EXPECTED: published version shows [Alpha, Gamma, Beta] (same as draft).
- *    -> BUG: published version stays [Beta, Alpha, Gamma].
+ * M2M relation order must be preserved on the published version after reordering
+ * relations in the draft and re-publishing the owning entry.
  */
 import type { Core, UID } from '@strapi/types';
 
+import { testInTransaction } from '../../../../utils';
+
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
-const { createAuthRequest } = require('api-tests/request');
 
 let strapi: Core.Strapi;
 const builder = createTestBuilder();
-let rq;
 
 const ARTICLE_UID = 'api::article.article' as UID.ContentType;
 const CATEGORY_UID = 'api::category.category' as UID.ContentType;
@@ -53,6 +45,12 @@ const articleModel = {
   collectionName: '',
 };
 
+const publishCategory = async (name: string) => {
+  const category = await strapi.documents(CATEGORY_UID).create({ data: { name } });
+  await strapi.documents(CATEGORY_UID).publish({ documentId: category.documentId });
+  return category.documentId;
+};
+
 const getPublishedCategoryNames = async (documentId: string) => {
   const published = await strapi.documents(ARTICLE_UID).findOne({
     documentId,
@@ -71,21 +69,19 @@ const getDraftCategoryNames = async (documentId: string) => {
   return (draft as any).categories.map((c: any) => c.name);
 };
 
-describe('M2M relation order preserved on re-publish after reorder', () => {
-  const categoryIds: Record<string, string> = {};
-  let articleId: string;
+const getPublishedArticleTitlesOnCategory = async (categoryDocumentId: string) => {
+  const category = await strapi.documents(CATEGORY_UID).findOne({
+    documentId: categoryDocumentId,
+    status: 'published',
+    populate: { articles: true },
+  });
+  return ((category as any).articles ?? []).map((a: any) => a.title);
+};
 
+describe('M2M relation order preserved on re-publish after reorder', () => {
   beforeAll(async () => {
     await builder.addContentTypes([categoryModel, articleModel]).build();
-
     strapi = await createStrapiInstance();
-    rq = await createAuthRequest({ strapi });
-
-    for (const name of ['Alpha', 'Beta', 'Gamma']) {
-      const category = await strapi.documents(CATEGORY_UID).create({ data: { name } });
-      await strapi.documents(CATEGORY_UID).publish({ documentId: category.documentId });
-      categoryIds[name] = category.documentId;
-    }
   });
 
   afterAll(async () => {
@@ -93,36 +89,277 @@ describe('M2M relation order preserved on re-publish after reorder', () => {
     await builder.cleanup();
   });
 
-  test('initial publish keeps connect order [Beta, Alpha, Gamma]', async () => {
-    const article = await strapi.documents(ARTICLE_UID).create({
-      data: {
-        title: 'Order test',
-        categories: [categoryIds.Beta, categoryIds.Alpha, categoryIds.Gamma],
-      },
-    });
-    articleId = article.documentId;
+  testInTransaction(
+    'full-array update: reorder draft then publish -> published matches draft',
+    async () => {
+      const categoryIds = {
+        Alpha: await publishCategory('Alpha'),
+        Beta: await publishCategory('Beta'),
+        Gamma: await publishCategory('Gamma'),
+      };
 
-    await strapi.documents(ARTICLE_UID).publish({ documentId: articleId });
+      const article = await strapi.documents(ARTICLE_UID).create({
+        data: {
+          title: 'Full-array order test',
+          categories: [categoryIds.Beta, categoryIds.Alpha, categoryIds.Gamma],
+        },
+      });
 
-    expect(await getDraftCategoryNames(articleId)).toEqual(['Beta', 'Alpha', 'Gamma']);
-    expect(await getPublishedCategoryNames(articleId)).toEqual(['Beta', 'Alpha', 'Gamma']);
-  });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
 
-  test('reorder draft to [Alpha, Gamma, Beta] then publish -> published matches draft', async () => {
-    await strapi.documents(ARTICLE_UID).update({
-      documentId: articleId,
-      data: {
-        categories: [categoryIds.Alpha, categoryIds.Gamma, categoryIds.Beta],
-      },
-    });
+      expect(await getDraftCategoryNames(article.documentId)).toEqual(['Beta', 'Alpha', 'Gamma']);
+      expect(await getPublishedCategoryNames(article.documentId)).toEqual([
+        'Beta',
+        'Alpha',
+        'Gamma',
+      ]);
 
-    // Draft reflects the new order immediately
-    expect(await getDraftCategoryNames(articleId)).toEqual(['Alpha', 'Gamma', 'Beta']);
+      await strapi.documents(ARTICLE_UID).update({
+        documentId: article.documentId,
+        data: {
+          categories: [categoryIds.Alpha, categoryIds.Gamma, categoryIds.Beta],
+        },
+      });
 
-    await strapi.documents(ARTICLE_UID).publish({ documentId: articleId });
+      expect(await getDraftCategoryNames(article.documentId)).toEqual(['Alpha', 'Gamma', 'Beta']);
 
-    // Published must now match the reordered draft
-    expect(await getPublishedCategoryNames(articleId)).toEqual(['Alpha', 'Gamma', 'Beta']);
-    expect(await getDraftCategoryNames(articleId)).toEqual(['Alpha', 'Gamma', 'Beta']);
-  });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+      expect(await getPublishedCategoryNames(article.documentId)).toEqual([
+        'Alpha',
+        'Gamma',
+        'Beta',
+      ]);
+      expect(await getDraftCategoryNames(article.documentId)).toEqual(['Alpha', 'Gamma', 'Beta']);
+    }
+  );
+
+  testInTransaction(
+    'connect + position: reorder draft then publish -> published matches draft',
+    async () => {
+      const categoryIds = {
+        Alpha: await publishCategory('Alpha'),
+        Beta: await publishCategory('Beta'),
+        Gamma: await publishCategory('Gamma'),
+      };
+
+      const article = await strapi.documents(ARTICLE_UID).create({
+        data: {
+          title: 'Connect position order test',
+          categories: [categoryIds.Beta, categoryIds.Alpha, categoryIds.Gamma],
+        },
+      });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+      await strapi.documents(ARTICLE_UID).update({
+        documentId: article.documentId,
+        data: {
+          categories: {
+            connect: [
+              { documentId: categoryIds.Alpha, position: { start: true } },
+              { documentId: categoryIds.Gamma, position: { after: categoryIds.Alpha } },
+              { documentId: categoryIds.Beta, position: { end: true } },
+            ],
+          },
+        },
+      });
+
+      expect(await getDraftCategoryNames(article.documentId)).toEqual(['Alpha', 'Gamma', 'Beta']);
+
+      await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+      expect(await getPublishedCategoryNames(article.documentId)).toEqual([
+        'Alpha',
+        'Gamma',
+        'Beta',
+      ]);
+      expect(await getDraftCategoryNames(article.documentId)).toEqual(['Alpha', 'Gamma', 'Beta']);
+    }
+  );
+
+  testInTransaction(
+    'connect + position single-item drag then publish -> published matches draft',
+    async () => {
+      const categoryIds = {
+        Alpha: await publishCategory('Alpha'),
+        Beta: await publishCategory('Beta'),
+        Gamma: await publishCategory('Gamma'),
+      };
+
+      const article = await strapi.documents(ARTICLE_UID).create({
+        data: {
+          title: 'Single drag order test',
+          categories: [categoryIds.Beta, categoryIds.Alpha, categoryIds.Gamma],
+        },
+      });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+      // Drag Beta to the end (Alpha -> Gamma -> Beta)
+      await strapi.documents(ARTICLE_UID).update({
+        documentId: article.documentId,
+        data: {
+          categories: {
+            connect: [{ documentId: categoryIds.Beta, position: { end: true } }],
+          },
+        },
+      });
+
+      expect(await getDraftCategoryNames(article.documentId)).toEqual(['Alpha', 'Gamma', 'Beta']);
+
+      await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+      expect(await getPublishedCategoryNames(article.documentId)).toEqual([
+        'Alpha',
+        'Gamma',
+        'Beta',
+      ]);
+    }
+  );
+
+  testInTransaction(
+    'multiple reorder/publish cycles keep published in sync with draft',
+    async () => {
+      const categoryIds = {
+        Alpha: await publishCategory('Alpha'),
+        Beta: await publishCategory('Beta'),
+        Gamma: await publishCategory('Gamma'),
+      };
+
+      const article = await strapi.documents(ARTICLE_UID).create({
+        data: {
+          title: 'Multi-cycle order test',
+          categories: [categoryIds.Beta, categoryIds.Alpha, categoryIds.Gamma],
+        },
+      });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+      const cycles = [
+        ['Alpha', 'Gamma', 'Beta'],
+        ['Gamma', 'Beta', 'Alpha'],
+        ['Beta', 'Alpha', 'Gamma'],
+      ] as const;
+
+      for (const names of cycles) {
+        await strapi.documents(ARTICLE_UID).update({
+          documentId: article.documentId,
+          data: {
+            categories: names.map((name) => categoryIds[name]),
+          },
+        });
+
+        expect(await getDraftCategoryNames(article.documentId)).toEqual([...names]);
+
+        await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+        expect(await getPublishedCategoryNames(article.documentId)).toEqual([...names]);
+        expect(await getDraftCategoryNames(article.documentId)).toEqual([...names]);
+      }
+    }
+  );
+
+  testInTransaction(
+    'inverse-side article order on category is preserved after owning-side reorder republish',
+    async () => {
+      const categoryIds = {
+        Alpha: await publishCategory('Alpha'),
+        Beta: await publishCategory('Beta'),
+        Gamma: await publishCategory('Gamma'),
+      };
+
+      const firstOnAlpha = await strapi.documents(ARTICLE_UID).create({
+        data: {
+          title: 'Inverse-first',
+          categories: [categoryIds.Alpha],
+        },
+      });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: firstOnAlpha.documentId });
+
+      const hub = await strapi.documents(ARTICLE_UID).create({
+        data: {
+          title: 'Inverse-hub',
+          categories: [categoryIds.Beta, categoryIds.Alpha, categoryIds.Gamma],
+        },
+      });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: hub.documentId });
+
+      const secondOnAlpha = await strapi.documents(ARTICLE_UID).create({
+        data: {
+          title: 'Inverse-second',
+          categories: [categoryIds.Alpha],
+        },
+      });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: secondOnAlpha.documentId });
+
+      expect(await getPublishedArticleTitlesOnCategory(categoryIds.Alpha)).toEqual([
+        'Inverse-first',
+        'Inverse-hub',
+        'Inverse-second',
+      ]);
+
+      await strapi.documents(ARTICLE_UID).update({
+        documentId: hub.documentId,
+        data: {
+          categories: [categoryIds.Alpha, categoryIds.Gamma, categoryIds.Beta],
+        },
+      });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: hub.documentId });
+
+      expect(await getPublishedCategoryNames(hub.documentId)).toEqual(['Alpha', 'Gamma', 'Beta']);
+      expect(await getPublishedArticleTitlesOnCategory(categoryIds.Alpha)).toEqual([
+        'Inverse-first',
+        'Inverse-hub',
+        'Inverse-second',
+      ]);
+    }
+  );
+
+  testInTransaction(
+    'related category republish after owning-side reorder does not revert article order',
+    async () => {
+      const categoryIds = {
+        Alpha: await publishCategory('Alpha'),
+        Beta: await publishCategory('Beta'),
+        Gamma: await publishCategory('Gamma'),
+      };
+
+      const article = await strapi.documents(ARTICLE_UID).create({
+        data: {
+          title: 'Related republish order test',
+          categories: [categoryIds.Beta, categoryIds.Alpha, categoryIds.Gamma],
+        },
+      });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+      await strapi.documents(ARTICLE_UID).update({
+        documentId: article.documentId,
+        data: {
+          categories: [categoryIds.Alpha, categoryIds.Gamma, categoryIds.Beta],
+        },
+      });
+      await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+      expect(await getPublishedCategoryNames(article.documentId)).toEqual([
+        'Alpha',
+        'Gamma',
+        'Beta',
+      ]);
+
+      await strapi.documents(CATEGORY_UID).update({
+        documentId: categoryIds.Alpha,
+        data: { name: 'Alpha-updated' },
+      });
+      await strapi.documents(CATEGORY_UID).publish({ documentId: categoryIds.Alpha });
+
+      expect(await getPublishedCategoryNames(article.documentId)).toEqual([
+        'Alpha-updated',
+        'Gamma',
+        'Beta',
+      ]);
+      expect(await getDraftCategoryNames(article.documentId)).toEqual([
+        'Alpha-updated',
+        'Gamma',
+        'Beta',
+      ]);
+    }
+  );
 });


### PR DESCRIPTION
## Summary

Fixes #26786 

For a **bidirectional many-to-many** relation with **Draft & Publish**, reordering the
related entries in the draft and re-publishing did **not** update the order on the
published version. The draft showed the new order, but the published tab (and GraphQL,
which reads the published version) kept the previous order.

Root cause is in `bidirectionalRelations` during `repository.publish()`:

1. The draft is read in the correct (reordered) order.
2. `bidirectionalRelations.load()` captures the **old published** entry's join rows —
   which still hold the stale order — *before* they are deleted.
3. The old published row is deleted and `entries.publish()` recreates it from the draft,
   writing the correct order.
4. `bidirectionalRelations.sync()` then runs a `CASE` `UPDATE` that **overwrites the
   freshly-written owning-side order with the stale captured order**, silently reverting
   the reorder.

The owning-side order is always rebuilt from the draft by `entries.publish()`, so it never
needs restoring on republish. Only the **inverse side** (the related entries' ordering of
this entry) is disturbed by a republish and must be restored. This PR skips the
old-published capture for the **owning side only**, leaving the inverse-side restoration
and the `draftsOnly` capture (related entry published later) untouched.

## What changed

- **`bidirectional-relations.ts`**: thread an `isOwningSide` flag into `captureJoinBatches`
  and skip the old-published rows capture when it is the owning side. Those rows are
  recreated in draft order by `entries.publish()`, so capturing them only lets `sync()`
  overwrite the freshly-published order with a stale one. The inverse side still uses the
  capture (needed to restore the related entries' ordering), and the `draftsOnly` capture
  is unaffected.
- **`m2m-order-republish.test.api.ts`**: regression test for the full-array `set` path —
  reorder draft, publish, assert published matches the draft.
- **`m2m-order-republish-connect.test.api.ts`**: regression test for the admin path —
  reorder via `connect` + `position` directives (including a single-item drag), across
  multiple reorder/publish cycles, asserting draft and published stay in sync.

## How to reproduce (before fix)

1. Enable **Draft & Publish** on two collection types with a many-to-many relation
   (e.g. Article ⇄ Category).
2. Create and publish categories Alpha, Beta, Gamma.
3. Create Article 1 with categories `Beta → Alpha → Gamma` and publish. Draft and Published
   both show `Beta → Alpha → Gamma`.
4. In the draft, reorder to `Alpha → Gamma → Beta` and publish.

**Before:** Published tab stays `Beta → Alpha → Gamma`; the GraphQL/REST response for the
published version returns the same stale order.
**After:** Draft tab, Published tab, and the API response all return `Alpha → Gamma → Beta`.

Reproduces on all databases (it is order-write logic, not dialect-specific SQL).

## Test plan

- [x] Added: `tests/api/core/strapi/document-service/relations/m2m-order-republish.test.api.ts`
- [x] Added: `tests/api/core/strapi/document-service/relations/m2m-order-republish-connect.test.api.ts`
- [x] Existing relation suites still pass: `tests/api/core/strapi/document-service/relations/` (9 suites, 54 tests) — including `bidirectional-relations` (publish-related-entry, interleaved publishes) and `invisible-relation-republish`
- [x] `publish` / `unpublish` / `discard-draft` document-service suites pass
- [x] `prettier:check`, `eslint` (0 errors), `tsc -p tsconfig.build.json --noEmit` (exit 0)
- [ ] Verified locally on **SQLite**; PostgreSQL/MySQL covered by CI
- [x] Added: `tests/api/core/strapi/document-service/relations/m2m-order-republish.test.api.ts`
      (covers both the full-array `set` path and the admin `connect` + `position` reorder path)