### PR TITLE
feat(create-strapi-app): detect nub package manager

### DIFF
--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -266,6 +266,10 @@ function getPkgManager(options: Options) {
     return 'pnpm';
   }
 
+  if (userAgent.startsWith('nub')) {
+    return 'nub';
+  }
+
   return 'npm';
 }
 

--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -13,6 +13,7 @@ import { checkInstallPath } from './utils/check-install-path';
 import { installID } from './utils/install-id';
 import { trackError } from './utils/usage';
 import { addDatabaseDependencies, getDatabaseInfos } from './utils/database';
+import { getPackageManagerFromUserAgent } from './utils/get-package-manager-args';
 
 import type { Options, Scope } from './types';
 import { logger } from './utils/logger';
@@ -258,19 +259,7 @@ function getPkgManager(options: Options) {
 
   const userAgent = process.env.npm_config_user_agent || '';
 
-  if (userAgent.startsWith('yarn')) {
-    return 'yarn';
-  }
-
-  if (userAgent.startsWith('pnpm')) {
-    return 'pnpm';
-  }
-
-  if (userAgent.startsWith('nub')) {
-    return 'nub';
-  }
-
-  return 'npm';
+  return getPackageManagerFromUserAgent(userAgent) ?? 'npm';
 }
 
 export { run, createStrapi };

--- a/packages/cli/create-strapi-app/src/types.ts
+++ b/packages/cli/create-strapi-app/src/types.ts
@@ -40,7 +40,7 @@ export type DBConfig = {
   };
 };
 
-export type PackageManager = 'npm' | 'yarn' | 'pnpm';
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'nub';
 
 export interface Scope {
   name: string;

--- a/packages/cli/create-strapi-app/src/utils/__tests__/get-package-manager-args.test.ts
+++ b/packages/cli/create-strapi-app/src/utils/__tests__/get-package-manager-args.test.ts
@@ -1,6 +1,6 @@
 import execa from 'execa';
 
-import { getInstallArgs } from '../get-package-manager-args';
+import { getInstallArgs, getPackageManagerFromUserAgent } from '../get-package-manager-args';
 
 jest.mock('execa');
 
@@ -43,5 +43,29 @@ describe('getInstallArgs', () => {
     const { cmdArgs } = await getInstallArgs('pnpm');
 
     expect(cmdArgs).toEqual(['install']);
+  });
+
+  it('does not add extra args or env for nub', async () => {
+    mockedExeca.mockResolvedValue({ stdout: '0.6.0' });
+
+    const { cmdArgs, envArgs } = await getInstallArgs('nub');
+
+    expect(cmdArgs).toEqual(['install']);
+    expect(envArgs).toEqual({});
+  });
+});
+
+describe('getPackageManagerFromUserAgent', () => {
+  it('detects nub before the npm compatibility segment', () => {
+    expect(getPackageManagerFromUserAgent('nub/0.6.0 npm/? node/v22.15.0 darwin arm64')).toBe('nub');
+  });
+
+  it('detects pnpm', () => {
+    expect(getPackageManagerFromUserAgent('pnpm/10.25.0 npm/? node/v22.15.0')).toBe('pnpm');
+  });
+
+  it('returns null for an unknown or empty user agent', () => {
+    expect(getPackageManagerFromUserAgent('npm/10.9.2 node/v22.15.0')).toBeNull();
+    expect(getPackageManagerFromUserAgent('')).toBeNull();
   });
 });

--- a/packages/cli/create-strapi-app/src/utils/get-package-manager-args.ts
+++ b/packages/cli/create-strapi-app/src/utils/get-package-manager-args.ts
@@ -28,6 +28,9 @@ const installArgumentsMap: {
   pnpm: {
     '*': [],
   },
+  nub: {
+    '*': [],
+  },
 };
 
 // Set environment variables for specific package managers, with full semver ranges
@@ -42,6 +45,9 @@ const installEnvMap: {
     '*': {},
   },
   pnpm: {
+    '*': {},
+  },
+  nub: {
     '*': {},
   },
 };

--- a/packages/cli/create-strapi-app/src/utils/get-package-manager-args.ts
+++ b/packages/cli/create-strapi-app/src/utils/get-package-manager-args.ts
@@ -1,7 +1,31 @@
 import execa from 'execa';
 import semver from 'semver';
 
+import type { PackageManager } from '../types';
+
 const installArguments = ['install'];
+
+/**
+ * Detects the package manager that invoked the CLI from `npm_config_user_agent`
+ * (e.g. `pnpm/9.1.0 …`, `nub/0.6.0 npm/? node/…`). nub reports its own agent
+ * ahead of the npm compatibility segment, so it is matched before the npm
+ * fallback. Returns `null` when no known package manager matches.
+ */
+export const getPackageManagerFromUserAgent = (userAgent: string): PackageManager | null => {
+  if (userAgent.startsWith('yarn')) {
+    return 'yarn';
+  }
+
+  if (userAgent.startsWith('pnpm')) {
+    return 'pnpm';
+  }
+
+  if (userAgent.startsWith('nub')) {
+    return 'nub';
+  }
+
+  return null;
+};
 
 type VersionedArgumentsMap = {
   [key: string]: string[]; // Maps semver ranges to argument arrays

--- a/packages/cli/create-strapi-app/src/utils/pnpm-config.ts
+++ b/packages/cli/create-strapi-app/src/utils/pnpm-config.ts
@@ -106,11 +106,18 @@ const hasParentPnpmWorkspace = async (rootPath: string): Promise<boolean> => {
   return false;
 };
 
+// nub is pnpm-compatible and reads pnpm-workspace.yaml (allowBuilds + minimumReleaseAgeExclude),
+// so it uses the same scaffold. With a null version it formats the pnpm 11-style file.
+const PNPM_WORKSPACE_PACKAGE_MANAGERS: ReadonlyArray<Scope['packageManager']> = ['pnpm', 'nub'];
+
 export const writePnpmWorkspaceConfig = async (
   scope: Scope,
   pnpmVersion: string | null
 ): Promise<void> => {
-  if (scope.packageManager !== 'pnpm' || !shouldUsePnpmWorkspaceConfig(pnpmVersion)) {
+  if (
+    !PNPM_WORKSPACE_PACKAGE_MANAGERS.includes(scope.packageManager) ||
+    !shouldUsePnpmWorkspaceConfig(pnpmVersion)
+  ) {
     return;
   }
 


### PR DESCRIPTION
When invoked through nub, create-strapi-app defaults to npm. `getPkgManager` reads `npm_config_user_agent`, matching `yarn`/`pnpm` and defaulting to npm; [nub](https://nubjs.com) advertises `nub/<version>`, so it isn't matched.

nub is a Rust CLI with a pnpm-compatible command grammar. This adds `nub` to the `PackageManager` type and the user-agent detection, plus entries in `installArgumentsMap`/`installEnvMap` (`getInstallArgs` indexes those maps by name and would otherwise throw on an unknown manager). nub needs no special install flags, so it mirrors pnpm's empty entries. The scaffold's install and script hints already build as `<pm> install` and `<pm> run <script>`, yielding `nub install` and `nub run develop`.


---
Fixes CPR-428