### PR TITLE
fix(data-transfer): restore localizations links that use document_id refs

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/resolve-link-ref.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/resolve-link-ref.test.ts
@@ -1,0 +1,74 @@
+import type { Core } from '@strapi/types';
+
+import type { ILink } from '../../../../../types';
+import {
+  isDocumentIdJoinColumnTarget,
+  resolveLinkRef,
+} from '../strategies/restore/resolve-link-ref';
+
+const buildStrapi = (attributes: Record<string, unknown>) =>
+  ({
+    db: {
+      metadata: {
+        get: () => ({ attributes }),
+      },
+    },
+  }) as unknown as Core.Strapi;
+
+describe('resolveLinkRef', () => {
+  const mapID = jest.fn((uid: string, id: number) => {
+    const mappings: Record<string, Record<number, number>> = {
+      'api::article.article': { 1: 101, 2: 102 },
+    };
+
+    return mappings[uid]?.[id];
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('maps numeric refs through the entities mapper', () => {
+    const link: ILink = {
+      kind: 'relation.basic',
+      relation: 'manyToMany',
+      left: { type: 'api::article.article', ref: 1, field: 'categories' },
+      right: { type: 'api::category.category', ref: 2 },
+    };
+
+    const strapi = buildStrapi({
+      categories: { type: 'relation', joinTable: { name: 'articles_categories_lnk' } },
+    });
+
+    expect(resolveLinkRef(strapi, link, 'left', mapID)).toBe(101);
+    expect(resolveLinkRef(strapi, link, 'right', mapID)).toBeUndefined();
+    expect(mapID).toHaveBeenCalledWith('api::article.article', 1);
+    expect(mapID).toHaveBeenCalledWith('api::category.category', 2);
+  });
+
+  test('passes document_id joinColumn targets through without id mapping', () => {
+    const documentId = 'kq4sntx4a0kymmdpvwvyblb9';
+    const link: ILink = {
+      kind: 'relation.circular',
+      relation: 'oneToMany',
+      left: { type: 'api::article.article', ref: 1, field: 'localizations' },
+      right: { type: 'api::article.article', ref: documentId },
+    };
+
+    const strapi = buildStrapi({
+      localizations: {
+        type: 'relation',
+        joinColumn: {
+          name: 'document_id',
+          referencedColumn: 'document_id',
+        },
+      },
+    });
+
+    expect(isDocumentIdJoinColumnTarget(strapi, link, 'right')).toBe(true);
+    expect(isDocumentIdJoinColumnTarget(strapi, link, 'left')).toBe(false);
+    expect(resolveLinkRef(strapi, link, 'left', mapID)).toBe(101);
+    expect(resolveLinkRef(strapi, link, 'right', mapID)).toBe(documentId);
+    expect(mapID).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore-links.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore-links.test.ts
@@ -12,9 +12,39 @@ jest.mock('../../../queries/link', () => ({
 
 afterEach(() => {
   jest.clearAllMocks();
+  insert.mockReset();
+  insert.mockResolvedValue(undefined);
 });
 
-const strapi = {} as unknown as Core.Strapi;
+beforeEach(() => {
+  insert.mockResolvedValue(undefined);
+});
+
+const strapi = {
+  db: {
+    metadata: {
+      get: () => ({ attributes: {} }),
+    },
+  },
+} as unknown as Core.Strapi;
+
+const strapiWithLocalizationsJoinColumn = {
+  db: {
+    metadata: {
+      get: () => ({
+        attributes: {
+          localizations: {
+            type: 'relation',
+            joinColumn: {
+              name: 'document_id',
+              referencedColumn: 'document_id',
+            },
+          },
+        },
+      }),
+    },
+  },
+} as unknown as Core.Strapi;
 
 const transaction = {
   attach: jest.fn(async (callback: (trx?: unknown) => unknown) => {
@@ -117,6 +147,37 @@ describe('createLinksWriteStream', () => {
     expect(insert).toHaveBeenCalledTimes(1);
     expect(onWarning).toHaveBeenCalledTimes(1);
     expect(onWarning).toHaveBeenCalledWith(expect.stringContaining('foreign key constraint'));
+  });
+
+  test('Should insert localizations links with mapped row id and unchanged document_id', async () => {
+    const documentId = 'kq4sntx4a0kymmdpvwvyblb9';
+    const mappings: Record<string, Record<number, number>> = {
+      'api::article.article': { 1: 101 },
+    };
+    const mapID = (uid: string, id: number) => mappings[uid]?.[id];
+    const onWarning = jest.fn();
+
+    const stream = createLinksWriteStream(
+      mapID,
+      strapiWithLocalizationsJoinColumn,
+      transaction,
+      onWarning
+    );
+
+    await writeLink(stream, {
+      kind: 'relation.circular',
+      relation: 'oneToMany',
+      left: { type: 'api::article.article', ref: 1, field: 'localizations' },
+      right: { type: 'api::article.article', ref: documentId },
+    });
+
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        left: expect.objectContaining({ ref: 101 }),
+        right: expect.objectContaining({ ref: documentId }),
+      })
+    );
+    expect(onWarning).not.toHaveBeenCalled();
   });
 
   test('Should propagate non foreign key errors', async () => {

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/links.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/links.ts
@@ -3,6 +3,7 @@ import type { Core } from '@strapi/types';
 import { ProviderTransferError } from '../../../../../errors/providers';
 import { ILink, Transaction } from '../../../../../types';
 import { createLinkQuery } from '../../../../queries/link';
+import { resolveLinkRef } from './resolve-link-ref';
 
 interface ErrorWithCode extends Error {
   code: string;
@@ -40,8 +41,8 @@ export const createLinksWriteStream = (
         const originalLeftRef = left.ref;
         const originalRightRef = right.ref;
 
-        const mappedLeftRef = mapID(left.type, originalLeftRef);
-        const mappedRightRef = mapID(right.type, originalRightRef);
+        const mappedLeftRef = resolveLinkRef(strapi, link, 'left', mapID);
+        const mappedRightRef = resolveLinkRef(strapi, link, 'right', mapID);
 
         // A missing mapping means the referenced row was never transferred
         // during the entities stage (e.g. an orphaned component or a dangling

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/resolve-link-ref.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/resolve-link-ref.ts
@@ -1,0 +1,52 @@
+import type { Core } from '@strapi/types';
+
+import type { ILink } from '../../../../../types';
+
+/**
+ * joinColumn relations (e.g. i18n `localizations`) store `document_id` on the
+ * inverse side. Export emits that value as a string ref; restore must not run it
+ * through the numeric id mapper.
+ */
+export const isDocumentIdJoinColumnTarget = (
+  strapi: Core.Strapi,
+  link: ILink,
+  side: 'left' | 'right'
+): boolean => {
+  if (side !== 'right') {
+    return false;
+  }
+
+  const metadata = strapi.db?.metadata?.get(link.left.type);
+  const attribute = metadata?.attributes?.[link.left.field];
+
+  if (!attribute || attribute.type !== 'relation') {
+    return false;
+  }
+
+  if (!('joinColumn' in attribute) || !attribute.joinColumn) {
+    return false;
+  }
+
+  return attribute.joinColumn.referencedColumn === 'document_id';
+};
+
+export const resolveLinkRef = (
+  strapi: Core.Strapi,
+  link: ILink,
+  side: 'left' | 'right',
+  mapID: (uid: string, id: number) => number | undefined
+): number | string | undefined => {
+  const { type, ref } = side === 'left' ? link.left : link.right;
+
+  if (isDocumentIdJoinColumnTarget(strapi, link, side)) {
+    return ref;
+  }
+
+  const numericRef = typeof ref === 'number' ? ref : Number(ref);
+
+  if (!Number.isFinite(numericRef)) {
+    return undefined;
+  }
+
+  return mapID(type, numericRef);
+};

--- a/packages/core/data-transfer/src/types/common-entities.ts
+++ b/packages/core/data-transfer/src/types/common-entities.ts
@@ -62,9 +62,9 @@ interface IDefaultLink {
      */
     type: string;
     /**
-     * Reference ID of the entity
+     * Reference ID of the entity (numeric row id, or document id for joinColumn targets)
      */
-    ref: number;
+    ref: number | string;
     /**
      * Field used to hold the link in the entity
      */
@@ -86,9 +86,9 @@ interface IDefaultLink {
      */
     type: string;
     /**
-     * Reference ID of the entity
+     * Reference ID of the entity (numeric row id, or document id for joinColumn targets)
      */
-    ref: number;
+    ref: number | string;
     /**
      * Field used to hold the link in the entity
      */


### PR DESCRIPTION
## Summary

- Fixes false-positive link skip warnings on import/transfer of i18n and draft-and-publish content
- i18n adds a virtual `localizations` relation whose join column targets `document_id`, not row `id`. Export emits links like `article:1 -> article:<documentId>`, but restore (#26531) only mapped numeric ids and skipped every such link as "not transferred"
- Restore now passes `document_id` joinColumn targets through unchanged (documentIds are preserved during entities restore)

## Related issue(s)/PR(s)

- Fixes CMS-1328

## Problem

On `releases/5.50.0`, a clean export/import round-trip of normally created content produces one warning per entity with locales or D&P — even when the database has no orphan join rows. Example warning:

```
Skipping link api::article.article:1 -> api::article.article:<documentId> because api::article.article:<documentId> was not transferred during the entities stage.
```

M2M relations using numeric join tables (e.g. article ↔ category) were unaffected.

## Test plan

### Automated

```bash
yarn nx test:unit @strapi/data-transfer --testPathPattern=restore-links
yarn nx test:unit @strapi/data-transfer --testPathPattern=resolve-link-ref
```

### Manual — getstarted round-trip (re-run 2026-07-01)

**Setup**

- App: `examples/getstarted` (SQLite, default plugins: i18n, users-permissions, review-workflows)
- Fresh `.tmp/data.db` per run (script removes and recreates it)
- Content created only through the **Document Service** (no raw SQL, no hand-edited join rows):
  - Categories (`api::category.category`, localized)
  - Article with M2M categories: create → update title → publish (localized, D&P)
  - Kitchensink + tag with a manyToOne relation
  - Second article: create → publish → delete (normal lifecycle)
- Transfer uses the same entity/link filters as `strapi import` / `strapi transfer` (`admin::` types excluded from entities; plugin types still flow through links)
- Export to tar, then import into a second empty Strapi instance (full restore)

**Command** (helper script used for reproducibility; not part of this PR):

```bash
yarn nx build @strapi/data-transfer
cd examples/getstarted
node ../../node_modules/tsx/dist/cli.mjs ../../tests/scripts/transfer-warning-smoke.ts
```

**Before this PR** (`releases/5.50.0` @ pre-fix):

```
Export counts: { entities: 25, links: 43, assets: 0 }
Import counts: { entities: 25, links: 43 }

Warning summary
  Total: 25
  Link/orphan: 25
```

All 25 warnings were `localizations` links (`field: "localizations"`), one per transferred entity row with a `document_id`. The 2 article↔category M2M links and remaining numeric join-table links imported without warnings. Transfer completed, but locale-variant links were silently dropped.

**After this PR** (`fix/data-transfer-localization-link-refs`):

```
Export counts: { entities: 25, links: 43, assets: 0 }
Import counts: { entities: 25, links: 43 }

Warning summary
  Total: 0
  Link/orphan: 0

  No warnings — clean round-trip.
```

Same data, same counts — no link skip warnings.
