### PR TITLE
fix(content-manager): respect disconnected draft relations in publish warning

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -92,6 +92,7 @@ function useHandleDisconnect(fieldName: string, consumerName: string) {
 
       addFieldRow(`${fieldName}.disconnect`, {
         id: relation.id,
+        status: relation.status,
         apiData: {
           id: relation.id,
           documentId: relation.documentId,
@@ -141,7 +142,7 @@ interface RelationsFieldProps
 
 export interface RelationsFormValue {
   connect?: Relation[];
-  disconnect?: Pick<Relation, 'id'>[];
+  disconnect?: Pick<Relation, 'id' | 'status'>[];
 }
 
 /**

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/draftRelationCounts.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/draftRelationCounts.ts
@@ -36,6 +36,11 @@ export const mergeDraftRelationCounts = (
   draftM2mLinks: left.draftM2mLinks + right.draftM2mLinks,
 });
 
+export const clampDraftRelationCounts = (counts: DraftRelationCounts): DraftRelationCounts => ({
+  unpublishedRelations: Math.max(0, counts.unpublishedRelations),
+  draftM2mLinks: Math.max(0, counts.draftM2mLinks),
+});
+
 export const normalizeDraftRelationCounts = (payload: unknown): DraftRelationCounts => {
   if (
     payload &&
@@ -60,14 +65,14 @@ export const resolveDraftRelationCounts = (
   serverCounts: DraftRelationCounts
 ): DraftRelationCounts => {
   if (!documentId) {
-    return localCounts;
+    return clampDraftRelationCounts(localCounts);
   }
 
   const hasUnsavedDraftRelations =
     localCounts.unpublishedRelations > 0 || localCounts.draftM2mLinks > 0;
 
   if (modified || hasUnsavedDraftRelations) {
-    return mergeDraftRelationCounts(localCounts, serverCounts);
+    return clampDraftRelationCounts(mergeDraftRelationCounts(localCounts, serverCounts));
   }
 
   return serverCounts;
@@ -130,25 +135,32 @@ export const countLocalDraftRelations = (
           return counts;
         }
 
-        if (typeof value === 'object' && value !== null && 'connect' in value) {
+        if (
+          typeof value === 'object' &&
+          value !== null &&
+          ('connect' in value || 'disconnect' in value)
+        ) {
+          const formValue = value as RelationsFormValue;
           const draftConnectCount =
-            (value as RelationsFormValue).connect?.filter((relation) => relation.status === 'draft')
-              .length ?? 0;
+            formValue.connect?.filter((relation) => relation.status === 'draft').length ?? 0;
+          const draftDisconnectCount =
+            formValue.disconnect?.filter((relation) => relation.status === 'draft').length ?? 0;
 
-          if (draftConnectCount === 0) {
+          if (draftConnectCount === 0 && draftDisconnectCount === 0) {
             return counts;
           }
 
           if (isBidirectionalManyToMany(attribute)) {
             return {
               ...counts,
-              draftM2mLinks: counts.draftM2mLinks + draftConnectCount,
+              draftM2mLinks: counts.draftM2mLinks + draftConnectCount - draftDisconnectCount,
             };
           }
 
           return {
             ...counts,
-            unpublishedRelations: counts.unpublishedRelations + draftConnectCount,
+            unpublishedRelations:
+              counts.unpublishedRelations + draftConnectCount - draftDisconnectCount,
           };
         }
 

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/tests/draftRelationCounts.test.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/tests/draftRelationCounts.test.ts
@@ -284,6 +284,60 @@ describe('draftRelationCounts', () => {
         draftM2mLinks: 0,
       });
     });
+
+    it('subtracts disconnected draft xToOne relations from local counts', () => {
+      const counts = countLocalDraftRelations(
+        {
+          category: {
+            disconnect: [{ id: 1, status: 'draft' }],
+          },
+        },
+        articleSchema,
+        components,
+        'api::article.article'
+      );
+
+      expect(counts).toEqual({
+        unpublishedRelations: -1,
+        draftM2mLinks: 0,
+      });
+    });
+
+    it('subtracts disconnected draft bidirectional M2M relations from local counts', () => {
+      const counts = countLocalDraftRelations(
+        {
+          tags: {
+            disconnect: [{ id: 1, status: 'draft' }],
+          },
+        },
+        articleSchema,
+        components,
+        'api::article.article'
+      );
+
+      expect(counts).toEqual({
+        unpublishedRelations: 0,
+        draftM2mLinks: -1,
+      });
+    });
+
+    it('ignores disconnects of published relations', () => {
+      const counts = countLocalDraftRelations(
+        {
+          category: {
+            disconnect: [{ id: 1, status: 'published' }],
+          },
+        },
+        articleSchema,
+        components,
+        'api::article.article'
+      );
+
+      expect(counts).toEqual({
+        unpublishedRelations: 0,
+        draftM2mLinks: 0,
+      });
+    });
   });
 
   describe('resolveDraftRelationCounts', () => {
@@ -329,6 +383,27 @@ describe('draftRelationCounts', () => {
           { unpublishedRelations: 0, draftM2mLinks: 2 }
         )
       ).toEqual({ unpublishedRelations: 0, draftM2mLinks: 2 });
+    });
+
+    it('nets disconnected draft relations against stale server counts when modified', () => {
+      const localCounts = countLocalDraftRelations(
+        {
+          category: {
+            disconnect: [{ id: 1, status: 'draft' }],
+          },
+        },
+        articleSchema,
+        components,
+        'api::article.article'
+      );
+
+      const counts = resolveDraftRelationCounts('doc-1', true, localCounts, {
+        unpublishedRelations: 1,
+        draftM2mLinks: 0,
+      });
+
+      expect(counts).toEqual({ unpublishedRelations: 0, draftM2mLinks: 0 });
+      expect(getDraftRelationsPublishState(counts).hasDraftRelations).toBe(false);
     });
 
     it('does not warn when server reports no draft relations for published M2M targets', () => {


### PR DESCRIPTION
## Summary
- Fixes relation-on-the-fly modal showing a stale draft-relations publish warning after disconnecting a draft relation without saving first.
- `countLocalDraftRelations` now subtracts unsaved `disconnect` entries with `status: 'draft'`, and `resolveDraftRelationCounts` clamps merged counts to zero so stale server counts are offset by local form changes.
- Relation disconnect payloads now retain `status` so draft vs published disconnects are distinguished.

## Related issue(s)/PR(s)
- Follow-up from review on #26858

## Test plan
- [x] yarn test:front packages/core/content-manager/admin/src/pages/EditView/utils/tests/draftRelationCounts.test.ts
- [ ] Manual: (repro steps from bug report)
  1. Content type A has a relation to content type B.
  2. Content type B has two relation fields: one to a draft-only entry, one to a published entry.
  3. Open an entry of type A in edit view. Click the relation field to open entry B in the relation-on-the-fly modal.
  4. Inside the modal, remove/disconnect the draft-only relation from entry B. Do NOT click Save.
  5. Click Publish inside the modal.
  6. Confirm no draft-relations confirmation dialog appears; publish proceeds directly.