### PR TITLE
ci: update issues-helper action to backup version

### DIFF
--- a/.github/workflows/issues_dailyCron.yml
+++ b/.github/workflows/issues_dailyCron.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check for inactive issues that can't be reproduced
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper-backup@d65454423c6fbbd20026b9b499d403f79422ac69
         with:
           actions: 'close-issues'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

The original repository has been disabled by GitHub, so the official backup repository is used instead.

See: https://github.com/actions-cool/#-remind

### Why is it needed?

Before this change, the workflow would never succeed, and we would receive failure notification emails every day. This creates unnecessary noise.

https://github.com/strapi/strapi/actions/workflows/issues_dailyCron.yml

### How to test it?

Merged this PR.

### Related issue(s)/PR(s)

No.