### PR TITLE
enhancement(content-manager): keep sidebar primary actions and search bar fixed…

### DIFF
--- a/packages/core/admin/admin/src/components/SubNav.tsx
+++ b/packages/core/admin/admin/src/components/SubNav.tsx
@@ -21,10 +21,10 @@ import {
 
 import { tours } from './GuidedTour/Tours';
 
-const MainSubNav = styled(DSSubNav)`
+const MainSubNav = styled(DSSubNav)<{ $isFullPage?: boolean }>`
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow: ${({ $isFullPage }) => ($isFullPage ? 'visible' : 'hidden')};
   background-color: ${({ theme }) => theme.colors.neutral0};
   display: flex;
   flex-direction: column;
@@ -36,13 +36,23 @@ const MainSubNav = styled(DSSubNav)`
     width: ${WIDTH_SIDE_NAVIGATION};
     position: sticky;
     top: 0;
+    overflow: hidden;
     border-right: 1px solid ${({ theme }) => theme.colors.neutral150};
     overscroll-behavior: contain;
   }
 `;
 
-const Main = ({ children, ...props }: { children: React.ReactNode; isFullPage?: boolean }) => (
-  <MainSubNav {...props}>{children}</MainSubNav>
+const Main = ({
+  children,
+  isFullPage,
+  ...props
+}: {
+  children: React.ReactNode;
+  isFullPage?: boolean;
+}) => (
+  <MainSubNav $isFullPage={isFullPage} {...props}>
+    {children}
+  </MainSubNav>
 );
 
 const StyledLink = styled(NavLink)`

--- a/packages/core/content-manager/admin/src/components/LeftMenu.tsx
+++ b/packages/core/content-manager/admin/src/components/LeftMenu.tsx
@@ -100,12 +100,46 @@ const LeftMenu = ({ isFullPage = false }: { isFullPage?: boolean }) => {
     );
   }
 
+  const searchBar = (
+    <Flex
+      paddingLeft={{
+        initial: 3,
+        large: 5,
+      }}
+      paddingRight={{
+        initial: 3,
+        large: 5,
+      }}
+      paddingTop={5}
+      paddingBottom={{ initial: 1, large: 0 }}
+      gap={3}
+      direction="column"
+      alignItems="stretch"
+    >
+      <Searchbar
+        value={search}
+        onChange={handleChangeSearch}
+        onClear={handleClear}
+        placeholder={formatMessage({
+          id: 'search.placeholder',
+          defaultMessage: 'Search',
+        })}
+        size="S"
+        // eslint-disable-next-line react/no-children-prop
+        children={undefined}
+        name={'search_contentType'}
+        clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
+      />
+    </Flex>
+  );
+
   return (
     <SubNav.Main aria-label={label}>
       {!isFullPage && (
         <>
           <SubNav.Header label={label} />
           <Divider />
+          {searchBar}
         </>
       )}
       <SubNav.Content>
@@ -113,38 +147,9 @@ const LeftMenu = ({ isFullPage = false }: { isFullPage?: boolean }) => {
           <>
             <SubNav.Header label={label} />
             <Divider />
+            {searchBar}
           </>
         )}
-        <Flex
-          paddingLeft={{
-            initial: 3,
-            large: 5,
-          }}
-          paddingRight={{
-            initial: 3,
-            large: 5,
-          }}
-          paddingTop={5}
-          paddingBottom={{ initial: 1, large: 0 }}
-          gap={3}
-          direction="column"
-          alignItems="stretch"
-        >
-          <Searchbar
-            value={search}
-            onChange={handleChangeSearch}
-            onClear={handleClear}
-            placeholder={formatMessage({
-              id: 'search.placeholder',
-              defaultMessage: 'Search',
-            })}
-            size="S"
-            // eslint-disable-next-line react/no-children-prop
-            children={undefined}
-            name={'search_contentType'}
-            clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
-          />
-        </Flex>
         <SubNav.Sections>
           {menu.map((section) => {
             return (

--- a/packages/core/content-manager/admin/src/components/LeftMenu.tsx
+++ b/packages/core/content-manager/admin/src/components/LeftMenu.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
 
 import { SubNav } from '@strapi/admin/strapi-admin';
-import { Flex, Searchbar, useCollator, useFilter, Divider, Loader } from '@strapi/design-system';
+import {
+  Box,
+  Flex,
+  Searchbar,
+  useCollator,
+  useFilter,
+  Divider,
+  Loader,
+} from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
 import { useContentManagerInitData } from '../hooks/useContentManagerInitData';
@@ -90,7 +98,7 @@ const LeftMenu = ({ isFullPage = false }: { isFullPage?: boolean }) => {
   // Show loading state while data is being fetched
   if (isLoading) {
     return (
-      <SubNav.Main aria-label={label}>
+      <SubNav.Main aria-label={label} isFullPage={isFullPage}>
         <SubNav.Header label={label} />
         <Divider />
         <Flex padding={4} justifyContent="center">
@@ -134,22 +142,18 @@ const LeftMenu = ({ isFullPage = false }: { isFullPage?: boolean }) => {
   );
 
   return (
-    <SubNav.Main aria-label={label}>
-      {!isFullPage && (
-        <>
-          <SubNav.Header label={label} />
-          <Divider />
-          {searchBar}
-        </>
-      )}
+    <SubNav.Main aria-label={label} isFullPage={isFullPage}>
+      <SubNav.Header label={label} />
+      <Divider />
+      <Box
+        position={isFullPage ? 'sticky' : 'static'}
+        top={isFullPage ? '0px' : undefined}
+        zIndex={isFullPage ? 2 : undefined}
+        background={isFullPage ? 'neutral100' : 'neutral0'}
+      >
+        {searchBar}
+      </Box>
       <SubNav.Content>
-        {isFullPage && (
-          <>
-            <SubNav.Header label={label} />
-            <Divider />
-            {searchBar}
-          </>
-        )}
         <SubNav.Sections>
           {menu.map((section) => {
             return (

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/ContentTypeBuilderNav.tsx
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/ContentTypeBuilderNav.tsx
@@ -99,103 +99,103 @@ export const ContentTypeBuilderNav = () => {
     <SubNav.Main aria-label={pluginName}>
       <SubNav.Header label={pluginName} />
       <Divider background="neutral150" />
-      <SubNav.Content>
-        <Flex padding={5} gap={3} direction={'column'} alignItems={'stretch'}>
-          <tours.contentTypeBuilder.Save>
-            <Flex gap={2}>
-              <Button
-                flex={1}
-                onClick={(e) => {
-                  e.preventDefault();
-                  saveSchema();
-                }}
-                type="submit"
-                disabled={!isModified || !isInDevelopmentMode}
-                fullWidth
+      <Flex padding={5} gap={3} direction={'column'} alignItems={'stretch'}>
+        <tours.contentTypeBuilder.Save>
+          <Flex gap={2}>
+            <Button
+              flex={1}
+              onClick={(e) => {
+                e.preventDefault();
+                saveSchema();
+              }}
+              type="submit"
+              disabled={!isModified || !isInDevelopmentMode}
+              fullWidth
+              size="S"
+            >
+              {formatMessage({
+                id: 'global.save',
+                defaultMessage: 'Save',
+              })}
+            </Button>
+            <Menu.Root open={menuIsOpen} onOpenChange={setMenuIsOpen}>
+              <Menu.Trigger
                 size="S"
+                endIcon={null}
+                paddingTop="4px"
+                paddingLeft="7px"
+                paddingRight="7px"
+                variant="tertiary"
               >
-                {formatMessage({
-                  id: 'global.save',
-                  defaultMessage: 'Save',
-                })}
-              </Button>
-              <Menu.Root open={menuIsOpen} onOpenChange={setMenuIsOpen}>
-                <Menu.Trigger
-                  size="S"
-                  endIcon={null}
-                  paddingTop="4px"
-                  paddingLeft="7px"
-                  paddingRight="7px"
-                  variant="tertiary"
+                <More fill="neutral500" aria-hidden focusable={false} />
+                <VisuallyHidden tag="span">
+                  {formatMessage({
+                    id: 'global.more.actions',
+                    defaultMessage: 'More actions',
+                  })}
+                </VisuallyHidden>
+              </Menu.Trigger>
+              <Menu.Content zIndex={1}>
+                <Menu.Item
+                  disabled={!history.canUndo || !isInDevelopmentMode}
+                  onSelect={undoHandler}
+                  startIcon={<ArrowCounterClockwise />}
                 >
-                  <More fill="neutral500" aria-hidden focusable={false} />
-                  <VisuallyHidden tag="span">
-                    {formatMessage({
-                      id: 'global.more.actions',
-                      defaultMessage: 'More actions',
-                    })}
-                  </VisuallyHidden>
-                </Menu.Trigger>
-                <Menu.Content zIndex={1}>
-                  <Menu.Item
-                    disabled={!history.canUndo || !isInDevelopmentMode}
-                    onSelect={undoHandler}
-                    startIcon={<ArrowCounterClockwise />}
-                  >
-                    {formatMessage({
-                      id: 'global.last-change.undo',
-                      defaultMessage: 'Undo last change',
-                    })}
-                  </Menu.Item>
-                  <Menu.Item
-                    disabled={!history.canRedo || !isInDevelopmentMode}
-                    onSelect={redoHandler}
-                    startIcon={<ArrowClockwise />}
-                  >
-                    {formatMessage({
-                      id: 'global.last-change.redo',
-                      defaultMessage: 'Redo last change',
-                    })}
-                  </Menu.Item>
-                  <Menu.Separator />
-                  <DiscardAllMenuItem
-                    disabled={!history.canDiscardAll || !isInDevelopmentMode}
-                    onSelect={discardHandler}
-                  >
-                    <Flex gap={2}>
-                      <Cross />
-                      <Typography>
-                        {formatMessage({
-                          id: 'global.last-changes.discard',
-                          defaultMessage: 'Discard last changes',
-                        })}
-                      </Typography>
-                    </Flex>
-                  </DiscardAllMenuItem>
-                </Menu.Content>
-              </Menu.Root>
-            </Flex>
-          </tours.contentTypeBuilder.Save>
+                  {formatMessage({
+                    id: 'global.last-change.undo',
+                    defaultMessage: 'Undo last change',
+                  })}
+                </Menu.Item>
+                <Menu.Item
+                  disabled={!history.canRedo || !isInDevelopmentMode}
+                  onSelect={redoHandler}
+                  startIcon={<ArrowClockwise />}
+                >
+                  {formatMessage({
+                    id: 'global.last-change.redo',
+                    defaultMessage: 'Redo last change',
+                  })}
+                </Menu.Item>
+                <Menu.Separator />
+                <DiscardAllMenuItem
+                  disabled={!history.canDiscardAll || !isInDevelopmentMode}
+                  onSelect={discardHandler}
+                >
+                  <Flex gap={2}>
+                    <Cross />
+                    <Typography>
+                      {formatMessage({
+                        id: 'global.last-changes.discard',
+                        defaultMessage: 'Discard last changes',
+                      })}
+                    </Typography>
+                  </Flex>
+                </DiscardAllMenuItem>
+              </Menu.Content>
+            </Menu.Root>
+          </Flex>
+        </tours.contentTypeBuilder.Save>
 
-          <Searchbar
-            value={search.value}
-            onChange={(e) => search.onChange(e.target.value)}
-            onClear={() => search.onChange('')}
-            placeholder={formatMessage({
-              id: getTrad('search.placeholder'),
-              defaultMessage: 'Search',
-            })}
-            size="S"
-            // eslint-disable-next-line react/no-children-prop
-            children={undefined}
-            name={'search_contentType'}
-            clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
-            aria-label={formatMessage({
-              id: getTrad('search.placeholder'),
-              defaultMessage: 'Search',
-            })}
-          />
-        </Flex>
+        <Searchbar
+          value={search.value}
+          onChange={(e) => search.onChange(e.target.value)}
+          onClear={() => search.onChange('')}
+          placeholder={formatMessage({
+            id: getTrad('search.placeholder'),
+            defaultMessage: 'Search',
+          })}
+          size="S"
+          // eslint-disable-next-line react/no-children-prop
+          children={undefined}
+          name={'search_contentType'}
+          clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
+          aria-label={formatMessage({
+            id: getTrad('search.placeholder'),
+            defaultMessage: 'Search',
+          })}
+        />
+      </Flex>
+      <SubNav.Content>
         <SubNav.Sections>
           {menu.map((section) => (
             <Fragment key={section.name}>

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -10,14 +10,14 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   background: #eaeaef;
 }
 
-.c10 {
+.c8 {
   padding-block-start: 20px;
   padding-inline-end: 20px;
   padding-block-end: 20px;
   padding-inline-start: 20px;
 }
 
-.c13 {
+.c11 {
   border-radius: 4px;
   cursor: pointer;
   flex: 1;
@@ -26,7 +26,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   width: 100%;
 }
 
-.c17 {
+.c15 {
   border-radius: 4px;
   cursor: pointer;
   padding-inline-start: 7px;
@@ -96,21 +96,21 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   display: flex;
 }
 
-.c11 {
+.c9 {
   gap: 12px;
   align-items: stretch;
   flex-direction: column;
   display: flex;
 }
 
-.c12 {
+.c10 {
   gap: 8px;
   align-items: center;
   flex-direction: row;
   display: flex;
 }
 
-.c14 {
+.c12 {
   gap: 8px;
   align-items: center;
   justify-content: center;
@@ -118,14 +118,14 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   display: inline-flex;
 }
 
-.c21 {
+.c19 {
   gap: 4px;
   align-items: stretch;
   flex-direction: column;
   display: flex;
 }
 
-.c22 {
+.c20 {
   gap: 8px;
   align-items: center;
   justify-content: space-between;
@@ -196,7 +196,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   color: currentcolor;
 }
 
-.c16 {
+.c14 {
   font-size: 1.2rem;
   line-height: 1.33;
   color: currentcolor;
@@ -225,7 +225,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   font-weight: 500;
 }
 
-.c19 {
+.c17 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -236,7 +236,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   width: 1px;
 }
 
-.c15 {
+.c13 {
   height: 4rem;
   text-decoration: none;
   border: 1px solid #4945ff;
@@ -244,24 +244,24 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   color: #ffffff;
 }
 
-.c15:hover {
+.c13:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c15:active {
+.c13:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
 
-.c15[aria-disabled='true'] {
+.c13[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
   color: #666687;
   cursor: default;
 }
 
-.c18 {
+.c16 {
   height: 4rem;
   text-decoration: none;
   border: 1px solid #dcdce4;
@@ -269,15 +269,15 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   color: #32324d;
 }
 
-.c18:hover {
+.c16:hover {
   background-color: #f6f6f9;
 }
 
-.c18:active {
+.c16:active {
   background-color: #eaeaef;
 }
 
-.c18[aria-disabled='true'] {
+.c16[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
   color: #666687;
@@ -312,7 +312,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   cursor: default;
 }
 
-.c27 {
+.c25 {
   border: none;
   border-radius: 4px;
   color: #32324d;
@@ -327,21 +327,21 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   padding-block: 8px;
 }
 
-.c27::placeholder {
+.c25::placeholder {
   color: #666687;
   opacity: 1;
 }
 
-.c27[aria-disabled='true'] {
+.c25[aria-disabled='true'] {
   color: inherit;
 }
 
-.c27:focus {
+.c25:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c23 {
+.c21 {
   border: 1px solid #dcdce4;
   border-radius: 4px;
   background: #ffffff;
@@ -353,19 +353,19 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   transition-duration: 0.2s;
 }
 
-.c23:focus-within {
+.c21:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c8 {
+.c26 {
   width: 100%;
   height: 100%;
   overflow: hidden;
   display: flex;
 }
 
-.c9 {
+.c27 {
   min-width: 100%;
 }
 
@@ -375,24 +375,24 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   flex-shrink: 0;
 }
 
-.c26 {
+.c24 {
   font-size: 1rem;
 }
 
-.c26 path {
+.c24 path {
   fill: #8e8ea9;
 }
 
-.c20 {
+.c18 {
   border-radius: 4px;
   border: 1px solid #eaeaef;
 }
 
-.c20:focus-within .c25 {
+.c18:focus-within .c23 {
   fill: #4945ff;
 }
 
-.c24 {
+.c22 {
   border: 1px solid #eaeaef;
   padding: 0 0 0 8px;
   color: #32324d;
@@ -402,31 +402,31 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   transition-duration: 0.2s;
 }
 
-.c24:hover button {
+.c22:hover button {
   cursor: pointer;
 }
 
-.c24:focus-within {
+.c22:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c24 >input::-ms-clear {
+.c22 >input::-ms-clear {
   display: none;
   width: 0;
   height: 0;
 }
 
-.c24 >input::-ms-reveal {
+.c22 >input::-ms-reveal {
   display: none;
   width: 0;
   height: 0;
 }
 
-.c24 >input::-webkit-search-decoration,
-.c24 >input::-webkit-search-cancel-button,
-.c24 >input::-webkit-search-results-button,
-.c24 >input::-webkit-search-results-decoration {
+.c22 >input::-webkit-search-decoration,
+.c22 >input::-webkit-search-cancel-button,
+.c22 >input::-webkit-search-results-button,
+.c22 >input::-webkit-search-results-decoration {
   display: none;
 }
 
@@ -587,25 +587,25 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
 }
 
 @media (min-width: 768px) {
-  .c15 {
+  .c13 {
     height: 3.2rem;
   }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .c15 {
+  .c13 {
     transition: background-color 120ms cubic-bezier(0.25, 0.46, 0.45, 0.94),color 120ms cubic-bezier(0.25, 0.46, 0.45, 0.94),border-color 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   }
 }
 
 @media (min-width: 768px) {
-  .c18 {
+  .c16 {
     height: 3.2rem;
   }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .c18 {
+  .c16 {
     transition: background-color 120ms cubic-bezier(0.25, 0.46, 0.45, 0.94),color 120ms cubic-bezier(0.25, 0.46, 0.45, 0.94),border-color 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   }
 }
@@ -624,14 +624,14 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
 }
 
 @media (min-width: 768px) {
-  .c27 {
+  .c25 {
     font-size: 1.4rem;
     line-height: 2.2rem;
   }
 }
 
 @media (min-width: 768px) {
-  .c27 {
+  .c25 {
     padding-block: 4px;
   }
 }
@@ -680,7 +680,96 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
       role="separator"
     />
     <div
-      class="c8"
+      class="c8 c9"
+    >
+      <div
+        class="c10"
+      >
+        <button
+          aria-disabled="false"
+          class="c11 c12 c13"
+          type="submit"
+        >
+          <span
+            class="c14"
+          >
+            Save
+          </span>
+        </button>
+        <button
+          aria-disabled="false"
+          aria-expanded="false"
+          aria-haspopup="menu"
+          class="c15 c12 c16"
+          data-state="closed"
+          id="radix-:r0:"
+          type="button"
+        >
+          <span
+            class="c14"
+          >
+            <svg
+              aria-hidden="true"
+              fill="#8e8ea9"
+              focusable="false"
+              height="16"
+              viewBox="0 0 32 32"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M18 16a2 2 0 1 1-4 0 2 2 0 0 1 4 0M7.5 14a2 2 0 1 0 0 4 2 2 0 0 0 0-4m17 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4"
+              />
+            </svg>
+            <span
+              class="c17"
+            >
+              More actions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div
+        class="c18"
+      >
+        <div
+          class="c19"
+        >
+          <span
+            class="c17"
+          />
+          <div
+            class="c20 c21 c22"
+          >
+            <svg
+              aria-hidden="true"
+              class="c23 c24"
+              fill="currentColor"
+              height="16"
+              viewBox="0 0 32 32"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M29.061 26.939 23.125 21A11.515 11.515 0 1 0 21 23.125l5.941 5.942a1.503 1.503 0 0 0 2.125-2.125zM5.5 14a8.5 8.5 0 1 1 8.5 8.5A8.51 8.51 0 0 1 5.5 14"
+              />
+            </svg>
+            <input
+              aria-disabled="false"
+              aria-label="Search"
+              class="c25"
+              id=":r2:"
+              name="search_contentType"
+              placeholder="Search"
+              type="search"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c26"
       dir="ltr"
       style="position: relative; --radix-scroll-area-corner-width: 0px; --radix-scroll-area-corner-height: 0px;"
     >
@@ -688,102 +777,13 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
         [data-radix-scroll-area-viewport]{scrollbar-width:none;-ms-overflow-style:none;-webkit-overflow-scrolling:touch;}[data-radix-scroll-area-viewport]::-webkit-scrollbar{display:none}
       </style>
       <div
-        class="c9"
+        class="c27"
         data-radix-scroll-area-viewport=""
         style="overflow-x: scroll; overflow-y: scroll;"
       >
         <div
           style="min-width: 100%; display: table;"
         >
-          <div
-            class="c10 c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-disabled="false"
-                class="c13 c14 c15"
-                type="submit"
-              >
-                <span
-                  class="c16"
-                >
-                  Save
-                </span>
-              </button>
-              <button
-                aria-disabled="false"
-                aria-expanded="false"
-                aria-haspopup="menu"
-                class="c17 c14 c18"
-                data-state="closed"
-                id="radix-:r0:"
-                type="button"
-              >
-                <span
-                  class="c16"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="#8e8ea9"
-                    focusable="false"
-                    height="16"
-                    viewBox="0 0 32 32"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 16a2 2 0 1 1-4 0 2 2 0 0 1 4 0M7.5 14a2 2 0 1 0 0 4 2 2 0 0 0 0-4m17 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4"
-                    />
-                  </svg>
-                  <span
-                    class="c19"
-                  >
-                    More actions
-                  </span>
-                </span>
-              </button>
-            </div>
-            <div
-              class="c20"
-            >
-              <div
-                class="c21"
-              >
-                <span
-                  class="c19"
-                />
-                <div
-                  class="c22 c23 c24"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="c25 c26"
-                    fill="currentColor"
-                    height="16"
-                    viewBox="0 0 32 32"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M29.061 26.939 23.125 21A11.515 11.515 0 1 0 21 23.125l5.941 5.942a1.503 1.503 0 0 0 2.125-2.125zM5.5 14a8.5 8.5 0 1 1 8.5 8.5A8.51 8.51 0 0 1 5.5 14"
-                    />
-                  </svg>
-                  <input
-                    aria-disabled="false"
-                    aria-label="Search"
-                    class="c27"
-                    id=":r2:"
-                    name="search_contentType"
-                    placeholder="Search"
-                    type="search"
-                    value=""
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
           <div
             class="c28"
           >
@@ -798,7 +798,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                     class="c31"
                   >
                     <div
-                      class="c32 c22"
+                      class="c32 c20"
                     >
                       <div
                         class="c33"
@@ -836,7 +836,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                             />
                           </svg>
                           <span
-                            class="c19"
+                            class="c17"
                           >
                             Create new collection type
                           </span>
@@ -866,7 +866,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                               address
                             </div>
                             <div
-                              class="c12"
+                              class="c10"
                             >
                               <span
                                 class="c48"
@@ -894,7 +894,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                               category
                             </div>
                             <div
-                              class="c12"
+                              class="c10"
                             >
                               <span
                                 class="c48"
@@ -915,7 +915,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                     class="c31"
                   >
                     <div
-                      class="c32 c22"
+                      class="c32 c20"
                     >
                       <div
                         class="c33"
@@ -953,7 +953,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                             />
                           </svg>
                           <span
-                            class="c19"
+                            class="c17"
                           >
                             Create new single type
                           </span>
@@ -983,7 +983,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                               Homepage
                             </div>
                             <div
-                              class="c12"
+                              class="c10"
                             >
                               <span
                                 class="c48"
@@ -1004,7 +1004,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                     class="c31"
                   >
                     <div
-                      class="c32 c22"
+                      class="c32 c20"
                     >
                       <div
                         class="c33"
@@ -1042,7 +1042,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                             />
                           </svg>
                           <span
-                            class="c19"
+                            class="c17"
                           >
                             Create a new component
                           </span>
@@ -1115,7 +1115,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                                     simple
                                   </div>
                                   <div
-                                    class="c12"
+                                    class="c10"
                                   >
                                     <span
                                       class="c48"
@@ -1189,7 +1189,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                                     closingperiod
                                   </div>
                                   <div
-                                    class="c12"
+                                    class="c10"
                                   >
                                     <span
                                       class="c48"
@@ -1219,7 +1219,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                                     dish
                                   </div>
                                   <div
-                                    class="c12"
+                                    class="c10"
                                   >
                                     <span
                                       class="c48"
@@ -1242,7 +1242,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
     </div>
   </nav>
   <span
-    class="c19"
+    class="c17"
   >
     <p
       aria-live="polite"

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -641,6 +641,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
     width: 23.2rem;
     position: sticky;
     top: 0;
+    overflow: hidden;
     border-right: 1px solid #eaeaef;
     overscroll-behavior: contain;
   }


### PR DESCRIPTION
… when content list scrolls

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Moves the Save button, More actions menu, and Search bar out of the ScrollArea (SubNav.Content) in both the Content-Type Builder nav and the Content Manager left menu, so they remain fixed at the top of the sidebar while the list of content types scrolls independently.

In the Content Manager, the fix only applies to the desktop sidebar (`isFullPage=false`). The mobile full-page
navigation keeps the original layout where everything scrolls together, since that view has no fixed sidebar constraint.

### Why is it needed?
When a project has many content types or components, the sidebar list becomes long enough to scroll. Previously, the primary actions (Save, search) would scroll out of view along with the list, forcing users to scroll back up to access them. Keeping these controls fixed improves usability — the most important actions stay reachable at all times.

### How to test it?
Requirements: A Strapi instance with enough content types/components to make the sidebar scrollable (10+ is enough).

Content-Type Builder:
1. Open the CTB
2. Scroll the left sidebar: verify the Save button, More actions menu (...), and Search bar stay fixed at the top
3. Confirm Save, Undo/Redo/Discard, and Search still work correctly

Content Manager — desktop:
1. Open the CM on a desktop viewport
2. Scroll the left sidebar: verify the Search bar stays fixed at the top
3. Confirm search filtering still works

Content Manager — mobile:
1. Set browser viewport to a mobile size (e.g. 390px wide) or test on your mobile
2. Navigate to the CM: verify the Search bar stays fixed at the top when scrolling on the full-page navigation
3. Confirm the full-page navigation renders correctly

### Related issue(s)/PR(s)
Inspired by https://github.com/strapi/strapi/pull/26530