### PR TITLE
fix(content-manager): skip publish warning for M2M links to published entries

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -747,12 +747,8 @@ const PublishAction: DocumentActionComponent = ({
   }, [isErrorDraftRelations, toggleNotification, formatMessage]);
 
   React.useEffect(() => {
-    if (!documentId || modified) {
-      setLocalDraftRelationCounts(countLocalDraftRelations(formValues, schema, components, model));
-    } else {
-      setLocalDraftRelationCounts(EMPTY_DRAFT_RELATION_COUNTS);
-    }
-  }, [components, documentId, formValues, model, modified, schema]);
+    setLocalDraftRelationCounts(countLocalDraftRelations(formValues, schema, components, model));
+  }, [components, formValues, model, schema]);
 
   const fetchDraftRelationsCount = React.useCallback(async () => {
     if (!document?.documentId || isListView) {
@@ -989,6 +985,17 @@ const PublishAction: DocumentActionComponent = ({
     }
   };
 
+  const getFreshDraftRelationCounts = React.useCallback(
+    (): DraftRelationCounts =>
+      resolveDraftRelationCounts(
+        documentId,
+        modified,
+        countLocalDraftRelations(getValues(), schema, components, model),
+        serverDraftRelationCounts
+      ),
+    [components, documentId, getValues, model, modified, schema, serverDraftRelationCounts]
+  );
+
   const draftRelationCounts = resolveDraftRelationCounts(
     documentId,
     modified,
@@ -1003,6 +1010,8 @@ const PublishAction: DocumentActionComponent = ({
     bodyIcon,
     confirmLabel,
   } = getDraftRelationsPublishState(draftRelationCounts);
+
+  const supportsDraftRelationWarning = Boolean(schema?.options?.draftAndPublish);
 
   /**
    * Disabled when:
@@ -1044,7 +1053,7 @@ const PublishAction: DocumentActionComponent = ({
         return;
       }
 
-      if (hasDraftRelations) {
+      if (getDraftRelationsPublishState(getFreshDraftRelationCounts()).hasDraftRelations) {
         openPublishConfirmDialog(publishConfirmScope);
         return;
       }
@@ -1059,7 +1068,7 @@ const PublishAction: DocumentActionComponent = ({
     };
   }, [
     fromRelationModal,
-    hasDraftRelations,
+    getFreshDraftRelationCounts,
     isDisabled,
     isRelationModalOpen,
     performPublish,
@@ -1076,21 +1085,23 @@ const PublishAction: DocumentActionComponent = ({
     loading: isLoading,
     position: ['panel', 'preview', 'relation-modal'],
     disabled: isDisabled,
-    publishConfirmScope: hasDraftRelations ? publishConfirmScope : undefined,
+    publishConfirmScope: supportsDraftRelationWarning ? publishConfirmScope : undefined,
     label: formatMessage({
       id: 'app.utils.publish',
       defaultMessage: 'Publish',
     }),
     onClick: async () => {
-      if (hasDraftRelations) {
-        // In this case we need to show the user a confirmation dialog.
-        // Return from the onClick and let the dialog handle the process.
+      if (getDraftRelationsPublishState(getFreshDraftRelationCounts()).hasDraftRelations) {
+        // Let DocumentActionButton open the confirmation dialog.
         return;
       }
 
       await performPublish();
+
+      // Skip the registered dialog when publishing directly.
+      return true;
     },
-    dialog: hasDraftRelations
+    dialog: supportsDraftRelationWarning
       ? {
           type: 'dialog',
           variant: dialogVariant,

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/draftRelationCounts.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/draftRelationCounts.ts
@@ -63,7 +63,10 @@ export const resolveDraftRelationCounts = (
     return localCounts;
   }
 
-  if (modified) {
+  const hasUnsavedDraftRelations =
+    localCounts.unpublishedRelations > 0 || localCounts.draftM2mLinks > 0;
+
+  if (modified || hasUnsavedDraftRelations) {
     return mergeDraftRelationCounts(localCounts, serverCounts);
   }
 

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/tests/draftRelationCounts.test.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/tests/draftRelationCounts.test.ts
@@ -309,12 +309,23 @@ describe('draftRelationCounts', () => {
       ).toEqual({ unpublishedRelations: 3, draftM2mLinks: 2 });
     });
 
-    it('uses server counts for saved unmodified documents', () => {
+    it('merges local draft connects when the form is not marked modified yet', () => {
       expect(
         resolveDraftRelationCounts(
           'doc-1',
           false,
           { unpublishedRelations: 1, draftM2mLinks: 0 },
+          { unpublishedRelations: 0, draftM2mLinks: 0 }
+        )
+      ).toEqual({ unpublishedRelations: 1, draftM2mLinks: 0 });
+    });
+
+    it('uses server counts for saved unmodified documents', () => {
+      expect(
+        resolveDraftRelationCounts(
+          'doc-1',
+          false,
+          { unpublishedRelations: 0, draftM2mLinks: 0 },
           { unpublishedRelations: 0, draftM2mLinks: 2 }
         )
       ).toEqual({ unpublishedRelations: 0, draftM2mLinks: 2 });

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/tests/draftRelationCounts.test.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/tests/draftRelationCounts.test.ts
@@ -191,6 +191,27 @@ describe('draftRelationCounts', () => {
       });
     });
 
+    it('ignores published bidirectional M2M connects', () => {
+      const counts = countLocalDraftRelations(
+        {
+          tags: {
+            connect: [
+              { id: 1, status: 'published' },
+              { id: 2, status: 'published' },
+            ],
+          },
+        },
+        articleSchema,
+        components,
+        'api::article.article'
+      );
+
+      expect(counts).toEqual({
+        unpublishedRelations: 0,
+        draftM2mLinks: 0,
+      });
+    });
+
     it('counts draft relations inside components and dynamic zones', () => {
       const counts = countLocalDraftRelations(
         {
@@ -297,6 +318,17 @@ describe('draftRelationCounts', () => {
           { unpublishedRelations: 0, draftM2mLinks: 2 }
         )
       ).toEqual({ unpublishedRelations: 0, draftM2mLinks: 2 });
+    });
+
+    it('does not warn when server reports no draft relations for published M2M targets', () => {
+      const counts = resolveDraftRelationCounts(
+        'doc-1',
+        false,
+        { unpublishedRelations: 0, draftM2mLinks: 0 },
+        { unpublishedRelations: 0, draftM2mLinks: 0 }
+      );
+
+      expect(getDraftRelationsPublishState(counts).hasDraftRelations).toBe(false);
     });
   });
 

--- a/packages/core/content-manager/server/src/services/__tests__/document-manager.test.ts
+++ b/packages/core/content-manager/server/src/services/__tests__/document-manager.test.ts
@@ -1,0 +1,71 @@
+import documentManager from '../document-manager';
+import { sumDraftCounts } from '../utils/draft';
+import { getDeepPopulateDraftCount } from '../utils/populate';
+
+jest.mock('../utils/draft', () => ({
+  sumDraftCounts: jest.fn(),
+}));
+
+jest.mock('../utils/populate', () => ({
+  getDeepPopulateDraftCount: jest.fn(),
+}));
+
+const RELATION_LAB_UID = 'api::relation-lab.relation-lab';
+
+describe('document-manager', () => {
+  const findMany = jest.fn();
+  const sumDraftCountsMock = sumDraftCounts as jest.MockedFunction<typeof sumDraftCounts>;
+  const getDeepPopulateDraftCountMock = getDeepPopulateDraftCount as jest.MockedFunction<
+    typeof getDeepPopulateDraftCount
+  >;
+
+  beforeEach(() => {
+    findMany.mockReset();
+    sumDraftCountsMock.mockReset();
+    getDeepPopulateDraftCountMock.mockReturnValue({
+      populate: { manyToManyBi: true },
+      hasRelations: true,
+    });
+
+    global.strapi = {
+      documents: jest.fn(() => ({
+        findMany,
+      })),
+    } as any;
+  });
+
+  describe('countManyEntriesDraftRelations', () => {
+    it('uses the document service so non-localized types are found despite locale=en', async () => {
+      const entities = [{ documentId: 'doc-1' }, { documentId: 'doc-2' }];
+      findMany.mockResolvedValue(entities);
+      sumDraftCountsMock
+        .mockResolvedValueOnce({ unpublishedRelations: 0, draftM2mLinks: 1 })
+        .mockResolvedValueOnce({ unpublishedRelations: 1, draftM2mLinks: 0 });
+
+      const service = documentManager({ strapi: global.strapi });
+      const total = await service.countManyEntriesDraftRelations(
+        ['doc-1', 'doc-2'],
+        RELATION_LAB_UID,
+        'en'
+      );
+
+      expect(findMany).toHaveBeenCalledWith({
+        populate: { manyToManyBi: true },
+        filters: { documentId: { $in: ['doc-1', 'doc-2'] } },
+        locale: 'en',
+        status: 'draft',
+      });
+      expect(total).toBe(2);
+    });
+
+    it('returns 0 when the content type has no relations to count', async () => {
+      getDeepPopulateDraftCountMock.mockReturnValue({ populate: {}, hasRelations: false });
+
+      const service = documentManager({ strapi: global.strapi });
+      const total = await service.countManyEntriesDraftRelations(['doc-1'], RELATION_LAB_UID, 'en');
+
+      expect(total).toBe(0);
+      expect(findMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/content-manager/server/src/services/document-manager.ts
+++ b/packages/core/content-manager/server/src/services/document-manager.ts
@@ -281,15 +281,11 @@ const documentManager = ({ strapi }: { strapi: Core.Strapi }) => {
         },
       });
 
-      const totalNumberDraftRelations: number = entities!.reduce(
-        (count: number, entity: Document) => {
-          const { unpublishedRelations } = sumDraftCounts(entity, uid);
-          return count + unpublishedRelations;
-        },
-        0
+      const counts = await Promise.all(
+        entities!.map((entity: Document) => sumDraftCounts(entity, uid))
       );
 
-      return totalNumberDraftRelations;
+      return counts.reduce((count, entityCounts) => count + entityCounts.unpublishedRelations, 0);
     },
   };
 };

--- a/packages/core/content-manager/server/src/services/document-manager.ts
+++ b/packages/core/content-manager/server/src/services/document-manager.ts
@@ -254,7 +254,7 @@ const documentManager = ({ strapi }: { strapi: Core.Strapi }) => {
         );
       }
 
-      return sumDraftCounts(document, uid);
+      return sumDraftCounts(strapi, document, uid);
     },
 
     async countManyEntriesDraftRelations(
@@ -276,7 +276,7 @@ const documentManager = ({ strapi }: { strapi: Core.Strapi }) => {
       });
 
       const counts = await Promise.all(
-        entities.map((entity: Document) => sumDraftCounts(entity, uid))
+        entities.map((entity: Document) => sumDraftCounts(strapi, entity, uid))
       );
 
       return counts.reduce(

--- a/packages/core/content-manager/server/src/services/document-manager.ts
+++ b/packages/core/content-manager/server/src/services/document-manager.ts
@@ -268,24 +268,22 @@ const documentManager = ({ strapi }: { strapi: Core.Strapi }) => {
         return 0;
       }
 
-      let localeFilter = {};
-      if (locale) {
-        localeFilter = Array.isArray(locale) ? { locale: { $in: locale } } : { locale };
-      }
-
-      const entities = await strapi.db.query(uid).findMany({
+      const entities = await strapi.documents(uid).findMany({
         populate,
-        where: {
-          documentId: { $in: documentIds },
-          ...localeFilter,
-        },
+        filters: { documentId: { $in: documentIds } } as any,
+        locale,
+        status: 'draft',
       });
 
       const counts = await Promise.all(
-        entities!.map((entity: Document) => sumDraftCounts(entity, uid))
+        entities.map((entity: Document) => sumDraftCounts(entity, uid))
       );
 
-      return counts.reduce((count, entityCounts) => count + entityCounts.unpublishedRelations, 0);
+      return counts.reduce(
+        (total, entityCounts) =>
+          total + entityCounts.unpublishedRelations + entityCounts.draftM2mLinks,
+        0
+      );
     },
   };
 };

--- a/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
@@ -27,69 +27,69 @@ describe('draft-relations utils', () => {
 
   describe('sumDraftCounts', () => {
     const findMany = jest.fn();
-
-    beforeEach(() => {
-      findMany.mockReset();
-
-      global.strapi = {
-        getModel: jest.fn((uid: string) => {
-          if (uid === 'api::article.article') {
-            return {
-              uid,
-              pluginOptions: { i18n: { localized: true } },
-              attributes: {
-                category: {
-                  type: 'relation',
-                  relation: 'manyToOne',
-                  target: 'api::tag.tag',
-                },
-                tags: {
-                  type: 'relation',
-                  relation: 'manyToMany',
-                  target: 'api::tag.tag',
-                  inversedBy: 'articles',
-                },
-                authors: {
-                  type: 'relation',
-                  relation: 'manyToMany',
-                  target: 'api::author.author',
-                  inversedBy: 'articles',
-                },
-              },
-            };
-          }
-
-          if (uid === 'api::author.author') {
-            return {
-              uid,
-              attributes: {
-                name: { type: 'string' },
-              },
-              options: { draftAndPublish: true },
-            };
-          }
-
+    const strapiMock = {
+      getModel: jest.fn((uid: string) => {
+        if (uid === 'api::article.article') {
           return {
             uid,
             pluginOptions: { i18n: { localized: true } },
+            attributes: {
+              category: {
+                type: 'relation',
+                relation: 'manyToOne',
+                target: 'api::tag.tag',
+              },
+              tags: {
+                type: 'relation',
+                relation: 'manyToMany',
+                target: 'api::tag.tag',
+                inversedBy: 'articles',
+              },
+              authors: {
+                type: 'relation',
+                relation: 'manyToMany',
+                target: 'api::author.author',
+                inversedBy: 'articles',
+              },
+            },
+          };
+        }
+
+        if (uid === 'api::author.author') {
+          return {
+            uid,
             attributes: {
               name: { type: 'string' },
             },
             options: { draftAndPublish: true },
           };
-        }),
-        db: {
-          query: jest.fn(() => ({
-            findMany,
-          })),
-        },
-      } as any;
+        }
+
+        return {
+          uid,
+          pluginOptions: { i18n: { localized: true } },
+          attributes: {
+            name: { type: 'string' },
+          },
+          options: { draftAndPublish: true },
+        };
+      }),
+      db: {
+        query: jest.fn(() => ({
+          findMany,
+        })),
+      },
+    } as any;
+
+    beforeEach(() => {
+      findMany.mockReset();
     });
 
     it('splits bidirectional M2M counts from xToOne counts', async () => {
       findMany.mockResolvedValue([]);
 
       const counts = await sumDraftCounts(
+        strapiMock,
         {
           category: { documentId: 'draft-category', locale: 'en' },
           tags: [
@@ -110,6 +110,7 @@ describe('draft-relations utils', () => {
       findMany.mockResolvedValue([{ documentId: 'published-category', locale: 'en' }]);
 
       const counts = await sumDraftCounts(
+        strapiMock,
         {
           category: { documentId: 'published-category', locale: 'en' },
         },
@@ -126,6 +127,7 @@ describe('draft-relations utils', () => {
       findMany.mockResolvedValue([]);
 
       const counts = await sumDraftCounts(
+        strapiMock,
         {
           category: { id: 1, documentId: 'draft-category', publishedAt: null },
         },
@@ -145,6 +147,7 @@ describe('draft-relations utils', () => {
       ]);
 
       const counts = await sumDraftCounts(
+        strapiMock,
         {
           tags: [
             { documentId: 'published-tag', locale: 'en' },
@@ -165,6 +168,7 @@ describe('draft-relations utils', () => {
       findMany.mockResolvedValue([{ documentId: 'tag-fr', locale: 'fr' }]);
 
       const counts = await sumDraftCounts(
+        strapiMock,
         {
           tags: [
             { documentId: 'tag-fr', locale: 'fr' },
@@ -184,6 +188,7 @@ describe('draft-relations utils', () => {
       findMany.mockResolvedValue([{ documentId: 'published-author', locale: null }]);
 
       const counts = await sumDraftCounts(
+        strapiMock,
         {
           authors: [{ documentId: 'published-author', locale: 'en' }],
         },

--- a/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
@@ -26,7 +26,11 @@ describe('draft-relations utils', () => {
   });
 
   describe('sumDraftCounts', () => {
+    const findMany = jest.fn();
+
     beforeEach(() => {
+      findMany.mockReset();
+
       global.strapi = {
         getModel: jest.fn((uid: string) => {
           if (uid === 'api::article.article') {
@@ -56,14 +60,24 @@ describe('draft-relations utils', () => {
             options: { draftAndPublish: true },
           };
         }),
+        db: {
+          query: jest.fn(() => ({
+            findMany,
+          })),
+        },
       } as any;
     });
 
-    it('splits bidirectional M2M counts from xToOne counts', () => {
-      const counts = sumDraftCounts(
+    it('splits bidirectional M2M counts from xToOne counts', async () => {
+      findMany.mockResolvedValue([]);
+
+      const counts = await sumDraftCounts(
         {
           category: { count: 1 },
-          tags: { count: 2 },
+          tags: [
+            { documentId: 'draft-tag', locale: 'en' },
+            { documentId: 'another-draft-tag', locale: 'en' },
+          ],
         },
         'api::article.article'
       );
@@ -71,6 +85,48 @@ describe('draft-relations utils', () => {
       expect(counts).toEqual({
         unpublishedRelations: 1,
         draftM2mLinks: 2,
+      });
+    });
+
+    it('ignores bidirectional M2M links to documents that already have a published version', async () => {
+      findMany.mockResolvedValue([
+        { documentId: 'published-tag', locale: 'en' },
+        { documentId: 'another-published-tag', locale: 'en' },
+      ]);
+
+      const counts = await sumDraftCounts(
+        {
+          tags: [
+            { documentId: 'published-tag', locale: 'en' },
+            { documentId: 'another-published-tag', locale: 'en' },
+            { documentId: 'draft-only-tag', locale: 'en' },
+          ],
+        },
+        'api::article.article'
+      );
+
+      expect(counts).toEqual({
+        unpublishedRelations: 0,
+        draftM2mLinks: 1,
+      });
+    });
+
+    it('scopes published-version checks by locale for bidirectional M2M links', async () => {
+      findMany.mockResolvedValue([{ documentId: 'tag-fr', locale: 'fr' }]);
+
+      const counts = await sumDraftCounts(
+        {
+          tags: [
+            { documentId: 'tag-fr', locale: 'fr' },
+            { documentId: 'tag-fr', locale: 'en' },
+          ],
+        },
+        'api::article.article'
+      );
+
+      expect(counts).toEqual({
+        unpublishedRelations: 0,
+        draftM2mLinks: 1,
       });
     });
   });

--- a/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
@@ -106,6 +106,22 @@ describe('draft-relations utils', () => {
       });
     });
 
+    it('counts joinColumn populate shapes that omit a count property', async () => {
+      findMany.mockResolvedValue([]);
+
+      const counts = await sumDraftCounts(
+        {
+          category: { id: 1, documentId: 'draft-category', publishedAt: null },
+        },
+        'api::article.article'
+      );
+
+      expect(counts).toEqual({
+        unpublishedRelations: 1,
+        draftM2mLinks: 0,
+      });
+    });
+
     it('ignores bidirectional M2M links to documents that already have a published version', async () => {
       findMany.mockResolvedValue([
         { documentId: 'published-tag', locale: 'en' },

--- a/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
@@ -36,6 +36,7 @@ describe('draft-relations utils', () => {
           if (uid === 'api::article.article') {
             return {
               uid,
+              pluginOptions: { i18n: { localized: true } },
               attributes: {
                 category: {
                   type: 'relation',
@@ -48,12 +49,29 @@ describe('draft-relations utils', () => {
                   target: 'api::tag.tag',
                   inversedBy: 'articles',
                 },
+                authors: {
+                  type: 'relation',
+                  relation: 'manyToMany',
+                  target: 'api::author.author',
+                  inversedBy: 'articles',
+                },
               },
+            };
+          }
+
+          if (uid === 'api::author.author') {
+            return {
+              uid,
+              attributes: {
+                name: { type: 'string' },
+              },
+              options: { draftAndPublish: true },
             };
           }
 
           return {
             uid,
+            pluginOptions: { i18n: { localized: true } },
             attributes: {
               name: { type: 'string' },
             },
@@ -127,6 +145,22 @@ describe('draft-relations utils', () => {
       expect(counts).toEqual({
         unpublishedRelations: 0,
         draftM2mLinks: 1,
+      });
+    });
+
+    it('ignores locale when the M2M target content type is not localized', async () => {
+      findMany.mockResolvedValue([{ documentId: 'published-author', locale: null }]);
+
+      const counts = await sumDraftCounts(
+        {
+          authors: [{ documentId: 'published-author', locale: 'en' }],
+        },
+        'api::article.article'
+      );
+
+      expect(counts).toEqual({
+        unpublishedRelations: 0,
+        draftM2mLinks: 0,
       });
     });
   });

--- a/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts
@@ -91,7 +91,7 @@ describe('draft-relations utils', () => {
 
       const counts = await sumDraftCounts(
         {
-          category: { count: 1 },
+          category: { documentId: 'draft-category', locale: 'en' },
           tags: [
             { documentId: 'draft-tag', locale: 'en' },
             { documentId: 'another-draft-tag', locale: 'en' },
@@ -103,6 +103,22 @@ describe('draft-relations utils', () => {
       expect(counts).toEqual({
         unpublishedRelations: 1,
         draftM2mLinks: 2,
+      });
+    });
+
+    it('counts xToOne links to documents that already have a published version as published', async () => {
+      findMany.mockResolvedValue([{ documentId: 'published-category', locale: 'en' }]);
+
+      const counts = await sumDraftCounts(
+        {
+          category: { documentId: 'published-category', locale: 'en' },
+        },
+        'api::article.article'
+      );
+
+      expect(counts).toEqual({
+        unpublishedRelations: 0,
+        draftM2mLinks: 0,
       });
     });
 

--- a/packages/core/content-manager/server/src/services/utils/draft.ts
+++ b/packages/core/content-manager/server/src/services/utils/draft.ts
@@ -1,6 +1,6 @@
 import { castArray } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
-import type { UID } from '@strapi/types';
+import type { Core, UID } from '@strapi/types';
 
 import { type DraftRelationCounts, isBidirectionalManyToMany } from './draft-relations';
 
@@ -49,6 +49,7 @@ const toDraftRelationLink = (
 };
 
 const collectDraftRelationLinks = (
+  strapi: Core.Strapi,
   entity: any,
   uid: UID.Schema,
   documentLocale?: string | null
@@ -71,7 +72,7 @@ const collectDraftRelationLinks = (
             return collected;
           }
 
-          const targetModel = strapi.getModel(attribute.target);
+          const targetModel = strapi.getModel(attribute.target as UID.Schema);
           if (!targetModel || !hasDraftAndPublish(targetModel)) {
             return collected;
           }
@@ -107,7 +108,7 @@ const collectDraftRelationLinks = (
             (componentCollected, componentValue) =>
               mergeCollectedLinks(
                 componentCollected,
-                collectDraftRelationLinks(componentValue, attribute.component, locale)
+                collectDraftRelationLinks(strapi, componentValue, attribute.component, locale)
               ),
             collected
           );
@@ -116,7 +117,7 @@ const collectDraftRelationLinks = (
           return value.reduce((zoneCollected: CollectedDraftRelationLinks, componentValue: any) => {
             return mergeCollectedLinks(
               zoneCollected,
-              collectDraftRelationLinks(componentValue, componentValue.__component, locale)
+              collectDraftRelationLinks(strapi, componentValue, componentValue.__component, locale)
             );
           }, collected);
         }
@@ -128,7 +129,10 @@ const collectDraftRelationLinks = (
   );
 };
 
-const countLinksToUnpublishedDocuments = async (links: DraftRelationLinkRef[]) => {
+const countLinksToUnpublishedDocuments = async (
+  strapi: Core.Strapi,
+  links: DraftRelationLinkRef[]
+) => {
   if (links.length === 0) {
     return 0;
   }
@@ -180,12 +184,16 @@ const countLinksToUnpublishedDocuments = async (links: DraftRelationLinkRef[]) =
  * - unpublishedRelations: xToOne / oneToMany style links stripped from the published version
  * - draftM2mLinks: bidirectional manyToMany links to documents without a published version
  */
-const sumDraftCounts = async (entity: any, uid: UID.Schema): Promise<DraftRelationCounts> => {
-  const { m2mLinks, xToOneLinks } = collectDraftRelationLinks(entity, uid);
+const sumDraftCounts = async (
+  strapi: Core.Strapi,
+  entity: any,
+  uid: UID.Schema
+): Promise<DraftRelationCounts> => {
+  const { m2mLinks, xToOneLinks } = collectDraftRelationLinks(strapi, entity, uid);
 
   const [draftM2mLinks, unpublishedRelations] = await Promise.all([
-    countLinksToUnpublishedDocuments(m2mLinks),
-    countLinksToUnpublishedDocuments(xToOneLinks),
+    countLinksToUnpublishedDocuments(strapi, m2mLinks),
+    countLinksToUnpublishedDocuments(strapi, xToOneLinks),
   ]);
 
   return {

--- a/packages/core/content-manager/server/src/services/utils/draft.ts
+++ b/packages/core/content-manager/server/src/services/utils/draft.ts
@@ -20,8 +20,13 @@ type M2mLinkRef = {
 const toPublishedDocumentKey = (documentId: string, locale?: string | null) =>
   `${documentId}:${locale ?? ''}`;
 
-const collectBidirectionalM2mLinks = (entity: any, uid: UID.Schema): M2mLinkRef[] => {
+const collectBidirectionalM2mLinks = (
+  entity: any,
+  uid: UID.Schema,
+  documentLocale?: string | null
+): M2mLinkRef[] => {
   const model = strapi.getModel(uid);
+  const locale = entity.locale ?? documentLocale;
 
   return Object.keys(model.attributes).reduce((links, attributeName) => {
     const attribute: any = model.attributes[attributeName];
@@ -53,7 +58,7 @@ const collectBidirectionalM2mLinks = (entity: any, uid: UID.Schema): M2mLinkRef[
             ...relatedEntries.map((entry) => ({
               targetUid: attribute.target,
               documentId: entry.documentId,
-              locale: entry.locale,
+              locale: entry.locale ?? locale,
             })),
           ];
         }
@@ -64,7 +69,7 @@ const collectBidirectionalM2mLinks = (entity: any, uid: UID.Schema): M2mLinkRef[
         return castArray(value).reduce(
           (componentLinks, componentValue) => [
             ...componentLinks,
-            ...collectBidirectionalM2mLinks(componentValue, attribute.component),
+            ...collectBidirectionalM2mLinks(componentValue, attribute.component, locale),
           ],
           links
         );
@@ -73,7 +78,7 @@ const collectBidirectionalM2mLinks = (entity: any, uid: UID.Schema): M2mLinkRef[
         return value.reduce((zoneLinks: M2mLinkRef[], componentValue: any) => {
           return [
             ...zoneLinks,
-            ...collectBidirectionalM2mLinks(componentValue, componentValue.__component),
+            ...collectBidirectionalM2mLinks(componentValue, componentValue.__component, locale),
           ];
         }, links);
       }

--- a/packages/core/content-manager/server/src/services/utils/draft.ts
+++ b/packages/core/content-manager/server/src/services/utils/draft.ts
@@ -11,6 +11,9 @@ import {
 
 const { isVisibleAttribute, hasDraftAndPublish } = strapiUtils.contentTypes;
 
+const isLocalizedContentType = (model: { pluginOptions?: unknown }) =>
+  (model.pluginOptions as { i18n?: { localized?: boolean } } | undefined)?.i18n?.localized === true;
+
 type M2mLinkRef = {
   targetUid: UID.Schema;
   documentId: string;
@@ -53,12 +56,14 @@ const collectBidirectionalM2mLinks = (
 
         if (isBidirectionalManyToMany(attribute)) {
           const relatedEntries = castArray(value);
+          const targetIsLocalized = isLocalizedContentType(targetModel);
+
           return [
             ...links,
             ...relatedEntries.map((entry) => ({
               targetUid: attribute.target,
               documentId: entry.documentId,
-              locale: entry.locale ?? locale,
+              locale: targetIsLocalized ? (entry.locale ?? locale) : null,
             })),
           ];
         }
@@ -102,6 +107,8 @@ const countLinksToUnpublishedDocuments = async (links: M2mLinkRef[]) => {
 
   const counts = await Promise.all(
     Array.from(linksByTarget.entries()).map(async ([targetUid, targetLinks]) => {
+      const targetModel = strapi.getModel(targetUid);
+      const targetIsLocalized = isLocalizedContentType(targetModel);
       const documentIds = [...new Set(targetLinks.map((link) => link.documentId))];
 
       const publishedRows = await strapi.db.query(targetUid).findMany({
@@ -111,6 +118,12 @@ const countLinksToUnpublishedDocuments = async (links: M2mLinkRef[]) => {
           publishedAt: { $notNull: true },
         },
       });
+
+      if (!targetIsLocalized) {
+        const publishedDocumentIds = new Set(publishedRows.map((row) => row.documentId));
+
+        return targetLinks.filter((link) => !publishedDocumentIds.has(link.documentId)).length;
+      }
 
       const publishedDocumentKeys = new Set(
         publishedRows.map((row) => toPublishedDocumentKey(row.documentId, row.locale))

--- a/packages/core/content-manager/server/src/services/utils/draft.ts
+++ b/packages/core/content-manager/server/src/services/utils/draft.ts
@@ -2,125 +2,138 @@ import { castArray } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
 import type { UID } from '@strapi/types';
 
-import {
-  type DraftRelationCounts,
-  EMPTY_DRAFT_RELATION_COUNTS,
-  isBidirectionalManyToMany,
-  mergeDraftRelationCounts,
-} from './draft-relations';
+import { type DraftRelationCounts, isBidirectionalManyToMany } from './draft-relations';
 
 const { isVisibleAttribute, hasDraftAndPublish } = strapiUtils.contentTypes;
 
 const isLocalizedContentType = (model: { pluginOptions?: unknown }) =>
   (model.pluginOptions as { i18n?: { localized?: boolean } } | undefined)?.i18n?.localized === true;
 
-type M2mLinkRef = {
+type DraftRelationLinkRef = {
   targetUid: UID.Schema;
   documentId: string;
   locale?: string | null;
 };
 
+type CollectedDraftRelationLinks = {
+  m2mLinks: DraftRelationLinkRef[];
+  xToOneLinks: DraftRelationLinkRef[];
+};
+
 const toPublishedDocumentKey = (documentId: string, locale?: string | null) =>
   `${documentId}:${locale ?? ''}`;
 
-/**
- * Draft-count populate uses `{ count: true, filters: { publishedAt: { $null: true } } }`.
- * joinColumn xToOne / oneToMany paths still return populated entities or arrays (not `{ count }`),
- * but only rows matching the draft filter are included.
- */
-const getUnpublishedRelationCount = (value: unknown): number => {
-  if (!value) {
-    return 0;
+const mergeCollectedLinks = (
+  left: CollectedDraftRelationLinks,
+  right: CollectedDraftRelationLinks
+): CollectedDraftRelationLinks => ({
+  m2mLinks: [...left.m2mLinks, ...right.m2mLinks],
+  xToOneLinks: [...left.xToOneLinks, ...right.xToOneLinks],
+});
+
+const toDraftRelationLink = (
+  entry: { documentId?: string; locale?: string | null },
+  targetUid: UID.Schema,
+  targetIsLocalized: boolean,
+  documentLocale?: string | null
+): DraftRelationLinkRef | null => {
+  if (!entry?.documentId) {
+    return null;
   }
 
-  if (typeof value === 'object' && value !== null && 'count' in value) {
-    const count = (value as { count: unknown }).count;
-    return typeof count === 'number' ? count : 0;
-  }
-
-  if (Array.isArray(value)) {
-    return value.length;
-  }
-
-  return 1;
+  return {
+    targetUid,
+    documentId: entry.documentId,
+    locale: targetIsLocalized ? (entry.locale ?? documentLocale) : null,
+  };
 };
 
-const collectBidirectionalM2mLinks = (
+const collectDraftRelationLinks = (
   entity: any,
   uid: UID.Schema,
   documentLocale?: string | null
-): M2mLinkRef[] => {
+): CollectedDraftRelationLinks => {
   const model = strapi.getModel(uid);
   const locale = entity.locale ?? documentLocale;
 
-  return Object.keys(model.attributes).reduce((links, attributeName) => {
-    const attribute: any = model.attributes[attributeName];
-    const value = entity[attributeName];
+  return Object.keys(model.attributes).reduce(
+    (collected, attributeName) => {
+      const attribute: any = model.attributes[attributeName];
+      const value = entity[attributeName];
 
-    if (!value) {
-      return links;
-    }
+      if (!value) {
+        return collected;
+      }
 
-    switch (attribute.type) {
-      case 'relation': {
-        if (!('target' in attribute)) {
-          return links;
-        }
+      switch (attribute.type) {
+        case 'relation': {
+          if (!('target' in attribute)) {
+            return collected;
+          }
 
-        const targetModel = strapi.getModel(attribute.target);
-        if (!targetModel || !hasDraftAndPublish(targetModel)) {
-          return links;
-        }
+          const targetModel = strapi.getModel(attribute.target);
+          if (!targetModel || !hasDraftAndPublish(targetModel)) {
+            return collected;
+          }
 
-        if (attribute.target === uid || !isVisibleAttribute(model, attributeName)) {
-          return links;
-        }
+          if (attribute.target === uid || !isVisibleAttribute(model, attributeName)) {
+            return collected;
+          }
 
-        if (isBidirectionalManyToMany(attribute)) {
-          const relatedEntries = castArray(value);
           const targetIsLocalized = isLocalizedContentType(targetModel);
+          const relatedEntries = castArray(value);
+          const links = relatedEntries
+            .map((entry) => toDraftRelationLink(entry, attribute.target, targetIsLocalized, locale))
+            .filter((link): link is DraftRelationLinkRef => link !== null);
 
-          return [
-            ...links,
-            ...relatedEntries.map((entry) => ({
-              targetUid: attribute.target,
-              documentId: entry.documentId,
-              locale: targetIsLocalized ? (entry.locale ?? locale) : null,
-            })),
-          ];
+          if (links.length === 0) {
+            return collected;
+          }
+
+          if (isBidirectionalManyToMany(attribute)) {
+            return {
+              ...collected,
+              m2mLinks: [...collected.m2mLinks, ...links],
+            };
+          }
+
+          return {
+            ...collected,
+            xToOneLinks: [...collected.xToOneLinks, ...links],
+          };
         }
-
-        return links;
+        case 'component': {
+          return castArray(value).reduce(
+            (componentCollected, componentValue) =>
+              mergeCollectedLinks(
+                componentCollected,
+                collectDraftRelationLinks(componentValue, attribute.component, locale)
+              ),
+            collected
+          );
+        }
+        case 'dynamiczone': {
+          return value.reduce((zoneCollected: CollectedDraftRelationLinks, componentValue: any) => {
+            return mergeCollectedLinks(
+              zoneCollected,
+              collectDraftRelationLinks(componentValue, componentValue.__component, locale)
+            );
+          }, collected);
+        }
+        default:
+          return collected;
       }
-      case 'component': {
-        return castArray(value).reduce(
-          (componentLinks, componentValue) => [
-            ...componentLinks,
-            ...collectBidirectionalM2mLinks(componentValue, attribute.component, locale),
-          ],
-          links
-        );
-      }
-      case 'dynamiczone': {
-        return value.reduce((zoneLinks: M2mLinkRef[], componentValue: any) => {
-          return [
-            ...zoneLinks,
-            ...collectBidirectionalM2mLinks(componentValue, componentValue.__component, locale),
-          ];
-        }, links);
-      }
-      default:
-        return links;
-    }
-  }, [] as M2mLinkRef[]);
+    },
+    { m2mLinks: [], xToOneLinks: [] } as CollectedDraftRelationLinks
+  );
 };
 
-const countLinksToUnpublishedDocuments = async (links: M2mLinkRef[]) => {
+const countLinksToUnpublishedDocuments = async (links: DraftRelationLinkRef[]) => {
   if (links.length === 0) {
     return 0;
   }
 
-  const linksByTarget = links.reduce<Map<UID.Schema, M2mLinkRef[]>>((acc, link) => {
+  const linksByTarget = links.reduce<Map<UID.Schema, DraftRelationLinkRef[]>>((acc, link) => {
     const targetLinks = acc.get(link.targetUid) ?? [];
     targetLinks.push(link);
     acc.set(link.targetUid, targetLinks);
@@ -167,79 +180,16 @@ const countLinksToUnpublishedDocuments = async (links: M2mLinkRef[]) => {
  * - unpublishedRelations: xToOne / oneToMany style links stripped from the published version
  * - draftM2mLinks: bidirectional manyToMany links to documents without a published version
  */
-const sumDraftCountsSync = (entity: any, uid: UID.Schema): DraftRelationCounts => {
-  const model = strapi.getModel(uid);
-
-  return Object.keys(model.attributes).reduce((counts, attributeName) => {
-    const attribute: any = model.attributes[attributeName];
-    const value = entity[attributeName];
-
-    if (!value) {
-      return counts;
-    }
-
-    switch (attribute.type) {
-      case 'relation': {
-        if (!('target' in attribute)) {
-          return counts;
-        }
-
-        const targetModel = strapi.getModel(attribute.target);
-        if (!targetModel || !hasDraftAndPublish(targetModel)) {
-          return counts;
-        }
-
-        // Self-referential relations are preserved on publish (see self-referential-relations.ts).
-        if (attribute.target === uid) {
-          return counts;
-        }
-
-        if (!isVisibleAttribute(model, attributeName)) {
-          return counts;
-        }
-
-        if (isBidirectionalManyToMany(attribute)) {
-          return counts;
-        }
-
-        return {
-          ...counts,
-          unpublishedRelations: counts.unpublishedRelations + getUnpublishedRelationCount(value),
-        };
-      }
-      case 'component': {
-        const compoCounts = castArray(value).reduce(
-          (acc, componentValue) =>
-            mergeDraftRelationCounts(acc, sumDraftCountsSync(componentValue, attribute.component)),
-          EMPTY_DRAFT_RELATION_COUNTS
-        );
-
-        return mergeDraftRelationCounts(counts, compoCounts);
-      }
-      case 'dynamiczone': {
-        const dzCounts = value.reduce((acc: DraftRelationCounts, componentValue: any) => {
-          return mergeDraftRelationCounts(
-            acc,
-            sumDraftCountsSync(componentValue, componentValue.__component)
-          );
-        }, EMPTY_DRAFT_RELATION_COUNTS);
-
-        return mergeDraftRelationCounts(counts, dzCounts);
-      }
-      default:
-        return counts;
-    }
-  }, EMPTY_DRAFT_RELATION_COUNTS);
-};
-
 const sumDraftCounts = async (entity: any, uid: UID.Schema): Promise<DraftRelationCounts> => {
-  const counts = sumDraftCountsSync(entity, uid);
-  const draftM2mLinks = await countLinksToUnpublishedDocuments(
-    collectBidirectionalM2mLinks(entity, uid)
-  );
+  const { m2mLinks, xToOneLinks } = collectDraftRelationLinks(entity, uid);
+
+  const [draftM2mLinks, unpublishedRelations] = await Promise.all([
+    countLinksToUnpublishedDocuments(m2mLinks),
+    countLinksToUnpublishedDocuments(xToOneLinks),
+  ]);
 
   return {
-    ...counts,
+    unpublishedRelations,
     draftM2mLinks,
   };
 };

--- a/packages/core/content-manager/server/src/services/utils/draft.ts
+++ b/packages/core/content-manager/server/src/services/utils/draft.ts
@@ -23,6 +23,28 @@ type M2mLinkRef = {
 const toPublishedDocumentKey = (documentId: string, locale?: string | null) =>
   `${documentId}:${locale ?? ''}`;
 
+/**
+ * Draft-count populate uses `{ count: true, filters: { publishedAt: { $null: true } } }`.
+ * joinColumn xToOne / oneToMany paths still return populated entities or arrays (not `{ count }`),
+ * but only rows matching the draft filter are included.
+ */
+const getUnpublishedRelationCount = (value: unknown): number => {
+  if (!value) {
+    return 0;
+  }
+
+  if (typeof value === 'object' && value !== null && 'count' in value) {
+    const count = (value as { count: unknown }).count;
+    return typeof count === 'number' ? count : 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+
+  return 1;
+};
+
 const collectBidirectionalM2mLinks = (
   entity: any,
   uid: UID.Schema,
@@ -182,7 +204,7 @@ const sumDraftCountsSync = (entity: any, uid: UID.Schema): DraftRelationCounts =
 
         return {
           ...counts,
-          unpublishedRelations: counts.unpublishedRelations + value.count,
+          unpublishedRelations: counts.unpublishedRelations + getUnpublishedRelationCount(value),
         };
       }
       case 'component': {

--- a/packages/core/content-manager/server/src/services/utils/draft.ts
+++ b/packages/core/content-manager/server/src/services/utils/draft.ts
@@ -1,5 +1,6 @@
 import { castArray } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
+import type { UID } from '@strapi/types';
 
 import {
   type DraftRelationCounts,
@@ -10,14 +11,123 @@ import {
 
 const { isVisibleAttribute, hasDraftAndPublish } = strapiUtils.contentTypes;
 
+type M2mLinkRef = {
+  targetUid: UID.Schema;
+  documentId: string;
+  locale?: string | null;
+};
+
+const toPublishedDocumentKey = (documentId: string, locale?: string | null) =>
+  `${documentId}:${locale ?? ''}`;
+
+const collectBidirectionalM2mLinks = (entity: any, uid: UID.Schema): M2mLinkRef[] => {
+  const model = strapi.getModel(uid);
+
+  return Object.keys(model.attributes).reduce((links, attributeName) => {
+    const attribute: any = model.attributes[attributeName];
+    const value = entity[attributeName];
+
+    if (!value) {
+      return links;
+    }
+
+    switch (attribute.type) {
+      case 'relation': {
+        if (!('target' in attribute)) {
+          return links;
+        }
+
+        const targetModel = strapi.getModel(attribute.target);
+        if (!targetModel || !hasDraftAndPublish(targetModel)) {
+          return links;
+        }
+
+        if (attribute.target === uid || !isVisibleAttribute(model, attributeName)) {
+          return links;
+        }
+
+        if (isBidirectionalManyToMany(attribute)) {
+          const relatedEntries = castArray(value);
+          return [
+            ...links,
+            ...relatedEntries.map((entry) => ({
+              targetUid: attribute.target,
+              documentId: entry.documentId,
+              locale: entry.locale,
+            })),
+          ];
+        }
+
+        return links;
+      }
+      case 'component': {
+        return castArray(value).reduce(
+          (componentLinks, componentValue) => [
+            ...componentLinks,
+            ...collectBidirectionalM2mLinks(componentValue, attribute.component),
+          ],
+          links
+        );
+      }
+      case 'dynamiczone': {
+        return value.reduce((zoneLinks: M2mLinkRef[], componentValue: any) => {
+          return [
+            ...zoneLinks,
+            ...collectBidirectionalM2mLinks(componentValue, componentValue.__component),
+          ];
+        }, links);
+      }
+      default:
+        return links;
+    }
+  }, [] as M2mLinkRef[]);
+};
+
+const countLinksToUnpublishedDocuments = async (links: M2mLinkRef[]) => {
+  if (links.length === 0) {
+    return 0;
+  }
+
+  const linksByTarget = links.reduce<Map<UID.Schema, M2mLinkRef[]>>((acc, link) => {
+    const targetLinks = acc.get(link.targetUid) ?? [];
+    targetLinks.push(link);
+    acc.set(link.targetUid, targetLinks);
+    return acc;
+  }, new Map());
+
+  const counts = await Promise.all(
+    Array.from(linksByTarget.entries()).map(async ([targetUid, targetLinks]) => {
+      const documentIds = [...new Set(targetLinks.map((link) => link.documentId))];
+
+      const publishedRows = await strapi.db.query(targetUid).findMany({
+        select: ['documentId', 'locale'],
+        where: {
+          documentId: { $in: documentIds },
+          publishedAt: { $notNull: true },
+        },
+      });
+
+      const publishedDocumentKeys = new Set(
+        publishedRows.map((row) => toPublishedDocumentKey(row.documentId, row.locale))
+      );
+
+      return targetLinks.filter(
+        (link) => !publishedDocumentKeys.has(toPublishedDocumentKey(link.documentId, link.locale))
+      ).length;
+    })
+  );
+
+  return counts.reduce((total, count) => total + count, 0);
+};
+
 /**
  * sumDraftCounts works recursively on the attributes of a model counting draft relations
  * that matter for publish warnings.
  *
  * - unpublishedRelations: xToOne / oneToMany style links stripped from the published version
- * - draftM2mLinks: bidirectional manyToMany links kept on publish (informational)
+ * - draftM2mLinks: bidirectional manyToMany links to documents without a published version
  */
-const sumDraftCounts = (entity: any, uid: any): DraftRelationCounts => {
+const sumDraftCountsSync = (entity: any, uid: UID.Schema): DraftRelationCounts => {
   const model = strapi.getModel(uid);
 
   return Object.keys(model.attributes).reduce((counts, attributeName) => {
@@ -49,10 +159,7 @@ const sumDraftCounts = (entity: any, uid: any): DraftRelationCounts => {
         }
 
         if (isBidirectionalManyToMany(attribute)) {
-          return {
-            ...counts,
-            draftM2mLinks: counts.draftM2mLinks + value.count,
-          };
+          return counts;
         }
 
         return {
@@ -63,7 +170,7 @@ const sumDraftCounts = (entity: any, uid: any): DraftRelationCounts => {
       case 'component': {
         const compoCounts = castArray(value).reduce(
           (acc, componentValue) =>
-            mergeDraftRelationCounts(acc, sumDraftCounts(componentValue, attribute.component)),
+            mergeDraftRelationCounts(acc, sumDraftCountsSync(componentValue, attribute.component)),
           EMPTY_DRAFT_RELATION_COUNTS
         );
 
@@ -73,7 +180,7 @@ const sumDraftCounts = (entity: any, uid: any): DraftRelationCounts => {
         const dzCounts = value.reduce((acc: DraftRelationCounts, componentValue: any) => {
           return mergeDraftRelationCounts(
             acc,
-            sumDraftCounts(componentValue, componentValue.__component)
+            sumDraftCountsSync(componentValue, componentValue.__component)
           );
         }, EMPTY_DRAFT_RELATION_COUNTS);
 
@@ -83,6 +190,18 @@ const sumDraftCounts = (entity: any, uid: any): DraftRelationCounts => {
         return counts;
     }
   }, EMPTY_DRAFT_RELATION_COUNTS);
+};
+
+const sumDraftCounts = async (entity: any, uid: UID.Schema): Promise<DraftRelationCounts> => {
+  const counts = sumDraftCountsSync(entity, uid);
+  const draftM2mLinks = await countLinksToUnpublishedDocuments(
+    collectBidirectionalM2mLinks(entity, uid)
+  );
+
+  return {
+    ...counts,
+    draftM2mLinks,
+  };
 };
 
 export { sumDraftCounts };

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -348,7 +348,7 @@ const getDeepPopulateDraftCount = (uid: UID.Schema): { populate: any; hasRelatio
           // documents that still have a draft row (those links are kept on publish).
           if (isBidirectionalManyToMany(attribute)) {
             populateAcc[attributeName] = {
-              fields: ['documentId', 'locale'],
+              fields: ['documentId'],
               filters: { [PUBLISHED_AT_ATTRIBUTE]: { $null: true } },
             };
           } else {

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -2,7 +2,6 @@ import { merge, isEmpty, set, propEq } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
 import type { UID, Schema, Modules } from '@strapi/types';
 import { getService } from '../../utils';
-import { isBidirectionalManyToMany } from './draft-relations';
 
 const {
   isVisibleAttribute,
@@ -13,6 +12,9 @@ const {
 } = strapiUtils.contentTypes;
 const { isAnyToMany } = strapiUtils.relations;
 const { PUBLISHED_AT_ATTRIBUTE } = strapiUtils.contentTypes.constants;
+
+const isLocalizedContentType = (model: { pluginOptions?: unknown }) =>
+  (model.pluginOptions as { i18n?: { localized?: boolean } } | undefined)?.i18n?.localized === true;
 
 const isMorphToRelation = (attribute: any) =>
   isRelation(attribute) && attribute.relation.includes('morphTo');
@@ -343,20 +345,17 @@ const getDeepPopulateDraftCount = (uid: UID.Schema): { populate: any; hasRelatio
         }
 
         if (isVisibleAttribute(model, attributeName)) {
-          // Bidirectional M2M links on draft entries point at draft rows of related documents.
-          // We need documentId/locale to distinguish truly unpublished targets from published
-          // documents that still have a draft row (those links are kept on publish).
-          if (isBidirectionalManyToMany(attribute)) {
-            populateAcc[attributeName] = {
-              fields: ['documentId'],
-              filters: { [PUBLISHED_AT_ATTRIBUTE]: { $null: true } },
-            };
-          } else {
-            populateAcc[attributeName] = {
-              count: true,
-              filters: { [PUBLISHED_AT_ATTRIBUTE]: { $null: true } },
-            };
+          // Draft entries link to draft rows of related documents. Populate documentId/locale
+          // so we can distinguish truly unpublished targets from published documents that
+          // still have a draft row (those links are kept on publish for M2M, or remapped for xToOne).
+          const fields: string[] = ['documentId'];
+          if (isLocalizedContentType(targetModel)) {
+            fields.push('locale');
           }
+          populateAcc[attributeName] = {
+            fields,
+            filters: { [PUBLISHED_AT_ATTRIBUTE]: { $null: true } },
+          };
           hasRelations = true;
         }
         break;

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -2,6 +2,7 @@ import { merge, isEmpty, set, propEq } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
 import type { UID, Schema, Modules } from '@strapi/types';
 import { getService } from '../../utils';
+import { isBidirectionalManyToMany } from './draft-relations';
 
 const {
   isVisibleAttribute,
@@ -342,10 +343,20 @@ const getDeepPopulateDraftCount = (uid: UID.Schema): { populate: any; hasRelatio
         }
 
         if (isVisibleAttribute(model, attributeName)) {
-          populateAcc[attributeName] = {
-            count: true,
-            filters: { [PUBLISHED_AT_ATTRIBUTE]: { $null: true } },
-          };
+          // Bidirectional M2M links on draft entries point at draft rows of related documents.
+          // We need documentId/locale to distinguish truly unpublished targets from published
+          // documents that still have a draft row (those links are kept on publish).
+          if (isBidirectionalManyToMany(attribute)) {
+            populateAcc[attributeName] = {
+              fields: ['documentId', 'locale'],
+              filters: { [PUBLISHED_AT_ATTRIBUTE]: { $null: true } },
+            };
+          } else {
+            populateAcc[attributeName] = {
+              count: true,
+              filters: { [PUBLISHED_AT_ATTRIBUTE]: { $null: true } },
+            };
+          }
           hasRelations = true;
         }
         break;

--- a/tests/api/core/content-manager/api/draft-relations-bidirectional-m2m.test.api.ts
+++ b/tests/api/core/content-manager/api/draft-relations-bidirectional-m2m.test.api.ts
@@ -54,6 +54,140 @@ describe('CM API - countDraftRelations splits bidirectional M2M from xToOne', ()
     await builder.cleanup();
   });
 
+  test('returns 0 when bidirectional M2M links use draft rows of published entries', async () => {
+    const {
+      body: {
+        data: { documentId: tagDocumentId },
+      },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${TAG_UID}`,
+      body: { name: 'Published tag' },
+    });
+
+    await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${TAG_UID}/${tagDocumentId}/actions/publish`,
+    });
+
+    const {
+      body: { data: draftTagRow },
+    } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${TAG_UID}/${tagDocumentId}`,
+      qs: { status: 'draft' },
+    });
+
+    const {
+      body: { data: article },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${ARTICLE_UID}`,
+      body: {
+        title: 'Article',
+        tags: [draftTagRow.id],
+      },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${ARTICLE_UID}/${article.documentId}/actions/countDraftRelations`,
+    });
+
+    expect(body.data.unpublishedRelations).toBe(0);
+    expect(body.data.draftM2mLinks).toBe(0);
+  });
+
+  test('returns 0 for bidirectional M2M links to published entries only', async () => {
+    const {
+      body: {
+        data: { documentId: tagDocumentId },
+      },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${TAG_UID}`,
+      body: { name: 'Published tag' },
+    });
+
+    const {
+      body: { data: publishedTag },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${TAG_UID}/${tagDocumentId}/actions/publish`,
+    });
+
+    const {
+      body: { data: article },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${ARTICLE_UID}`,
+      body: {
+        title: 'Article',
+        tags: [publishedTag.id],
+      },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${ARTICLE_UID}/${article.documentId}/actions/countDraftRelations`,
+    });
+
+    expect(body.data.unpublishedRelations).toBe(0);
+    expect(body.data.draftM2mLinks).toBe(0);
+  });
+
+  test('counts only draft-only bidirectional M2M links when mixed with published entries', async () => {
+    const {
+      body: { data: draftTag },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${TAG_UID}`,
+      body: { name: 'Draft tag' },
+    });
+
+    const {
+      body: {
+        data: { documentId: publishedTagDocumentId },
+      },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${TAG_UID}`,
+      body: { name: 'Published tag' },
+    });
+
+    await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${TAG_UID}/${publishedTagDocumentId}/actions/publish`,
+    });
+
+    const {
+      body: { data: publishedTagDraftRow },
+    } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${TAG_UID}/${publishedTagDocumentId}`,
+      qs: { status: 'draft' },
+    });
+
+    const {
+      body: { data: article },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${ARTICLE_UID}`,
+      body: {
+        title: 'Article',
+        tags: [draftTag.id, publishedTagDraftRow.id],
+      },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${ARTICLE_UID}/${article.documentId}/actions/countDraftRelations`,
+    });
+
+    expect(body.data.unpublishedRelations).toBe(0);
+    expect(body.data.draftM2mLinks).toBe(1);
+  });
+
   test('counts bidirectional M2M separately from manyToOne draft links', async () => {
     const {
       body: { data: draftTag },

--- a/tests/api/core/content-manager/api/draft-relations-bidirectional-m2m.test.api.ts
+++ b/tests/api/core/content-manager/api/draft-relations-bidirectional-m2m.test.api.ts
@@ -41,7 +41,7 @@ const articleModel = {
   },
 };
 
-describe('CM API - countDraftRelations splits bidirectional M2M from xToOne', () => {
+describe('CM API - countDraftRelations draft vs published relation targets', () => {
   beforeAll(async () => {
     await builder.addContentType(tagModel).addContentType(articleModel).build();
 
@@ -86,6 +86,50 @@ describe('CM API - countDraftRelations splits bidirectional M2M from xToOne', ()
       body: {
         title: 'Article',
         tags: [draftTagRow.id],
+      },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${ARTICLE_UID}/${article.documentId}/actions/countDraftRelations`,
+    });
+
+    expect(body.data.unpublishedRelations).toBe(0);
+    expect(body.data.draftM2mLinks).toBe(0);
+  });
+
+  test('returns 0 when manyToOne links use draft rows of published entries', async () => {
+    const {
+      body: {
+        data: { documentId: tagDocumentId },
+      },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${TAG_UID}`,
+      body: { name: 'Published category' },
+    });
+
+    await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${TAG_UID}/${tagDocumentId}/actions/publish`,
+    });
+
+    const {
+      body: { data: draftTagRow },
+    } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${TAG_UID}/${tagDocumentId}`,
+      qs: { status: 'draft' },
+    });
+
+    const {
+      body: { data: article },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${ARTICLE_UID}`,
+      body: {
+        title: 'Article',
+        category: draftTagRow.id,
       },
     });
 

--- a/tests/app-template/src/api/relation-lab/content-types/relation-lab/schema.json
+++ b/tests/app-template/src/api/relation-lab/content-types/relation-lab/schema.json
@@ -1,0 +1,46 @@
+{
+  "kind": "collectionType",
+  "collectionName": "relation_labs",
+  "info": {
+    "singularName": "relation-lab",
+    "pluralName": "relation-labs",
+    "displayName": "Relation lab",
+    "description": "Exercises every relation type against relation-target for publish-warning E2E tests"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "manyToOne": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::relation-target.relation-target"
+    },
+    "oneToOne": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::relation-target.relation-target"
+    },
+    "oneToMany": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::relation-target.relation-target"
+    },
+    "manyToMany": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::relation-target.relation-target"
+    },
+    "manyToManyBi": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::relation-target.relation-target",
+      "inversedBy": "relationLabs"
+    }
+  }
+}

--- a/tests/app-template/src/api/relation-lab/controllers/relation-lab.js
+++ b/tests/app-template/src/api/relation-lab/controllers/relation-lab.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::relation-lab.relation-lab');

--- a/tests/app-template/src/api/relation-lab/routes/relation-lab.js
+++ b/tests/app-template/src/api/relation-lab/routes/relation-lab.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::relation-lab.relation-lab');

--- a/tests/app-template/src/api/relation-lab/services/relation-lab.js
+++ b/tests/app-template/src/api/relation-lab/services/relation-lab.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::relation-lab.relation-lab');

--- a/tests/app-template/src/api/relation-target/content-types/relation-target/schema.json
+++ b/tests/app-template/src/api/relation-target/content-types/relation-target/schema.json
@@ -1,0 +1,26 @@
+{
+  "kind": "collectionType",
+  "collectionName": "relation_targets",
+  "info": {
+    "singularName": "relation-target",
+    "pluralName": "relation-targets",
+    "displayName": "Relation target",
+    "description": "Draft & publish targets for relation-lab E2E tests"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "relationLabs": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::relation-lab.relation-lab",
+      "mappedBy": "manyToManyBi"
+    }
+  }
+}

--- a/tests/app-template/src/api/relation-target/controllers/relation-target.js
+++ b/tests/app-template/src/api/relation-target/controllers/relation-target.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::relation-target.relation-target');

--- a/tests/app-template/src/api/relation-target/routes/relation-target.js
+++ b/tests/app-template/src/api/relation-target/routes/relation-target.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::relation-target.relation-target');

--- a/tests/app-template/src/api/relation-target/services/relation-target.js
+++ b/tests/app-template/src/api/relation-target/services/relation-target.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::relation-target.relation-target');

--- a/tests/cli/tests/strapi/strapi/__snapshots__/content-types-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/content-types-list.test.cli.js.snap
@@ -23,6 +23,8 @@ exports[`content-types:list should output list of content-types 1`] = `
 │ api::homepage.homepage                               │
 │ api::match.match                                     │
 │ api::product.product                                 │
+│ api::relation-lab.relation-lab                       │
+│ api::relation-target.relation-target                 │
 │ api::shop.shop                                       │
 │ api::single-type-localized.single-type-localized     │
 │ api::single-type-non-local.single-type-non-local     │

--- a/tests/cli/tests/strapi/strapi/__snapshots__/controllers-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/controllers-list.test.cli.js.snap
@@ -45,6 +45,8 @@ exports[`controllers:list should output list of controllers 1`] = `
 │ api::country.country                                 │
 │ api::homepage.homepage                               │
 │ api::product.product                                 │
+│ api::relation-lab.relation-lab                       │
+│ api::relation-target.relation-target                 │
 │ api::shop.shop                                       │
 │ api::single-type-localized.single-type-localized     │
 │ api::single-type-non-local.single-type-non-local     │

--- a/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
@@ -742,6 +742,136 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
         ],
         "type": "object",
       },
+      "ApiRelationLabRelationLabDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiRelationLabRelationLabDocument",
+        "properties": {
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "manyToMany": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            },
+            "type": "array",
+          },
+          "manyToManyBi": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            },
+            "type": "array",
+          },
+          "manyToOne": {
+            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            "description": "A relational field",
+          },
+          "oneToMany": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            },
+            "type": "array",
+          },
+          "oneToOne": {
+            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            "description": "A relational field",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "title": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "title",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiRelationTargetRelationTargetDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiRelationTargetRelationTargetDocument",
+        "properties": {
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "name": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "relationLabs": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+            },
+            "type": "array",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "name",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
       "ApiShopShopDocument": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -18083,6 +18213,3136 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
         },
         "tags": [
           "product",
+        ],
+      },
+    },
+    "/relation-labs": {
+      "get": {
+        "operationId": "relation-lab/get/relation_labs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "title",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "title",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "title",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "title",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "manyToMany": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            },
+                            "type": "array",
+                          },
+                          "manyToManyBi": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            },
+                            "type": "array",
+                          },
+                          "manyToOne": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            "description": "A relational field",
+                          },
+                          "oneToMany": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            },
+                            "type": "array",
+                          },
+                          "oneToOne": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            "description": "A relational field",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "title": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "title",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+      "post": {
+        "operationId": "relation-lab/post/relation_labs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "manyToMany": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "manyToManyBi": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "manyToOne": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "oneToMany": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "oneToOne": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "title": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "title",
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "manyToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToManyBi": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "oneToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "oneToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+    },
+    "/relation-labs/{id}": {
+      "delete": {
+        "operationId": "relation-lab/delete/relation_labs_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "manyToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToManyBi": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "oneToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "oneToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+      "get": {
+        "operationId": "relation-lab/get/relation_labs_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "title",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "title",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "title",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "title",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "manyToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToManyBi": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "oneToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "oneToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+      "put": {
+        "operationId": "relation-lab/put/relation_labs_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "manyToMany": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "manyToManyBi": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "manyToOne": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "oneToMany": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "oneToOne": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "title": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "manyToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToManyBi": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "oneToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "oneToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+    },
+    "/relation-targets": {
+      "get": {
+        "operationId": "relation-target/get/relation_targets",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "name": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "relationLabs": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                            },
+                            "type": "array",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "name",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
+        ],
+      },
+      "post": {
+        "operationId": "relation-target/post/relation_targets",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "relationLabs": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "relationLabs": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                          },
+                          "type": "array",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
+        ],
+      },
+    },
+    "/relation-targets/{id}": {
+      "delete": {
+        "operationId": "relation-target/delete/relation_targets_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "relationLabs": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                          },
+                          "type": "array",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
+        ],
+      },
+      "get": {
+        "operationId": "relation-target/get/relation_targets_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "relationLabs": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                          },
+                          "type": "array",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
+        ],
+      },
+      "put": {
+        "operationId": "relation-target/put/relation_targets_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "relationLabs": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "relationLabs": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                          },
+                          "type": "array",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
         ],
       },
     },

--- a/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
@@ -51,6 +51,16 @@ exports[`routes:list should output list of routes 1`] = `
 │ POST               │ /api/products                                                                   │
 │ PUT                │ /api/products/:id                                                               │
 │ DELETE             │ /api/products/:id                                                               │
+│ HEAD|GET           │ /api/relation-labs                                                              │
+│ HEAD|GET           │ /api/relation-labs/:id                                                          │
+│ POST               │ /api/relation-labs                                                              │
+│ PUT                │ /api/relation-labs/:id                                                          │
+│ DELETE             │ /api/relation-labs/:id                                                          │
+│ HEAD|GET           │ /api/relation-targets                                                           │
+│ HEAD|GET           │ /api/relation-targets/:id                                                       │
+│ POST               │ /api/relation-targets                                                           │
+│ PUT                │ /api/relation-targets/:id                                                       │
+│ DELETE             │ /api/relation-targets/:id                                                       │
 │ HEAD|GET           │ /api/shop                                                                       │
 │ PUT                │ /api/shop                                                                       │
 │ DELETE             │ /api/shop                                                                       │

--- a/tests/cli/tests/strapi/strapi/__snapshots__/services-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/services-list.test.cli.js.snap
@@ -71,6 +71,8 @@ exports[`services:list should output list of services 1`] = `
 │ api::country.country                                 │
 │ api::homepage.homepage                               │
 │ api::product.product                                 │
+│ api::relation-lab.relation-lab                       │
+│ api::relation-target.relation-target                 │
 │ api::shop.shop                                       │
 │ api::single-type-localized.single-type-localized     │
 │ api::single-type-non-local.single-type-non-local     │

--- a/tests/e2e/tests/content-manager/bulk-publish-draft-relations-warning.spec.ts
+++ b/tests/e2e/tests/content-manager/bulk-publish-draft-relations-warning.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../../../utils/login';
+import {
+  resetDatabaseAndImportDataFromPath,
+  resyncSuperAdminPermissionsAfterImport,
+} from '../../../utils/dts-import';
+import { clickAndWait, findAndClose, navToHeader } from '../../../utils/shared';
+import {
+  BIDIRECTIONAL_M2M_LAB_FIELD,
+  connectRelationTarget,
+  createRelationTarget,
+  saveRelationLabDraft,
+} from './publish-draft-relations-warning.utils';
+
+test.describe('Bulk publish draft-relations warning', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetDatabaseAndImportDataFromPath('with-admin', (cts) => cts, { coreStore: false });
+    await resyncSuperAdminPermissionsAfterImport();
+    await page.goto('/admin');
+    await login({ page });
+  });
+
+  test('warns when bulk publishing non-i18n relation-lab entries linked to draft-only targets', async ({
+    page,
+  }) => {
+    await createRelationTarget(page, 'Bulk M2M target one', { publish: false });
+    await createRelationTarget(page, 'Bulk M2M target two', { publish: false });
+
+    for (const [title, targetName] of [
+      ['Bulk lab one', 'Bulk M2M target one'],
+      ['Bulk lab two', 'Bulk M2M target two'],
+    ] as const) {
+      await navToHeader(page, ['Content Manager', 'Relation lab'], 'Relation lab');
+      await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+      await saveRelationLabDraft(page, title);
+      await connectRelationTarget(page, BIDIRECTIONAL_M2M_LAB_FIELD, targetName, 'draft');
+      await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+      await findAndClose(page, 'Saved Document');
+    }
+
+    await navToHeader(page, ['Content Manager', 'Relation lab'], 'Relation lab');
+
+    await page
+      .getByRole('row', { name: /Bulk lab one/ })
+      .getByRole('checkbox')
+      .check();
+    await page
+      .getByRole('row', { name: /Bulk lab two/ })
+      .getByRole('checkbox')
+      .check();
+
+    await clickAndWait(page, page.getByRole('button', { name: 'Publish' }).first());
+
+    await expect(page.getByRole('heading', { name: 'Publish entries' })).toBeVisible();
+    await clickAndWait(
+      page,
+      page.getByLabel('Publish entries').getByRole('button', { name: 'Publish' })
+    );
+
+    const dialog = page.getByRole('alertdialog', { name: 'Confirmation' });
+    await expect(dialog).toBeVisible();
+    // ICU plural chunks add extra spaces in the DOM text Playwright reads — avoid tight single-space regexes.
+    await expect(dialog).toContainText('not published yet and might lead to unexpected behavior');
+    await expect(dialog).toContainText(/2\s+relations\s+out of\s+2\s+entries/i);
+    await expect(dialog.getByRole('button', { name: 'Publish' })).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).not.toBeVisible();
+  });
+});

--- a/tests/e2e/tests/content-manager/bulk-publish-draft-relations-warning.spec.ts
+++ b/tests/e2e/tests/content-manager/bulk-publish-draft-relations-warning.spec.ts
@@ -67,4 +67,51 @@ test.describe('Bulk publish draft-relations warning', () => {
     await dialog.getByRole('button', { name: 'Cancel' }).click();
     await expect(dialog).not.toBeVisible();
   });
+
+  test('warns when bulk publishing relation-lab entries with xToOne draft-only targets only', async ({
+    page,
+  }) => {
+    await createRelationTarget(page, 'Bulk xToOne target one', { publish: false });
+    await createRelationTarget(page, 'Bulk xToOne target two', { publish: false });
+
+    for (const [title, targetName] of [
+      ['Bulk xToOne lab one', 'Bulk xToOne target one'],
+      ['Bulk xToOne lab two', 'Bulk xToOne target two'],
+    ] as const) {
+      await navToHeader(page, ['Content Manager', 'Relation lab'], 'Relation lab');
+      await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+      await saveRelationLabDraft(page, title);
+      await connectRelationTarget(page, 'manyToOne', targetName, 'draft');
+      await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+      await findAndClose(page, 'Saved Document');
+    }
+
+    await navToHeader(page, ['Content Manager', 'Relation lab'], 'Relation lab');
+
+    await page
+      .getByRole('row', { name: /Bulk xToOne lab one/ })
+      .getByRole('checkbox')
+      .check();
+    await page
+      .getByRole('row', { name: /Bulk xToOne lab two/ })
+      .getByRole('checkbox')
+      .check();
+
+    await clickAndWait(page, page.getByRole('button', { name: 'Publish' }).first());
+
+    await expect(page.getByRole('heading', { name: 'Publish entries' })).toBeVisible();
+    await clickAndWait(
+      page,
+      page.getByLabel('Publish entries').getByRole('button', { name: 'Publish' })
+    );
+
+    const dialog = page.getByRole('alertdialog', { name: 'Confirmation' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('not published yet and might lead to unexpected behavior');
+    await expect(dialog).toContainText(/2\s+relations\s+out of\s+2\s+entries/i);
+    await expect(dialog.getByRole('button', { name: 'Publish' })).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).not.toBeVisible();
+  });
 });

--- a/tests/e2e/tests/content-manager/bulk-publish-draft-relations-warning.spec.ts
+++ b/tests/e2e/tests/content-manager/bulk-publish-draft-relations-warning.spec.ts
@@ -7,6 +7,7 @@ import {
 import { clickAndWait, findAndClose, navToHeader } from '../../../utils/shared';
 import {
   BIDIRECTIONAL_M2M_LAB_FIELD,
+  clickBulkPublishExpectNoDraftRelationsDialog,
   connectRelationTarget,
   createRelationTarget,
   saveRelationLabDraft,
@@ -113,5 +114,69 @@ test.describe('Bulk publish draft-relations warning', () => {
 
     await dialog.getByRole('button', { name: 'Cancel' }).click();
     await expect(dialog).not.toBeVisible();
+  });
+
+  test('does not warn when bulk publishing relation-lab entries linked to published targets only', async ({
+    page,
+  }) => {
+    await createRelationTarget(page, 'Bulk published M2M one', { publish: true });
+    await createRelationTarget(page, 'Bulk published M2M two', { publish: true });
+
+    for (const [title, targetName] of [
+      ['Bulk published lab one', 'Bulk published M2M one'],
+      ['Bulk published lab two', 'Bulk published M2M two'],
+    ] as const) {
+      await navToHeader(page, ['Content Manager', 'Relation lab'], 'Relation lab');
+      await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+      await saveRelationLabDraft(page, title);
+      await connectRelationTarget(page, BIDIRECTIONAL_M2M_LAB_FIELD, targetName, 'published');
+      await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+      await findAndClose(page, 'Saved Document');
+    }
+
+    await navToHeader(page, ['Content Manager', 'Relation lab'], 'Relation lab');
+
+    await page
+      .getByRole('row', { name: /Bulk published lab one/ })
+      .getByRole('checkbox')
+      .check();
+    await page
+      .getByRole('row', { name: /Bulk published lab two/ })
+      .getByRole('checkbox')
+      .check();
+
+    await clickBulkPublishExpectNoDraftRelationsDialog(page);
+  });
+
+  test('does not warn when bulk publishing relation-lab entries with xToOne published targets only', async ({
+    page,
+  }) => {
+    await createRelationTarget(page, 'Bulk published xToOne one', { publish: true });
+    await createRelationTarget(page, 'Bulk published xToOne two', { publish: true });
+
+    for (const [title, targetName] of [
+      ['Bulk published xToOne lab one', 'Bulk published xToOne one'],
+      ['Bulk published xToOne lab two', 'Bulk published xToOne two'],
+    ] as const) {
+      await navToHeader(page, ['Content Manager', 'Relation lab'], 'Relation lab');
+      await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+      await saveRelationLabDraft(page, title);
+      await connectRelationTarget(page, 'manyToOne', targetName, 'published');
+      await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+      await findAndClose(page, 'Saved Document');
+    }
+
+    await navToHeader(page, ['Content Manager', 'Relation lab'], 'Relation lab');
+
+    await page
+      .getByRole('row', { name: /Bulk published xToOne lab one/ })
+      .getByRole('checkbox')
+      .check();
+    await page
+      .getByRole('row', { name: /Bulk published xToOne lab two/ })
+      .getByRole('checkbox')
+      .check();
+
+    await clickBulkPublishExpectNoDraftRelationsDialog(page);
   });
 });

--- a/tests/e2e/tests/content-manager/publish-draft-relations-by-relation-type.spec.ts
+++ b/tests/e2e/tests/content-manager/publish-draft-relations-by-relation-type.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../../../utils/login';
+import {
+  resetDatabaseAndImportDataFromPath,
+  resyncSuperAdminPermissionsAfterImport,
+} from '../../../utils/dts-import';
+import {
+  clickAndWait,
+  clickPublishExpectDraftRelationsDialog,
+  clickPublishExpectNoDraftRelationsDialog,
+  findAndClose,
+  navToHeader,
+  withContentManagerPublish,
+} from '../../../utils/shared';
+import {
+  RELATION_LAB_FIELDS,
+  connectRelationTarget,
+  createRelationTarget,
+  openNewRelationLab,
+  saveRelationLabDraft,
+} from './publish-draft-relations-warning.utils';
+
+const ARTICLE_CREATE_URL =
+  /\/admin\/content-manager\/collection-types\/api::article.article\/create(\?.*)?/;
+
+test.describe('Publish draft-relations warning by relation type', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetDatabaseAndImportDataFromPath('with-admin', (cts) => cts, { coreStore: false });
+    await resyncSuperAdminPermissionsAfterImport();
+    await page.goto('/admin');
+    await login({ page });
+  });
+
+  for (const { field, dialogVariant } of RELATION_LAB_FIELDS) {
+    test(`warns on publish when ${field} links to a draft-only target`, async ({ page }) => {
+      const targetName = `Draft ${field}`;
+
+      await createRelationTarget(page, targetName, { publish: false });
+      await openNewRelationLab(page);
+      await saveRelationLabDraft(page, `Lab ${field} draft target`);
+      await connectRelationTarget(page, field, targetName, false);
+
+      await clickPublishExpectDraftRelationsDialog(page, dialogVariant);
+    });
+
+    test(`does not warn on publish when ${field} links to a published target`, async ({ page }) => {
+      const targetName = `Published ${field}`;
+
+      await createRelationTarget(page, targetName, { publish: true });
+      await openNewRelationLab(page);
+      await saveRelationLabDraft(page, `Lab ${field} published target`);
+      await connectRelationTarget(page, field, targetName, true);
+
+      await clickPublishExpectNoDraftRelationsDialog(page);
+      await findAndClose(page, 'Published Document');
+    });
+  }
+});
+
+test.describe('Publish draft-relations warning — fixture content types', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetDatabaseAndImportDataFromPath('with-admin', (cts) => cts, { coreStore: false });
+    await resyncSuperAdminPermissionsAfterImport();
+    await page.goto('/admin');
+    await login({ page });
+  });
+
+  test('bidirectional M2M (Article authors): warns for draft author', async ({ page }) => {
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+    await page.waitForURL(ARTICLE_CREATE_URL);
+
+    await page.getByRole('textbox', { name: 'title' }).fill('Article draft author warning');
+    await page.getByRole('combobox', { name: 'authors' }).click();
+    await page.getByLabel('Coach BeardDraft').click();
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await findAndClose(page, 'Saved Document');
+
+    await clickPublishExpectDraftRelationsDialog(page, 'm2m');
+  });
+
+  test('bidirectional M2M (Article authors): no warning for published author', async ({ page }) => {
+    await navToHeader(page, ['Content Manager', 'Author'], 'Author');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+    await page.getByRole('textbox', { name: 'name' }).fill('Published Author');
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await findAndClose(page, 'Saved Document');
+    await withContentManagerPublish(page, () =>
+      page.getByRole('button', { name: 'Publish', exact: true }).click()
+    );
+    await findAndClose(page, 'Published Document');
+
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+    await page.waitForURL(ARTICLE_CREATE_URL);
+
+    await page.getByRole('textbox', { name: 'title' }).fill('Article published author');
+    await page.getByRole('combobox', { name: 'authors' }).click();
+    await page.getByLabel('Published AuthorPublished').click();
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await findAndClose(page, 'Saved Document');
+
+    await clickPublishExpectNoDraftRelationsDialog(page);
+    await findAndClose(page, 'Published Document');
+  });
+
+  test('oneToMany (Shop product carousel): warns for draft product', async ({ page }) => {
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Shop' }));
+    await page.waitForResponse(
+      (response) =>
+        response.request().method() === 'GET' &&
+        response.url().includes('/actions/countDraftRelations') &&
+        response.ok()
+    );
+
+    await clickAndWait(page, page.getByRole('button', { name: 'Product carousel - 23/24 kits' }));
+    await page.getByRole('combobox', { name: 'products' }).click();
+    await page.getByLabel('Nike Mens 23/24 Away Stadium').click();
+    await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
+
+    await clickPublishExpectDraftRelationsDialog(page, 'xToOne');
+  });
+
+  test('oneToMany (Shop product carousel): no warning for published product', async ({ page }) => {
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+    await clickAndWait(
+      page,
+      page.getByRole('gridcell', { name: 'Nike Mens 23/24 Away Stadium Jersey' })
+    );
+    await withContentManagerPublish(page, () =>
+      page.getByRole('button', { name: 'Publish', exact: true }).click()
+    );
+    await findAndClose(page, 'Published Document');
+
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Shop' }));
+    await page.waitForResponse(
+      (response) =>
+        response.request().method() === 'GET' &&
+        response.url().includes('/actions/countDraftRelations') &&
+        response.ok()
+    );
+
+    await clickAndWait(page, page.getByRole('button', { name: 'Product carousel - 23/24 kits' }));
+    await page.getByRole('combobox', { name: 'products' }).click();
+    await page.getByLabel('Nike Mens 23/24 Away StadiumPublished').click();
+    await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
+
+    await clickPublishExpectNoDraftRelationsDialog(page);
+    await findAndClose(page, 'Published Document');
+  });
+
+  test('self-referential oneToMany (Dog related): no draft-relations warning', async ({ page }) => {
+    await navToHeader(page, ['Content Manager', 'Dog'], 'Dog');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+    await page.getByRole('textbox', { name: 'name' }).fill('Rex');
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await findAndClose(page, 'Saved Document');
+
+    await page.getByRole('combobox', { name: 'related' }).click();
+    await clickAndWait(page, page.getByRole('option', { name: 'Rex' }));
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await findAndClose(page, 'Saved Document');
+
+    await clickPublishExpectNoDraftRelationsDialog(page);
+    await findAndClose(page, 'Published Document');
+  });
+});
+
+test.describe('Publish draft-relations warning — no relations', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetDatabaseAndImportDataFromPath('with-admin');
+    await page.goto('/admin');
+    await login({ page });
+  });
+
+  test('does not warn when publishing a draft entry without relations', async ({ page }) => {
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+    await page.waitForURL(ARTICLE_CREATE_URL);
+
+    await page.getByRole('textbox', { name: 'title' }).fill('No relations');
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await findAndClose(page, 'Saved Document');
+
+    await clickPublishExpectNoDraftRelationsDialog(page);
+    await findAndClose(page, 'Published Document');
+  });
+});

--- a/tests/e2e/tests/content-manager/publish-draft-relations-by-relation-type.spec.ts
+++ b/tests/e2e/tests/content-manager/publish-draft-relations-by-relation-type.spec.ts
@@ -108,6 +108,20 @@ test.describe('Publish draft-relations warning — bidirectional M2M regression'
     await clickPublishExpectNoDraftRelationsDialog(page);
     await findAndClose(page, 'Published Document');
   });
+
+  test('relation-lab with both xToOne and bidirectional M2M draft targets uses the danger modal', async ({
+    page,
+  }) => {
+    await createRelationTarget(page, 'Mixed M2M target', { publish: false });
+    await createRelationTarget(page, 'Mixed xToOne target', { publish: false });
+
+    await openNewRelationLab(page);
+    await saveRelationLabDraft(page, 'Mixed relations lab');
+    await connectRelationTarget(page, 'manyToOne', 'Mixed xToOne target', 'draft');
+    await connectRelationTarget(page, BIDIRECTIONAL_M2M_LAB_FIELD, 'Mixed M2M target', 'draft');
+
+    await clickPublishExpectDraftRelationsDialog(page, 'mixed');
+  });
 });
 
 test.describe('Publish draft-relations warning — xToOne-style relations', () => {

--- a/tests/e2e/tests/content-manager/publish-draft-relations-by-relation-type.spec.ts
+++ b/tests/e2e/tests/content-manager/publish-draft-relations-by-relation-type.spec.ts
@@ -13,17 +13,25 @@ import {
   withContentManagerPublish,
 } from '../../../utils/shared';
 import {
-  RELATION_LAB_FIELDS,
+  BIDIRECTIONAL_M2M_LAB_FIELD,
+  XTOONE_LAB_FIELDS,
   connectRelationTarget,
   createRelationTarget,
   openNewRelationLab,
   saveRelationLabDraft,
+  selectRelationComboboxOption,
 } from './publish-draft-relations-warning.utils';
 
 const ARTICLE_CREATE_URL =
   /\/admin\/content-manager\/collection-types\/api::article.article\/create(\?.*)?/;
 
-test.describe('Publish draft-relations warning by relation type', () => {
+/**
+ * Seed product name in the app-template dataset (see entities_00001.jsonl).
+ * Combobox options use the full name plus a Draft/Published suffix — see relation-option-probe.spec.ts.
+ */
+const NIKE_JERSEY_NAME = 'Nike Mens 23/24 Away Stadium Jersey';
+
+test.describe('Publish draft-relations warning — bidirectional M2M regression', () => {
   test.beforeEach(async ({ page }) => {
     await resetDatabaseAndImportDataFromPath('with-admin', (cts) => cts, { coreStore: false });
     await resyncSuperAdminPermissionsAfterImport();
@@ -31,58 +39,28 @@ test.describe('Publish draft-relations warning by relation type', () => {
     await login({ page });
   });
 
-  for (const { field, dialogVariant } of RELATION_LAB_FIELDS) {
-    test(`warns on publish when ${field} links to a draft-only target`, async ({ page }) => {
-      const targetName = `Draft ${field}`;
-
-      await createRelationTarget(page, targetName, { publish: false });
-      await openNewRelationLab(page);
-      await saveRelationLabDraft(page, `Lab ${field} draft target`);
-      await connectRelationTarget(page, field, targetName, false);
-
-      await clickPublishExpectDraftRelationsDialog(page, dialogVariant);
-    });
-
-    test(`does not warn on publish when ${field} links to a published target`, async ({ page }) => {
-      const targetName = `Published ${field}`;
-
-      await createRelationTarget(page, targetName, { publish: true });
-      await openNewRelationLab(page);
-      await saveRelationLabDraft(page, `Lab ${field} published target`);
-      await connectRelationTarget(page, field, targetName, true);
-
-      await clickPublishExpectNoDraftRelationsDialog(page);
-      await findAndClose(page, 'Published Document');
-    });
-  }
-});
-
-test.describe('Publish draft-relations warning — fixture content types', () => {
-  test.beforeEach(async ({ page }) => {
-    await resetDatabaseAndImportDataFromPath('with-admin', (cts) => cts, { coreStore: false });
-    await resyncSuperAdminPermissionsAfterImport();
-    await page.goto('/admin');
-    await login({ page });
-  });
-
-  test('bidirectional M2M (Article authors): warns for draft author', async ({ page }) => {
+  test('shows the M2M warning when authors link to a draft-only entry', async ({ page }) => {
     await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
     await page.waitForURL(ARTICLE_CREATE_URL);
 
-    await page.getByRole('textbox', { name: 'title' }).fill('Article draft author warning');
+    await page.getByRole('textbox', { name: 'title' }).fill('Article with draft author');
     await page.getByRole('combobox', { name: 'authors' }).click();
-    await page.getByLabel('Coach BeardDraft').click();
+    await selectRelationComboboxOption(page, 'Coach Beard', 'draft');
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
     await findAndClose(page, 'Saved Document');
 
     await clickPublishExpectDraftRelationsDialog(page, 'm2m');
   });
 
-  test('bidirectional M2M (Article authors): no warning for published author', async ({ page }) => {
+  test('does not warn when authors link to a document that is already published', async ({
+    page,
+  }) => {
+    const authorName = 'Jane Smith';
+
     await navToHeader(page, ['Content Manager', 'Author'], 'Author');
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
-    await page.getByRole('textbox', { name: 'name' }).fill('Published Author');
+    await page.getByRole('textbox', { name: 'name' }).fill(authorName);
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
     await findAndClose(page, 'Saved Document');
     await withContentManagerPublish(page, () =>
@@ -94,9 +72,9 @@ test.describe('Publish draft-relations warning — fixture content types', () =>
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
     await page.waitForURL(ARTICLE_CREATE_URL);
 
-    await page.getByRole('textbox', { name: 'title' }).fill('Article published author');
+    await page.getByRole('textbox', { name: 'title' }).fill('Article with published author');
     await page.getByRole('combobox', { name: 'authors' }).click();
-    await page.getByLabel('Published AuthorPublished').click();
+    await selectRelationComboboxOption(page, authorName, 'published');
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
     await findAndClose(page, 'Saved Document');
 
@@ -104,7 +82,69 @@ test.describe('Publish draft-relations warning — fixture content types', () =>
     await findAndClose(page, 'Published Document');
   });
 
-  test('oneToMany (Shop product carousel): warns for draft product', async ({ page }) => {
+  test('relation-lab manyToManyBi warns when the target document is draft-only', async ({
+    page,
+  }) => {
+    const targetName = 'Draft-only M2M target';
+
+    await createRelationTarget(page, targetName, { publish: false });
+    await openNewRelationLab(page);
+    await saveRelationLabDraft(page, 'Lab draft M2M target');
+    await connectRelationTarget(page, BIDIRECTIONAL_M2M_LAB_FIELD, targetName, 'draft');
+
+    await clickPublishExpectDraftRelationsDialog(page, 'm2m');
+  });
+
+  test('relation-lab manyToManyBi does not warn when the target document is already published', async ({
+    page,
+  }) => {
+    const targetName = 'Published M2M target';
+
+    await createRelationTarget(page, targetName, { publish: true });
+    await openNewRelationLab(page);
+    await saveRelationLabDraft(page, 'Lab published M2M target');
+    await connectRelationTarget(page, BIDIRECTIONAL_M2M_LAB_FIELD, targetName, 'published');
+
+    await clickPublishExpectNoDraftRelationsDialog(page);
+    await findAndClose(page, 'Published Document');
+  });
+});
+
+test.describe('Publish draft-relations warning — xToOne-style relations', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetDatabaseAndImportDataFromPath('with-admin', (cts) => cts, { coreStore: false });
+    await resyncSuperAdminPermissionsAfterImport();
+    await page.goto('/admin');
+    await login({ page });
+  });
+
+  for (const field of XTOONE_LAB_FIELDS) {
+    test(`relation-lab ${field} warns when the target document is draft-only`, async ({ page }) => {
+      const targetName = `${field} draft-only target`;
+
+      await createRelationTarget(page, targetName, { publish: false });
+      await openNewRelationLab(page);
+      await saveRelationLabDraft(page, `Lab ${field} draft target`);
+      await connectRelationTarget(page, field, targetName, 'draft');
+
+      await clickPublishExpectDraftRelationsDialog(page, 'xToOne');
+    });
+  }
+
+  test('relation-lab unidirectional manyToMany warns when the target document is draft-only', async ({
+    page,
+  }) => {
+    const targetName = 'Uni M2M draft-only target';
+
+    await createRelationTarget(page, targetName, { publish: false });
+    await openNewRelationLab(page);
+    await saveRelationLabDraft(page, 'Lab uni M2M draft target');
+    await connectRelationTarget(page, 'manyToMany', targetName, 'draft');
+
+    await clickPublishExpectDraftRelationsDialog(page, 'xToOne');
+  });
+
+  test('Shop product carousel warns when linking an unpublished product', async ({ page }) => {
     await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
     await clickAndWait(page, page.getByRole('link', { name: 'Shop' }));
     await page.waitForResponse(
@@ -116,18 +156,17 @@ test.describe('Publish draft-relations warning — fixture content types', () =>
 
     await clickAndWait(page, page.getByRole('button', { name: 'Product carousel - 23/24 kits' }));
     await page.getByRole('combobox', { name: 'products' }).click();
-    await page.getByLabel('Nike Mens 23/24 Away Stadium').click();
+    await selectRelationComboboxOption(page, NIKE_JERSEY_NAME, 'draft');
     await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
 
     await clickPublishExpectDraftRelationsDialog(page, 'xToOne');
   });
 
-  test('oneToMany (Shop product carousel): no warning for published product', async ({ page }) => {
+  test('Shop product carousel does not warn when linking an already-published product', async ({
+    page,
+  }) => {
     await navToHeader(page, ['Content Manager', 'Products'], 'Products');
-    await clickAndWait(
-      page,
-      page.getByRole('gridcell', { name: 'Nike Mens 23/24 Away Stadium Jersey' })
-    );
+    await clickAndWait(page, page.getByRole('gridcell', { name: NIKE_JERSEY_NAME }));
     await withContentManagerPublish(page, () =>
       page.getByRole('button', { name: 'Publish', exact: true }).click()
     );
@@ -144,45 +183,8 @@ test.describe('Publish draft-relations warning — fixture content types', () =>
 
     await clickAndWait(page, page.getByRole('button', { name: 'Product carousel - 23/24 kits' }));
     await page.getByRole('combobox', { name: 'products' }).click();
-    await page.getByLabel('Nike Mens 23/24 Away StadiumPublished').click();
+    await selectRelationComboboxOption(page, NIKE_JERSEY_NAME, 'published');
     await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
-
-    await clickPublishExpectNoDraftRelationsDialog(page);
-    await findAndClose(page, 'Published Document');
-  });
-
-  test('self-referential oneToMany (Dog related): no draft-relations warning', async ({ page }) => {
-    await navToHeader(page, ['Content Manager', 'Dog'], 'Dog');
-    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
-    await page.getByRole('textbox', { name: 'name' }).fill('Rex');
-    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Saved Document');
-
-    await page.getByRole('combobox', { name: 'related' }).click();
-    await clickAndWait(page, page.getByRole('option', { name: 'Rex' }));
-    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Saved Document');
-
-    await clickPublishExpectNoDraftRelationsDialog(page);
-    await findAndClose(page, 'Published Document');
-  });
-});
-
-test.describe('Publish draft-relations warning — no relations', () => {
-  test.beforeEach(async ({ page }) => {
-    await resetDatabaseAndImportDataFromPath('with-admin');
-    await page.goto('/admin');
-    await login({ page });
-  });
-
-  test('does not warn when publishing a draft entry without relations', async ({ page }) => {
-    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
-    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
-    await page.waitForURL(ARTICLE_CREATE_URL);
-
-    await page.getByRole('textbox', { name: 'title' }).fill('No relations');
-    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Saved Document');
 
     await clickPublishExpectNoDraftRelationsDialog(page);
     await findAndClose(page, 'Published Document');

--- a/tests/e2e/tests/content-manager/publish-draft-relations-by-relation-type.spec.ts
+++ b/tests/e2e/tests/content-manager/publish-draft-relations-by-relation-type.spec.ts
@@ -143,6 +143,20 @@ test.describe('Publish draft-relations warning — xToOne-style relations', () =
 
       await clickPublishExpectDraftRelationsDialog(page, 'xToOne');
     });
+
+    test(`relation-lab ${field} does not warn when the target document is already published`, async ({
+      page,
+    }) => {
+      const targetName = `${field} published target`;
+
+      await createRelationTarget(page, targetName, { publish: true });
+      await openNewRelationLab(page);
+      await saveRelationLabDraft(page, `Lab ${field} published target`);
+      await connectRelationTarget(page, field, targetName, 'published');
+
+      await clickPublishExpectNoDraftRelationsDialog(page);
+      await findAndClose(page, 'Published Document');
+    });
   }
 
   test('relation-lab unidirectional manyToMany warns when the target document is draft-only', async ({
@@ -154,6 +168,34 @@ test.describe('Publish draft-relations warning — xToOne-style relations', () =
     await openNewRelationLab(page);
     await saveRelationLabDraft(page, 'Lab uni M2M draft target');
     await connectRelationTarget(page, 'manyToMany', targetName, 'draft');
+
+    await clickPublishExpectDraftRelationsDialog(page, 'xToOne');
+  });
+
+  test('relation-lab unidirectional manyToMany does not warn when the target document is already published', async ({
+    page,
+  }) => {
+    const targetName = 'Uni M2M published target';
+
+    await createRelationTarget(page, targetName, { publish: true });
+    await openNewRelationLab(page);
+    await saveRelationLabDraft(page, 'Lab uni M2M published target');
+    await connectRelationTarget(page, 'manyToMany', targetName, 'published');
+
+    await clickPublishExpectNoDraftRelationsDialog(page);
+    await findAndClose(page, 'Published Document');
+  });
+
+  test('relation-lab oneToMany warns when linked to both published and draft-only targets', async ({
+    page,
+  }) => {
+    await createRelationTarget(page, 'O2M mixed published target', { publish: true });
+    await createRelationTarget(page, 'O2M mixed draft target', { publish: false });
+
+    await openNewRelationLab(page);
+    await saveRelationLabDraft(page, 'Lab O2M mixed targets');
+    await connectRelationTarget(page, 'oneToMany', 'O2M mixed published target', 'published');
+    await connectRelationTarget(page, 'oneToMany', 'O2M mixed draft target', 'draft');
 
     await clickPublishExpectDraftRelationsDialog(page, 'xToOne');
   });

--- a/tests/e2e/tests/content-manager/publish-draft-relations-warning.utils.ts
+++ b/tests/e2e/tests/content-manager/publish-draft-relations-warning.utils.ts
@@ -63,13 +63,19 @@ export const openNewRelationLab = async (page: Page) => {
   await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
 };
 
+/** Combobox accessible name includes a relation count after the first link, e.g. `oneToMany (1)`. */
+const relationFieldCombobox = (page: Page, field: RelationLabField | 'manyToMany') =>
+  page.getByRole('combobox', {
+    name: new RegExp(`^${field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}( \\(\\d+\\))?$`),
+  });
+
 export const connectRelationTarget = async (
   page: Page,
   field: RelationLabField | 'manyToMany',
   targetName: string,
   status: 'draft' | 'published'
 ) => {
-  await page.getByRole('combobox', { name: field, exact: true }).click();
+  await clickAndWait(page, relationFieldCombobox(page, field));
   await selectRelationComboboxOption(page, targetName, status);
 };
 

--- a/tests/e2e/tests/content-manager/publish-draft-relations-warning.utils.ts
+++ b/tests/e2e/tests/content-manager/publish-draft-relations-warning.utils.ts
@@ -15,7 +15,7 @@ export type RelationDialogVariant = 'm2m' | 'xToOne';
 /** xToOne-style fields in relation-lab (unidirectional — stripped on publish). */
 export const XTOONE_LAB_FIELDS: RelationLabField[] = ['manyToOne', 'oneToOne', 'oneToMany'];
 
-/** Bidirectional M2M in relation-lab — the relation type this PR fixes. */
+/** Bidirectional M2M in relation-lab. */
 export const BIDIRECTIONAL_M2M_LAB_FIELD: RelationLabField = 'manyToManyBi';
 
 /**
@@ -77,4 +77,27 @@ export const saveRelationLabDraft = async (page: Page, title: string) => {
   await page.getByRole('textbox', { name: 'title' }).fill(title);
   await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
   await findAndClose(page, 'Saved Document');
+};
+
+/**
+ * Bulk-publish selected list entries and assert the draft-relations warning is absent.
+ * Bulk publish always opens a Confirmation dialog ("Are you sure…"); only the draft-relations
+ * paragraph is omitted when countManyEntriesDraftRelations is 0 (see ConfirmDialogPublishAll).
+ */
+export const clickBulkPublishExpectNoDraftRelationsDialog = async (page: Page) => {
+  await clickAndWait(page, page.getByRole('button', { name: 'Publish' }).first());
+
+  await expect(page.getByRole('heading', { name: 'Publish entries' })).toBeVisible();
+  await clickAndWait(
+    page,
+    page.getByLabel('Publish entries').getByRole('button', { name: 'Publish' })
+  );
+
+  const dialog = page.getByRole('alertdialog', { name: 'Confirmation' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('Are you sure you want to publish these entries?');
+  await expect(dialog).not.toContainText('not published yet and might lead to unexpected behavior');
+
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(dialog).not.toBeVisible();
 };

--- a/tests/e2e/tests/content-manager/publish-draft-relations-warning.utils.ts
+++ b/tests/e2e/tests/content-manager/publish-draft-relations-warning.utils.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import {
   clickAndWait,
@@ -7,28 +8,36 @@ import {
   withContentManagerPublish,
 } from '../../../utils/shared';
 
-export type RelationLabField =
-  | 'manyToOne'
-  | 'oneToOne'
-  | 'oneToMany'
-  | 'manyToMany'
-  | 'manyToManyBi';
+export type RelationLabField = 'manyToOne' | 'oneToOne' | 'oneToMany' | 'manyToManyBi';
 
 export type RelationDialogVariant = 'm2m' | 'xToOne';
 
-export const RELATION_LAB_FIELDS: Array<{
-  field: RelationLabField;
-  dialogVariant: RelationDialogVariant;
-}> = [
-  { field: 'manyToOne', dialogVariant: 'xToOne' },
-  { field: 'oneToOne', dialogVariant: 'xToOne' },
-  { field: 'oneToMany', dialogVariant: 'xToOne' },
-  { field: 'manyToMany', dialogVariant: 'xToOne' },
-  { field: 'manyToManyBi', dialogVariant: 'm2m' },
-];
+/** xToOne-style fields in relation-lab (unidirectional — stripped on publish). */
+export const XTOONE_LAB_FIELDS: RelationLabField[] = ['manyToOne', 'oneToOne', 'oneToMany'];
 
-export const relationTargetOptionLabel = (name: string, published: boolean) =>
-  `${name}${published ? 'Published' : 'Draft'}`;
+/** Bidirectional M2M in relation-lab — the relation type this PR fixes. */
+export const BIDIRECTIONAL_M2M_LAB_FIELD: RelationLabField = 'manyToManyBi';
+
+/**
+ * Select a relation in an open CM combobox.
+ *
+ * Each option is a label span plus a DocumentStatus badge (`role="status"`,
+ * `aria-label="draft"|"published"`). Do not use `getByRole('option', { name })` — the
+ * accessible name does not match a simple `${label}Draft` string even when textContent does.
+ */
+export const selectRelationComboboxOption = async (
+  page: Page,
+  label: string,
+  status: 'draft' | 'published'
+) => {
+  const option = page
+    .getByRole('option')
+    .filter({ has: page.getByText(label, { exact: true }) })
+    .filter({ has: page.getByRole('status', { name: status }) });
+
+  await expect(option).toHaveCount(1);
+  await clickAndWait(page, option);
+};
 
 export const createRelationTarget = async (
   page: Page,
@@ -56,12 +65,12 @@ export const openNewRelationLab = async (page: Page) => {
 
 export const connectRelationTarget = async (
   page: Page,
-  field: RelationLabField,
+  field: RelationLabField | 'manyToMany',
   targetName: string,
-  published: boolean
+  status: 'draft' | 'published'
 ) => {
   await page.getByRole('combobox', { name: field, exact: true }).click();
-  await clickAndWait(page, page.getByLabel(relationTargetOptionLabel(targetName, published)));
+  await selectRelationComboboxOption(page, targetName, status);
 };
 
 export const saveRelationLabDraft = async (page: Page, title: string) => {

--- a/tests/e2e/tests/content-manager/publish-draft-relations-warning.utils.ts
+++ b/tests/e2e/tests/content-manager/publish-draft-relations-warning.utils.ts
@@ -1,0 +1,71 @@
+import type { Page } from '@playwright/test';
+
+import {
+  clickAndWait,
+  findAndClose,
+  navToHeader,
+  withContentManagerPublish,
+} from '../../../utils/shared';
+
+export type RelationLabField =
+  | 'manyToOne'
+  | 'oneToOne'
+  | 'oneToMany'
+  | 'manyToMany'
+  | 'manyToManyBi';
+
+export type RelationDialogVariant = 'm2m' | 'xToOne';
+
+export const RELATION_LAB_FIELDS: Array<{
+  field: RelationLabField;
+  dialogVariant: RelationDialogVariant;
+}> = [
+  { field: 'manyToOne', dialogVariant: 'xToOne' },
+  { field: 'oneToOne', dialogVariant: 'xToOne' },
+  { field: 'oneToMany', dialogVariant: 'xToOne' },
+  { field: 'manyToMany', dialogVariant: 'xToOne' },
+  { field: 'manyToManyBi', dialogVariant: 'm2m' },
+];
+
+export const relationTargetOptionLabel = (name: string, published: boolean) =>
+  `${name}${published ? 'Published' : 'Draft'}`;
+
+export const createRelationTarget = async (
+  page: Page,
+  name: string,
+  { publish }: { publish: boolean }
+) => {
+  await navToHeader(page, ['Content Manager', 'Relation target'], 'Relation target');
+  await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+  await page.getByRole('textbox', { name: 'name' }).fill(name);
+  await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+  await findAndClose(page, 'Saved Document');
+
+  if (publish) {
+    await withContentManagerPublish(page, () =>
+      page.getByRole('button', { name: 'Publish', exact: true }).click()
+    );
+    await findAndClose(page, 'Published Document');
+  }
+};
+
+export const openNewRelationLab = async (page: Page) => {
+  await navToHeader(page, ['Content Manager', 'Relation lab'], 'Relation lab');
+  await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+};
+
+export const connectRelationTarget = async (
+  page: Page,
+  field: RelationLabField,
+  targetName: string,
+  published: boolean
+) => {
+  await page.getByRole('combobox', { name: field, exact: true }).click();
+  await clickAndWait(page, page.getByLabel(relationTargetOptionLabel(targetName, published)));
+};
+
+export const saveRelationLabDraft = async (page: Page, title: string) => {
+  await page.getByRole('textbox', { name: 'title' }).fill(title);
+  await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+  await findAndClose(page, 'Saved Document');
+};

--- a/tests/utils/shared.ts
+++ b/tests/utils/shared.ts
@@ -189,7 +189,7 @@ export const withContentManagerPublish = async (
  */
 export const publishAndConfirmDraftRelations = async (
   page: Page,
-  publishButton: Locator = page.getByRole('button', { name: 'Publish' })
+  publishButton: Locator = page.getByRole('button', { name: 'Publish', exact: true })
 ) => {
   const dialog = page.getByRole('alertdialog', { name: 'Confirmation' });
   const publishDone = waitForContentManagerMutation(page, 'publish');
@@ -217,6 +217,51 @@ export const publishAndConfirmDraftRelations = async (
   await withContentManagerPublish(page, () =>
     dialog.getByRole('button', { name: 'Publish', exact: true }).click()
   );
+};
+
+/**
+ * Clicks Publish and asserts the draft-relations confirmation dialog does not appear
+ * (publish completes directly).
+ */
+export const clickPublishExpectNoDraftRelationsDialog = async (page: Page) => {
+  const dialog = page.getByRole('alertdialog', { name: 'Confirmation' });
+  const publishDone = waitForContentManagerMutation(page, 'publish');
+
+  await page.getByRole('button', { name: 'Publish', exact: true }).click();
+
+  const dialogAppeared = await Promise.race([
+    dialog.waitFor({ state: 'visible', timeout: 5000 }).then(() => true as const),
+    publishDone.then(() => false as const),
+  ]);
+
+  expect(dialogAppeared).toBe(false);
+};
+
+export type DraftRelationsDialogVariant = 'm2m' | 'xToOne';
+
+/**
+ * Clicks Publish and asserts the draft-relations confirmation dialog appears with the
+ * expected copy and confirm button for the relation category.
+ */
+export const clickPublishExpectDraftRelationsDialog = async (
+  page: Page,
+  variant: DraftRelationsDialogVariant
+) => {
+  const dialog = page.getByRole('alertdialog', { name: 'Confirmation' });
+
+  await page.getByRole('button', { name: 'Publish', exact: true }).click();
+  await expect(dialog).toBeVisible();
+
+  if (variant === 'm2m') {
+    await expect(dialog.getByText(/linked entr(y|ies) (is|are) still in draft/)).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Publish', exact: true })).toBeVisible();
+  } else {
+    await expect(dialog.getByText(/related to .* draft entr/)).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Publish without relations' })).toBeVisible();
+  }
+
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(dialog).not.toBeVisible();
 };
 
 /** Map a segment under `/admin` (or legacy `/admin/…`) to a pathname. */

--- a/tests/utils/shared.ts
+++ b/tests/utils/shared.ts
@@ -237,7 +237,7 @@ export const clickPublishExpectNoDraftRelationsDialog = async (page: Page) => {
   expect(dialogAppeared).toBe(false);
 };
 
-export type DraftRelationsDialogVariant = 'm2m' | 'xToOne';
+export type DraftRelationsDialogVariant = 'm2m' | 'xToOne' | 'mixed';
 
 /**
  * Clicks Publish and asserts the draft-relations confirmation dialog appears with the
@@ -255,6 +255,11 @@ export const clickPublishExpectDraftRelationsDialog = async (
   if (variant === 'm2m') {
     await expect(dialog.getByText(/linked entr(y|ies) (is|are) still in draft/)).toBeVisible();
     await expect(dialog.getByRole('button', { name: 'Publish', exact: true })).toBeVisible();
+  } else if (variant === 'mixed') {
+    await expect(dialog.getByText(/not be included in the published version/)).toBeVisible();
+    await expect(dialog.getByText(/many-to-many link/)).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Publish without relations' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Publish', exact: true })).not.toBeVisible();
   } else {
     await expect(dialog.getByText(/related to .* draft entr/)).toBeVisible();
     await expect(dialog.getByRole('button', { name: 'Publish without relations' })).toBeVisible();


### PR DESCRIPTION
## Summary

- Fixes a regression from #26736 where publishing a draft entry with bidirectional many-to-many relations to **already published** entries incorrectly showed the draft-relations confirmation dialog.
- `countDraftRelations` now only counts M2M links whose target document has no published version for that locale (draft-row links to published documents are kept on publish and remapped by the document service).
- Adds unit, admin, and API tests covering published targets, draft-row linking (UI behavior), and mixed published/draft-only M2M links.

## Related issue(s)/PR(s)

- Fixes CMS-1327

## Test plan

- [x] `yarn test:unit packages/core/content-manager/server/src/services/utils/__tests__/draft-relations.test.ts`
- [x] `yarn test:front packages/core/content-manager/admin/src/pages/EditView/utils/tests/draftRelationCounts.test.ts`
- [ ] `yarn test:api -- tests/api/core/content-manager/api/draft-relations-bidirectional-m2m.test.api.ts`
- [ ] Manual: create published B, create draft A with M2M to B → Publish A → no confirmation dialog