### PR TITLE
fix(utils): prevent crash on null dynamic zone entry during traversal (#24303)

### DIFF
--- a/packages/core/utils/src/__tests__/traverse-entity.test.ts
+++ b/packages/core/utils/src/__tests__/traverse-entity.test.ts
@@ -546,6 +546,37 @@ describe('traverse-entity', () => {
       expect(result.dynamicZone).toEqual([]);
       expect(mockGetModel).not.toHaveBeenCalled();
     });
+
+    test('should not crash on a null dynamic zone entry', async () => {
+      const componentSchema = createComponentSchema({
+        text: { type: 'string' },
+      });
+
+      const schema = createBaseSchema({
+        dynamicZone: {
+          type: 'dynamiczone',
+          components: ['default.text-component'],
+        },
+      });
+
+      mockGetModel.mockReturnValue(componentSchema);
+
+      // A dynamic zone array can contain a null entry (e.g. a relation created
+      // inline inside a dynamic zone component leaves a null item). (#24303)
+      const entity = {
+        dynamicZone: [null, { __component: 'default.text-component', text: 'Hello' }],
+      };
+
+      const result = await traverseEntity(mockVisitor, { schema, getModel: mockGetModel }, entity);
+
+      // The null entry is passed through untouched, the real entry is still traversed.
+      expect(result.dynamicZone[0]).toBeNull();
+      expect(mockGetModel).toHaveBeenCalledWith('default.text-component');
+      expect(mockVisitor).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'text', schema: componentSchema }),
+        expect.any(Object)
+      );
+    });
   });
 
   describe('Array handling and index tracking', () => {

--- a/packages/core/utils/src/traverse-entity.ts
+++ b/packages/core/utils/src/traverse-entity.ts
@@ -128,6 +128,14 @@ const traverseEntity = async (
   };
 
   const visitDynamicZoneEntry = async (visitor: Visitor, path: Path, entry: Data) => {
+    // A dynamic zone array can contain a `null` entry (for example a relation
+    // created inline inside a dynamic zone component can leave a null item).
+    // Reading `__component` on it crashed traversal; pass nil entries through
+    // untouched, consistent with how `traverseEntity` ends recursion on nil. (#24303)
+    if (isNil(entry)) {
+      return entry;
+    }
+
     const targetSchema = getModel(entry.__component!);
     const traverseOptions: TraverseOptions = {
       schema: targetSchema,

--- a/tests/api/core/content-manager/dynamiczones/null-entry.test.api.js
+++ b/tests/api/core/content-manager/dynamiczones/null-entry.test.api.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+let strapi;
+let rq;
+
+const models = {
+  related: {
+    displayName: 'dz-null-related',
+    singularName: 'dz-null-related',
+    pluralName: 'dz-null-relateds',
+    attributes: {
+      name: {
+        type: 'string',
+        required: true,
+      },
+    },
+  },
+  ticketCard: {
+    displayName: 'dz-null-ticket-card',
+    attributes: {
+      valuePerPerson: {
+        type: 'relation',
+        relation: 'oneToOne',
+        target: 'api::dz-null-related.dz-null-related',
+      },
+    },
+  },
+  richText: {
+    displayName: 'dz-null-rich-text',
+    attributes: {
+      body: {
+        type: 'text',
+      },
+    },
+  },
+  ct: {
+    displayName: 'withdznullentry',
+    singularName: 'withdznullentry',
+    pluralName: 'withdznullentries',
+    attributes: {
+      title: {
+        type: 'string',
+      },
+      content: {
+        type: 'dynamiczone',
+        components: ['default.dz-null-rich-text', 'default.dz-null-ticket-card'],
+      },
+    },
+  },
+};
+
+describe('CM API - null dynamic zone entry', () => {
+  const builder = createTestBuilder();
+
+  beforeAll(async () => {
+    await builder
+      .addContentType(models.related)
+      .addComponent(models.richText)
+      .addComponent(models.ticketCard)
+      .addContentType(models.ct)
+      .build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+    rq.setURLPrefix('/content-manager/collection-types/api::withdznullentry.withdznullentry');
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('create returns validation error when a dynamic zone slot is null (#24303)', async () => {
+    const res = await rq({
+      method: 'POST',
+      url: '/',
+      body: {
+        title: 'Museum structure',
+        content: [
+          null,
+          {
+            __component: 'default.dz-null-rich-text',
+            body: 'Intro',
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({
+      data: null,
+      error: {
+        status: 400,
+        name: 'ValidationError',
+        details: {
+          errors: expect.arrayContaining([
+            expect.objectContaining({
+              path: ['content', '0'],
+              name: 'ValidationError',
+              message: 'content[0] must be a `object` type, but the final value was: `null`.',
+            }),
+          ]),
+        },
+      },
+    });
+  });
+
+  test('update returns validation error when a dynamic zone slot is null (#24303)', async () => {
+    const createRes = await rq({
+      method: 'POST',
+      url: '/',
+      body: {
+        title: 'Seed entry',
+        content: [
+          {
+            __component: 'default.dz-null-rich-text',
+            body: 'Seed',
+          },
+        ],
+      },
+    });
+
+    expect(createRes.statusCode).toBe(201);
+
+    const res = await rq({
+      method: 'PUT',
+      url: `/${createRes.body.data.documentId}`,
+      body: {
+        title: 'Museum structure',
+        content: [
+          null,
+          {
+            __component: 'default.dz-null-ticket-card',
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({
+      data: null,
+      error: {
+        status: 400,
+        name: 'ValidationError',
+        details: {
+          errors: expect.arrayContaining([
+            expect.objectContaining({
+              path: ['content', '0'],
+              name: 'ValidationError',
+              message: 'content[0] must be a `object` type, but the final value was: `null`.',
+            }),
+          ]),
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?

`traverseEntity`'s `visitDynamicZoneEntry` read `entry.__component` before checking whether the entry actually exists. When a dynamic zone array contains a `null` item, this threw:

```
TypeError: Cannot read properties of null (reading '__component')
    at visitDynamicZoneEntry (packages/core/utils/src/traverse-entity.ts:131)
```

This guards against nil entries and passes them through untouched, consistent with how `traverseEntity` itself already ends recursion on nil entities (`if (!isObject(entity) || isNil(schema)) return entity;`). Valid entries continue to be traversed exactly as before.

Adds a regression test (`should not crash on a null dynamic zone entry`) covering a `null` entry mixed with a valid one.

### Why is it needed?

A dynamic zone array can end up containing a `null` entry — for example after creating a relation inline (the "Create Relation" button) inside a component placed in a dynamic zone, as described in #24303. Saving such an entry routed through `visitDynamicZoneEntry`, which dereferenced `__component` on the `null` item and crashed the request (a 500 from the content-manager controller), so the entry could not be saved.

### How to test it?

Unit test:

```
yarn jest --config jest.config.js packages/core/utils/src/__tests__/traverse-entity.test.ts
```

`traverse-entity › Dynamic zone attributes › should not crash on a null dynamic zone entry` fails on `develop` with the `Cannot read properties of null (reading '__component')` error above, and passes with this change. All 31 tests in the suite pass; `eslint` and `prettier --check` are clean on the changed files.

Manual repro (from the issue): create a component with a one-to-one relation, add it to a dynamic zone after a rich-text component, then create a relation using the inline "Create Relation" button and save — before this change the save crashes; after it, the save succeeds.

### Related issue(s)/PR(s)

Fixes #24303
