### PR TITLE
fix(create-strapi-app): limit odd Node major warning to versions before 26

### DIFF
--- a/packages/cli/create-strapi-app/src/utils/check-requirements.ts
+++ b/packages/cli/create-strapi-app/src/utils/check-requirements.ts
@@ -6,6 +6,7 @@ import { logger } from './logger';
 
 export function checkNodeRequirements() {
   const currentNodeVersion = process.versions.node;
+  const nodeMajor = semver.major(currentNodeVersion);
 
   // error if the node version isn't supported
   if (!semver.satisfies(currentNodeVersion, engines.node)) {
@@ -16,8 +17,8 @@ export function checkNodeRequirements() {
     ]);
   }
 
-  // warn if not using a LTS version
-  else if (semver.major(currentNodeVersion) % 2 !== 0) {
+  // warn if not using a LTS version (odd majors are non-LTS before Node 26)
+  else if (nodeMajor < 26 && nodeMajor % 2 !== 0) {
     logger.warn([
       chalk.yellow(`You are running ${chalk.bold(`Node.js ${currentNodeVersion}`)}`),
       `Strapi only supports ${chalk.bold(chalk.green('LTS versions of Node.js'))}, other versions may not be compatible.`,


### PR DESCRIPTION
### What does it do?

Limits the `create-strapi-app` non-LTS Node warning to odd major versions below 26. Previously, any odd major (e.g. 25) triggered a warning that Strapi only supports LTS versions.

### Why is it needed?

Node.js is shifting to LTS for every major release from v26 onward. The old odd/even heuristic still applies to older lines (e.g. Node 25 is Current/EOL, not LTS), but would incorrectly warn on supported Node 27+ once those versions are in range.

### How to test it?

1. Run `create-strapi-app` on Node 25 — should still show the LTS warning.
2. Run on Node 26+ (or mock `process.versions.node`) — should not show the odd-major warning.
3. Unsupported versions outside `engines.node` should still fatal as before.

### Related issue(s)/PR(s)

Fixes CMS-1317
