### PR TITLE
fix(providers): bump nodemailer to 9.0.1

### DIFF
--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -72,7 +72,7 @@
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
-    "nodemailer": "8.0.9"
+    "nodemailer": "9.0.1"
   },
   "devDependencies": {
     "@types/nodemailer": "7.0.11",

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -45,7 +45,7 @@
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
-    "nodemailer": "8.0.9"
+    "nodemailer": "9.0.1"
   },
   "devDependencies": {
     "@types/nodemailer": "7.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9783,7 +9783,7 @@ __metadata:
   dependencies:
     "@types/nodemailer": "npm:7.0.11"
     eslint-config-custom: "npm:5.49.0"
-    nodemailer: "npm:8.0.9"
+    nodemailer: "npm:9.0.1"
     tsconfig: "npm:5.49.0"
   languageName: unknown
   linkType: soft
@@ -9805,7 +9805,7 @@ __metadata:
   dependencies:
     "@types/nodemailer": "npm:7.0.11"
     eslint-config-custom: "npm:5.49.0"
-    nodemailer: "npm:8.0.9"
+    nodemailer: "npm:9.0.1"
     tsconfig: "npm:5.49.0"
   languageName: unknown
   linkType: soft
@@ -24865,10 +24865,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:8.0.9":
-  version: 8.0.9
-  resolution: "nodemailer@npm:8.0.9"
-  checksum: 10c0/f5c671ed1c28b27fc997416be70c41aa068ea7540feebc8aca1d0c4f18ac1017d05d74d08218b5aa13206d2639d6a4605f9f3b2acbcb84d20b9cc89d50c5ab5a
+"nodemailer@npm:9.0.1":
+  version: 9.0.1
+  resolution: "nodemailer@npm:9.0.1"
+  checksum: 10c0/4213f01aa211127c1ce33243c5e45e7f831601a933d03fa864cd827b1bd5ea2782cb4b43722bee7028cbc193733d9802dad1120fe67181448eb0b7de52218a37
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumps `nodemailer` from `8.0.9` to `9.0.1` in `@strapi/provider-email-nodemailer` and `@strapi/provider-email-sendmail`
- Clears GHSA-p6gq-j5cr-w38f (high)
- No Strapi code changes — users already pass nodemailer transport options via `providerOptions`

## Breaking change assessment (user-facing)

Nodemailer 9.0.0 enforces TLS certificate validation when fetching remote content (attachment URLs, OAuth2 token endpoints, proxy CONNECT). **Standard SMTP relay usage is unaffected.**

Users relying on self-signed/expired certs for remote attachments, internal OAuth2, or proxies can opt out via existing passthrough config:

```js
providerOptions: {
  tls: { rejectUnauthorized: false },
}
```

Investigation report: `docs/dependency-remediation/06-nodemailer.md`

## Test plan

- [x] `yarn nx run @strapi/provider-email-nodemailer:test:unit` (98 tests)
- [x] `yarn nx run @strapi/provider-email-sendmail:test:unit` (44 tests)
- [ ] CI
- [ ] Manual: admin email settings → Send test email