### PR TITLE
fix: give the ability to open a list item in a new tab

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -82,7 +82,6 @@ const ListViewPage = () => {
   const { copy } = useClipboard();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler(getTranslation);
   const isMobile = useIsMobile();
-  const isDesktop = useIsDesktop();
 
   const handleCopyDocumentId = React.useCallback(
     async (e: React.MouseEvent, documentId: string | undefined) => {
@@ -351,7 +350,7 @@ const ListViewPage = () => {
   const NON_LINKABLE_TYPES = ['media', 'relation', 'component', 'dynamiczone'];
   const primaryLinkField = tableHeaders.find(
     ({ name, attribute, cellFormatter }) =>
-      !['status', 'documentId'].includes(name) &&
+      !['status'].includes(name) &&
       !['createdBy', 'updatedBy'].includes(name.split('.')[0]) &&
       typeof cellFormatter !== 'function' &&
       attribute &&

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -341,6 +341,23 @@ const ListViewPage = () => {
     });
   };
 
+  /**
+   * The first non-interactive (scalar) column is rendered as a link to the entry,
+   * so it can be opened in a new tab (right-click / cmd+click / middle-click).
+   * Interactive cell types embed their own links/menus, so we skip them — wrapping
+   * them in an anchor would nest interactive elements. Computed columns and the
+   * synthetic status/documentId/createdBy/updatedBy columns are not entry fields.
+   */
+  const NON_LINKABLE_TYPES = ['media', 'relation', 'component', 'dynamiczone'];
+  const primaryLinkField = tableHeaders.find(
+    ({ name, attribute, cellFormatter }) =>
+      !['status', 'documentId'].includes(name) &&
+      !['createdBy', 'updatedBy'].includes(name.split('.')[0]) &&
+      typeof cellFormatter !== 'function' &&
+      attribute &&
+      !NON_LINKABLE_TYPES.includes(attribute.type)
+  )?.name;
+
   const isEmptyState = !isFetching && results.length === 0;
 
   const endActions = (
@@ -530,6 +547,14 @@ const ListViewPage = () => {
                                   content={row[header.name.split('.')[0]]}
                                   rowId={row.documentId}
                                   {...header}
+                                  linkTo={
+                                    header.name === primaryLinkField
+                                      ? {
+                                          pathname: row.documentId,
+                                          search: stringify({ plugins: query.plugins }),
+                                        }
+                                      : undefined
+                                  }
                                 />
                               </Table.Cell>
                             );

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -60,7 +60,7 @@ import { DocumentStatus } from '../EditView/components/DocumentStatus';
 import { BulkActionsRenderer } from './components/BulkActions/Actions';
 import { listViewFilters as Filters } from './components/Filters';
 import { TableActions } from './components/TableActions';
-import { CellContent } from './components/TableCells/CellContent';
+import { CellContent, hasContent } from './components/TableCells/CellContent';
 import { ViewSettingsMenu } from './components/ViewSettingsMenu';
 
 import type { Modules } from '@strapi/types';
@@ -341,24 +341,35 @@ const ListViewPage = () => {
   };
 
   /**
-   * The first non-interactive (scalar) column is rendered as a link to the entry,
-   * so it can be opened in a new tab (right-click / cmd+click / middle-click).
-   * Interactive cell types embed their own links/menus, so we skip them — wrapping
-   * them in an anchor would nest interactive elements. Computed columns and the
-   * synthetic status/documentId/createdBy/updatedBy columns are not entry fields.
+   * The entry link is rendered on the first non-interactive column *that has a
+   * value for the row* (resolved per row, so an empty cell — rendered as "-" —
+   * is skipped and the next candidate carries the link instead). Any scalar
+   * column qualifies — text, numbers, dates (createdAt/updatedAt), `id`, and
+   * `documentId` (its id text becomes the link, the copy button stays separate).
+   * Only genuinely interactive cells are skipped: relations, media, components,
+   * dynamic zones (they embed their own links/menus), plugin-formatted columns
+   * (`cellFormatter`), and the synthetic `status` column.
    */
-  // Text-like scalar types the entry can be linked from. We only link genuine
-  // text columns (the title etc.), never relations/media/components (interactive
-  // cells) or `documentId` — which is rendered by its own copy-ID cell and never
-  // goes through CellContent, so it can't carry the link.
-  const LINKABLE_TEXT_TYPES = ['string', 'text', 'email', 'uid', 'enumeration'];
-  const primaryLinkField = tableHeaders.find(
+  const NON_LINKABLE_TYPES = ['media', 'relation', 'component', 'dynamiczone'];
+  const linkCandidates = tableHeaders.filter(
     ({ name, attribute, cellFormatter }) =>
-      name !== 'documentId' &&
+      name !== 'status' &&
       typeof cellFormatter !== 'function' &&
       attribute &&
-      LINKABLE_TEXT_TYPES.includes(attribute.type)
-  )?.name;
+      !NON_LINKABLE_TYPES.includes(attribute.type)
+  );
+
+  // The link column for a given row: the first candidate that actually has a
+  // value (uses CellContent's own hasContent so it matches the "-" the cell
+  // would otherwise render). documentId is checked directly (its own cell).
+  const getRowLinkField = (row: (typeof results)[number]) =>
+    linkCandidates.find((header) => {
+      if (header.name === 'documentId') {
+        return Boolean(row.documentId);
+      }
+      const value = row[header.name.split('.')[0]];
+      return hasContent(value, header.mainField, header.attribute);
+    })?.name;
 
   const isEmptyState = !isFetching && results.length === 0;
 
@@ -480,6 +491,7 @@ const ListViewPage = () => {
                   <Table.Empty action={canCreate ? <CreateButton variant="secondary" /> : null} />
                   <Table.Body>
                     {results.map((row) => {
+                      const rowLinkField = getRowLinkField(row);
                       return (
                         <Table.Row
                           cursor="pointer"
@@ -512,12 +524,32 @@ const ListViewPage = () => {
                               );
                             }
                             if (header.name === 'documentId') {
+                              // When documentId is the primary link column, only its
+                              // id text becomes the link; the copy button stays outside.
+                              const isDocumentIdLink =
+                                header.name === rowLinkField && Boolean(row.documentId);
                               return (
                                 <Table.Cell key={header.name}>
                                   <Flex gap={2} alignItems="center" width="100%" minWidth={0}>
-                                    <Typography textColor="neutral800" maxWidth="30rem" ellipsis>
-                                      {row.documentId || '-'}
-                                    </Typography>
+                                    {isDocumentIdLink ? (
+                                      <Typography
+                                        tag={ReactRouterLink}
+                                        to={{
+                                          pathname: row.documentId,
+                                          search: stringify({ plugins: query.plugins }),
+                                        }}
+                                        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                                        textColor="neutral800"
+                                        maxWidth="30rem"
+                                        ellipsis
+                                      >
+                                        {row.documentId}
+                                      </Typography>
+                                    ) : (
+                                      <Typography textColor="neutral800" maxWidth="30rem" ellipsis>
+                                        {row.documentId || '-'}
+                                      </Typography>
+                                    )}
                                     {row.documentId && (
                                       <IconButton
                                         variant="ghost"
@@ -550,7 +582,7 @@ const ListViewPage = () => {
                                   rowId={row.documentId}
                                   {...header}
                                   linkTo={
-                                    header.name === primaryLinkField
+                                    header.name === rowLinkField
                                       ? {
                                           pathname: row.documentId,
                                           search: stringify({ plugins: query.plugins }),

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -347,14 +347,17 @@ const ListViewPage = () => {
    * them in an anchor would nest interactive elements. Computed columns and the
    * synthetic status/documentId/createdBy/updatedBy columns are not entry fields.
    */
-  const NON_LINKABLE_TYPES = ['media', 'relation', 'component', 'dynamiczone'];
+  // Text-like scalar types the entry can be linked from. We only link genuine
+  // text columns (the title etc.), never relations/media/components (interactive
+  // cells) or `documentId` — which is rendered by its own copy-ID cell and never
+  // goes through CellContent, so it can't carry the link.
+  const LINKABLE_TEXT_TYPES = ['string', 'text', 'email', 'uid', 'enumeration'];
   const primaryLinkField = tableHeaders.find(
     ({ name, attribute, cellFormatter }) =>
-      !['status'].includes(name) &&
-      !['createdBy', 'updatedBy'].includes(name.split('.')[0]) &&
+      name !== 'documentId' &&
       typeof cellFormatter !== 'function' &&
       attribute &&
-      !NON_LINKABLE_TYPES.includes(attribute.type)
+      LINKABLE_TEXT_TYPES.includes(attribute.type)
   )?.name;
 
   const isEmptyState = !isFetching && results.length === 0;

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableActions.tsx
@@ -7,10 +7,10 @@ import {
   useQueryParams,
 } from '@strapi/admin/strapi-admin';
 import { Button, LinkButton, Modal } from '@strapi/design-system';
-import { Duplicate, Pencil } from '@strapi/icons';
+import { Duplicate, ExternalLink, Pencil } from '@strapi/icons';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
-import { NavLink, useNavigate } from 'react-router-dom';
+import { NavLink, useHref, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { useDocumentRBAC } from '../../../features/DocumentRBAC';
@@ -137,6 +137,43 @@ const StyledPencil = styled(Pencil)`
   }
 `;
 
+const OpenInNewTabAction: DocumentActionComponent = ({ documentId }) => {
+  const { formatMessage } = useIntl();
+  const { canRead } = useDocumentRBAC('OpenInNewTabAction', ({ canRead }) => ({ canRead }));
+  const [{ query }] = useQueryParams<{ plugins?: object }>();
+
+  // Resolve the entry's absolute URL (incl. router basename) so we can open it
+  // in a real new browser tab. The primary list-view cell is also a link, this
+  // gives the same affordance an explicit, discoverable menu entry.
+  const href = useHref({
+    pathname: documentId ?? '',
+    search: stringify({ plugins: query.plugins }),
+  });
+
+  return {
+    disabled: !canRead || !documentId,
+    icon: <StyledExternalLink />,
+    label: formatMessage({
+      id: 'content-manager.actions.open-in-new-tab.label',
+      defaultMessage: 'Open in new tab',
+    }),
+    position: 'table-row',
+    onClick: () => {
+      window.open(href, '_blank', 'noopener,noreferrer');
+    },
+  };
+};
+
+// No `type` is set: it's an optional discriminator constrained to a known union
+// and this action is identified by its component name instead.
+OpenInNewTabAction.position = 'table-row';
+
+const StyledExternalLink = styled(ExternalLink)`
+  path {
+    fill: currentColor;
+  }
+`;
+
 const CloneAction: DocumentActionComponent = ({ model, documentId }) => {
   const navigate = useNavigate();
   const { formatMessage } = useIntl();
@@ -253,6 +290,6 @@ const StyledDuplicate = styled(Duplicate)`
   }
 `;
 
-const DEFAULT_TABLE_ROW_ACTIONS = [EditAction, CloneAction];
+const DEFAULT_TABLE_ROW_ACTIONS = [EditAction, OpenInNewTabAction, CloneAction];
 
 export { TableActions, DEFAULT_TABLE_ROW_ACTIONS };

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
@@ -157,5 +157,5 @@ const isSingleRelation = (
   type: Extract<CellContentProps['attribute'], { type: 'relation' }>['relation']
 ) => ['oneToOne', 'manyToOne', 'oneToOneMorph'].includes(type);
 
-export { CellContent };
+export { CellContent, hasContent };
 export type { CellContentProps };

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
@@ -1,5 +1,8 @@
+import type { MouseEvent } from 'react';
+
 import { Tooltip, Typography } from '@strapi/design-system';
 import isEmpty from 'lodash/isEmpty';
+import { Link as ReactRouterLink } from 'react-router-dom';
 
 import { CellValue } from './CellValue';
 import { SingleComponent, RepeatableComponent } from './Components';
@@ -8,13 +11,21 @@ import { RelationMultiple, RelationSingle } from './Relations';
 
 import type { ListFieldLayout } from '../../../../hooks/useDocumentLayout';
 import type { Schema, Data } from '@strapi/types';
+import type { To } from 'react-router-dom';
 
 interface CellContentProps extends Omit<ListFieldLayout, 'cellFormatter'> {
   content: Schema.Attribute.Value<Schema.Attribute.AnyAttribute>;
   rowId: Data.ID;
+  /**
+   * When set, the cell renders its value as a navigational link to the entry.
+   * Used for the primary (first scalar) column so users can open an entry in a
+   * new tab via right-click / cmd+click / middle-click, while a plain click
+   * still navigates within the SPA. Only passed for non-interactive cell types.
+   */
+  linkTo?: To;
 }
 
-const CellContent = ({ content, mainField, attribute, rowId, name }: CellContentProps) => {
+const CellContent = ({ content, mainField, attribute, rowId, name, linkTo }: CellContentProps) => {
   const isIdColumn = name === 'id';
 
   if (!hasContent(content, mainField, attribute)) {
@@ -29,6 +40,27 @@ const CellContent = ({ content, mainField, attribute, rowId, name }: CellContent
         -
       </Typography>
     );
+  }
+
+  // Primary scalar column: render the value as a link to the entry so it gets
+  // native open-in-new-tab semantics. stopPropagation prevents the row's own
+  // onClick from firing a second navigation; React Router's Link still handles
+  // the click (stopPropagation does not preventDefault).
+  if (linkTo) {
+    const link = (
+      <Typography
+        tag={ReactRouterLink}
+        to={linkTo}
+        onClick={(e: MouseEvent) => e.stopPropagation()}
+        maxWidth="30rem"
+        ellipsis
+        textColor="neutral800"
+      >
+        <CellValue isIdColumn={isIdColumn} type={attribute.type} value={content} />
+      </Typography>
+    );
+
+    return attribute.type === 'string' ? <Tooltip label={content}>{link}</Tooltip> : link;
   }
 
   switch (attribute.type) {

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/tests/CellContent.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/tests/CellContent.test.tsx
@@ -1,0 +1,56 @@
+import { render as renderRTL, screen } from '@tests/utils';
+import { Route, Routes } from 'react-router-dom';
+
+import { CellContent } from '../CellContent';
+
+import type { CellContentProps } from '../CellContent';
+
+const render = (overrides: Partial<CellContentProps> = {}) => {
+  // Minimal valid props for the string cell branch; cast as the full union shape
+  // is heavier than this focused test needs.
+  const props = {
+    content: 'My entry title',
+    rowId: 'doc-1',
+    name: 'title',
+    attribute: { type: 'string' },
+    ...overrides,
+  } as CellContentProps;
+
+  return renderRTL(<CellContent {...props} />, {
+    renderOptions: {
+      wrapper({ children }) {
+        return (
+          <Routes>
+            <Route path="/content-manager/:collectionType/:slug/*" element={children} />
+          </Routes>
+        );
+      },
+    },
+    initialEntries: ['/content-manager/collection-types/api::address.address'],
+  });
+};
+
+describe('CellContent', () => {
+  it('renders a plain value (no link) when linkTo is not provided', () => {
+    render({});
+
+    expect(screen.getByText('My entry title')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders the value as a navigational link to the entry when linkTo is provided', () => {
+    render({ linkTo: { pathname: 'doc-1', search: 'plugins[i18n][locale]=en' } });
+
+    const link = screen.getByRole('link', { name: 'My entry title' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', expect.stringContaining('doc-1'));
+    expect(link).toHaveAttribute('href', expect.stringContaining('plugins'));
+  });
+
+  it('does not link an empty primary value (renders the dash fallback)', () => {
+    render({ content: '', linkTo: { pathname: 'doc-1' } });
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -9,6 +9,7 @@
   "actions.discard.dialog.body": "Are you sure you want to discard the changes? This action is irreversible.",
   "actions.edit.error": "An error occurred while trying to edit the document.",
   "actions.edit.label": "Edit",
+  "actions.open-in-new-tab.label": "Open in new tab",
   "actions.copy-documentId.label": "Copy document ID",
   "actions.copy-documentId.success": "Document ID copied to clipboard",
   "actions.unpublish.error": "An error occurred while trying to unpublish the document.",


### PR DESCRIPTION
### What does it do?

Makes Content Manager list view entries openable in a new tab, in two complementary ways:

- **Primary cell as a link** — the first non-interactive (scalar) column of each row is now rendered as a React Router `<Link>` to the entry (`CellContent.tsx`, `ListViewPage.tsx`). A plain click still navigates within the SPA as before, while cmd/ctrl+click, middle-click and right-click → "Open in new tab" / "Copy link" now work natively, and the destination URL shows on hover. Interactive column types (`media`, `relation`, `component`, `dynamiczone`) and the synthetic columns (`status`, `documentId`, `createdBy`, `updatedBy`, computed cells) are skipped, so no anchor ever wraps an interactive element. Clicking the link stops propagation to avoid a duplicate navigation from the row's existing `onClick`.
- **"Open in new tab" row action** — a new `OpenInNewTabAction` in the row's three-dots menu (`TableActions.tsx`) resolves the entry URL via `useHref` and opens it with `window.open(..., '_blank', 'noopener,noreferrer')`, giving the feature an explicit, discoverable entry point. Added to `DEFAULT_TABLE_ROW_ACTIONS` with an `ExternalLink` icon and an `actions.open-in-new-tab.label` translation key.

### Why is it needed?

Users reported they couldn't open a list view entry in a new tab (right-click / cmd+click) because rows navigated via a JS `onClick` handler with no underlying link. Making the whole row a single clickable link isn't viable since rows contain their own interactive elements (selects, relation/component menus, the actions menu). Linking only the primary scalar cell — plus an explicit menu action — restores native open-in-new-tab behaviour without nesting interactive elements inside an anchor.

### How to test it?

- Open any collection type that has entries in the Content Manager list view.
- On the **primary (first text) column**: cmd/ctrl+click or middle-click → entry opens in a new tab; right-click → browser shows "Open in New Tab" / "Copy Link"; plain click → navigates in the same tab as before.
- Open the **three-dots menu** on a row → "Open in new tab" → entry opens in a new tab.
- Confirm rows whose first column is a relation/component/media still behave normally (no link on that cell), and that checkboxes / relation dropdowns / the actions menu remain clickable.

Tests:
- Unit: `yarn nx run @strapi/content-manager:test:front --test-path-pattern="CellContent.test"`

### Related issue(s)/PR(s)

- Fixes #25619
- Alternative approach to #25621 (full-row link overlay) and #25583

🚀