### PR TITLE
test(e2e): stabilize content-releases home-widgets release creation

### DIFF
--- a/tests/e2e/tests/content-releases/home-widgets.spec.ts
+++ b/tests/e2e/tests/content-releases/home-widgets.spec.ts
@@ -36,16 +36,12 @@ describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () 
     await page.getByRole('button', { name: /new release/i }).click();
     await page.getByRole('textbox', { name: /name/i }).fill(nextReleaseName);
 
-    const date = new Date();
-    const hours = date.getHours();
-    const hoursFuture = (hours + 2) % 24;
-    const hoursFutureFormatted = hoursFuture < 10 ? `0${hoursFuture}` : `${hoursFuture}`;
-
     await page
       .getByRole('combobox', {
         name: /date/i,
       })
       .click();
+    const date = new Date();
     date.setDate(date.getDate() + 1);
     const formattedDate = date.toLocaleDateString('en-US', {
       weekday: 'long',
@@ -55,11 +51,13 @@ describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () 
     });
     await page.getByLabel(formattedDate).click();
 
-    await page.getByRole('combobox', { name: 'Time', exact: true }).click();
-    await page.getByRole('option', { name: `${hoursFutureFormatted}:00`, exact: true }).click();
+    await page.getByRole('combobox', { name: /^time$/i }).click();
+    await page.getByRole('option', { name: '08:00' }).click();
 
-    await page.getByRole('button', { name: /continue/i }).click();
-    await findAndClose(page, 'Release created');
+    await clickAndWait(page, page.getByRole('button', { name: /continue/i }));
+    // Success navigates to the release details page; the toast is too brief to assert reliably in CI.
+    await page.waitForURL('/admin/plugins/content-releases/*');
+    await expect(page.getByRole('heading', { name: nextReleaseName })).toBeVisible();
 
     // Go back to the homepage
     await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));


### PR DESCRIPTION
### What does it do?

Stabilizes `home-widgets.spec.ts` (EE content-releases) by aligning release creation assertions with `releases-page.spec.ts`:

- Fixed schedule time (`08:00`) instead of dynamic `hours + 2`
- After **Continue**, wait for navigation to `/admin/plugins/content-releases/*` and the release heading instead of the short-lived `"Release created"` toast

### Why is it needed?

EE e2e shard 1/4 fails intermittently on develop and unrelated PRs (e.g. #26823 deps-only commit `86b6c2d3`). Trunk marks this test as flaky. The toast disappears when `ReleasesPage` navigates on success — not a product regression.

### How to test it?

- CI: `[EE] e2e` shard 1/4 across chromium/firefox/webkit (content-releases domain)
- Locally (requires `STRAPI_LICENSE`): `yarn test:e2e:ee --domains content-releases --concurrency=1`

### Related issue(s)/PR(s)

Flake observed on #26823 / #26824 CI — unrelated to those changes.