### PR TITLE
chore: update cli deploy copies

### DIFF
--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -84,7 +84,9 @@ async function getProjectsList(
     spinner.succeed();
 
     if (!Array.isArray(projectList)) {
-      ctx.logger.log("We couldn't find any projects available for linking in Strapi Cloud.");
+      ctx.logger.log(
+        'No Cloud project found. To link a project, first create it via the Cloud dashboard (https://cloud.strapi.io).'
+      );
       return null;
     }
     const projects: ProjectsList = (projectList as unknown as Project[])
@@ -99,7 +101,9 @@ async function getProjectsList(
         };
       });
     if (projects.length === 0) {
-      ctx.logger.log("We couldn't find any projects available for linking in Strapi Cloud.");
+      ctx.logger.log(
+        'No Cloud project found. To link a project, first create it via the Cloud dashboard (https://cloud.strapi.io).'
+      );
       return null;
     }
     return projects;


### PR DESCRIPTION
### What does it do?

Following https://github.com/strapi/strapi/pull/26801, we slightly update the copy when doing `strapi link` in case of no existing Cloud project.

### How to test it?

`strapi login`
- `strapi link` (only visible when you are log on an account without any existing Cloud project)

