### PR TITLE
chore(utils): upgrade preferred-pm to v5 with dynamic import

### DIFF
--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -56,7 +56,7 @@
     "lodash": "4.18.1",
     "node-machine-id": "1.1.12",
     "p-map": "4.0.0",
-    "preferred-pm": "3.1.3",
+    "preferred-pm": "5.0.0",
     "yup": "0.32.9",
     "zod": "3.25.76"
   },

--- a/packages/core/utils/src/__tests__/package-manager.test.ts
+++ b/packages/core/utils/src/__tests__/package-manager.test.ts
@@ -1,25 +1,32 @@
-import preferredPM from 'preferred-pm';
 import execa from 'execa';
 import * as pkg from '../package-manager';
+import { getPreferredPM } from '../get-preferred-pm';
 
-jest.mock('preferred-pm');
+jest.mock('../get-preferred-pm');
 jest.mock('execa');
 
-const mockedPreferredPM = preferredPM as jest.MockedFunction<typeof preferredPM>;
+const mockedGetPreferredPM = getPreferredPM as jest.MockedFunction<typeof getPreferredPM>;
 const mockedExeca = execa as jest.MockedFunction<typeof execa>;
 
 describe('package-manager', () => {
+  const preferredPM = jest.fn();
+
+  beforeEach(() => {
+    preferredPM.mockReset();
+    mockedGetPreferredPM.mockResolvedValue(preferredPM);
+  });
+
   describe('getPreferred', () => {
     it('returns pnpm when preferred-pm detects pnpm', async () => {
-      mockedPreferredPM.mockResolvedValue({ name: 'pnpm', version: '10.12.1' });
+      preferredPM.mockResolvedValue({ name: 'pnpm', version: '10.12.1' });
 
       await expect(pkg.getPreferred('/some/project')).resolves.toBe('pnpm');
-      expect(mockedPreferredPM).toHaveBeenCalledWith('/some/project');
+      expect(preferredPM).toHaveBeenCalledWith('/some/project');
     });
 
     it('defaults to npm with a warning when the detected package manager is not supported', async () => {
       const warnSpy = jest.spyOn(process, 'emitWarning').mockImplementation(() => {});
-      mockedPreferredPM.mockResolvedValue({ name: 'bun', version: '1.2.0' });
+      preferredPM.mockResolvedValue({ name: 'bun', version: '1.2.0' });
 
       await expect(pkg.getPreferred('/some/project')).resolves.toBe('npm');
       expect(warnSpy).toHaveBeenCalled();
@@ -27,7 +34,7 @@ describe('package-manager', () => {
     });
 
     it('throws when preferred-pm cannot detect a package manager', async () => {
-      mockedPreferredPM.mockResolvedValue(undefined);
+      preferredPM.mockResolvedValue(null);
 
       await expect(pkg.getPreferred('/some/project')).rejects.toThrow(
         `Couldn't find a package manager in your project.`

--- a/packages/core/utils/src/get-preferred-pm.ts
+++ b/packages/core/utils/src/get-preferred-pm.ts
@@ -1,0 +1,9 @@
+type PreferredPM = typeof import('preferred-pm').preferredPM;
+
+let cached: Promise<PreferredPM> | undefined;
+
+/** Loads preferred-pm v5 via dynamic import (CJS-safe) and caches the named export. */
+export async function getPreferredPM(): Promise<PreferredPM> {
+  cached ??= import('preferred-pm').then((m) => m.preferredPM);
+  return cached;
+}

--- a/packages/core/utils/src/package-manager.ts
+++ b/packages/core/utils/src/package-manager.ts
@@ -1,7 +1,7 @@
 import execa from 'execa';
-import preferredPM from 'preferred-pm';
 
 import type { Options as ProcessOptions } from 'execa';
+import { getPreferredPM } from './get-preferred-pm';
 
 const SUPPORTED_PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm'] as const;
 const DEFAULT_PACKAGE_MANAGER = 'npm' as const;
@@ -9,10 +9,10 @@ const DEFAULT_PACKAGE_MANAGER = 'npm' as const;
 type SupportedPackageManagerName = (typeof SUPPORTED_PACKAGE_MANAGERS)[number];
 
 export const getPreferred = async (pkgPath: string): Promise<SupportedPackageManagerName> => {
+  const preferredPM = await getPreferredPM();
   const pm = await preferredPM(pkgPath);
 
-  const hasPackageManager = pm !== undefined;
-  if (!hasPackageManager) {
+  if (pm == null) {
     throw new Error(`Couldn't find a package manager in your project.`);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5040,6 +5040,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lazy-node/types-path@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@lazy-node/types-path@npm:1.0.3"
+  dependencies:
+    "@types/node": "npm:*"
+    ts-type: "npm:^3.0.1"
+    tslib: "npm:>=2"
+  checksum: 10c0/5aed736be0f240e75d02f99c35e9f08f9fe92a65fc955fbbcad67896d934e0d922033e9658ce9ccae8fd2a1eeffa37a308ad0b1cb73e39ff072b7f474d770bee
+  languageName: node
+  linkType: hard
+
 "@lezer/common@npm:^1.0.0":
   version: 1.2.1
   resolution: "@lezer/common@npm:1.2.1"
@@ -10365,7 +10376,7 @@ __metadata:
     lodash: "npm:4.18.1"
     node-machine-id: "npm:1.1.12"
     p-map: "npm:4.0.0"
-    preferred-pm: "npm:3.1.3"
+    preferred-pm: "npm:5.0.0"
     tsconfig: "npm:5.50.2"
     vitest: "catalog:"
     vitest-config: "npm:5.50.2"
@@ -18811,6 +18822,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-up-simple@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "find-up-simple@npm:1.0.1"
+  checksum: 10c0/ad34de157b7db925d50ff78302fefb28e309f3bc947c93ffca0f9b0bccf9cf1a2dc57d805d5c94ec9fc60f4838f5dbdfd2a48ecd77c23015fa44c6dd5f60bc40
+  languageName: node
+  linkType: hard
+
 "find-up@npm:^3.0.0":
   version: 3.0.0
   resolution: "find-up@npm:3.0.0"
@@ -18860,13 +18878,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-yarn-workspace-root2@npm:1.2.16":
-  version: 1.2.16
-  resolution: "find-yarn-workspace-root2@npm:1.2.16"
+"find-yarn-workspace-root2@npm:1.2.53":
+  version: 1.2.53
+  resolution: "find-yarn-workspace-root2@npm:1.2.53"
   dependencies:
-    micromatch: "npm:^4.0.2"
-    pkg-dir: "npm:^4.2.0"
-  checksum: 10c0/d576067c7823de517d71831eafb5f6dc60554335c2d14445708f2698551b234f89c976a7f259d9355a44e417c49e7a93b369d0474579af02bbe2498f780c92d3
+    micromatch: "npm:^4.0.8"
+    pkg-dir: "npm:<6 >=5"
+    tslib: "npm:>=2"
+    upath2: "npm:^3.1.23"
+  checksum: 10c0/63e0eca03dcdce4c272b6babf1c155ffbad898708450dd51d44eb81a5dc5de85840ffb349c17846bc30075e0ead115dd9692fdb032cc3a9dd159573c07e327b3
   languageName: node
   linkType: hard
 
@@ -19801,7 +19821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.5, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.8, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -22132,7 +22152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.0, js-yaml@npm:^3.13.1":
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1":
   version: 3.15.0
   resolution: "js-yaml@npm:3.15.0"
   dependencies:
@@ -23080,15 +23100,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"load-yaml-file@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "load-yaml-file@npm:0.2.0"
+"load-yaml-file@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "load-yaml-file@npm:1.0.0"
   dependencies:
-    graceful-fs: "npm:^4.1.5"
-    js-yaml: "npm:^3.13.0"
-    pify: "npm:^4.0.1"
-    strip-bom: "npm:^3.0.0"
-  checksum: 10c0/e00ed43048c0648dfef7639129b6d7e5c2272bc36d2a50dd983dd495f3341a02cd2c40765afa01345f798d0d894e5ba53212449933e72ddfa4d3f7a48f822d2f
+    graceful-fs: "npm:^4.2.8"
+    js-yaml: "npm:^4.1.0"
+    strip-bom: "npm:^5.0.0"
+  checksum: 10c0/801ae42855a0aa244a74b83df5373b45fde0f7b49b8b0e18953108d5ea94dcacfc116dbd825d47b0e0e7a18c24ff5c3b17c28c764dada0f3c7aa4e3a2733ecbd
   languageName: node
   linkType: hard
 
@@ -24204,7 +24223,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.7, micromatch@npm:^4.0.8":
+"micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.7, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -26005,6 +26024,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-is-network-drive@npm:^1.0.24":
+  version: 1.0.24
+  resolution: "path-is-network-drive@npm:1.0.24"
+  dependencies:
+    tslib: "npm:^2"
+  checksum: 10c0/1d97fd57c0b989102115cbc78d98b5cafc21e29eabd504e2058c2debbe6cb84c1b2679cb86d80f562994b4b0240a2ef3abd79d297714cf0eeaec3df10e3ca6f3
+  languageName: node
+  linkType: hard
+
 "path-key@npm:^2.0.1":
   version: 2.0.1
   resolution: "path-key@npm:2.0.1"
@@ -26056,6 +26084,15 @@ __metadata:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
   checksum: 10c0/b35ad37cf6557a87fd057121ce2be7695380c9138d93e87ae928609da259ea0a170fac6f3ef1eb3ece8a068e8b7f2f3adf5bb2374cf4d4a57fe484954fcc9482
+  languageName: node
+  linkType: hard
+
+"path-strip-sep@npm:^1.0.21":
+  version: 1.0.21
+  resolution: "path-strip-sep@npm:1.0.21"
+  dependencies:
+    tslib: "npm:^2"
+  checksum: 10c0/62cca64ef1cd754f3ef9c670aad50d1e0fdf2a9e41c3b0f7489733dc6de1996877425dd726abb623ed02fd315c7a323dc62303ae5ecca8d44114b367eace710f
   languageName: node
   linkType: hard
 
@@ -26307,6 +26344,15 @@ __metadata:
   version: 5.0.1
   resolution: "pkce-challenge@npm:5.0.1"
   checksum: 10c0/207f4cb976682f27e8324eb49cf71937c98fbb8341a0b8f6142bc6f664825b30e049a54a21b5c034e823ee3c3d412f10d74bd21de78e17452a6a496c2991f57c
+  languageName: node
+  linkType: hard
+
+"pkg-dir@npm:<6 >=5":
+  version: 5.0.0
+  resolution: "pkg-dir@npm:5.0.0"
+  dependencies:
+    find-up: "npm:^5.0.0"
+  checksum: 10c0/793a496d685dc55bbbdbbb22d884535c3b29241e48e3e8d37e448113a71b9e42f5481a61fdc672d7322de12fbb2c584dd3a68bf89b18fffce5c48a390f911bc5
   languageName: node
   linkType: hard
 
@@ -26577,15 +26623,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"preferred-pm@npm:3.1.3":
-  version: 3.1.3
-  resolution: "preferred-pm@npm:3.1.3"
+"preferred-pm@npm:5.0.0":
+  version: 5.0.0
+  resolution: "preferred-pm@npm:5.0.0"
   dependencies:
-    find-up: "npm:^5.0.0"
-    find-yarn-workspace-root2: "npm:1.2.16"
-    path-exists: "npm:^4.0.0"
-    which-pm: "npm:2.0.0"
-  checksum: 10c0/8eb9c35e4818d8e20b5b61a2117f5c77678649e1d20492fe4fdae054a9c4b930d04582b17e8a59b2dc923f2f788c7ded7fc99fd22c04631d836f7f52aeb79bde
+    find-up-simple: "npm:^1.0.1"
+    find-yarn-workspace-root2: "npm:1.2.53"
+    which-pm: "npm:^4.0.0"
+  checksum: 10c0/dbd63cc25c6a63582cf0d5a4ea367f35967d7adcd4dfb160fa60d7648a588522360b803f5a41927d9b8c189cc2eb8f49aac81851bb0c6aad4e14a23e0c32e579
   languageName: node
   linkType: hard
 
@@ -29824,6 +29869,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-bom@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "strip-bom@npm:5.0.0"
+  checksum: 10c0/f87e212f8a41e08e77d3994b3d9c4112258bd3a13688f9c7c85a6705a87a8e526422bce0762326cc2d9655c32a8c0ff1a2b14936795384c353828e4637823bc6
+  languageName: node
+  linkType: hard
+
 "strip-dirs@npm:^3.0.0":
   version: 3.0.0
   resolution: "strip-dirs@npm:3.0.0"
@@ -30598,6 +30650,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-type@npm:^3.0.1":
+  version: 3.0.13
+  resolution: "ts-type@npm:3.0.13"
+  dependencies:
+    "@types/node": "npm:*"
+    tslib: "npm:>=2.8.1"
+    typedarray-dts: "npm:^1.0.0"
+  peerDependencies:
+    ts-toolbelt: ^9.6.0
+  checksum: 10c0/7e9cdef80e27be21c2ed0d96d118401d154c5b80bb334670fd7e1b0d0fff97df97aef0695ec80251e9d031b46a57b22ed4dc191492d53914cfdd8bda9bc3325c
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.14.2":
   version: 3.14.2
   resolution: "tsconfig-paths@npm:3.14.2"
@@ -30641,17 +30706,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"tslib@npm:>=2, tslib@npm:>=2.8.1, tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.2, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 10c0/69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.2, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
-  version: 2.8.1
-  resolution: "tslib@npm:2.8.1"
-  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 
@@ -30983,6 +31048,13 @@ __metadata:
     possible-typed-array-names: "npm:^1.0.0"
     reflect.getprototypeof: "npm:^1.0.6"
   checksum: 10c0/e38f2ae3779584c138a2d8adfa8ecf749f494af3cd3cdafe4e688ce51418c7d2c5c88df1bd6be2bbea099c3f7cea58c02ca02ed438119e91f162a9de23f61295
+  languageName: node
+  linkType: hard
+
+"typedarray-dts@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "typedarray-dts@npm:1.0.0"
+  checksum: 10c0/a1d192c83a8cea5cdabf0b56af1600bee399a165243262875517f431f9556adcecb5bccb31e12e487744cf066c59c17240ab00c0ae7cbd15cb1297bae9a819f6
   languageName: node
   linkType: hard
 
@@ -31477,6 +31549,19 @@ __metadata:
   version: 4.0.0
   resolution: "untildify@npm:4.0.0"
   checksum: 10c0/d758e624c707d49f76f7511d75d09a8eda7f2020d231ec52b67ff4896bcf7013be3f9522d8375f57e586e9a2e827f5641c7e06ee46ab9c435fc2b2b2e9de517a
+  languageName: node
+  linkType: hard
+
+"upath2@npm:^3.1.23":
+  version: 3.1.23
+  resolution: "upath2@npm:3.1.23"
+  dependencies:
+    "@lazy-node/types-path": "npm:^1.0.3"
+    "@types/node": "npm:*"
+    path-is-network-drive: "npm:^1.0.24"
+    path-strip-sep: "npm:^1.0.21"
+    tslib: "npm:^2"
+  checksum: 10c0/67e8dc693902dc2e3eef2b5ac581b27df8dbb201a44fcd8552a58c28a01d3756a9c3c80a575e5eaa9de701ba65947593691519e43316efcbc2bbcd5aa14542f1
   languageName: node
   linkType: hard
 
@@ -32166,13 +32251,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-pm@npm:2.0.0":
-  version: 2.0.0
-  resolution: "which-pm@npm:2.0.0"
+"which-pm@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "which-pm@npm:4.0.0"
   dependencies:
-    load-yaml-file: "npm:^0.2.0"
-    path-exists: "npm:^4.0.0"
-  checksum: 10c0/499fdf18fb259ea7dd58aab0df5f44240685364746596d0d08d9d68ac3a7205bde710ec1023dbc9148b901e755decb1891aa6790ceffdb81c603b6123ec7b5e4
+    load-yaml-file: "npm:^1.0.0"
+  checksum: 10c0/8423c666b5aa009846174d922225ff23642f45b6fa942a396a9e1eda6068a94817cf74a15a64bc18e912b33e4113507e39f5d688bf0f45cf65fb619193c008fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Upgrades `preferred-pm` from `3.1.3` to `5.0.0` in `@strapi/utils`.

v5 is ESM-only and exports a named `preferredPM` function (v3 used a default export). To keep the CJS `@strapi/utils` build working, loading follows the same pattern as `inquirer` and `package-json`: a cached dynamic import via `get-preferred-pm.ts`.

Also handles v5 returning `null` (instead of `undefined`) when no package manager is detected.

### Why is it needed?

Dependency audit remediation — `preferred-pm@3.x` pulls in deprecated transitive deps. v5 is the maintained release.

Only consumer is `@strapi/upgrade` (`packageManager.getPreferred`); users cannot configure this library directly.

### How to test it?

- `yarn workspace @strapi/utils test:unit`
- `yarn workspace @strapi/upgrade test:unit`
- Smoke: run `@strapi/upgrade` in a project with `yarn.lock`, `pnpm-lock.yaml`, and `package-lock.json` and confirm the detected PM matches expectations.

### Related issue(s)/PR(s)

Part of npm audit dependency remediation (Phase 4).