### PR TITLE
test(api): reuse one Strapi instance during builder cleanup

### DIFF
--- a/packages/utils/api-tests/builder/action-registry.js
+++ b/packages/utils/api-tests/builder/action-registry.js
@@ -25,7 +25,8 @@ module.exports = {
           createdModel = await modelsUtils.createContentType(contentType);
           ctx.addModel(createdModel);
         },
-        cleanup: () => modelsUtils.deleteContentType(createdModel.uid),
+        cleanup: (_ctx, { strapi } = {}) =>
+          modelsUtils.deleteContentType(createdModel.uid, { strapi }),
       };
     },
 
@@ -37,9 +38,9 @@ module.exports = {
           createdModels = await modelsUtils.createContentTypes(contentTypes);
           createdModels.forEach(ctx.addModel);
         },
-        async cleanup() {
+        async cleanup(_ctx, { strapi } = {}) {
           for (const model of createdModels) {
-            await modelsUtils.deleteContentType(model.uid);
+            await modelsUtils.deleteContentType(model.uid, { strapi });
           }
         },
       };
@@ -57,9 +58,9 @@ module.exports = {
             ctx.addModel(model);
           }
         },
-        async cleanup() {
+        async cleanup(_ctx, { strapi } = {}) {
           for (const model of createdModels) {
-            await modelsUtils.deleteContentType(model.uid);
+            await modelsUtils.deleteContentType(model.uid, { strapi });
           }
         },
       };
@@ -74,7 +75,8 @@ module.exports = {
           createdModel = await modelsUtils.createComponent(component);
           ctx.addModel(createdModel);
         },
-        cleanup: () => modelsUtils.deleteComponent(createdModel.uid),
+        cleanup: (_ctx, { strapi } = {}) =>
+          modelsUtils.deleteComponent(createdModel.uid, { strapi }),
       };
     },
   },
@@ -93,7 +95,8 @@ module.exports = {
 
           ctx.addFixtures(modelName, createdEntries);
         },
-        cleanup: () => modelsUtils.deleteFixturesFor(modelName, createdEntries),
+        cleanup: (_ctx, { strapi } = {}) =>
+          modelsUtils.deleteFixturesFor(modelName, createdEntries, { strapi }),
       };
     },
   },

--- a/packages/utils/api-tests/builder/index.js
+++ b/packages/utils/api-tests/builder/index.js
@@ -2,6 +2,7 @@
 
 const { get } = require('lodash/fp');
 
+const { createStrapiInstance } = require('../strapi');
 const modelsUtils = require('../models');
 const { sanitize } = require('../../../core/utils');
 const actionRegistry = require('./action-registry');
@@ -77,20 +78,34 @@ const createTestBuilder = (options = {}) => {
     },
 
     async cleanup(options = {}) {
-      const { enableTestDataAutoCleanup = true } = options;
+      const { enableTestDataAutoCleanup = true, strapi: strapiOption } = options;
       const { models, actions } = ctx.state;
 
-      if (enableTestDataAutoCleanup) {
-        for (const model of models.reverse()) {
-          await modelsUtils.cleanupModel(model.uid);
+      let strapi = strapiOption;
+      let shouldDestroyStrapi = false;
+
+      if (!strapi) {
+        strapi = await createStrapiInstance();
+        shouldDestroyStrapi = true;
+      }
+
+      try {
+        if (enableTestDataAutoCleanup) {
+          for (const model of models.reverse()) {
+            await modelsUtils.cleanupModel(model.uid, { strapi });
+          }
+        }
+
+        for (const action of actions.reverse()) {
+          await action.cleanup(ctx, { strapi });
+        }
+      } finally {
+        ctx.resetState();
+
+        if (shouldDestroyStrapi) {
+          await strapi.destroy();
         }
       }
-
-      for (const action of actions.reverse()) {
-        await action.cleanup(ctx);
-      }
-
-      ctx.resetState();
 
       return this;
     },


### PR DESCRIPTION
## Summary

- `builder.cleanup()` no longer bootstraps a fresh Strapi instance for every content-type, component, and fixture delete when the test instance has already been destroyed.
- Reuses a single Strapi instance for the full teardown pass, then destroys it once in a `finally` block.
- Action-registry cleanup handlers forward the shared `{ strapi }` instance to `modelsUtils`.

This fixes flaky API integration `afterAll` timeouts (e.g. document-service suites) that occur when Strapi bootstrap gets slower — without raising Jest timeouts.

## Test plan

- [ ] CI API integration suite passes (all DB shards)
- [ ] Document-service API tests complete within default 60s hook timeout