### PR TITLE
feat(utils): add env.required for strict scaffold secrets

### DIFF
--- a/packages/cli/create-strapi-app/templates/example/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/admin.ts
@@ -2,18 +2,18 @@ import type { Core } from '@strapi/strapi';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET')!,
+    secret: env.required('ADMIN_JWT_SECRET'),
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT')!,
+    salt: env.required('API_TOKEN_SALT'),
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT')!,
+      salt: env.required('TRANSFER_TOKEN_SALT'),
     },
   },
   secrets: {
-    encryptionKey: env('ENCRYPTION_KEY')!,
+    encryptionKey: env.required('ENCRYPTION_KEY'),
   },
   flags: {
     nps: env.bool('FLAG_NPS', true),

--- a/packages/cli/create-strapi-app/templates/example/config/server.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/server.ts
@@ -4,7 +4,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server =>
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS')!,
+    keys: env.array.required('APP_KEYS'),
   },
 });
 

--- a/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
@@ -2,18 +2,18 @@ import type { Core } from '@strapi/strapi';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET')!,
+    secret: env.required('ADMIN_JWT_SECRET'),
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT')!,
+    salt: env.required('API_TOKEN_SALT'),
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT')!,
+      salt: env.required('TRANSFER_TOKEN_SALT'),
     },
   },
   secrets: {
-    encryptionKey: env('ENCRYPTION_KEY')!,
+    encryptionKey: env.required('ENCRYPTION_KEY'),
   },
   flags: {
     nps: env.bool('FLAG_NPS', true),

--- a/packages/cli/create-strapi-app/templates/vanilla/config/server.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/server.ts
@@ -4,7 +4,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server =>
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS')!,
+    keys: env.array.required('APP_KEYS'),
   },
 });
 

--- a/packages/core/utils/src/__tests__/env-helper.test.ts
+++ b/packages/core/utils/src/__tests__/env-helper.test.ts
@@ -143,6 +143,46 @@ describe('Env helper', () => {
     });
   });
 
+  describe('env with required cast', () => {
+    test('Returns env var when defined', () => {
+      process.env.REQUIRED_VAR = 'secret';
+      expect(envHelper.required('REQUIRED_VAR')).toEqual('secret');
+    });
+
+    test('Throws if env var is not defined', () => {
+      expect(() => envHelper.required('MISSING_REQUIRED_VAR')).toThrow(
+        'Missing required environment variable MISSING_REQUIRED_VAR'
+      );
+    });
+
+    test('Throws if env var is empty', () => {
+      process.env.EMPTY_REQUIRED_VAR = '';
+      expect(() => envHelper.required('EMPTY_REQUIRED_VAR')).toThrow(
+        'Missing required environment variable EMPTY_REQUIRED_VAR'
+      );
+    });
+  });
+
+  describe('env with required array cast', () => {
+    test('Returns env var as array when defined', () => {
+      process.env.REQUIRED_ARRAY_VAR = 'first,second';
+      expect(envHelper.array.required('REQUIRED_ARRAY_VAR')).toEqual(['first', 'second']);
+    });
+
+    test('Throws if env var is not defined', () => {
+      expect(() => envHelper.array.required('MISSING_REQUIRED_ARRAY_VAR')).toThrow(
+        'Missing required environment variable MISSING_REQUIRED_ARRAY_VAR'
+      );
+    });
+
+    test('Throws if env var is empty', () => {
+      process.env.EMPTY_REQUIRED_ARRAY_VAR = '';
+      expect(() => envHelper.array.required('EMPTY_REQUIRED_ARRAY_VAR')).toThrow(
+        'Missing required environment variable EMPTY_REQUIRED_ARRAY_VAR'
+      );
+    });
+  });
+
   describe('env with union cast', () => {
     test('Throws if expectedValues is not provided', () => {
       // @ts-expect-error missing 2nd parameter (that's the point of the test)

--- a/packages/core/utils/src/env-helper.ts
+++ b/packages/core/utils/src/env-helper.ts
@@ -79,6 +79,28 @@ function array(key: string, defaultValue?: string[]): string[] | undefined {
   });
 }
 
+function required(key: string): string {
+  const value = envFn(key);
+
+  if (value === undefined || value === '') {
+    throw new Error(`Missing required environment variable ${key}`);
+  }
+
+  return value;
+}
+
+function requiredArray(key: string): string[] {
+  const value = array(key);
+
+  if (!value?.length || value.every((v) => v === '')) {
+    throw new Error(`Missing required environment variable ${key}`);
+  }
+
+  return value;
+}
+
+const arrayWithRequired = Object.assign(array, { required: requiredArray });
+
 function date(key: string, defaultValue: Date): Date;
 function date(key: string, defaultValue?: Date | undefined): Date | undefined;
 function date(key: string, defaultValue?: Date): Date | undefined {
@@ -128,9 +150,10 @@ const utils = {
   float,
   bool,
   json,
-  array,
+  array: arrayWithRequired,
   date,
   oneOf,
+  required,
 };
 
 const env: Env = Object.assign(envFn, utils);


### PR DESCRIPTION
## Summary

Follow-up to #26779 addressing [this discussion](https://github.com/strapi/strapi/pull/26779#discussion_r3472604570).

- Adds `env.required(key)` and `env.array.required(key)` to `@strapi/utils` — returns a typed value or throws at config load when the variable is missing/empty
- Replaces `!` non-null assertions in the create-strapi-app TypeScript scaffolds with the new helpers
- Adds unit tests for both helpers

This keeps strict-mode type safety without code defaults for secrets (no `tobemodified` fallback in config) and without lying to TypeScript via `!`.

## Test plan

- [x] `yarn test:unit` in `packages/core/utils` (env-helper tests)
- [x] `npx tsc --noEmit` in `packages/cli/create-strapi-app/templates/vanilla`
- [ ] CI on stacked PR

## Related issue(s)/PR(s)

- Builds on #26779