### PR TITLE
ci: replace issues-helper with actions/github-script

### DIFF
--- a/.github/workflows/issues_dailyCron.yml
+++ b/.github/workflows/issues_dailyCron.yml
@@ -3,6 +3,7 @@ name: 'Daily Cron - 00:00'
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 permissions:
   issues: write
@@ -12,19 +13,59 @@ jobs:
   cron-tasks:
     runs-on: ubuntu-latest
     steps:
-      - name: check for inactive issues that can't be reproduced
-        uses: actions-cool/issues-helper@v3
+      - name: Close inactive "can not reproduce" issues
+        uses: actions/github-script@v9
         with:
-          actions: 'close-issues'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'status: can not reproduce'
-          inactive-day: 14
-          close-reason: 'completed'
-          body: |
-            Hello!
+          script: |
+            const { owner, repo } = context.repo;
+            const inactiveDays = 14;
+            const label = 'status: can not reproduce';
+            const cutoff = new Date(Date.now() - inactiveDays * 24 * 60 * 60 * 1000);
+            const closeComment = `Hello!
 
             As we have not received any new or updated information to reproduce this issue in the last 14 days we are marking this issue as closed. Should you have new information please feel free to respond and we will consider reopening it.
 
             If anyone else have updated information for this issue, please open up a new bug report and simply reference this closed bug report so that we can get any new information you may have. If you have questions please refer to the [contributor's guide](https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md#reporting-an-issue) on opening issues.
 
-            Thank you and have a great day!
+            Thank you and have a great day!`;
+
+            let closed = 0;
+
+            for await (const response of github.paginate.iterator(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            })) {
+              for (const issue of response.data) {
+                if (issue.pull_request) {
+                  continue;
+                }
+
+                if (new Date(issue.updated_at) > cutoff) {
+                  continue;
+                }
+
+                core.info(`Closing inactive issue #${issue.number} (last updated ${issue.updated_at})`);
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: closeComment,
+                });
+
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+
+                closed += 1;
+              }
+            }
+
+            core.info(`Closed ${closed} inactive issue(s) with label "${label}"`);

--- a/.github/workflows/issues_handleLabel.yml
+++ b/.github/workflows/issues_handleLabel.yml
@@ -16,38 +16,54 @@ jobs:
   issue-labeled:
     runs-on: ubuntu-latest
     steps:
-      # Unable to Reproduce Tasks
-      - name: 'Comment: unable to reproduce'
-        if: "${{ github.event.label.name == 'status: can not reproduce' }}"
-        uses: actions-cool/issues-helper@v3
+      - name: Handle issue label automation
+        uses: actions/github-script@v9
         with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            > This is a templated message
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+            const login = context.payload.issue.user.login;
+            const label = context.payload.label.name;
 
-            Hello @${{ github.event.issue.user.login }},
+            const comment = async (body) => {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            };
 
-            Thank you for reporting this bug, however we are unable to reproduce the issue you described given the information we have on hand. Can you please create a fresh project that you are able to reproduce the issue in, provide clear steps to reproduce this issue, and either upload this fresh project to a new GitHub repo or compress it into a `.zip` and upload it on this issue?
+            const close = async (state_reason) => {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number,
+                state: 'closed',
+                state_reason,
+              });
+            };
+
+            const lock = async (lock_reason) => {
+              await github.rest.issues.lock({ owner, repo, issue_number, lock_reason });
+            };
+
+            const handlers = {
+              'status: can not reproduce': async () => {
+                await comment(
+                  `> This is a templated message
+
+            Hello @${login},
+
+            Thank you for reporting this bug, however we are unable to reproduce the issue you described given the information we have on hand. Can you please create a fresh project that you are able to reproduce the issue in, provide clear steps to reproduce this issue, and either upload this fresh project to a new GitHub repo or compress it into a \`.zip\` and upload it on this issue?
 
             We would greatly appreciate your assistance with this, by working in a fresh project it will cut out any possible variables that might be unrelated.
-            Please note that issues labeled with `status: can not reproduce` will be closed in 14 days if there is no activity.
+            Please note that issues labeled with \`status: can not reproduce\` will be closed in 14 days if there is no activity.
 
-            Thank you!
+            Thank you!`
+                );
+              },
 
-      # v3 Legacy Issues
-      - name: 'Comment: unsupported v3 issues'
-        if: "${{ github.event.label.name == 'flag: v3-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            > This is a templated message
+              'flag: v3-unsupported': async () => {
+                await comment(
+                  `> This is a templated message
 
-            Hello @${{ github.event.issue.user.login }},
+            Hello @${login},
 
             Thank you for reporting this potential bug report, please keep in mind that we are no longer accepting bug reports for Strapi v3.
             The recommended action we suggest for v3 users is to utilize the various migration resources to upgrade your package from Strapi v3 to Strapi v4:
@@ -59,28 +75,16 @@ jobs:
             Please see our [Security file](https://github.com/strapi/strapi/security) for more information about supported versions.
             For now this issue is marked as closed.
 
-            Thank You
-      - name: 'Close: unsupported v3 issues'
-        if: "${{ github.event.label.name == 'flag: v3-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'not_planned'
+            Thank You`
+                );
+                await close('not_planned');
+              },
 
-      # v4 Legacy Issues
-      - name: 'Comment: unsupported v4 issues'
-        if: "${{ github.event.label.name == 'flag: v4-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            > This is a templated message
+              'flag: v4-unsupported': async () => {
+                await comment(
+                  `> This is a templated message
 
-            Hello @${{ github.event.issue.user.login }},
+            Hello @${login},
 
             Thank you for reporting this potential bug report, please keep in mind that we are no longer accepting low/medium severity bug reports for Strapi v4.
             We have confirmed that this issue is a low/medium severity bug and is not reproducable in Strapi 5. We advise upgrading to Strapi 5 to resolve this issue.
@@ -96,28 +100,16 @@ jobs:
             Please see our [Security file](https://github.com/strapi/strapi/security) for more information about supported versions.
             For now this issue is marked as closed.
 
-            Thank You
-      - name: 'Close: unsupported v4 issues'
-        if: "${{ github.event.label.name == 'flag: v4-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'not_planned'
+            Thank You`
+                );
+                await close('not_planned');
+              },
 
-      # Feature request redirections
-      - name: 'Comment: redirect feature request to canny'
-        if: "${{ github.event.label.name == 'issue: feature request' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            > This is a templated message
+              'issue: feature request': async () => {
+                await comment(
+                  `> This is a templated message
 
-            Hello @${{ github.event.issue.user.login }},
+            Hello @${login},
 
             First thank you for reporting this feature need.
             To manage feature requests and the Strapi roadmap, we are using Canny.
@@ -128,56 +120,32 @@ jobs:
 
             In order to keep our GitHub issues clean and for valid bug reports this issue will be marked as closed, but please feel free to continue the discussion with other community members here.
 
-            Thank you for your insight and have a good day.
-      - name: 'Close: redirect feature request to canny'
-        if: "${{ github.event.label.name == 'issue: feature request' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'completed'
+            Thank you for your insight and have a good day.`
+                );
+                await close('completed');
+              },
 
-      # Invalid bug report template actions
-      - name: 'Comment: invalid bug report template'
-        if: "${{ github.event.label.name == 'flag: invalid template' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            > This is a templated message
+              'flag: invalid template': async () => {
+                await comment(
+                  `> This is a templated message
 
-            Hello @${{ github.event.issue.user.login }},
+            Hello @${login},
 
             We ask that you please follow the issue template.
             A proper issue submission let's us better understand the origin of your bug and therefore help you. You can see the template guidelines for bug reports [here](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md#reporting-an-issue).
 
             Please create a new issue and completely fill out the issue template, you can [open a new issue here](https://github.com/strapi/strapi/issues/new?template=BUG_REPORT.yml).
 
-            Thank you.
-      - name: 'Close: invalid bug report template'
-        if: "${{ github.event.label.name == 'flag: invalid template' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'not_planned'
+            Thank you.`
+                );
+                await close('not_planned');
+              },
 
-      # Redirect questions to GitHub Discussions
-      - name: 'Comment: redirect question to discussions'
-        if: "${{ github.event.label.name == 'flag: question' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            > This is a templated message
+              'flag: question': async () => {
+                await comment(
+                  `> This is a templated message
 
-            Hello @${{ github.event.issue.user.login }},
+            Hello @${login},
 
             Thank you for your interest in Strapi! However, this issue appears to be a question rather than a bug report. GitHub Issues are reserved for reproducible bug reports.
 
@@ -185,20 +153,19 @@ jobs:
 
             You can also check out our [Discord](https://discord.strapi.io) for real-time help.
 
-            Thank you!
-      - name: 'Close: redirect question to discussions'
-        if: "${{ github.event.label.name == 'flag: question' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'not_planned'
-      - name: 'Lock: redirect question to discussions'
-        if: "${{ github.event.label.name == 'flag: question' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'lock-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          lock-reason: 'off-topic'
+            Thank you!`
+                );
+                await close('not_planned');
+                await lock('off_topic');
+              },
+            };
+
+            const handler = handlers[label];
+
+            if (!handler) {
+              core.info(`No automation configured for label "${label}"`);
+              return;
+            }
+
+            core.info(`Running automation for label "${label}" on issue #${issue_number}`);
+            await handler();


### PR DESCRIPTION
### What does it do?

Removes all usage of `actions-cool/issues-helper` (TOS-blocked by GitHub) and replaces it with `actions/github-script`:

- **`issues_handleLabel.yml`** — single script step handles all label-triggered comments, closes, and locks (same templates and behavior as before).
- **`issues_dailyCron.yml`** — closes open issues labeled `status: can not reproduce` after 14 days of inactivity, with the same closing comment. Adds `workflow_dispatch` for manual testing.

### Why is it needed?

`actions-cool/issues-helper` has been blocked by GitHub since May 2025 (`Repository access blocked`), causing `issues_dailyCron.yml` and `issues_handleLabel.yml` to fail on every run. Using the official `github-script` action avoids a third-party dependency, org actions-allowlist concerns, and the maintainer's backup mirror.

Supersedes #26803.

### How to test it?

1. **Label automation** — on a test issue, apply each trigger label (`status: can not reproduce`, `flag: v3-unsupported`, etc.) and confirm the expected comment / close / lock behavior.
2. **Daily cron** — run **Daily Cron - 00:00** via `workflow_dispatch` and confirm it processes matching issues (or logs `Closed 0` when none qualify).

### Related issue(s)/PR(s)

Fixes CMS-1318

Closes approach in #26803 (backup-repo workaround).
