### PR TITLE
fix(translations): correct ja "characters" mistranslation in WYSIWYG controls

### DIFF
--- a/packages/core/admin/admin/src/translations/ja.json
+++ b/packages/core/admin/admin/src/translations/ja.json
@@ -383,7 +383,7 @@
   "components.Wysiwyg.selectOptions.title": "タイトルを追加する",
   "components.Wysiwyg.ToggleMode.markdown-mode": "Markdownモード",
   "components.Wysiwyg.ToggleMode.preview-mode": "プレビューモード",
-  "components.WysiwygBottomControls.charactersIndicators": "キャラクター",
+  "components.WysiwygBottomControls.charactersIndicators": "文字",
   "components.WysiwygBottomControls.fullscreen": "広げる",
   "components.WysiwygBottomControls.uploadFiles": "ファイルをドラッグ＆ドロップ, クリップボードからペースト もしくは {browse}.",
   "components.WysiwygBottomControls.uploadFiles.browse": "選ぶ",


### PR DESCRIPTION
The Japanese translation for the WYSIWYG editor's character indicator uses キャラクター, which means a fictional character or persona, not a text character.

The English source for `components.WysiwygBottomControls.charactersIndicators` is "characters" (the count of typed characters shown beneath the rich text editor). The Japanese word for a text character is 文字.

Every other locale already translates this entry in the text-character sense, for example zh 字元, zh-Hans 字符, ko 문자, fr caractères, pt caracteres, id karakter, no tegn. The rest of this same `ja.json` also uses 文字 consistently, such as the password hints (`パスワードは8文字以上...`). Only this one entry slipped into キャラクター.

This changes a single value. The file still parses and the key count is unchanged.


---
Fixes CPR-427