### PR TITLE
fix(content-manager): use ListViewTable relation-loaded translation key

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
@@ -61,7 +61,7 @@ const RelationMultiple = ({ mainField, content, rowId, name }: RelationMultipleP
     if (data) {
       notifyStatus(
         formatMessage({
-          id: getTranslation('DynamicTable.relation-loaded'),
+          id: getTranslation('ListViewTable.relation-loaded'),
           defaultMessage: 'Relations have been loaded',
         })
       );


### PR DESCRIPTION
## Summary

- Fixes the relations-loaded toast using `ListViewTable.relation-loaded` instead of `DynamicTable.relation-loaded`.
- `en.json` and all locale files already define `ListViewTable.relation-loaded`; the code referenced a stale key, so non-English locales fell back to the English `defaultMessage`.

## Test plan

- [x] Verified `en.json` and locale files use `ListViewTable.relation-loaded`
- [x] Confirmed `DynamicTable.relation-loaded` is not referenced elsewhere in content-manager
- [ ] Manual: open a list view with relations in a non-English locale and confirm the "relations loaded" toast is translated