### PR TITLE
fix(utils): align polymorphic populate validation with conversion

### DIFF
--- a/packages/core/utils/src/__tests__/validate.visitors.test.ts
+++ b/packages/core/utils/src/__tests__/validate.visitors.test.ts
@@ -475,6 +475,96 @@ describe('Validate visitors util', () => {
       );
     });
 
+    test.each<[label: string, populateValue: unknown]>([
+      ['boolean true', true],
+      ['boolean false', false],
+      ['empty object', {}],
+      ['populate array', ['title']],
+      ['number', 42],
+    ])(
+      'throws ValidationError for non-wildcard polymorphic nested populate value (%s)',
+      async (_label, populateValue) => {
+        const dynamicZoneModel: any = {
+          uid: 'api::article.article',
+          modelType: 'contentType',
+          kind: 'collectionType',
+          info: { singularName: 'article', pluralName: 'articles', displayName: 'Article' },
+          options: {},
+          attributes: {
+            id: { type: 'integer' },
+            contentBlocks: {
+              type: 'dynamiczone',
+              components: ['default.component'],
+            },
+          },
+        };
+
+        const models = {
+          'api::article.article': dynamicZoneModel,
+          'default.component': {
+            uid: 'default.component',
+            modelType: 'component',
+            info: { singularName: 'component', pluralName: 'components' },
+            options: {},
+            attributes: { title: { type: 'string' } },
+          },
+        };
+
+        const ctxDynamic: any = {
+          schema: dynamicZoneModel,
+          getModel: (uid: string) => models[uid as keyof typeof models],
+        };
+
+        await expect(
+          validators.defaultValidatePopulate(ctxDynamic, {
+            contentBlocks: { populate: populateValue },
+          })
+        ).rejects.toThrow(ValidationError);
+      }
+    );
+
+    test.each([null, undefined])(
+      'allows nil polymorphic nested populate value (%s)',
+      async (populateValue) => {
+        const dynamicZoneModel: any = {
+          uid: 'api::article.article',
+          modelType: 'contentType',
+          kind: 'collectionType',
+          info: { singularName: 'article', pluralName: 'articles', displayName: 'Article' },
+          options: {},
+          attributes: {
+            id: { type: 'integer' },
+            contentBlocks: {
+              type: 'dynamiczone',
+              components: ['default.component'],
+            },
+          },
+        };
+
+        const models = {
+          'api::article.article': dynamicZoneModel,
+          'default.component': {
+            uid: 'default.component',
+            modelType: 'component',
+            info: { singularName: 'component', pluralName: 'components' },
+            options: {},
+            attributes: { title: { type: 'string' } },
+          },
+        };
+
+        const ctxDynamic: any = {
+          schema: dynamicZoneModel,
+          getModel: (uid: string) => models[uid as keyof typeof models],
+        };
+
+        await expect(
+          validators.defaultValidatePopulate(ctxDynamic, {
+            contentBlocks: { populate: populateValue },
+          })
+        ).resolves.toBeDefined();
+      }
+    );
+
     const withDynamicZonePopulateCtx = () => {
       const dynamicZoneModel: any = {
         uid: 'api::withdynamiczone.withdynamiczone',

--- a/packages/core/utils/src/validate/validators.ts
+++ b/packages/core/utils/src/validate/validators.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isNil, isObject, isPlainObject, trim } from 'lodash/fp';
+import { isEmpty, isNil, isObject, trim } from 'lodash/fp';
 
 import { pipe as pipeAsync } from '../async';
 import {
@@ -398,11 +398,8 @@ const validateMorphLikeNestedPopulate = (
   populateValue: unknown,
   { path }: { path: string | null }
 ) => {
-  if (typeof populateValue === 'string' && populateValue !== '*' && !isNil(populateValue)) {
-    throwInvalidKey({ key: 'populate', path });
-  }
-
-  if (isPlainObject(populateValue) && !isEmpty(populateValue) && !isNil(populateValue)) {
+  // Keep in sync with convert-query-params polymorphic nested populate handling.
+  if (!isNil(populateValue) && populateValue !== '*') {
     throwInvalidKey({ key: 'populate', path });
   }
 };


### PR DESCRIPTION
## Summary

- Tightens `validateMorphLikeNestedPopulate` to mirror `convert-query-params`: reject any non-nil nested `populate` value other than `'*'` on dynamic zones and morphTo relations
- Closes the gap left by #25854 where boolean, array, empty-object, and other non-string invalid values still passed validation and could surface as 500s from conversion
- Adds unit tests for the additional invalid value shapes and nil allow-list regression

## Test plan

- [x] `yarn test:unit --testPathPattern=validate.visitors` in `packages/core/utils`
- [ ] CI green

## Related issue(s)/PR(s)

Fixes CMS-1321
Follow-up to #25854
Fixes #25788