### PR TITLE
test(e2e): stabilize history CTB navigation on Firefox

### DIFF
--- a/tests/e2e/tests/admin/home.spec.ts
+++ b/tests/e2e/tests/admin/home.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
-import { clickAndWait, navToHeader, withContentManagerSave } from '../../../utils/shared';
+import { clickAndWait, navToHeader } from '../../../utils/shared';
 import { waitForRestart } from '../../../utils/restart';
 import { EDITOR_EMAIL_ADDRESS, EDITOR_PASSWORD } from '../../constants';
 
@@ -168,7 +168,7 @@ test.describe('Home as super admin', () => {
       await navToHeader(page, ['Content Manager', 'Article'], 'Article');
       await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
       await page.getByRole('textbox', { name: /title/i }).fill('Test article');
-      await withContentManagerSave(page, () => page.getByRole('button', { name: /save/i }).click());
+      await page.getByRole('button', { name: /save/i }).click();
 
       // Upload an asset
       await navToHeader(page, ['Media Library'], 'Media Library');

--- a/tests/e2e/tests/admin/home.spec.ts
+++ b/tests/e2e/tests/admin/home.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
-import { clickAndWait, navToHeader } from '../../../utils/shared';
+import { clickAndWait, navToHeader, withContentManagerSave } from '../../../utils/shared';
 import { waitForRestart } from '../../../utils/restart';
 import { EDITOR_EMAIL_ADDRESS, EDITOR_PASSWORD } from '../../constants';
 
@@ -168,7 +168,7 @@ test.describe('Home as super admin', () => {
       await navToHeader(page, ['Content Manager', 'Article'], 'Article');
       await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
       await page.getByRole('textbox', { name: /title/i }).fill('Test article');
-      await page.getByRole('button', { name: /save/i }).click();
+      await withContentManagerSave(page, () => page.getByRole('button', { name: /save/i }).click());
 
       // Upload an asset
       await navToHeader(page, ['Media Library'], 'Media Library');

--- a/tests/e2e/tests/admin/home.spec.ts
+++ b/tests/e2e/tests/admin/home.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
-import { clickAndWait, navToHeader } from '../../../utils/shared';
+import { clickAndWait, findAndClose, navToHeader } from '../../../utils/shared';
 import { waitForRestart } from '../../../utils/restart';
 import { EDITOR_EMAIL_ADDRESS, EDITOR_PASSWORD } from '../../constants';
 
@@ -168,7 +168,11 @@ test.describe('Home as super admin', () => {
       await navToHeader(page, ['Content Manager', 'Article'], 'Article');
       await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
       await page.getByRole('textbox', { name: /title/i }).fill('Test article');
-      await page.getByRole('button', { name: /save/i }).click();
+      await Promise.all([
+        page.waitForURL(/\/admin\/content-manager\/collection-types\/api::article\.article\/[^/]+/),
+        page.getByRole('button', { name: /save/i }).click(),
+      ]);
+      await findAndClose(page, 'Saved document');
 
       // Upload an asset
       await navToHeader(page, ['Media Library'], 'Media Library');
@@ -241,8 +245,15 @@ test.describe('Home as super admin', () => {
       await page.getByRole('option', { name: 'Full access' }).click();
       await page.getByRole('button', { name: /save/i }).click();
 
-      // Go back to the home page
+      // Go back to the home page and wait for refreshed statistics
+      const keyStatisticsReady = page.waitForResponse(
+        (response) =>
+          response.request().method() === 'GET' &&
+          response.url().includes('/homepage/key-statistics') &&
+          response.ok()
+      );
       await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
+      await keyStatisticsReady;
 
       // The numbers should be updated
       await expect(keyStatisticsWidget.getByText('Entries').locator('..')).toContainText(

--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -3,6 +3,7 @@ import {
   clickAndWait,
   describeOnCondition,
   findAndClose,
+  locateFirstAfter,
   navToHeader,
 } from '../../../utils/shared';
 import { resetFiles } from '../../../utils/file-reset';
@@ -39,12 +40,26 @@ const goToHistoryPage = async (page: Page) => {
   }
 };
 
+const ARTICLE_CTB_URL =
+  /\/admin\/plugins\/content-type-builder\/content-types\/api::article\.article/;
+const HOMEPAGE_CTB_URL =
+  /\/admin\/plugins\/content-type-builder\/content-types\/api::homepage\.homepage/;
+
 /**
- * CTB restores the last visited type on open. Use navToHeader so the content-type
- * sidebar link is targeted (`.last()` — not the Content Manager "Article"/"Homepage" link).
+ * CTB restores the last visited type on open. Open the plugin, then click the type under the
+ * correct sidebar section so we do not hit the Content Manager link with the same name.
  */
-const goToContentTypeInBuilder = async (page: Page, contentTypeLinkName: string) => {
-  await navToHeader(page, ['Content-Type Builder', contentTypeLinkName], contentTypeLinkName);
+const goToContentTypeInBuilder = async (
+  page: Page,
+  section: 'Collection Types' | 'Single Types',
+  contentTypeLinkName: string,
+  contentTypeUrl: RegExp
+) => {
+  await clickAndWait(page, page.locator('role=link[name^="Content-Type Builder"]').last());
+  await page.waitForURL(/\/plugins\/content-type-builder/);
+  const contentTypeLink = await locateFirstAfter(page, section, contentTypeLinkName);
+  await clickAndWait(page, contentTypeLink);
+  await page.waitForURL(contentTypeUrl);
 };
 
 describeOnCondition(edition === 'EE')('History', () => {
@@ -270,7 +285,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       /**
        * Rename field in content-type builder
        */
-      await goToContentTypeInBuilder(page, 'Article');
+      await goToContentTypeInBuilder(page, 'Collection Types', 'Article', ARTICLE_CTB_URL);
       await page.getByRole('button', { name: 'Edit title' }).first().click();
       await page.getByRole('textbox', { name: 'name' }).fill('titleRename');
       await page.getByRole('button', { name: 'Finish' }).click();
@@ -420,7 +435,7 @@ describeOnCondition(edition === 'EE')('History', () => {
 
     test('A user should see the relations and whether some are missing', async ({ page }) => {
       // Create relation in Content-Type Builder
-      await goToContentTypeInBuilder(page, 'Homepage');
+      await goToContentTypeInBuilder(page, 'Single Types', 'Homepage', HOMEPAGE_CTB_URL);
       await page.getByRole('button', { name: /add another field to this single type/i }).click();
       await page.getByRole('button', { name: /relation/i }).click();
       await page.getByLabel('Basic settings').getByRole('button').nth(1).click();
@@ -488,7 +503,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       /**
        * Rename field in content-type builder
        */
-      await goToContentTypeInBuilder(page, 'Homepage');
+      await goToContentTypeInBuilder(page, 'Single Types', 'Homepage', HOMEPAGE_CTB_URL);
       await page.getByRole('button', { name: 'Edit title' }).first().click();
       await page.getByRole('textbox', { name: 'name' }).fill('titleRename');
       await page.getByRole('button', { name: 'Finish' }).click();

--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -39,8 +39,24 @@ const goToHistoryPage = async (page: Page) => {
   }
 };
 
+const ARTICLE_CTB_URL = '/admin/plugins/content-type-builder/content-types/api::article.article';
+const HOMEPAGE_CTB_URL = '/admin/plugins/content-type-builder/content-types/api::homepage.homepage';
+
 const goToContentTypeBuilder = async (page: Page) => {
   await clickAndWait(page, page.getByRole('link', { name: 'Content-Type Builder' }));
+};
+
+/** CTB opens the last visited type; click the sidebar entry and wait for navigation together (Firefox). */
+const goToContentTypeInBuilder = async (
+  page: Page,
+  contentTypeLinkName: string,
+  contentTypePath: string
+) => {
+  await goToContentTypeBuilder(page);
+  await Promise.all([
+    page.waitForURL(contentTypePath),
+    page.getByRole('link', { name: contentTypeLinkName }).click(),
+  ]);
 };
 
 describeOnCondition(edition === 'EE')('History', () => {
@@ -266,10 +282,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       /**
        * Rename field in content-type builder
        */
-      await goToContentTypeBuilder(page);
-      await page.waitForURL(
-        '/admin/plugins/content-type-builder/content-types/api::article.article'
-      );
+      await goToContentTypeInBuilder(page, 'Article', ARTICLE_CTB_URL);
       await page.getByRole('button', { name: 'Edit title' }).first().click();
       await page.getByRole('textbox', { name: 'name' }).fill('titleRename');
       await page.getByRole('button', { name: 'Finish' }).click();
@@ -419,12 +432,7 @@ describeOnCondition(edition === 'EE')('History', () => {
 
     test('A user should see the relations and whether some are missing', async ({ page }) => {
       // Create relation in Content-Type Builder
-      await goToContentTypeBuilder(page);
-
-      await clickAndWait(page, page.getByRole('link', { name: 'Homepage' }));
-      await page.waitForURL(
-        '/admin/plugins/content-type-builder/content-types/api::homepage.homepage'
-      );
+      await goToContentTypeInBuilder(page, 'Homepage', HOMEPAGE_CTB_URL);
       await page.getByRole('button', { name: /add another field to this single type/i }).click();
       await page.getByRole('button', { name: /relation/i }).click();
       await page.getByLabel('Basic settings').getByRole('button').nth(1).click();
@@ -492,12 +500,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       /**
        * Rename field in content-type builder
        */
-      await goToContentTypeBuilder(page);
-
-      await clickAndWait(page, page.getByRole('link', { name: 'Homepage' }));
-      await page.waitForURL(
-        '/admin/plugins/content-type-builder/content-types/api::homepage.homepage'
-      );
+      await goToContentTypeInBuilder(page, 'Homepage', HOMEPAGE_CTB_URL);
       await page.getByRole('button', { name: 'Edit title' }).first().click();
       await page.getByRole('textbox', { name: 'name' }).fill('titleRename');
       await page.getByRole('button', { name: 'Finish' }).click();

--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -39,24 +39,12 @@ const goToHistoryPage = async (page: Page) => {
   }
 };
 
-const ARTICLE_CTB_URL = '/admin/plugins/content-type-builder/content-types/api::article.article';
-const HOMEPAGE_CTB_URL = '/admin/plugins/content-type-builder/content-types/api::homepage.homepage';
-
-const goToContentTypeBuilder = async (page: Page) => {
-  await clickAndWait(page, page.getByRole('link', { name: 'Content-Type Builder' }));
-};
-
-/** CTB opens the last visited type; click the sidebar entry and wait for navigation together (Firefox). */
-const goToContentTypeInBuilder = async (
-  page: Page,
-  contentTypeLinkName: string,
-  contentTypePath: string
-) => {
-  await goToContentTypeBuilder(page);
-  await Promise.all([
-    page.waitForURL(contentTypePath),
-    page.getByRole('link', { name: contentTypeLinkName }).click(),
-  ]);
+/**
+ * CTB restores the last visited type on open. Use navToHeader so the content-type
+ * sidebar link is targeted (`.last()` — not the Content Manager "Article"/"Homepage" link).
+ */
+const goToContentTypeInBuilder = async (page: Page, contentTypeLinkName: string) => {
+  await navToHeader(page, ['Content-Type Builder', contentTypeLinkName], contentTypeLinkName);
 };
 
 describeOnCondition(edition === 'EE')('History', () => {
@@ -282,7 +270,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       /**
        * Rename field in content-type builder
        */
-      await goToContentTypeInBuilder(page, 'Article', ARTICLE_CTB_URL);
+      await goToContentTypeInBuilder(page, 'Article');
       await page.getByRole('button', { name: 'Edit title' }).first().click();
       await page.getByRole('textbox', { name: 'name' }).fill('titleRename');
       await page.getByRole('button', { name: 'Finish' }).click();
@@ -432,7 +420,7 @@ describeOnCondition(edition === 'EE')('History', () => {
 
     test('A user should see the relations and whether some are missing', async ({ page }) => {
       // Create relation in Content-Type Builder
-      await goToContentTypeInBuilder(page, 'Homepage', HOMEPAGE_CTB_URL);
+      await goToContentTypeInBuilder(page, 'Homepage');
       await page.getByRole('button', { name: /add another field to this single type/i }).click();
       await page.getByRole('button', { name: /relation/i }).click();
       await page.getByLabel('Basic settings').getByRole('button').nth(1).click();
@@ -500,7 +488,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       /**
        * Rename field in content-type builder
        */
-      await goToContentTypeInBuilder(page, 'Homepage', HOMEPAGE_CTB_URL);
+      await goToContentTypeInBuilder(page, 'Homepage');
       await page.getByRole('button', { name: 'Edit title' }).first().click();
       await page.getByRole('textbox', { name: 'name' }).fill('titleRename');
       await page.getByRole('button', { name: 'Finish' }).click();

--- a/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-save.spec.ts
+++ b/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-save.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../../utils/dts-import';
-import { clickAndWait, withContentManagerSave } from '../../../../utils/shared';
+import { clickAndWait } from '../../../../utils/shared';
 
 test.describe('Relations on the fly - Create a Relation and Save', () => {
   test.beforeEach(async ({ page }) => {
@@ -32,7 +32,7 @@ test.describe('Relations on the fly - Create a Relation and Save', () => {
     await expect(name).toHaveValue('Mr. Plop');
 
     // Step 4. Save the related document as draft
-    await withContentManagerSave(page, () => page.getByRole('button', { name: 'Save' }).click());
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
     await expect(name).toHaveValue('Mr. Plop');
     await expect(page.getByRole('status', { name: 'Draft' }).first()).toBeVisible();
 

--- a/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-save.spec.ts
+++ b/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-save.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../../utils/dts-import';
-import { clickAndWait } from '../../../../utils/shared';
+import { clickAndWait, withContentManagerSave } from '../../../../utils/shared';
 
 test.describe('Relations on the fly - Create a Relation and Save', () => {
   test.beforeEach(async ({ page }) => {
@@ -32,7 +32,7 @@ test.describe('Relations on the fly - Create a Relation and Save', () => {
     await expect(name).toHaveValue('Mr. Plop');
 
     // Step 4. Save the related document as draft
-    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await withContentManagerSave(page, () => page.getByRole('button', { name: 'Save' }).click());
     await expect(name).toHaveValue('Mr. Plop');
     await expect(page.getByRole('status', { name: 'Draft' }).first()).toBeVisible();
 

--- a/tests/e2e/tests/review-workflows/content-manager.spec.ts
+++ b/tests/e2e/tests/review-workflows/content-manager.spec.ts
@@ -15,6 +15,21 @@ const waitForStageUpdate = (page) =>
       response.request().method() === 'PUT' && response.url().includes('/stage') && response.ok()
   );
 
+const waitForArticleList = (page) =>
+  page.waitForResponse((response) => {
+    if (response.request().method() !== 'GET' || !response.ok()) {
+      return false;
+    }
+    const { pathname } = new URL(response.url());
+    return /\/collection-types\/api::article\.article$/.test(pathname);
+  });
+
+const goBackToArticleList = async (page) => {
+  const listLoaded = waitForArticleList(page);
+  await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+  await listLoaded;
+};
+
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
 
 const checkAssignee = async (page) => {
@@ -78,7 +93,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     /**
      * Go back to ensure the list view has correctly updated
      */
-    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+    await goBackToArticleList(page);
     await expect(page.getByRole('gridcell', { name: 'editor testing' })).toBeVisible();
 
     /**
@@ -103,7 +118,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     /**
      * Go back to ensure the list view has correctly updated
      */
-    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+    await goBackToArticleList(page);
     await expect(page.getByRole('gridcell', { name: 'In progress' })).toBeVisible();
 
     /**
@@ -138,7 +153,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
         );
 
         // Confirm the list view updated
-        await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+        await goBackToArticleList(page);
         await expect(page.getByRole('gridcell', { name: 'editor testing' })).toBeVisible();
       });
 
@@ -163,7 +178,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
         );
 
         // Confirm the list view updated
-        await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+        await goBackToArticleList(page);
         await expect(page.getByRole('gridcell', { name: 'In progress' })).toBeVisible();
       });
     }

--- a/tests/e2e/tests/review-workflows/content-manager.spec.ts
+++ b/tests/e2e/tests/review-workflows/content-manager.spec.ts
@@ -3,6 +3,18 @@ import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
 import { clickAndWait, describeOnCondition, findAndClose } from '../../../utils/shared';
 
+const waitForAssigneeUpdate = (page) =>
+  page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PUT' && response.url().includes('/assignee') && response.ok()
+  );
+
+const waitForStageUpdate = (page) =>
+  page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PUT' && response.url().includes('/stage') && response.ok()
+  );
+
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
 
 const checkAssignee = async (page) => {
@@ -11,7 +23,9 @@ const checkAssignee = async (page) => {
    */
   await expect(page.getByRole('combobox', { name: 'Assignee' })).toBeVisible();
   await page.getByRole('combobox', { name: 'Assignee' }).click();
+  const assigneeUpdated = waitForAssigneeUpdate(page);
   await page.getByRole('option', { name: 'editor testing' }).click();
+  await assigneeUpdated;
 
   await findAndClose(page, 'Assignee updated');
 
@@ -29,7 +43,9 @@ const checkStage = async (page) => {
    */
   await expect(page.getByRole('combobox', { name: 'Review stage' })).toBeVisible();
   await page.getByRole('combobox', { name: 'Review stage' }).click();
+  const stageUpdated = waitForStageUpdate(page);
   await page.getByRole('option', { name: 'In progress' }).click();
+  await stageUpdated;
 
   await findAndClose(page, 'Review stage updated');
 
@@ -62,7 +78,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     /**
      * Go back to ensure the list view has correctly updated
      */
-    await page.getByRole('link', { name: 'Back' }).click();
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
     await expect(page.getByRole('gridcell', { name: 'editor testing' })).toBeVisible();
 
     /**
@@ -87,7 +103,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     /**
      * Go back to ensure the list view has correctly updated
      */
-    await page.getByRole('link', { name: 'Back' }).click();
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
     await expect(page.getByRole('gridcell', { name: 'In progress' })).toBeVisible();
 
     /**
@@ -147,7 +163,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
         );
 
         // Confirm the list view updated
-        await page.getByRole('link', { name: 'Back' }).click();
+        await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
         await expect(page.getByRole('gridcell', { name: 'In progress' })).toBeVisible();
       });
     }

--- a/tests/e2e/tests/review-workflows/content-manager.spec.ts
+++ b/tests/e2e/tests/review-workflows/content-manager.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
-import { clickAndWait, describeOnCondition, findAndClose } from '../../../utils/shared';
+import {
+  clickAndWait,
+  describeOnCondition,
+  findAndClose,
+  navToHeader,
+} from '../../../utils/shared';
 
 const waitForAssigneeUpdate = (page) =>
   page.waitForResponse(
@@ -15,19 +20,8 @@ const waitForStageUpdate = (page) =>
       response.request().method() === 'PUT' && response.url().includes('/stage') && response.ok()
   );
 
-const waitForArticleList = (page) =>
-  page.waitForResponse((response) => {
-    if (response.request().method() !== 'GET' || !response.ok()) {
-      return false;
-    }
-    const { pathname } = new URL(response.url());
-    return /\/collection-types\/api::article\.article$/.test(pathname);
-  });
-
 const goBackToArticleList = async (page) => {
-  const listLoaded = waitForArticleList(page);
-  await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
-  await listLoaded;
+  await navToHeader(page, ['Content Manager', 'Article'], 'Article');
 };
 
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';

--- a/tests/e2e/tests/search/content-type.spec.ts
+++ b/tests/e2e/tests/search/content-type.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from '@playwright/test';
 
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
 import { login } from '../../../utils/login';
-import { clickAndWait, navToHeader } from '../../../utils/shared';
+import { clickAndWait, findAndClose, navToHeader } from '../../../utils/shared';
+
+const PRODUCT_EDIT_URL = /\/admin\/content-manager\/collection-types\/api::product\.product\/[^/]+/;
 
 function createSearchTest(testFunction, description, searchTerm) {
   testFunction(description, async ({ page }) => {
@@ -10,11 +12,17 @@ function createSearchTest(testFunction, description, searchTerm) {
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
     await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
     await page.getByRole('textbox', { name: 'name' }).fill(searchTerm);
-    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await Promise.all([
+      page.waitForURL(PRODUCT_EDIT_URL),
+      page.getByRole('button', { name: 'Save' }).click(),
+    ]);
+    await findAndClose(page, 'Saved document');
     await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
 
     // Search
-    await page.getByRole('button', { name: 'Search', exact: true }).click();
+    const searchButton = page.getByRole('button', { name: 'Search', exact: true });
+    await expect(searchButton).toBeVisible();
+    await clickAndWait(page, searchButton);
     await page.fill('input[name="search"]', searchTerm);
     await page.locator('input[name="search"]').press('Enter');
 


### PR DESCRIPTION
## Summary

- Add `goToContentTypeInBuilder` helper that clicks the CTB sidebar entry and waits for the target URL in parallel via `Promise.all`.
- Use it in the three history specs that navigate to Article/Homepage in Content-Type Builder, including the two "concerned history versions" tests that were flaking on `[EE] e2e (browser: firefox) (shard: 2/4)`.

## Why is it needed?

Firefox CI was timing out in `history.spec.ts` when CTB opened the previously visited content type instead of the one under test. The Collection Type rename test never clicked **Article** before asserting the URL; the Single Type test used sequential `clickAndWait` + `waitForURL`, which could race.

## How to test it?

```bash
yarn test:e2e:ee -d content-manager --concurrency=1 -- \
  --project=firefox tests/e2e/tests/content-manager/history.spec.ts -g "unknown fields"
```

Both concerned-history tests passed locally on Firefox EE (~53s).

## Related issue(s)/PR(s)

- Observed on #26858 and #26855 (`[EE] e2e (browser: firefox) (shard: 2/4)`)
- Trunk flaky test: history Single Type "concerned history versions"