### PR TITLE
fix(content-manager): markdown editor shortcuts and image paste (#24742)

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Editor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Editor.tsx
@@ -5,6 +5,7 @@ import { styled } from 'styled-components';
 
 import { PreviewWysiwyg } from './PreviewWysiwyg';
 import { newlineAndIndentContinueMarkdownList } from './utils/continueList';
+import { createMarkdownKeyboardShortcuts } from './utils/keyboardShortcuts';
 
 import type { FieldValue, InputProps } from '@strapi/admin/strapi-admin';
 
@@ -20,6 +21,7 @@ interface EditorProps extends Omit<FieldValue, 'initialValue'>, Omit<InputProps,
   isPreviewMode?: boolean;
   isExpandMode?: boolean;
   textareaRef: React.RefObject<HTMLTextAreaElement>;
+  onPasteFiles?: (event: ClipboardEvent) => void;
 }
 
 const Editor = React.forwardRef<EditorApi, EditorProps>(
@@ -35,14 +37,20 @@ const Editor = React.forwardRef<EditorApi, EditorProps>(
       placeholder,
       textareaRef,
       value,
+      onPasteFiles,
     },
     forwardedRef
   ) => {
     const onChangeRef = React.useRef(onChange);
+    const onPasteFilesRef = React.useRef(onPasteFiles);
 
     React.useEffect(() => {
       onChangeRef.current = onChange;
     }, [onChange]);
+
+    React.useEffect(() => {
+      onPasteFilesRef.current = onPasteFiles;
+    }, [onPasteFiles]);
 
     React.useEffect(() => {
       if (editorRef.current) {
@@ -56,6 +64,7 @@ const Editor = React.forwardRef<EditorApi, EditorProps>(
           Enter: 'newlineAndIndentContinueMarkdownList',
           Tab: false,
           'Shift-Tab': false,
+          ...createMarkdownKeyboardShortcuts(editorRef),
         },
         readOnly: false,
         smartIndent: false,
@@ -74,6 +83,17 @@ const Editor = React.forwardRef<EditorApi, EditorProps>(
         }
         onChangeRef.current(name, cm.getValue());
       });
+
+      const handlePaste = (event: ClipboardEvent) => {
+        onPasteFilesRef.current?.(event);
+      };
+
+      const wrapper = editorRef.current.getWrapperElement();
+      wrapper.addEventListener('paste', handlePaste);
+
+      return () => {
+        wrapper.removeEventListener('paste', handlePaste);
+      };
     }, [editorRef, textareaRef, name, placeholder]);
 
     React.useEffect(() => {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
@@ -1,13 +1,21 @@
 import * as React from 'react';
 
-import { useField, useStrapiApp, useIsMobile, type InputProps } from '@strapi/admin/strapi-admin';
+import {
+  useField,
+  useStrapiApp,
+  useIsMobile,
+  useNotification,
+  type InputProps,
+} from '@strapi/admin/strapi-admin';
 import { Box, Field, Flex } from '@strapi/design-system';
 import { EditorFromTextArea } from 'codemirror5';
+import { useIntl } from 'react-intl';
 
 import { prefixFileUrlWithBackendUrl } from '../../../../../utils/urls';
 
 import { Editor, EditorApi } from './Editor';
 import { EditorLayout } from './EditorLayout';
+import { useWysiwygImageUpload } from './hooks/useWysiwygImageUpload';
 import { insertFile } from './utils/utils';
 import { WysiwygFooter } from './WysiwygFooter';
 import { WysiwygNav, WysiwygPreviewToggleButton } from './WysiwygNav';
@@ -22,6 +30,9 @@ interface WysiwygProps extends Omit<InputProps, 'type'> {
 const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
   ({ hint, disabled, label, name, placeholder, required, labelAction }, forwardedRef) => {
     const field = useField(name);
+    const { formatMessage } = useIntl();
+    const { toggleNotification } = useNotification();
+    const { uploadImages } = useWysiwygImageUpload();
     const textareaRef = React.useRef<HTMLTextAreaElement>(null);
     const editorRef = React.useRef<EditorFromTextArea>(
       null
@@ -52,6 +63,65 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
       setMediaLibVisible(false);
     };
 
+    const handlePasteFiles = React.useCallback(
+      async (event: ClipboardEvent) => {
+        if (disabled || isPreviewMode) {
+          return;
+        }
+
+        const clipboardItems = event.clipboardData?.items;
+
+        if (!clipboardItems?.length) {
+          return;
+        }
+
+        const files = Array.from(clipboardItems)
+          .filter((item) => item.kind === 'file')
+          .map((item) => item.getAsFile())
+          .filter((file): file is File => file !== null);
+
+        if (!files.length) {
+          return;
+        }
+
+        const imageFiles = files.filter((file) => file.type.startsWith('image/'));
+
+        if (!imageFiles.length) {
+          toggleNotification({
+            type: 'warning',
+            message: formatMessage({
+              id: 'components.Wysiwyg.paste.nonImage',
+              defaultMessage: 'Only image files can be pasted into the markdown editor.',
+            }),
+          });
+          return;
+        }
+
+        event.preventDefault();
+
+        try {
+          const uploadedFiles = await uploadImages(imageFiles);
+
+          const formattedFiles = uploadedFiles.map((file) => ({
+            alt: file.alternativeText || file.name,
+            url: prefixFileUrlWithBackendUrl(file.url),
+            mime: file.mime,
+          }));
+
+          insertFile(editorRef, formattedFiles);
+        } catch {
+          toggleNotification({
+            type: 'danger',
+            message: formatMessage({
+              id: 'components.Wysiwyg.paste.uploadError',
+              defaultMessage: 'An error occurred while uploading the pasted image.',
+            }),
+          });
+        }
+      },
+      [disabled, formatMessage, isPreviewMode, toggleNotification, uploadImages]
+    );
+
     return (
       <Field.Root name={name} hint={hint} error={field.error} required={required}>
         <Flex direction="column" alignItems="stretch" gap={1}>
@@ -78,6 +148,7 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
               isPreviewMode={isPreviewMode}
               name={name}
               onChange={field.onChange}
+              onPasteFiles={handlePasteFiles}
               placeholder={placeholder}
               textareaRef={textareaRef}
               value={field.value}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/hooks/useWysiwygImageUpload.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/hooks/useWysiwygImageUpload.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import { useFetchClient } from '@strapi/admin/strapi-admin';
+
+interface UploadedFile {
+  alternativeText?: string | null;
+  mime: string;
+  name: string;
+  url: string;
+}
+
+export const useWysiwygImageUpload = () => {
+  const { post } = useFetchClient();
+
+  const uploadImages = React.useCallback(
+    async (files: File[]) => {
+      const formData = new FormData();
+
+      files.forEach((file) => {
+        formData.append('files', file);
+        formData.append(
+          'fileInfo',
+          JSON.stringify({
+            name: file.name,
+            alternativeText: file.name,
+            folder: null,
+          })
+        );
+      });
+
+      const response = await post<UploadedFile[]>('/upload', formData);
+
+      return response.data;
+    },
+    [post]
+  );
+
+  return { uploadImages };
+};

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/__tests__/utils.test.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/__tests__/utils.test.ts
@@ -1,0 +1,27 @@
+import { toggleMarkdownSelection } from '../utils';
+
+describe('toggleMarkdownSelection', () => {
+  it('wraps plain text with bold markdown', () => {
+    expect(toggleMarkdownSelection('hello', 'Bold')).toBe('**hello**');
+  });
+
+  it('unwraps already bold text', () => {
+    expect(toggleMarkdownSelection('**hello**', 'Bold')).toBe('hello');
+  });
+
+  it('wraps plain text with italic markdown', () => {
+    expect(toggleMarkdownSelection('hello', 'Italic')).toBe('_hello_');
+  });
+
+  it('unwraps already italic text', () => {
+    expect(toggleMarkdownSelection('_hello_', 'Italic')).toBe('hello');
+  });
+
+  it('unwraps link markdown', () => {
+    expect(toggleMarkdownSelection('[hello](https://example.com)', 'Link')).toBe('hello');
+  });
+
+  it('wraps plain text with link markdown', () => {
+    expect(toggleMarkdownSelection('hello', 'Link')).toBe('[hello](link)');
+  });
+});

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/keyboardShortcuts.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/keyboardShortcuts.ts
@@ -1,0 +1,29 @@
+import type { MutableRefObject } from 'react';
+
+import { markdownHandler } from './utils';
+
+import type CodeMirror from 'codemirror5';
+
+type ShortcutHandler = (cm: CodeMirror.Editor) => void;
+
+const createMarkdownShortcut =
+  (
+    editorRef: MutableRefObject<CodeMirror.EditorFromTextArea>,
+    markdownType: string
+  ): ShortcutHandler =>
+  () => {
+    markdownHandler(editorRef, markdownType);
+  };
+
+export const createMarkdownKeyboardShortcuts = (
+  editorRef: MutableRefObject<CodeMirror.EditorFromTextArea>
+): Record<string, ShortcutHandler> => ({
+  'Cmd-B': createMarkdownShortcut(editorRef, 'Bold'),
+  'Ctrl-B': createMarkdownShortcut(editorRef, 'Bold'),
+  'Cmd-I': createMarkdownShortcut(editorRef, 'Italic'),
+  'Ctrl-I': createMarkdownShortcut(editorRef, 'Italic'),
+  'Cmd-U': createMarkdownShortcut(editorRef, 'Underline'),
+  'Ctrl-U': createMarkdownShortcut(editorRef, 'Underline'),
+  'Cmd-K': createMarkdownShortcut(editorRef, 'Link'),
+  'Ctrl-K': createMarkdownShortcut(editorRef, 'Link'),
+});

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/utils.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/utils.ts
@@ -114,6 +114,41 @@ export const insertListOrTitle = (markdown: string) => {
   return textToInsert;
 };
 
+const INLINE_MARKDOWN_WRAPPERS: Record<string, { prefix: string; suffix: string }> = {
+  Bold: { prefix: '**', suffix: '**' },
+  Italic: { prefix: '_', suffix: '_' },
+  Underline: { prefix: '<u>', suffix: '</u>' },
+  Strikethrough: { prefix: '~~', suffix: '~~' },
+};
+
+const LINK_MARKDOWN_PATTERN = /^\[(.+)\]\([^)]*\)$/;
+
+export const toggleMarkdownSelection = (text: string, markdownType: string) => {
+  if (markdownType === 'Link') {
+    const linkMatch = text.match(LINK_MARKDOWN_PATTERN);
+
+    if (linkMatch) {
+      return linkMatch[1];
+    }
+
+    return replaceText(markdownType, text);
+  }
+
+  const wrapper = INLINE_MARKDOWN_WRAPPERS[markdownType];
+
+  if (!wrapper) {
+    return replaceText(markdownType, text);
+  }
+
+  const { prefix, suffix } = wrapper;
+
+  if (text.startsWith(prefix) && text.endsWith(suffix)) {
+    return text.slice(prefix.length, text.length - suffix.length);
+  }
+
+  return replaceText(markdownType, text);
+};
+
 // EDITOR ACTIONS FUNCTIONS
 
 export const markdownHandler = (
@@ -124,7 +159,7 @@ export const markdownHandler = (
   let textToInsert;
 
   if (textToEdit) {
-    const editedText = replaceText(markdownType, textToEdit);
+    const editedText = toggleMarkdownSelection(textToEdit, markdownType);
     editor.current.replaceSelection(editedText);
     editor.current.focus();
   } else {


### PR DESCRIPTION

Fixes #24742

## How does it work?

### Keyboard shortcuts

- Register Cmd/Ctrl+B, I, U, and K in CodeMirror `extraKeys` so shortcuts are handled by the editor instead of the browser.
- Reuse the existing `markdownHandler` logic, extended with **toggle** behavior: if the selection is already wrapped (e.g. `**text**`), the shortcut unwraps it instead of double-wrapping.

### Image paste

- Listen for paste events on the CodeMirror wrapper.
- When clipboard contains image files, upload them via the `/upload` API using a local `useWysiwygImageUpload` hook (`useFetchClient`).
- Insert the uploaded assets as markdown (`![alt](url)`) using the existing `insertFile` helper.
- Show a warning notification when non-image files are pasted.

## Files changed

| File | Change |
|------|--------|
| `Editor.tsx` | Wire keyboard shortcuts + paste listener |
| `Field.tsx` | Paste handler with upload + notifications |
| `hooks/useWysiwygImageUpload.ts` | Upload pasted images via `/upload` |
| `utils/keyboardShortcuts.ts` | CodeMirror shortcut map |
| `utils/utils.ts` | `toggleMarkdownSelection` for wrap/unwrap |
| `utils/__tests__/utils.test.ts` | Unit tests for toggle logic |

## Test plan

- [ ] Open a collection type with a **Rich text (Markdown)** field
- [ ] Select text → **Cmd/Ctrl+B** → text becomes `**bold**` and stays bold
- [ ] Run **Cmd/Ctrl+B** again on bold text → formatting is removed (toggle)
- [ ] Repeat for **Cmd/Ctrl+I**, **Cmd/Ctrl+U**, **Cmd/Ctrl+K**
- [ ] Copy an image from the OS → paste in editor → `![alt](url)` is inserted
- [ ] Paste a non-image file (e.g. PDF) → warning notification, no upload
- [ ] Toolbar bold/italic buttons still work as before
- [ ] `yarn workspace @strapi/content-manager test:unit admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/__tests__/utils.test.ts` passes

---
Fixes CPR-441