### PR TITLE
enhancement(utils): add env.required for strict scaffold secrets

### DIFF
--- a/packages/cli/create-strapi-app/templates/example/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/admin.ts
@@ -2,18 +2,18 @@ import type { Core } from '@strapi/strapi';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET')!,
+    secret: env.required('ADMIN_JWT_SECRET'),
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT')!,
+    salt: env.required('API_TOKEN_SALT'),
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT')!,
+      salt: env.required('TRANSFER_TOKEN_SALT'),
     },
   },
   secrets: {
-    encryptionKey: env('ENCRYPTION_KEY')!,
+    encryptionKey: env.required('ENCRYPTION_KEY'),
   },
   flags: {
     nps: env.bool('FLAG_NPS', true),

--- a/packages/cli/create-strapi-app/templates/example/config/server.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/server.ts
@@ -4,7 +4,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server =>
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS')!,
+    keys: env.array.required('APP_KEYS'),
   },
   webhooks: {
     populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),

--- a/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
@@ -2,18 +2,18 @@ import type { Core } from '@strapi/strapi';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET')!,
+    secret: env.required('ADMIN_JWT_SECRET'),
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT')!,
+    salt: env.required('API_TOKEN_SALT'),
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT')!,
+      salt: env.required('TRANSFER_TOKEN_SALT'),
     },
   },
   secrets: {
-    encryptionKey: env('ENCRYPTION_KEY')!,
+    encryptionKey: env.required('ENCRYPTION_KEY'),
   },
   flags: {
     nps: env.bool('FLAG_NPS', true),

--- a/packages/cli/create-strapi-app/templates/vanilla/config/server.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/server.ts
@@ -4,7 +4,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server =>
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS')!,
+    keys: env.array.required('APP_KEYS'),
   },
   webhooks: {
     populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),

--- a/packages/core/utils/src/__tests__/env-helper.test.ts
+++ b/packages/core/utils/src/__tests__/env-helper.test.ts
@@ -144,6 +144,12 @@ describe('Env helper', () => {
   });
 
   describe('env with required cast', () => {
+    afterEach(() => {
+      delete process.env.REQUIRED_VAR;
+      delete process.env.EMPTY_REQUIRED_VAR;
+      delete process.env.WHITESPACE_REQUIRED_VAR;
+    });
+
     test('Returns env var when defined', () => {
       process.env.REQUIRED_VAR = 'secret';
       expect(envHelper.required('REQUIRED_VAR')).toEqual('secret');
@@ -171,6 +177,13 @@ describe('Env helper', () => {
   });
 
   describe('env with required array cast', () => {
+    afterEach(() => {
+      delete process.env.REQUIRED_ARRAY_VAR;
+      delete process.env.EMPTY_REQUIRED_ARRAY_VAR;
+      delete process.env.MANY_EMPTY_REQUIRED_ARRAY_VAR;
+      delete process.env.WHITESPACE_REQUIRED_ARRAY_VAR;
+    });
+
     test('Returns env var as array when defined', () => {
       process.env.REQUIRED_ARRAY_VAR = 'first,second';
       expect(envHelper.array.required('REQUIRED_ARRAY_VAR')).toEqual(['first', 'second']);

--- a/packages/core/utils/src/__tests__/env-helper.test.ts
+++ b/packages/core/utils/src/__tests__/env-helper.test.ts
@@ -158,7 +158,14 @@ describe('Env helper', () => {
     test('Throws if env var is empty', () => {
       process.env.EMPTY_REQUIRED_VAR = '';
       expect(() => envHelper.required('EMPTY_REQUIRED_VAR')).toThrow(
-        'Missing required environment variable EMPTY_REQUIRED_VAR'
+        'Required environment variable EMPTY_REQUIRED_VAR must not be empty'
+      );
+    });
+
+    test('Throws if env var is whitespace only', () => {
+      process.env.WHITESPACE_REQUIRED_VAR = '   ';
+      expect(() => envHelper.required('WHITESPACE_REQUIRED_VAR')).toThrow(
+        'Required environment variable WHITESPACE_REQUIRED_VAR must not be empty'
       );
     });
   });
@@ -178,7 +185,21 @@ describe('Env helper', () => {
     test('Throws if env var is empty', () => {
       process.env.EMPTY_REQUIRED_ARRAY_VAR = '';
       expect(() => envHelper.array.required('EMPTY_REQUIRED_ARRAY_VAR')).toThrow(
-        'Missing required environment variable EMPTY_REQUIRED_ARRAY_VAR'
+        'Required environment variable EMPTY_REQUIRED_ARRAY_VAR must not be empty'
+      );
+    });
+
+    test('Throws if env var is only empty comma-separated values', () => {
+      process.env.MANY_EMPTY_REQUIRED_ARRAY_VAR = ',,,';
+      expect(() => envHelper.array.required('MANY_EMPTY_REQUIRED_ARRAY_VAR')).toThrow(
+        'Required environment variable MANY_EMPTY_REQUIRED_ARRAY_VAR must not be empty'
+      );
+    });
+
+    test('Throws if env var is whitespace only', () => {
+      process.env.WHITESPACE_REQUIRED_ARRAY_VAR = '   ';
+      expect(() => envHelper.array.required('WHITESPACE_REQUIRED_ARRAY_VAR')).toThrow(
+        'Required environment variable WHITESPACE_REQUIRED_ARRAY_VAR must not be empty'
       );
     });
   });

--- a/packages/core/utils/src/__tests__/env-helper.test.ts
+++ b/packages/core/utils/src/__tests__/env-helper.test.ts
@@ -143,6 +143,46 @@ describe('Env helper', () => {
     });
   });
 
+  describe('env with required cast', () => {
+    test('Returns env var when defined', () => {
+      process.env.REQUIRED_VAR = 'secret';
+      expect(envHelper.required('REQUIRED_VAR')).toEqual('secret');
+    });
+
+    test('Throws if env var is not defined', () => {
+      expect(() => envHelper.required('MISSING_REQUIRED_VAR')).toThrow(
+        'Missing required environment variable MISSING_REQUIRED_VAR'
+      );
+    });
+
+    test('Throws if env var is empty', () => {
+      process.env.EMPTY_REQUIRED_VAR = '';
+      expect(() => envHelper.required('EMPTY_REQUIRED_VAR')).toThrow(
+        'Missing required environment variable EMPTY_REQUIRED_VAR'
+      );
+    });
+  });
+
+  describe('env with required array cast', () => {
+    test('Returns env var as array when defined', () => {
+      process.env.REQUIRED_ARRAY_VAR = 'first,second';
+      expect(envHelper.array.required('REQUIRED_ARRAY_VAR')).toEqual(['first', 'second']);
+    });
+
+    test('Throws if env var is not defined', () => {
+      expect(() => envHelper.array.required('MISSING_REQUIRED_ARRAY_VAR')).toThrow(
+        'Missing required environment variable MISSING_REQUIRED_ARRAY_VAR'
+      );
+    });
+
+    test('Throws if env var is empty', () => {
+      process.env.EMPTY_REQUIRED_ARRAY_VAR = '';
+      expect(() => envHelper.array.required('EMPTY_REQUIRED_ARRAY_VAR')).toThrow(
+        'Missing required environment variable EMPTY_REQUIRED_ARRAY_VAR'
+      );
+    });
+  });
+
   describe('env with union cast', () => {
     test('Throws if expectedValues is not provided', () => {
       // @ts-expect-error missing 2nd parameter (that's the point of the test)

--- a/packages/core/utils/src/env-helper.ts
+++ b/packages/core/utils/src/env-helper.ts
@@ -79,6 +79,28 @@ function array(key: string, defaultValue?: string[]): string[] | undefined {
   });
 }
 
+function required(key: string): string {
+  const value = envFn(key);
+
+  if (value === undefined || value === '') {
+    throw new Error(`Missing required environment variable ${key}`);
+  }
+
+  return value;
+}
+
+function requiredArray(key: string): string[] {
+  const value = array(key);
+
+  if (!value?.length || value.every((v) => v === '')) {
+    throw new Error(`Missing required environment variable ${key}`);
+  }
+
+  return value;
+}
+
+const arrayWithRequired = Object.assign(array, { required: requiredArray });
+
 function date(key: string, defaultValue: Date): Date;
 function date(key: string, defaultValue?: Date | undefined): Date | undefined;
 function date(key: string, defaultValue?: Date): Date | undefined {
@@ -128,9 +150,10 @@ const utils = {
   float,
   bool,
   json,
-  array,
+  array: arrayWithRequired,
   date,
   oneOf,
+  required,
 };
 
 const env: Env = Object.assign(envFn, utils);

--- a/packages/core/utils/src/env-helper.ts
+++ b/packages/core/utils/src/env-helper.ts
@@ -82,8 +82,12 @@ function array(key: string, defaultValue?: string[]): string[] | undefined {
 function required(key: string): string {
   const value = envFn(key);
 
-  if (value === undefined || value === '') {
+  if (value === undefined) {
     throw new Error(`Missing required environment variable ${key}`);
+  }
+
+  if (value.trim() === '') {
+    throw new Error(`Required environment variable ${key} must not be empty`);
   }
 
   return value;
@@ -92,8 +96,12 @@ function required(key: string): string {
 function requiredArray(key: string): string[] {
   const value = array(key);
 
-  if (!value?.length || value.every((v) => v === '')) {
+  if (value === undefined) {
     throw new Error(`Missing required environment variable ${key}`);
+  }
+
+  if (!value.length || value.every((v) => v.trim() === '')) {
+    throw new Error(`Required environment variable ${key} must not be empty`);
   }
 
   return value;


### PR DESCRIPTION
## Summary

- Adds `env.required(key)` and `env.array.required(key)` to `@strapi/utils` — returns a typed value or throws at config load when the variable is missing/empty
- Uses the new helpers in create-strapi-app vanilla and example scaffolds for secrets (JWT salts, encryption key, app keys)
- Adds unit tests for both helpers, including distinct error messages for missing vs empty values

## Test plan

- [x] `yarn test:unit` in `packages/core/utils` (env-helper tests)
- [ ] CI on PR

## Related issue(s)/PR(s)

- Follow-up to discussion on #26779