### PR TITLE
feat(content-type-builder): CTB AI v2 operations client (draft)

### DIFF
--- a/CTB_AI_V2/AGENT-orchestrator.md
+++ b/CTB_AI_V2/AGENT-orchestrator.md
@@ -1,0 +1,212 @@
+# Orchestrator — CTB AI v2 (operations-based schema changes)
+
+> **You are the lead agent.** Read this file, then manage parallel subagents for
+> strapi-ai and the Strapi monorepo. Do not start coding until you have read the
+> linked docs below.
+
+---
+
+## Mission
+
+Ship **CTB AI v2**: strapi-ai returns an ordered list of **Content-Type Builder
+admin operations**; the Strapi admin dispatches them **1:1** to `DataManager`;
+rename migrations work through the **existing save pipeline** — no schema-snapshot
+diffing, no client-side rename guessing.
+
+```
+strapi-ai  ──operations[]──►  OperationsProvider  ──DataManager.*()──►  reducer state
+                                                                              │
+                                                                         saveSchema()
+                                                                              ▼
+                                                                    rename migration file
+```
+
+**Do not** build a new server-side "operations → migration" layer. Operations →
+`editAttribute` → `recordRename` → `renames[]` → `cleanData` →
+`generateRenameMigrations` is the design (already implemented on this branch for
+manual CTB edits).
+
+---
+
+## Read first (in order)
+
+| #   | File                                                   | Why                                                                             |
+| --- | ------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| 1   | [`CTB_RENAME_PROGRESS.md`](../CTB_RENAME_PROGRESS.md)  | Rename-migration feature status; AI v2 is the remaining gap                     |
+| 2   | [`CTB_RENAME_PLAN.md`](../CTB_RENAME_PLAN.md)          | How renames flow admin → server → migration file                                |
+| 3   | [`HANDOFF.md`](HANDOFF.md)                             | **Canonical v2 reference** — op catalog, wire contract, examples, file pointers |
+| 4   | [`AGENT-strapi-ai.md`](AGENT-strapi-ai.md)             | Subagent brief — strapi-ai repo                                                 |
+| 5   | [`AGENT-strapi-monorepo.md`](AGENT-strapi-monorepo.md) | Subagent brief — this repo                                                      |
+
+Repo conventions: [`AGENTS.md`](../AGENTS.md) at monorepo root.
+
+---
+
+## Repos & branches
+
+| Workstream            | Repo             | Path                           | Branch                               |
+| --------------------- | ---------------- | ------------------------------ | ------------------------------------ |
+| **Strapi CTB client** | strapi/strapi    | _this checkout_                | `feat/ctb-rename-migration-builder`  |
+| **AI Server**         | strapi/strapi-ai | `../ai-server` (sibling clone) | `feat/ctb-operations-v2` from `main` |
+
+**PR (Strapi):** https://github.com/strapi/strapi/pull/26749 (draft)  
+**Linear:** CMS-635 (related CG-979, CG-1001)
+
+---
+
+## Orchestration
+
+Launch **two subagents in parallel** after you have skimmed `HANDOFF.md`:
+
+1. **strapi-ai** — point at [`AGENT-strapi-ai.md`](AGENT-strapi-ai.md) + `HANDOFF.md`
+2. **Strapi monorepo** — point at [`AGENT-strapi-monorepo.md`](AGENT-strapi-monorepo.md) + `HANDOFF.md`
+
+**Shared contract** (both sides must agree before Phase 1 integration):
+
+- Tool name: `schemaOperationsTool`
+- Client part type: `tool-schemaOperationsTool`
+- Output: `{ operations: CTBOperation[] }`
+- Each `op` = public `DataManager` method name (`createSchema`, `addAttribute`,
+  `editAttribute`, `removeAttribute`, …)
+- Full type union: [`HANDOFF.md` § Wire contract](HANDOFF.md#wire-contract)
+
+**Phase plan:**
+
+| Phase | strapi-ai                                  | Strapi                                            | Gate                                               |
+| ----- | ------------------------------------------ | ------------------------------------------------- | -------------------------------------------------- |
+| **0** | `@ai/types` `CTBOperation` + Zod           | Mirror types; `applyCTBOperations()` + unit tests | Types compile; dispatcher tests pass with fixtures |
+| **1** | Tool + validator + `POST /schemas/chat/v2` | `OperationsProvider` + feature flag               | Rename op → `renames[]` in reducer state           |
+| **2** | Prompts, swap macro, DZ ops                | Enable v2 URL; message UI markers                 | **Live E2E** (see below)                           |
+| **3** | Deprecate v1 prompts for new Strapi        | Remove `applyChange` AI path                      | v1 route kept for old Strapi                       |
+
+---
+
+## AI Server — local build & run
+
+Clone/path: **`../ai-server`** (`github.com/strapi/strapi-ai`).
+
+Read that repo before running commands:
+
+- `README.md`
+- `docs/setup.md`
+- `docs/development.md`
+- `docs/environment-variables.md`
+
+**Prerequisites:** Node 18+, **pnpm**, Docker (Postgres + MinIO).
+
+```bash
+cd ../ai-server
+pnpm install
+pnpm dev:db          # start Docker services
+pnpm --filter @packages/database db:migrate
+pnpm dev             # http://localhost:3001
+```
+
+**Verify:** `curl http://localhost:3001/_health`
+
+**Useful scripts:**
+
+| Command                 | Purpose                |
+| ----------------------- | ---------------------- |
+| `pnpm dev:mock:license` | Mock license registry  |
+| `pnpm token:generate`   | Dev auth tokens        |
+| `pnpm test`             | Vitest across packages |
+
+Point Strapi at local AI Server (admin build reads this at compile time):
+
+```bash
+# from examples/getstarted (or your sandbox)
+STRAPI_AI_URL=http://localhost:3001 yarn develop
+```
+
+Strapi resolves chat URL from `packages/core/content-type-builder/admin/src/components/AIChat/lib/constants.ts` (`STRAPI_AI_URL` + `/schemas/chat`; v2 adds `/schemas/chat/v2`).
+
+---
+
+## Strapi — local dev & tests
+
+```bash
+# monorepo root
+yarn install && yarn setup   # if needed
+
+# watch packages + sandbox (two terminals)
+yarn watch
+cd examples/getstarted && STRAPI_AI_URL=http://localhost:3001 yarn develop --watch-admin
+```
+
+**Quality gates (Strapi changes):**
+
+```bash
+yarn test:unit && yarn test:front && yarn test:ts && yarn lint && yarn prettier:check
+yarn test:api rename-migration   # rename-migration feature still relevant
+```
+
+**Key client files** (Strapi subagent):
+
+| File                                                                                          | Role                              |
+| --------------------------------------------------------------------------------------------- | --------------------------------- |
+| `packages/core/content-type-builder/admin/src/components/AIChat/providers/SchemaProvider.tsx` | v1 apply path — replace for v2    |
+| `packages/core/content-type-builder/admin/src/components/DataManager/DataManagerContext.ts`   | Public API to call                |
+| `packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts`              | `recordRename` in `editAttribute` |
+| `CTB_AI_V2/AGENT-strapi-monorepo.md`                                                          | Implementation checklist          |
+
+**Key server files** (strapi-ai subagent):
+
+| File                                                            | Role                     |
+| --------------------------------------------------------------- | ------------------------ |
+| `packages/ai/architect/src/services/chat/tools/generateSchema/` | v1 tool — reference only |
+| `packages/ai/architect/src/services/chat/chat-agent.ts`         | Register v2 tool         |
+| `apps/server/src/routes/schemas/chat.ts`                        | Add v2 route             |
+| `CTB_AI_V2/AGENT-strapi-ai.md`                                  | Implementation checklist |
+
+---
+
+## Live E2E acceptance test
+
+With **both** services running locally:
+
+1. Open CTB AI chat in admin (EE + AI enabled).
+2. Ask to rename a field on an existing type with data (e.g. `title` → `heading`).
+3. **Assert state before save:** `renames: [{ oldName, newName }]` on the type (not `REMOVED` + `NEW`).
+4. Save → rename migration modal (prompt mode) → accept hop.
+5. Restart → column renamed, **data preserved**.
+
+Repeat for a multi-hop case from [`HANDOFF.md` examples](HANDOFF.md#worked-examples) once swap/chain ops work.
+
+---
+
+## v1 context (what v2 replaces)
+
+|           | v1 (today)                                     | v2 (target)                                  |
+| --------- | ---------------------------------------------- | -------------------------------------------- |
+| AI output | `tool-schemaGenerationTool` + schema snapshots | `tool-schemaOperationsTool` + `operations[]` |
+| Client    | `transformChatToCTB` → `applyChange`           | `applyCTBOperations` → `DataManager.*()`     |
+| Renames   | Lost unless guessed in `toCTB.ts`              | `editAttribute` → `recordRename`             |
+
+Keep v1 working until v2 is shipped; gate v2 behind `STRAPI_AI_CTB_V2` or similar.
+
+---
+
+## Done criteria
+
+- [ ] `CTBOperation` types in strapi-ai `@ai/types` and mirrored in Strapi
+- [ ] strapi-ai: `schemaOperationsTool`, operation validator/simulator, `POST /schemas/chat/v2`, tests
+- [ ] Strapi: `applyCTBOperations`, `OperationsProvider`, v2 URL + flag, tests
+- [ ] Live E2E rename preserves data end-to-end
+- [ ] `CTB_AI_V2/` + `CTB_RENAME_PROGRESS.md` updated with status
+
+---
+
+## Subagent launch prompts
+
+**strapi-ai subagent:**
+
+> Read `CTB_AI_V2/HANDOFF.md` and `CTB_AI_V2/AGENT-strapi-ai.md` in the strapi
+> monorepo (path to this checkout). Implement the strapi-ai v2 work on branch
+> `feat/ctb-operations-v2` in `../ai-server`.
+
+**Strapi subagent:**
+
+> Read `CTB_AI_V2/HANDOFF.md` and `CTB_AI_V2/AGENT-strapi-monorepo.md` in this
+> repo on branch `feat/ctb-rename-migration-builder`. Implement the CTB client v2
+> work.

--- a/CTB_AI_V2/AGENT-strapi-ai.md
+++ b/CTB_AI_V2/AGENT-strapi-ai.md
@@ -1,0 +1,168 @@
+# Agent brief — strapi-ai (v2 operations API)
+
+> **Repo:** `github.com/strapi/strapi-ai` (local clone often at `../ai-server` relative to strapi monorepo).  
+> **Read first:** [`HANDOFF.md`](HANDOFF.md) in strapi monorepo `CTB_AI_V2/`.  
+> **Do not** change Strapi monorepo in this workstream except documenting the contract.
+
+---
+
+## Goal
+
+Replace (or supplement) the v1 `schemaGenerationTool` snapshot flow with v2
+`schemaOperationsTool` that returns an ordered `CTBOperation[]` matching Strapi CTB
+`DataManager` public methods. Keep v1 working for backward compatibility.
+
+---
+
+## Done criteria
+
+- [ ] `CTBOperation` union + Zod schemas in `packages/ai/types/src/ctb-operations.ts`, exported from `index.ts`
+- [ ] `schemaOperationsTool` in `packages/ai/architect/src/services/chat/tools/generateOperations/`
+- [ ] `operationValidator.validate(ops, previousSchemas)` applies ops sequentially against in-memory state; reuses existing attribute/schema validators where possible
+- [ ] `POST /schemas/chat/v2` route (or `X-CTB-API-Version: 2` header on existing route — pick one, document in HANDOFF)
+- [ ] `chat-agent.ts` registers v2 tool on v2 path; v1 unchanged on `/schemas/chat`
+- [ ] Prompts teach op sequences (rename = `editAttribute`, swap = 3 hops, etc.) — new `makeCTBOperationsSystemPrompt.ts`
+- [ ] Unit tests: rename, swap, chain+new field, invalid op rejected
+- [ ] E2E test in `apps/server/src/test/e2e/` for v2 route returning valid operations stream
+- [ ] Update `@ai/types` package comment / changelog noting Strapi mirror requirement
+
+---
+
+## Where to start
+
+1. Read v1 tool: `packages/ai/architect/src/services/chat/tools/generateSchema/createSchemaGenerateTool.ts`
+2. Read v1 validation: `packages/ai/architect/src/services/chat/validation/validate-schema.ts`
+3. Read chat route: `apps/server/src/routes/schemas/chat.ts`
+4. Read agent: `packages/ai/architect/src/services/chat/chat-agent.ts`
+
+---
+
+## Implementation guide
+
+### 1. Types (`packages/ai/types`)
+
+Create `ctb-operations.ts` per contract in `HANDOFF.md`. Export:
+
+```typescript
+export type CTBOperation = …;
+export type CTBOperationsResult = { operations: CTBOperation[] };
+```
+
+Add Zod discriminated union in architect (not necessarily in types package if that
+package stays TS-only — follow existing `schemas.ts` pattern).
+
+### 2. New tool
+
+`createSchemaOperationsTool.ts`:
+
+```typescript
+tool({
+  description: 'Apply CTB admin operations (create/edit/remove schemas and fields).',
+  inputSchema: z.object({ operations: z.array(ctbOperationSchema) }),
+  execute: async ({ operations }) => {
+    const result = await operationValidator.validate(operations, context.previousSchemas ?? []);
+    if (!result.valid) return { error: result.error };
+    return { operations: result.operations };
+  },
+});
+```
+
+Tool name for AI SDK: `schemaOperationsTool` → client part type `tool-schemaOperationsTool`.
+
+### 3. Operation validator / simulator
+
+New file: `validation/validate-operations.ts`
+
+**Responsibilities:**
+
+- Maintain mutable CTB-like state (content types + components map) seeded from `previousSchemas`
+- For each op in order:
+  - Verify preconditions (field exists for `editAttribute`, no duplicate names after rename, etc.)
+  - Apply op to state (mirror reducer semantics — see Strapi `reducer.ts`)
+  - Run existing validators on affected schemas
+- Return validated ops unchanged (or expanded macros)
+
+**Rename collision rule:** CTB never allows two fields with the same name at any instant. Validator must reject or expand invalid sequences.
+
+**Optional macro (phase 2):** `swapFields` → expand to 3× `editAttribute` with generated `__ctb_swap_*` temp name.
+
+**Reuse:** `attributeTypeValidator`, `relationTargetValidator`, `filterRemovedAttributesValidator` logic — but feed through op-applied state, not snapshot merge.
+
+### 4. Route v2
+
+`apps/server/src/routes/schemas/chat-v2.ts` (or extend `chat.ts`):
+
+- Same auth/telemetry/limiting as v1
+- Request schema adds `ctbApiVersion: z.literal(2).optional().default(2)`
+- Call architect with flag to use operations tool
+- Response headers unchanged (SSE)
+
+Wire in `apps/server/src/server.ts` router mount: `/schemas/chat/v2`.
+
+### 5. Prompts
+
+- New `makeCTBOperationsSystemPrompt.ts` — replace snapshot-update examples with op examples from `HANDOFF.md`
+- `makeIntroductionSystemPrompt.ts` — v2 branch references `schemaOperationsTool` not `schemaGenerationTool`
+- Keep `makeStrapiSchemaDesignSystemPrompt.ts` for attribute type / relation rules (still valid as design reference)
+- Add explicit section: **Renames are never snapshot diffs — always `editAttribute`**
+
+### 6. Do NOT remove v1 yet
+
+- `schemaGenerationTool` stays on `/schemas/chat`
+- v2 is additive until Strapi client ships
+
+---
+
+## Test commands
+
+```bash
+# From strapi-ai repo root
+yarn install
+yarn test                    # unit
+yarn test:e2e                # if configured — check package.json scripts
+```
+
+Add tests under:
+
+- `packages/ai/architect/src/services/chat/validation/__tests__/validate-operations.test.ts`
+- `packages/ai/architect/src/services/chat/tools/generateOperations/__tests__/`
+
+---
+
+## Contract for Strapi agent (coordinate via HANDOFF.md only)
+
+Strapi client will:
+
+1. `POST /schemas/chat/v2` with `ctbApiVersion: 2`
+2. Parse `tool-schemaOperationsTool` parts
+3. Call `applyCTBOperations(operations, dataManager)` in order
+
+Your output shape:
+
+```json
+{ "operations": [ { "op": "editAttribute", … } ] }
+```
+
+No `schemas[]` in v2 tool output.
+
+---
+
+## Pitfalls
+
+- **LLM emits full schemas in v2** — prompt must forbid; validator should reject unknown shapes
+- **Bidirectional relations** — `addAttribute` on one side may require ops on target type (same as v1 atomic schema rule)
+- **`previousSchemas` in context** — still sent by Strapi as read-only context; simulator seeds from this
+- **prepareStep hook** in `chat-agent.ts` pushes v1 `schemas` from tool results — add parallel handling for operations or merge into schema state for multi-step chats
+
+---
+
+## Suggested branch name
+
+`feat/ctb-operations-v2`
+
+---
+
+## References
+
+- Strapi reducer semantics: `packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts` (in strapi monorepo)
+- v1 schema types: `packages/ai/types/src/schema.ts`

--- a/CTB_AI_V2/AGENT-strapi-monorepo.md
+++ b/CTB_AI_V2/AGENT-strapi-monorepo.md
@@ -1,0 +1,225 @@
+# Agent brief — Strapi monorepo (v2 AI client)
+
+> **Repo:** `github.com/strapi/strapi` — branch `feat/ctb-rename-migration-builder` (or child of `develop`).  
+> **Read first:** [`HANDOFF.md`](HANDOFF.md) in `CTB_AI_V2/`.  
+> **Parallel work:** strapi-ai agent implements `/schemas/chat/v2` — you implement the client against the contract in HANDOFF.
+
+---
+
+## Goal
+
+Replace the v1 AI apply path (`transformChatToCTB` → `applyChange`) with a thin
+dispatcher that calls existing `DataManager` methods for each `CTBOperation` from
+`tool-schemaOperationsTool`. Renames must flow through `editAttribute` → `recordRename`
+→ existing save / rename-migration pipeline.
+
+---
+
+## Done criteria
+
+- [ ] `CTBOperation` types mirrored at `packages/core/content-type-builder/admin/src/components/AIChat/lib/types/ctb-operations.ts` (sync with strapi-ai `@ai/types`)
+- [ ] `applyCTBOperations.ts` — maps each `op` to `DataManager` method; handles wiring quirks (see below)
+- [ ] `OperationsProvider.tsx` (or refactor `SchemaProvider.tsx`) — extracts ops from `tool-schemaOperationsTool`, calls `applyCTBOperations` in order
+- [ ] v2 URL: `STRAPI_AI_CHAT_URL` → `/schemas/chat/v2` behind feature flag or Strapi version check; v1 fallback retained
+- [ ] `Message.tsx` markers for `tool-schemaOperationsTool`
+- [ ] Unit tests: dispatcher calls correct methods; `editAttribute` rename → `renames[]` in state
+- [ ] Remove or gate v1 `toCTB` rename inference when v2 enabled (avoid double-handling)
+- [ ] `yarn test:front` for content-type-builder passes
+- [ ] Manual test plan documented (or API test if feasible with mocked stream)
+
+---
+
+## Where to start
+
+| File                                                                    | Purpose                           |
+| ----------------------------------------------------------------------- | --------------------------------- |
+| `admin/src/components/AIChat/providers/SchemaProvider.tsx`              | v1 apply — replace for v2         |
+| `admin/src/components/AIChat/lib/constants.ts`                          | AI URL                            |
+| `admin/src/components/AIChat/providers/ChatProvider.tsx`                | Sends `schemas` context body      |
+| `admin/src/components/DataManager/DataManagerContext.ts`                | Public API to call                |
+| `admin/src/components/DataManager/DataManagerProvider.tsx`              | Method wiring + confirm dialogs   |
+| `admin/src/components/DataManager/reducer.ts`                           | `recordRename` in `editAttribute` |
+| `admin/src/components/DataManager/tests/reducerRenameAttribute.test.ts` | Rename behaviour tests            |
+
+---
+
+## Implementation guide
+
+### 1. Mirror types
+
+Copy `CTBOperation` union from HANDOFF.md into `lib/types/ctb-operations.ts`.
+
+### 2. `applyCTBOperations`
+
+Location: `admin/src/components/AIChat/lib/applyCTBOperations.ts`
+
+```typescript
+export function applyCTBOperations(
+  operations: CTBOperation[],
+  dm: Pick<DataManagerContextValue /* methods listed in HANDOFF */>,
+  options?: { dispatch?: AppDispatch } // for delete bypass
+): void {
+  for (const operation of operations) {
+    switch (operation.op) {
+      case 'createSchema':
+        dm.createSchema({ uid: operation.uid, data: operation.data });
+        break;
+      case 'editAttribute':
+        dm.editAttribute({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          name: operation.name,
+          attributeToSet: operation.attributeToSet,
+        });
+        break;
+      case 'removeAttribute':
+        dm.removeAttribute({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          attributeToRemoveName: operation.attributeToRemoveName,
+        });
+        break;
+      case 'updateComponentSchema':
+        dm.updateComponentSchema({
+          componentUID: operation.uid as any,
+          data: operation.data,
+        });
+        break;
+      case 'deleteContentType':
+        // Bypass window.confirm — dispatch actions.deleteContentType directly
+        options?.dispatch(actions.deleteContentType(operation.uid as any));
+        break;
+      // … all ops from HANDOFF
+    }
+  }
+}
+```
+
+**Wiring quirks (required):**
+
+| Op                                      | Issue                                          | Fix                                                                                            |
+| --------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `deleteContentType` / `deleteComponent` | `DataManagerProvider` shows `window.confirm`   | Dispatch `actions.delete*` directly via store, or add `deleteContentTypeWithoutConfirm` for AI |
+| `updateComponentSchema`                 | Provider expects `componentUID`, op uses `uid` | Map in dispatcher                                                                              |
+| `updateComponentUid`                    | Provider expects `componentUID`                | Map in dispatcher                                                                              |
+| `removeAttribute`                       | Reducer action is `removeField`                | Call public `removeAttribute` — already mapped                                                 |
+
+### 3. OperationsProvider
+
+Refactor `SchemaProvider.tsx` or add sibling provider:
+
+```typescript
+function extractOperationsFromMessage(message: AIMessage): CTBOperation[] {
+  // part.type === 'tool-schemaOperationsTool'
+  // part.output.operations
+}
+
+useEffect(() => {
+  if (status !== 'ready') return;
+  const ops = extractOperationsFromMessage(latestAssistantMessage);
+  if (!ops.length) return;
+  applyCTBOperations(ops, dataManager, { dispatch });
+  setLastRevisedId(message.id);
+}, [messages, status]);
+```
+
+Keep v1 path when `part.type === 'tool-schemaGenerationTool'` until phase 3.
+
+### 4. URL / version flag
+
+`constants.ts`:
+
+```typescript
+export const STRAPI_AI_CHAT_URL_V2 = `${STRAPI_AI_URL}/schemas/chat/v2`;
+```
+
+`useAIFetch` / `ChatProvider` — use v2 URL when `features.ctbAiOperationsV2` or env flag.
+
+Request body: add `ctbApiVersion: 2` per HANDOFF.
+
+### 5. Message UI
+
+`Message.tsx` — add `isOperationsToolPart`, `toMarkerFromOperationsTool` showing op list.
+
+### 6. Do NOT change save / server path
+
+`saveSchema` → `cleanData` → `update-schema` → `generateRenameMigrations` stays as-is.
+Verify `renames[]` appears in state after AI ops before save.
+
+### 7. Interim `toCTB.ts` rename inference
+
+If v2 flag on, skip v1 `applyChange` entirely for that message. The client-side
+rename inference added to `toCTB.ts` is a v1 safety net — document as deprecated when v2 ships.
+
+---
+
+## Tests to add
+
+### `applyCTBOperations.test.ts`
+
+- Mock DataManager methods
+- Assert rename op calls `editAttribute` with correct `name` / `attributeToSet.name`
+- Assert delete dispatches without confirm
+
+### Integration with reducer (optional but valuable)
+
+```typescript
+// Apply ops through real reducer via dispatch
+dispatch sequence → expect state.contentTypes[uid].renames
+```
+
+Reuse patterns from `reducerRenameAttribute.test.ts`.
+
+### Run
+
+```bash
+cd packages/core/content-type-builder
+yarn test:front --testPathPattern=applyCTBOperations
+yarn test:front --testPathPattern=OperationsProvider
+yarn test:unit   # server unaffected but run if touching shared types
+```
+
+---
+
+## Manual verification (until E2E with real AI)
+
+1. Mock assistant message with `tool-schemaOperationsTool` output in devtools / test harness
+2. Confirm CTB shows field renamed (not removed+added)
+3. Save → rename migration modal shows hop
+4. Accept → migration file written
+
+---
+
+## Feature flag suggestion
+
+```typescript
+// ChatProvider or config
+const useCtbOperationsV2 = process.env.STRAPI_AI_CTB_V2 === 'true';
+```
+
+Enables parallel development before strapi-ai v2 deploys to production.
+
+---
+
+## Pitfalls
+
+- **Calling `deleteContentType` on provider** — confirm dialog blocks AI flow
+- **Op order matters** — apply sequentially, never parallelize
+- **`useEffect` deps** — avoid re-applying same message (track `lastRevisedId` / op batch id)
+- **Undo stack** — each op should be separate history entry (dispatch per op, not one bulk)
+- **Guided tour** — preserve existing `addField` tour dispatch from SchemaProvider if still relevant
+
+---
+
+## Suggested branch name
+
+`feat/ctb-ai-operations-v2-client`
+
+---
+
+## Key dependency on strapi-ai
+
+Client can be developed against **fixture operations** before strapi-ai v2 is live.
+Use examples from `HANDOFF.md` in unit tests.
+
+When strapi-ai ships, point `STRAPI_AI_CHAT_URL` to v2 and integration-test end-to-end.

--- a/CTB_AI_V2/HANDOFF.md
+++ b/CTB_AI_V2/HANDOFF.md
@@ -1,0 +1,503 @@
+# CTB AI v2 — Full Reference & Handoff
+
+> Last updated: 2026-06-22.  
+> Repos: **strapi** (`packages/core/content-type-builder/…`) + **strapi-ai** (`../ai-server`).
+
+---
+
+## TL;DR
+
+|                  | v1 (today)                                     | v2 (target)                                            |
+| ---------------- | ---------------------------------------------- | ------------------------------------------------------ |
+| AI output        | Full schema snapshots (`schemaGenerationTool`) | Ordered admin ops (`schemaOperationsTool`)             |
+| Client apply     | `transformChatToCTB` → `applyChange`           | Dispatch to `DataManager` methods 1:1                  |
+| Renames          | Lost (REMOVED + NEW) unless inferred           | `editAttribute` → `recordRename` → `renames[]`         |
+| Save / migration | Same endpoint                                  | **Unchanged** — ops populate state, save does the rest |
+
+---
+
+## Problem statement
+
+The rename-migration branch expects explicit ordered `renames: [{ oldName, newName }]`
+per updated type. The manual CTB UI gets this via `editAttribute` → `recordRename`.
+
+The AI chat path uses `applyChange`, which bulk-replaces a schema and produces
+`REMOVED` + `NEW` attributes for renames — **no `renames[]`**, so data-preserving
+migrations are not generated.
+
+Complex cases (swap `A ↔ B`, chain `B→c, A→B, new A`) cannot be recovered from
+schema snapshots alone.
+
+**Solution:** strapi-ai returns the same ordered operations the UI would dispatch.
+
+---
+
+## Architecture
+
+```
+┌─────────────────┐   operations[]    ┌─────────────────────┐   DataManager.*()   ┌──────────────┐
+│   strapi-ai     │ ──────────────► │ OperationsProvider  │ ──────────────────► │ reducer state │
+│ schemaOperations│   1:1 payload   │ (thin dispatcher)   │   literal methods   │ + renames[]  │
+│     Tool        │                 └─────────────────────┘                     └──────┬───────┘
+└─────────────────┘                                                                    │
+                                                                                       │ saveSchema()
+                                                                                       ▼
+                                                                              ┌─────────────────┐
+                                                                              │ update-schema   │
+                                                                              │ generateRename  │
+                                                                              │ Migrations      │
+                                                                              └─────────────────┘
+```
+
+**No new server-side "operations → migration" layer.** Operations → reducer state →
+existing `cleanData` → `collectRenames` → migration file.
+
+---
+
+## Frontend operation catalog
+
+Source of truth:
+
+- Public API: `packages/core/content-type-builder/admin/src/components/DataManager/DataManagerContext.ts`
+- Wiring: `…/DataManager/DataManagerProvider.tsx`
+- Reducer: `…/DataManager/reducer.ts`
+
+### Schema lifecycle
+
+| Public method           | Reducer action          | Payload                                                                                          |
+| ----------------------- | ----------------------- | ------------------------------------------------------------------------------------------------ |
+| `createSchema`          | `createSchema`          | `{ uid, data: { displayName, singularName, pluralName, kind, draftAndPublish, pluginOptions } }` |
+| `createComponentSchema` | `createComponentSchema` | `{ uid, componentCategory, data: { icon, displayName } }`                                        |
+| `updateSchema`          | `updateSchema`          | `{ uid, data: { displayName, kind, draftAndPublish, pluginOptions } }`                           |
+| `updateComponentSchema` | `updateComponentSchema` | Provider: `{ componentUID, data }` → reducer: `{ uid, data: { icon, displayName, category? } }`  |
+| `deleteContentType`     | `deleteContentType`     | `uid: string`                                                                                    |
+| `deleteComponent`       | `deleteComponent`       | `uid: string`                                                                                    |
+
+### Field / attribute
+
+| Public method              | Reducer action             | Payload                                           | Notes                                                                  |
+| -------------------------- | -------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------- |
+| `addAttribute`             | `addAttribute`             | `{ forTarget, targetUid, attributeToSet }`        | Creates bidirectional relation inverse side                            |
+| `editAttribute`            | `editAttribute`            | `{ forTarget, targetUid, name, attributeToSet }`  | **Rename:** `name` = old, `attributeToSet.name` = new → `recordRename` |
+| `removeAttribute`          | **`removeField`**          | `{ forTarget, targetUid, attributeToRemoveName }` | Public name ≠ reducer name                                             |
+| `moveAttribute`            | `moveAttribute`            | `{ forTarget, targetUid, from, to }`              | Display order only                                                     |
+| `addCustomFieldAttribute`  | `addCustomFieldAttribute`  | same as `addAttribute`                            | Phase 2                                                                |
+| `editCustomFieldAttribute` | `editCustomFieldAttribute` | same as `editAttribute`                           | No `recordRename`                                                      |
+
+### Dynamic zones
+
+| Public method                      | Reducer action                     | Payload                                                          |
+| ---------------------------------- | ---------------------------------- | ---------------------------------------------------------------- |
+| `addCreatedComponentToDynamicZone` | `addCreatedComponentToDynamicZone` | `{ forTarget, targetUid, dynamicZoneTarget, componentsToAdd[] }` |
+| `changeDynamicZoneComponents`      | `changeDynamicZoneComponents`      | `{ forTarget, targetUid, dynamicZoneTarget, newComponents[] }`   |
+| `removeComponentFromDynamicZone`   | `removeComponentFromDynamicZone`   | `{ forTarget, targetUid, dzName, componentToRemoveIndex }`       |
+
+### Component UID (unsaved only)
+
+| Public method        | Reducer action       | Payload                                                          | Notes                        |
+| -------------------- | -------------------- | ---------------------------------------------------------------- | ---------------------------- |
+| `updateComponentUid` | `updateComponentUid` | `{ componentUID, newComponentUID }` → `{ uid, newComponentUID }` | Only when `status === 'NEW'` |
+
+### NOT AI operations
+
+|                                               | Reason                                          |
+| --------------------------------------------- | ----------------------------------------------- |
+| `applyChange`                                 | v1 AI bulk path — **replace**, do not use in v2 |
+| `saveSchema`                                  | User-triggered persist                          |
+| `history.undo` / `redo` / `discardAllChanges` | Local UI                                        |
+| `init`, `reloadPlugin`                        | Bootstrap / internal                            |
+
+### v1 AI path (to retire)
+
+`SchemaProvider.tsx` → `extractSchemaChangesFromMessage` → `transformChatToCTB` →
+`applyChange`. Only understands `tool-schemaGenerationTool`.
+
+---
+
+## v2 ↔ frontend alignment
+
+Planned v2 `op` field = **public `DataManager` method name**.
+
+| v2 `op`                            | Frontend method                    | Aligned | Dispatcher notes                                        |
+| ---------------------------------- | ---------------------------------- | ------- | ------------------------------------------------------- |
+| `createSchema`                     | `createSchema`                     | ✅      |                                                         |
+| `createComponentSchema`            | `createComponentSchema`            | ✅      |                                                         |
+| `addAttribute`                     | `addAttribute`                     | ✅      |                                                         |
+| `editAttribute`                    | `editAttribute`                    | ✅      | Renames, swaps (as hop sequences)                       |
+| `removeAttribute`                  | `removeAttribute`                  | ✅      | Dispatch `actions.removeField` or call method           |
+| `updateSchema`                     | `updateSchema`                     | ✅      |                                                         |
+| `updateComponentSchema`            | `updateComponentSchema`            | ⚠️      | Map `uid` → `componentUID` for provider                 |
+| `deleteContentType`                | `deleteContentType`                | ⚠️      | **Bypass `window.confirm`** — dispatch reducer directly |
+| `deleteComponent`                  | `deleteComponent`                  | ⚠️      | **Bypass `window.confirm`**                             |
+| `changeDynamicZoneComponents`      | `changeDynamicZoneComponents`      | ✅      | Phase 1                                                 |
+| `removeComponentFromDynamicZone`   | `removeComponentFromDynamicZone`   | ✅      | Phase 1                                                 |
+| `moveAttribute`                    | `moveAttribute`                    | ✅      | Phase 2                                                 |
+| `addCreatedComponentToDynamicZone` | `addCreatedComponentToDynamicZone` | ✅      | Phase 2                                                 |
+| `addCustomFieldAttribute`          | `addCustomFieldAttribute`          | ✅      | Phase 2                                                 |
+| `editCustomFieldAttribute`         | `editCustomFieldAttribute`         | ✅      | Phase 2                                                 |
+| `updateComponentUid`               | `updateComponentUid`               | ✅      | Phase 2                                                 |
+
+### Rename behaviour (why `editAttribute` matters)
+
+From `reducer.ts` `recordRename`:
+
+- Appends `{ oldName, newName }` to `type.renames` on each `editAttribute` where
+  `attributeToSet.name !== name` and the field is not `NEW`.
+- Ordered hops are preserved verbatim (chains, swaps via temp names).
+- Serialized by `cleanData.ts` on save; consumed by server `collectRenames` in
+  `packages/core/content-type-builder/server/src/services/schema.ts`.
+
+---
+
+## Wire contract
+
+### Request (Strapi → strapi-ai)
+
+```
+POST /schemas/chat/v2
+```
+
+```typescript
+{
+  id: string;
+  messages: UIMessage[];
+  schemas?: Schema[];           // read-only context (existing v1 shape via fromCTB)
+  ctbApiVersion: 2;
+  metadata?: { lastSeenSchemas?: string[] };
+}
+```
+
+v1 `POST /schemas/chat` unchanged for older Strapi versions.
+
+### Response (streaming)
+
+AI SDK UI message stream. Assistant message contains:
+
+```
+part.type === 'tool-schemaOperationsTool'
+part.output === { operations: CTBOperation[] }
+```
+
+### `CTBOperation` union (canonical: strapi-ai `@ai/types`)
+
+```typescript
+type ForTarget = 'contentType' | 'component';
+
+type CTBOperation =
+  | {
+      op: 'createSchema';
+      uid: string;
+      data: {
+        displayName: string;
+        singularName: string;
+        pluralName: string;
+        kind: 'collectionType' | 'singleType';
+        draftAndPublish: boolean;
+        pluginOptions: Record<string, unknown>;
+      };
+    }
+  | {
+      op: 'createComponentSchema';
+      uid: string;
+      componentCategory: string;
+      data: { icon: string; displayName: string };
+    }
+  | {
+      op: 'addAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      attributeToSet: Record<string, unknown>;
+    }
+  | {
+      op: 'editAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      name: string; // current field name
+      attributeToSet: Record<string, unknown>; // includes new `name` when renaming
+    }
+  | {
+      op: 'removeAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      attributeToRemoveName: string;
+    }
+  | {
+      op: 'updateSchema';
+      uid: string;
+      data: {
+        displayName: string;
+        kind: 'collectionType' | 'singleType';
+        draftAndPublish: boolean;
+        pluginOptions: Record<string, unknown>;
+      };
+    }
+  | {
+      op: 'updateComponentSchema';
+      uid: string;
+      data: { icon: string; displayName: string; category?: string };
+    }
+  | { op: 'deleteContentType'; uid: string }
+  | { op: 'deleteComponent'; uid: string }
+  | {
+      op: 'changeDynamicZoneComponents';
+      forTarget: ForTarget;
+      targetUid: string;
+      dynamicZoneTarget: string;
+      newComponents: string[];
+    }
+  | {
+      op: 'removeComponentFromDynamicZone';
+      forTarget: ForTarget;
+      targetUid: string;
+      dzName: string;
+      componentToRemoveIndex: number;
+    }
+  // Phase 2:
+  | {
+      op: 'moveAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      from: number;
+      to: number;
+    }
+  | {
+      op: 'addCreatedComponentToDynamicZone';
+      forTarget: ForTarget;
+      targetUid: string;
+      dynamicZoneTarget: string;
+      componentsToAdd: string[];
+    }
+  | {
+      op: 'addCustomFieldAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      attributeToSet: Record<string, unknown>;
+    }
+  | {
+      op: 'editCustomFieldAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      name: string;
+      attributeToSet: Record<string, unknown>;
+    }
+  | { op: 'updateComponentUid'; uid: string; newComponentUID: string };
+
+export type CTBOperationsResult = {
+  operations: CTBOperation[];
+};
+```
+
+> `@ai/types` already notes: _"Any change in this package should also be reflected
+> in the strapi monorepo."_ Mirror at
+> `packages/core/content-type-builder/admin/src/components/AIChat/lib/types/ctbOperations.ts`.
+
+---
+
+## Worked examples
+
+### Simple rename
+
+```json
+{
+  "operations": [
+    {
+      "op": "editAttribute",
+      "forTarget": "contentType",
+      "targetUid": "api::article.article",
+      "name": "title",
+      "attributeToSet": {
+        "name": "heading",
+        "type": "string",
+        "required": true
+      }
+    }
+  ]
+}
+```
+
+Reducer produces `renames: [{ "oldName": "title", "newName": "heading" }]`.
+
+### Swap A ↔ B (three hops)
+
+```json
+{
+  "operations": [
+    {
+      "op": "editAttribute",
+      "forTarget": "contentType",
+      "targetUid": "api::x.x",
+      "name": "a",
+      "attributeToSet": { "name": "__ctb_swap_tmp", "type": "string" }
+    },
+    {
+      "op": "editAttribute",
+      "forTarget": "contentType",
+      "targetUid": "api::x.x",
+      "name": "b",
+      "attributeToSet": { "name": "a", "type": "string" }
+    },
+    {
+      "op": "editAttribute",
+      "forTarget": "contentType",
+      "targetUid": "api::x.x",
+      "name": "__ctb_swap_tmp",
+      "attributeToSet": { "name": "b", "type": "string" }
+    }
+  ]
+}
+```
+
+strapi-ai validator should generate temp names and verify collision-freedom per hop.
+Optional macro: `{ "op": "swapFields", "a": "a", "b": "b" }` expanded server-side.
+
+### Chain: B→c, A→B, new A
+
+```json
+{
+  "operations": [
+    {
+      "op": "editAttribute",
+      "forTarget": "contentType",
+      "targetUid": "api::x.x",
+      "name": "b",
+      "attributeToSet": { "name": "c", "type": "string" }
+    },
+    {
+      "op": "editAttribute",
+      "forTarget": "contentType",
+      "targetUid": "api::x.x",
+      "name": "a",
+      "attributeToSet": { "name": "b", "type": "string" }
+    },
+    {
+      "op": "addAttribute",
+      "forTarget": "contentType",
+      "targetUid": "api::x.x",
+      "attributeToSet": { "name": "a", "type": "string" }
+    }
+  ]
+}
+```
+
+### New collection type with fields
+
+```json
+{
+  "operations": [
+    {
+      "op": "createSchema",
+      "uid": "api::article.article",
+      "data": {
+        "displayName": "Article",
+        "singularName": "article",
+        "pluralName": "articles",
+        "kind": "collectionType",
+        "draftAndPublish": true,
+        "pluginOptions": { "i18n": { "localized": false } }
+      }
+    },
+    {
+      "op": "addAttribute",
+      "forTarget": "contentType",
+      "targetUid": "api::article.article",
+      "attributeToSet": { "name": "title", "type": "string", "required": true }
+    },
+    {
+      "op": "addAttribute",
+      "forTarget": "contentType",
+      "targetUid": "api::article.article",
+      "attributeToSet": {
+        "name": "slug",
+        "type": "uid",
+        "targetField": "title",
+        "required": true
+      }
+    }
+  ]
+}
+```
+
+---
+
+## strapi-ai v1 baseline (for migration)
+
+| Piece           | Location                                                                   |
+| --------------- | -------------------------------------------------------------------------- |
+| Chat route      | `apps/server/src/routes/schemas/chat.ts` → `POST /schemas/chat`            |
+| Agent           | `packages/ai/architect/src/services/chat/chat-agent.ts`                    |
+| Tool            | `…/tools/generateSchema/createSchemaGenerateTool.ts`                       |
+| Schema types    | `packages/ai/types/src/schema.ts`                                          |
+| Validation      | `…/validation/validate-schema.ts` + `validators/`                          |
+| Prompts         | `makeIntroductionSystemPrompt.ts`, `makeStrapiSchemaDesignSystemPrompt.ts` |
+| Client constant | Strapi `AIChat/lib/constants.ts` → `STRAPI_AI_CHAT_URL`                    |
+
+v1 tool name: `schemaGenerationTool`.  
+v1 client part type: `tool-schemaGenerationTool`.
+
+---
+
+## Implementation status
+
+| Item                              | strapi-ai                                                       | Strapi monorepo                                 |
+| --------------------------------- | --------------------------------------------------------------- | ----------------------------------------------- |
+| `CTBOperation` types              | ✅ `packages/ai/types/src/ctb-operations.ts` + Zod in architect | ✅ `AIChat/lib/types/ctbOperations.ts`          |
+| `applyCTBOperations` dispatcher   | —                                                               | ✅ + 9 unit tests (rename, swap, delete bypass) |
+| `schemaOperationsTool`            | ✅ `createSchemaOperationsTool.ts`                              | —                                               |
+| Operation validator / simulator   | ✅ `validate-operations.ts` + 5 tests                           | —                                               |
+| v2 route + prompts                | ✅ `POST /schemas/chat/v2` + operations prompts                 | —                                               |
+| `OperationsProvider` + dispatcher | —                                                               | ✅ behind `STRAPI_AI_CTB_V2=true`               |
+| v2 URL + version flag             | —                                                               | ✅ `STRAPI_AI_CHAT_URL_V2` + `ctbApiVersion: 2` |
+| Client inference in `toCTB.ts`    | —                                                               | ✅ Gated when v2 enabled                        |
+| E2E integration                   | ❌                                                              | ❌                                              |
+
+---
+
+## Phased rollout
+
+| Phase | strapi-ai                                      | Strapi                                            | Done when                           |
+| ----- | ---------------------------------------------- | ------------------------------------------------- | ----------------------------------- |
+| **0** | Add `@ai/types` `ctb-operations.ts` + Zod      | Mirror types; `applyCTBOperations()` + unit tests | Types compile both sides            |
+| **1** | Tool + validator + `/schemas/chat/v2`; keep v1 | `OperationsProvider` behind flag                  | Rename via AI → `renames[]` on save |
+| **2** | Swap macro; DZ ops; prompt hardening           | Enable v2 by default                              | Multi-hop + component category      |
+| **3** | Deprecate v1 prompts for new Strapi            | Remove `applyChange` AI path                      | v1 route kept for old Strapi        |
+
+---
+
+## Key file pointers
+
+### Strapi monorepo
+
+| Area                     | Path                                                               |
+| ------------------------ | ------------------------------------------------------------------ |
+| AI chat entry            | `packages/core/content-type-builder/admin/src/components/AIChat/`  |
+| v1 apply path            | `…/AIChat/providers/SchemaProvider.tsx`                            |
+| v1 transform             | `…/AIChat/lib/transforms/schemas/toCTB.ts`                         |
+| Context → schemas (read) | `…/AIChat/lib/transforms/schemas/fromCTB.ts`                       |
+| DataManager API          | `…/DataManager/DataManagerContext.ts`                              |
+| Provider wiring          | `…/DataManager/DataManagerProvider.tsx`                            |
+| Reducer + `recordRename` | `…/DataManager/reducer.ts`                                         |
+| Save serialization       | `…/DataManager/utils/cleanData.ts`                                 |
+| Rename modal             | `…/DataManager/RenameMigrationModal.tsx`                           |
+| Server rename collect    | `packages/core/content-type-builder/server/src/services/schema.ts` |
+| Migration builder        | `…/server/src/services/migration-builder/`                         |
+
+### strapi-ai
+
+| Area          | Path                                                    |
+| ------------- | ------------------------------------------------------- |
+| Chat route    | `apps/server/src/routes/schemas/chat.ts`                |
+| Agent         | `packages/ai/architect/src/services/chat/chat-agent.ts` |
+| v1 tool       | `…/tools/generateSchema/`                               |
+| v1 validation | `…/validation/validate-schema.ts`                       |
+| Shared types  | `packages/ai/types/src/`                                |
+
+---
+
+## Testing checklist (integration)
+
+1. AI: "rename title to heading on Article" → one `editAttribute` op.
+2. Apply ops in Strapi → inspect state: `renames: [{ oldName: 'title', newName: 'heading' }]`.
+3. Save (prompt mode) → migration modal lists hop → accept.
+4. Restart → column renamed, data preserved (`rename-migration.test.api.js` pattern).
+5. Swap / chain cases from examples above.
+6. v1 Strapi + v1 route still works (regression).

--- a/CTB_AI_V2/README.md
+++ b/CTB_AI_V2/README.md
@@ -1,0 +1,49 @@
+# CTB AI v2 — Operations-Based Schema Changes
+
+Handoff docs for replacing the v1 **schema snapshot** AI flow with a v2 **admin
+operations** flow. The goal: strapi-ai returns ordered CTB `DataManager`
+operations; the Strapi admin dispatches them 1:1; the existing rename-migration
+save pipeline works without extra client inference.
+
+## How to use (parallel agents)
+
+**Orchestrator (recommended):** point one agent at [`AGENT-orchestrator.md`](AGENT-orchestrator.md) — it links everything below and describes how to run both repos locally for E2E.
+
+Or open **two fresh agents** — one per repo:
+
+| Repo                | Path                                                  | Kickoff brief                                          |
+| ------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| **strapi-ai**       | `github.com/strapi/strapi-ai` (local: `../ai-server`) | [`AGENT-strapi-ai.md`](AGENT-strapi-ai.md)             |
+| **strapi monorepo** | `github.com/strapi/strapi` (this repo)                | [`AGENT-strapi-monorepo.md`](AGENT-strapi-monorepo.md) |
+
+Shared reference (all agents should read): [`HANDOFF.md`](HANDOFF.md)
+
+## Dependency between workstreams
+
+```
+Phase 0 (parallel)     Phase 1 (parallel)              Phase 2 (integrate)
+─────────────────     ─────────────────────           ───────────────────
+@ai/types ops union   strapi-ai: tool + validator     E2E: Strapi ≥X + v2 URL
+Strapi: mirror types  Strapi: OperationsProvider      Enable v2 by default
+Strapi: dispatcher    strapi-ai: v2 route + prompts   Retire v1 AI path
+```
+
+**Contract boundary:** `CTBOperation[]` in tool output (`tool-schemaOperationsTool`).
+Types are defined in strapi-ai `@ai/types` first; mirrored in Strapi until published.
+
+## Related rename-migration docs
+
+This work **complements** the rename-migration feature (already on
+`feat/ctb-rename-migration-builder`):
+
+- `CTB_RENAME_PROGRESS.md` — rename migrations status
+- `CTB_RENAME_PLAN.md` — how `renames[]` flows admin → server → migration file
+
+AI v2 fixes **how changes reach** `renames[]` (via `editAttribute` instead of
+`applyChange`).
+
+## Branch / tracking
+
+- Strapi branch: `feat/ctb-rename-migration-builder` (base `develop`) or a child branch
+- strapi-ai: branch from `main`
+- Linear: CMS-635 (related CG-979, CG-1001)

--- a/CTB_RENAME_PROGRESS.md
+++ b/CTB_RENAME_PROGRESS.md
@@ -8,9 +8,11 @@
 > - `CTB_RENAME_STEPS/` — **one kickoff brief per remaining step.** To pick up a
 >   step, open a fresh AI and point it at the single matching
 >   `CTB_RENAME_STEPS/STEP-*.md` file (start with `CTB_RENAME_STEPS/README.md`).
+> - `CTB_AI_V2/` — **AI chat v2 handoff** (operations-based API for strapi-ai +
+>   Strapi client). Start with `CTB_AI_V2/README.md`.
 >
-> Branch: `feat/ctb-rename-migration-builder` (base: `develop`).
-> Linear: CMS-635 (related: CG-979, CG-1001). PR: #26749 (draft).
+> Branch: `feat/ctb-ai-v2-operations` (base: `feat/ctb-rename-migration-builder`).
+> Linear: CMS-635 (related: CG-979, CG-1001). Rename PR: #26749.
 > Last updated: 2026-07-01.
 
 ---
@@ -31,7 +33,7 @@
 | CLI `strapi rename:field` (optional)                           | ✅ done + tested          |
 | CLI `strapi rename:component` (optional)                       | ✅ done + tested          |
 | AI chat v1 rename inference / explicit metadata                | ✅ done + tested          |
-| AI chat v2 operations API                                      | ⬜ separate draft PR      |
+| AI chat v2 operations API (strapi-ai + client)                 | 🚧 draft PR (this branch) |
 | Content-type _level_ rename                                    | ➖ N/A (immutable in CTB) |
 
 Legend: ✅ done · ⬜ missing/todo · ➖ not applicable.
@@ -186,9 +188,26 @@ schema snapshots (matching type + properties) and accepts explicit
 `renames[]` / `previousName` metadata from the AI server. Renames flow into
 `applyChange` state and the existing save → `cleanData` → migration pipeline.
 
-**Follow-up (separate draft PR):** operations-based AI v2 client
-(`feat/ctb-ai-v2-operations`) — `schemaOperationsTool`, `OperationsProvider`,
-`STRAPI_AI_CTB_V2` flag, `/schemas/chat/v2`.
+### 8. AI chat v2 — operations API (in progress, this branch)
+
+v2 replaces full-schema `applyChange` with ordered `DataManager` operations from
+strapi-ai (`schemaOperationsTool`). Gated behind `STRAPI_AI_CTB_V2`.
+
+**Handoff:** [`CTB_AI_V2/AGENT-orchestrator.md`](CTB_AI_V2/AGENT-orchestrator.md) (start here) · [`CTB_AI_V2/`](CTB_AI_V2/)
+
+**Phase 0 done (2026-06-23):**
+
+- strapi-ai `feat/ctb-operations-v2`: `CTBOperation` types + Zod schemas + tests
+- Strapi: mirrored types, `applyCTBOperations()` dispatcher + 9 unit tests
+
+**Phase 1 done (2026-06-23):**
+
+- strapi-ai `feat/ctb-operations-v2`: `schemaOperationsTool`, validator, `POST /schemas/chat/v2`, prompts; `pnpm test` green
+- Strapi: `OperationsProvider`, v2 URL/flag, Message markers, `toCTB` gated; 16 front tests green
+
+**Next:** Phase 2 (swap macro, DZ ops, enable v2 by default) + live E2E with both services running.
+
+Depends on rename migrations landing via #26749 (`feat/ctb-rename-migration-builder`).
 
 ---
 

--- a/packages/core/content-type-builder/admin/src/components/AIChat/components/Messages/Message.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/components/Messages/Message.tsx
@@ -16,6 +16,8 @@ import { AttachmentPreview } from '../Attachments/AttachmentPreview';
 
 import { Marker } from './Marker';
 
+import type { CTBOperation } from '../../lib/types/ctbOperations';
+
 const MarkdownStyles = styled(Typography)`
   max-width: 65ch;
   margin: 0 auto;
@@ -155,6 +157,126 @@ const toMarkerFromSchemaTool = (part: SchemaToolPart): MarkerContentType => {
   };
 };
 
+// ---------------------------
+// Tool: schemaOperationsTool helpers
+// ---------------------------
+
+type OperationsToolPart = {
+  type: 'tool-schemaOperationsTool';
+  input?: { operations?: CTBOperation[] };
+  output?: { operations?: CTBOperation[]; error?: unknown };
+  toolCallId?: string;
+};
+
+const isOperationsToolPart = (part: any): part is OperationsToolPart =>
+  part && typeof part === 'object' && part.type === 'tool-schemaOperationsTool';
+
+const operationMarkerStatus = (op: CTBOperation): MarkerContentType['steps'][number]['status'] => {
+  switch (op.op) {
+    case 'createSchema':
+    case 'createComponentSchema':
+    case 'addAttribute':
+    case 'addCustomFieldAttribute':
+    case 'addCreatedComponentToDynamicZone':
+      return 'create';
+    case 'removeAttribute':
+    case 'deleteContentType':
+    case 'deleteComponent':
+    case 'removeComponentFromDynamicZone':
+      return 'remove';
+    default:
+      return 'update';
+  }
+};
+
+const getOperationTargetUid = (op: CTBOperation): string | undefined => {
+  if ('targetUid' in op) return op.targetUid;
+  if ('uid' in op) return op.uid;
+  return undefined;
+};
+
+const getOperationLink = (op: CTBOperation): string | undefined => {
+  const uid = getOperationTargetUid(op);
+  if (!uid) return undefined;
+
+  if (op.op === 'createComponentSchema' || op.op === 'deleteComponent' || uid.includes('.')) {
+    const category =
+      op.op === 'createComponentSchema'
+        ? op.componentCategory
+        : op.op === 'updateComponentSchema'
+          ? op.data.category
+          : '';
+    return `/plugins/content-type-builder/component-categories/${category}/${uid}`;
+  }
+
+  return `/plugins/content-type-builder/content-types/${uid}`;
+};
+
+const formatOperationDescription = (op: CTBOperation): string => {
+  switch (op.op) {
+    case 'editAttribute': {
+      const nextName =
+        typeof op.attributeToSet.name === 'string' ? op.attributeToSet.name : undefined;
+      if (nextName && nextName !== op.name) {
+        return `Rename ${op.name} → ${nextName}`;
+      }
+      return `Edit ${op.name}`;
+    }
+    case 'addAttribute':
+      return `Add ${String(op.attributeToSet.name ?? 'field')}`;
+    case 'removeAttribute':
+      return `Remove ${op.attributeToRemoveName}`;
+    case 'createSchema':
+      return `Create ${op.data.displayName}`;
+    case 'createComponentSchema':
+      return `Create ${op.data.displayName}`;
+    case 'updateSchema':
+      return `Update ${op.data.displayName}`;
+    case 'updateComponentSchema':
+      return `Update ${op.data.displayName}`;
+    case 'deleteContentType':
+    case 'deleteComponent':
+      return `Delete ${op.uid}`;
+    default:
+      return op.op;
+  }
+};
+
+const toMarkerFromOperationsTool = (part: OperationsToolPart): MarkerContentType => {
+  const outOperations = part.output?.operations ?? [];
+  const inOperations = part.input?.operations ?? [];
+
+  const operations = (outOperations.length ? outOperations : inOperations) as CTBOperation[];
+  const numOperations = operations.length;
+
+  const state: 'loading' | 'success' | 'error' = part.output
+    ? part.output.error
+      ? 'error'
+      : 'success'
+    : 'loading';
+
+  const steps = operations.map((operation, index) => ({
+    id: `${part.toolCallId ?? 'schemaOperationsTool'}-${index}`,
+    description: formatOperationDescription(operation),
+    status: operationMarkerStatus(operation),
+    link: getOperationLink(operation),
+  }));
+
+  const title =
+    state === 'success'
+      ? `Applied ${numOperations} operation${numOperations === 1 ? '' : 's'}`
+      : state === 'error'
+        ? `Failed to apply operation${numOperations === 1 ? '' : 's'}`
+        : 'Applying operations';
+
+  return {
+    type: 'marker',
+    title,
+    state,
+    steps,
+  };
+};
+
 const MessageContent = ({
   part,
 }: {
@@ -177,6 +299,11 @@ const MessageContent = ({
 
   if (isSchemaToolPart(part)) {
     const marker = toMarkerFromSchemaTool(part);
+    return <Marker {...marker} />;
+  }
+
+  if (isOperationsToolPart(part)) {
+    const marker = toMarkerFromOperationsTool(part);
     return <Marker {...marker} />;
   }
 

--- a/packages/core/content-type-builder/admin/src/components/AIChat/hooks/useAIFetch.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/hooks/useAIFetch.ts
@@ -12,7 +12,12 @@ import { useGetAiUsageQuery } from '@strapi/admin/strapi-admin/ee';
 import { DefaultChatTransport } from 'ai';
 
 import { fetchAI, makeChatFetch, safeParseJson } from '../lib/aiClient';
-import { STRAPI_AI_CHAT_URL, STRAPI_AI_URL } from '../lib/constants';
+import {
+  STRAPI_AI_CHAT_URL,
+  STRAPI_AI_CHAT_URL_V2,
+  STRAPI_AI_URL,
+  isCtbAiOperationsV2Enabled,
+} from '../lib/constants';
 import { Attachment } from '../lib/types/attachments';
 import { Schema } from '../lib/types/schema';
 
@@ -223,7 +228,7 @@ export const useAIChat: typeof useChat = (props) => {
   return useChat({
     ...props,
     transport: new DefaultChatTransport({
-      api: STRAPI_AI_CHAT_URL,
+      api: isCtbAiOperationsV2Enabled() ? STRAPI_AI_CHAT_URL_V2 : STRAPI_AI_CHAT_URL,
       fetch: customFetch,
     }),
   });

--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/applyCTBOperations.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/applyCTBOperations.ts
@@ -1,0 +1,164 @@
+import { actions } from '../../DataManager/reducer';
+
+import type { CTBOperation } from './types/ctbOperations';
+import type { DataManagerContextValue } from '../../DataManager/DataManagerContext';
+import type { Internal } from '@strapi/types';
+
+export type ApplyCTBOperationsDataManager = Pick<
+  DataManagerContextValue,
+  | 'createSchema'
+  | 'createComponentSchema'
+  | 'addAttribute'
+  | 'editAttribute'
+  | 'removeAttribute'
+  | 'updateSchema'
+  | 'updateComponentSchema'
+  | 'deleteContentType'
+  | 'deleteComponent'
+  | 'changeDynamicZoneComponents'
+  | 'removeComponentFromDynamicZone'
+  | 'moveAttribute'
+  | 'addCreatedComponentToDynamicZone'
+  | 'addCustomFieldAttribute'
+  | 'editCustomFieldAttribute'
+  | 'updateComponentUid'
+>;
+
+type DeleteBypassAction =
+  | ReturnType<typeof actions.deleteContentType>
+  | ReturnType<typeof actions.deleteComponent>;
+
+export type ApplyCTBOperationsOptions = {
+  /**
+   * When provided, `deleteContentType` / `deleteComponent` bypass `window.confirm`
+   * by dispatching reducer actions directly (see DataManagerProvider wiring).
+   */
+  dispatch?: (action: DeleteBypassAction) => void;
+};
+
+/**
+ * Applies an ordered list of CTB AI v2 operations by calling existing DataManager
+ * methods 1:1. Operations run sequentially — order matters for renames and swaps.
+ */
+export function applyCTBOperations(
+  operations: CTBOperation[],
+  dm: ApplyCTBOperationsDataManager,
+  options?: ApplyCTBOperationsOptions
+): void {
+  for (const operation of operations) {
+    switch (operation.op) {
+      case 'createSchema':
+        dm.createSchema({ uid: operation.uid, data: operation.data });
+        break;
+      case 'createComponentSchema':
+        dm.createComponentSchema({
+          uid: operation.uid,
+          componentCategory: operation.componentCategory,
+          data: operation.data,
+        });
+        break;
+      case 'addAttribute':
+        dm.addAttribute({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          attributeToSet: operation.attributeToSet,
+        });
+        break;
+      case 'editAttribute':
+        dm.editAttribute({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          name: operation.name,
+          attributeToSet: operation.attributeToSet,
+        });
+        break;
+      case 'removeAttribute':
+        dm.removeAttribute({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          attributeToRemoveName: operation.attributeToRemoveName,
+        });
+        break;
+      case 'updateSchema':
+        dm.updateSchema({ uid: operation.uid, data: operation.data });
+        break;
+      case 'updateComponentSchema':
+        dm.updateComponentSchema({
+          componentUID: operation.uid as Internal.UID.Component,
+          data: operation.data,
+        });
+        break;
+      case 'deleteContentType':
+        if (options?.dispatch) {
+          options.dispatch(actions.deleteContentType(operation.uid as Internal.UID.ContentType));
+        } else {
+          dm.deleteContentType(operation.uid as Internal.UID.ContentType);
+        }
+        break;
+      case 'deleteComponent':
+        if (options?.dispatch) {
+          options.dispatch(actions.deleteComponent(operation.uid as Internal.UID.Component));
+        } else {
+          dm.deleteComponent(operation.uid as Internal.UID.Component);
+        }
+        break;
+      case 'changeDynamicZoneComponents':
+        dm.changeDynamicZoneComponents({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          dynamicZoneTarget: operation.dynamicZoneTarget,
+          newComponents: operation.newComponents as Internal.UID.Component[],
+        });
+        break;
+      case 'removeComponentFromDynamicZone':
+        dm.removeComponentFromDynamicZone({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          dzName: operation.dzName,
+          componentToRemoveIndex: operation.componentToRemoveIndex,
+        });
+        break;
+      case 'moveAttribute':
+        dm.moveAttribute({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          from: operation.from,
+          to: operation.to,
+        });
+        break;
+      case 'addCreatedComponentToDynamicZone':
+        dm.addCreatedComponentToDynamicZone({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          dynamicZoneTarget: operation.dynamicZoneTarget,
+          componentsToAdd: operation.componentsToAdd as Internal.UID.Component[],
+        });
+        break;
+      case 'addCustomFieldAttribute':
+        dm.addCustomFieldAttribute({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          attributeToSet: operation.attributeToSet,
+        });
+        break;
+      case 'editCustomFieldAttribute':
+        dm.editCustomFieldAttribute({
+          forTarget: operation.forTarget,
+          targetUid: operation.targetUid,
+          name: operation.name,
+          attributeToSet: operation.attributeToSet,
+        });
+        break;
+      case 'updateComponentUid':
+        dm.updateComponentUid({
+          componentUID: operation.uid as Internal.UID.Component,
+          newComponentUID: operation.newComponentUID as Internal.UID.Component,
+        });
+        break;
+      default: {
+        const _exhaustive: never = operation;
+        throw new Error(`Unknown CTB operation: ${(_exhaustive as CTBOperation).op}`);
+      }
+    }
+  }
+}

--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/constants.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/constants.ts
@@ -11,6 +11,10 @@ export const STRAPI_MAX_ATTACHMENT_SIZE = 15 * 1024 * 1024; // 15MB
 export const STRAPI_AI_URL =
   process.env.STRAPI_AI_URL?.replace(/\/+$/, '') ?? 'https://strapi-ai.apps.strapi.io';
 export const STRAPI_AI_CHAT_URL = `${STRAPI_AI_URL}/schemas/chat`;
+export const STRAPI_AI_CHAT_URL_V2 = `${STRAPI_AI_URL}/schemas/chat/v2`;
+
+/** When true, chat uses v2 operations API and applies `tool-schemaOperationsTool` output. */
+export const isCtbAiOperationsV2Enabled = () => process.env.STRAPI_AI_CTB_V2 === 'true';
 export const STRAPI_AI_TITLE_URL = `/schemas/chat/generate-title` as const;
 export const STRAPI_AI_FEEDBACK_URL = `/schemas/chat/feedback` as const;
 export const STRAPI_AI_PROJECT_URL = `/schemas/chat/attachment` as const;

--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/tests/applyCTBOperations.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/tests/applyCTBOperations.test.ts
@@ -1,0 +1,316 @@
+import { actions, reducer } from '../../../DataManager/reducer';
+import { init, initCT } from '../../../DataManager/tests/utils';
+import { applyCTBOperations } from '../applyCTBOperations';
+
+import type { ApplyCTBOperationsDataManager } from '../applyCTBOperations';
+import type { CTBOperation } from '../types/ctbOperations';
+
+const createMockDataManager = () => ({
+  createSchema: jest.fn(),
+  createComponentSchema: jest.fn(),
+  addAttribute: jest.fn(),
+  editAttribute: jest.fn(),
+  removeAttribute: jest.fn(),
+  updateSchema: jest.fn(),
+  updateComponentSchema: jest.fn(),
+  deleteContentType: jest.fn(),
+  deleteComponent: jest.fn(),
+  changeDynamicZoneComponents: jest.fn(),
+  removeComponentFromDynamicZone: jest.fn(),
+  moveAttribute: jest.fn(),
+  addCreatedComponentToDynamicZone: jest.fn(),
+  addCustomFieldAttribute: jest.fn(),
+  editCustomFieldAttribute: jest.fn(),
+  updateComponentUid: jest.fn(),
+});
+
+describe('applyCTBOperations', () => {
+  describe('dispatcher (mocked DataManager)', () => {
+    it('calls editAttribute for a simple rename', () => {
+      const dm = createMockDataManager();
+      const operations: CTBOperation[] = [
+        {
+          op: 'editAttribute',
+          forTarget: 'contentType',
+          targetUid: 'api::article.article',
+          name: 'title',
+          attributeToSet: {
+            name: 'heading',
+            type: 'string',
+            required: true,
+          },
+        },
+      ];
+
+      applyCTBOperations(operations, dm);
+
+      expect(dm.editAttribute).toHaveBeenCalledTimes(1);
+      expect(dm.editAttribute).toHaveBeenCalledWith({
+        forTarget: 'contentType',
+        targetUid: 'api::article.article',
+        name: 'title',
+        attributeToSet: {
+          name: 'heading',
+          type: 'string',
+          required: true,
+        },
+      });
+    });
+
+    it('calls editAttribute in order for a swap (three hops)', () => {
+      const dm = createMockDataManager();
+      const operations: CTBOperation[] = [
+        {
+          op: 'editAttribute',
+          forTarget: 'contentType',
+          targetUid: 'api::x.x',
+          name: 'a',
+          attributeToSet: { name: '__ctb_swap_tmp', type: 'string' },
+        },
+        {
+          op: 'editAttribute',
+          forTarget: 'contentType',
+          targetUid: 'api::x.x',
+          name: 'b',
+          attributeToSet: { name: 'a', type: 'string' },
+        },
+        {
+          op: 'editAttribute',
+          forTarget: 'contentType',
+          targetUid: 'api::x.x',
+          name: '__ctb_swap_tmp',
+          attributeToSet: { name: 'b', type: 'string' },
+        },
+      ];
+
+      applyCTBOperations(operations, dm);
+
+      expect(dm.editAttribute).toHaveBeenCalledTimes(3);
+      expect(dm.editAttribute.mock.calls).toEqual([
+        [
+          {
+            forTarget: 'contentType',
+            targetUid: 'api::x.x',
+            name: 'a',
+            attributeToSet: { name: '__ctb_swap_tmp', type: 'string' },
+          },
+        ],
+        [
+          {
+            forTarget: 'contentType',
+            targetUid: 'api::x.x',
+            name: 'b',
+            attributeToSet: { name: 'a', type: 'string' },
+          },
+        ],
+        [
+          {
+            forTarget: 'contentType',
+            targetUid: 'api::x.x',
+            name: '__ctb_swap_tmp',
+            attributeToSet: { name: 'b', type: 'string' },
+          },
+        ],
+      ]);
+    });
+
+    it('maps uid to componentUID for updateComponentSchema', () => {
+      const dm = createMockDataManager();
+
+      applyCTBOperations(
+        [
+          {
+            op: 'updateComponentSchema',
+            uid: 'default.hero',
+            data: { icon: 'star', displayName: 'Hero', category: 'sections' },
+          },
+        ],
+        dm
+      );
+
+      expect(dm.updateComponentSchema).toHaveBeenCalledWith({
+        componentUID: 'default.hero',
+        data: { icon: 'star', displayName: 'Hero', category: 'sections' },
+      });
+    });
+
+    it('maps uid to componentUID for updateComponentUid', () => {
+      const dm = createMockDataManager();
+
+      applyCTBOperations(
+        [
+          {
+            op: 'updateComponentUid',
+            uid: 'default.hero',
+            newComponentUID: 'default.hero-block',
+          },
+        ],
+        dm
+      );
+
+      expect(dm.updateComponentUid).toHaveBeenCalledWith({
+        componentUID: 'default.hero',
+        newComponentUID: 'default.hero-block',
+      });
+    });
+
+    it('dispatches deleteContentType directly when dispatch is provided (bypass confirm)', () => {
+      const dm = createMockDataManager();
+      const dispatch = jest.fn();
+
+      applyCTBOperations([{ op: 'deleteContentType', uid: 'api::article.article' }], dm, {
+        dispatch,
+      });
+
+      expect(dispatch).toHaveBeenCalledWith(actions.deleteContentType('api::article.article'));
+      expect(dm.deleteContentType).not.toHaveBeenCalled();
+    });
+
+    it('dispatches deleteComponent directly when dispatch is provided (bypass confirm)', () => {
+      const dm = createMockDataManager();
+      const dispatch = jest.fn();
+
+      applyCTBOperations([{ op: 'deleteComponent', uid: 'default.hero' }], dm, { dispatch });
+
+      expect(dispatch).toHaveBeenCalledWith(actions.deleteComponent('default.hero'));
+      expect(dm.deleteComponent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reducer integration', () => {
+    const uid = 'api::article.article';
+
+    const buildDispatchingDataManager = (dispatch: (action: unknown) => void) =>
+      ({
+        createSchema: (payload) => dispatch(actions.createSchema(payload)),
+        createComponentSchema: (payload) => dispatch(actions.createComponentSchema(payload)),
+        addAttribute: (payload) => dispatch(actions.addAttribute(payload)),
+        editAttribute: (payload) => dispatch(actions.editAttribute(payload)),
+        removeAttribute: (payload) => dispatch(actions.removeField(payload)),
+        updateSchema: (payload) => dispatch(actions.updateSchema(payload)),
+        updateComponentSchema: (payload) =>
+          dispatch(
+            actions.updateComponentSchema({ uid: payload.componentUID, data: payload.data })
+          ),
+        deleteContentType: (contentTypeUid) => dispatch(actions.deleteContentType(contentTypeUid)),
+        deleteComponent: (componentUid) => dispatch(actions.deleteComponent(componentUid)),
+        changeDynamicZoneComponents: (payload) =>
+          dispatch(actions.changeDynamicZoneComponents(payload)),
+        removeComponentFromDynamicZone: (payload) =>
+          dispatch(actions.removeComponentFromDynamicZone(payload)),
+        moveAttribute: (payload) => dispatch(actions.moveAttribute(payload)),
+        addCreatedComponentToDynamicZone: (payload) =>
+          dispatch(actions.addCreatedComponentToDynamicZone(payload)),
+        addCustomFieldAttribute: (payload) => dispatch(actions.addCustomFieldAttribute(payload)),
+        editCustomFieldAttribute: (payload) => dispatch(actions.editCustomFieldAttribute(payload)),
+        updateComponentUid: (payload) =>
+          dispatch(
+            actions.updateComponentUid({
+              uid: payload.componentUID,
+              newComponentUID: payload.newComponentUID,
+            })
+          ),
+      }) satisfies ApplyCTBOperationsDataManager;
+
+    it('produces renames[] for a simple rename via editAttribute', () => {
+      let state = init({
+        contentTypes: {
+          [uid]: initCT('article', {
+            attributes: [{ name: 'title', type: 'string', status: 'UNCHANGED' }],
+          }),
+        },
+      });
+
+      const dispatch = (action: unknown) => {
+        state = reducer(state, action as never);
+      };
+
+      applyCTBOperations(
+        [
+          {
+            op: 'editAttribute',
+            forTarget: 'contentType',
+            targetUid: uid,
+            name: 'title',
+            attributeToSet: { name: 'heading', type: 'string', required: true },
+          },
+        ],
+        buildDispatchingDataManager(dispatch)
+      );
+
+      expect(state.current.contentTypes[uid].renames).toEqual([
+        { oldName: 'title', newName: 'heading' },
+      ]);
+    });
+
+    it('records ordered rename hops for a swap sequence', () => {
+      let state = init({
+        contentTypes: {
+          [uid]: initCT('article', {
+            attributes: [
+              { name: 'a', type: 'string', status: 'UNCHANGED' },
+              { name: 'b', type: 'string', status: 'UNCHANGED' },
+            ],
+          }),
+        },
+      });
+
+      const dispatch = (action: unknown) => {
+        state = reducer(state, action as never);
+      };
+
+      applyCTBOperations(
+        [
+          {
+            op: 'editAttribute',
+            forTarget: 'contentType',
+            targetUid: uid,
+            name: 'a',
+            attributeToSet: { name: '__ctb_swap_tmp', type: 'string' },
+          },
+          {
+            op: 'editAttribute',
+            forTarget: 'contentType',
+            targetUid: uid,
+            name: 'b',
+            attributeToSet: { name: 'a', type: 'string' },
+          },
+          {
+            op: 'editAttribute',
+            forTarget: 'contentType',
+            targetUid: uid,
+            name: '__ctb_swap_tmp',
+            attributeToSet: { name: 'b', type: 'string' },
+          },
+        ],
+        buildDispatchingDataManager(dispatch)
+      );
+
+      expect(state.current.contentTypes[uid].renames).toEqual([
+        { oldName: 'a', newName: '__ctb_swap_tmp' },
+        { oldName: 'b', newName: 'a' },
+        { oldName: '__ctb_swap_tmp', newName: 'b' },
+      ]);
+    });
+
+    it('deleteContentType bypasses provider confirm via dispatch option', () => {
+      let state = init({
+        contentTypes: {
+          [uid]: initCT('article', { attributes: [] }),
+        },
+      });
+
+      const dispatch = jest.fn((action: unknown) => {
+        state = reducer(state, action as never);
+      });
+
+      const dm = createMockDataManager();
+
+      applyCTBOperations([{ op: 'deleteContentType', uid }], dm, { dispatch });
+
+      expect(dispatch).toHaveBeenCalledWith(actions.deleteContentType(uid));
+      expect(dm.deleteContentType).not.toHaveBeenCalled();
+      expect(state.current.contentTypes[uid].status).toBe('REMOVED');
+    });
+  });
+});

--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/toCTB.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/toCTB.ts
@@ -3,6 +3,7 @@ import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import pluralize from 'pluralize';
 
+import { isCtbAiOperationsV2Enabled } from '../../constants';
 import { Schema } from '../../types/schema';
 
 import type { ContentType, Component, AnyAttribute, RenameHop } from '../../../../../types';
@@ -263,6 +264,13 @@ export const transformAttributesFromChatToCTB = (
 
   const explicitRenames = [...schemaRenames, ...explicitAttributeRenames];
   const reconciled = applyExplicitRenames(processedAttributes, removedAttributes, explicitRenames);
+
+  if (isCtbAiOperationsV2Enabled()) {
+    return {
+      attributes: [...reconciled.processedAttributes, ...reconciled.removedAttributes],
+      renames: dedupeRenames(explicitRenames),
+    };
+  }
 
   const inferred = inferRenamesFromAttributeDiff(
     reconciled.processedAttributes,

--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/types/ctbOperations.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/types/ctbOperations.ts
@@ -1,0 +1,110 @@
+/**
+ * CTB AI v2 operation wire contract.
+ *
+ * Keep in sync with strapi-ai `@ai/types` — any change here should be reflected there.
+ * @see CTB_AI_V2/HANDOFF.md
+ */
+
+export type ForTarget = 'contentType' | 'component';
+
+export type CTBOperation =
+  | {
+      op: 'createSchema';
+      uid: string;
+      data: {
+        displayName: string;
+        singularName: string;
+        pluralName: string;
+        kind: 'collectionType' | 'singleType';
+        draftAndPublish: boolean;
+        pluginOptions: Record<string, unknown>;
+      };
+    }
+  | {
+      op: 'createComponentSchema';
+      uid: string;
+      componentCategory: string;
+      data: { icon: string; displayName: string };
+    }
+  | {
+      op: 'addAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      attributeToSet: Record<string, unknown>;
+    }
+  | {
+      op: 'editAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      name: string;
+      attributeToSet: Record<string, unknown>;
+    }
+  | {
+      op: 'removeAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      attributeToRemoveName: string;
+    }
+  | {
+      op: 'updateSchema';
+      uid: string;
+      data: {
+        displayName: string;
+        kind: 'collectionType' | 'singleType';
+        draftAndPublish: boolean;
+        pluginOptions: Record<string, unknown>;
+      };
+    }
+  | {
+      op: 'updateComponentSchema';
+      uid: string;
+      data: { icon: string; displayName: string; category?: string };
+    }
+  | { op: 'deleteContentType'; uid: string }
+  | { op: 'deleteComponent'; uid: string }
+  | {
+      op: 'changeDynamicZoneComponents';
+      forTarget: ForTarget;
+      targetUid: string;
+      dynamicZoneTarget: string;
+      newComponents: string[];
+    }
+  | {
+      op: 'removeComponentFromDynamicZone';
+      forTarget: ForTarget;
+      targetUid: string;
+      dzName: string;
+      componentToRemoveIndex: number;
+    }
+  | {
+      op: 'moveAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      from: number;
+      to: number;
+    }
+  | {
+      op: 'addCreatedComponentToDynamicZone';
+      forTarget: ForTarget;
+      targetUid: string;
+      dynamicZoneTarget: string;
+      componentsToAdd: string[];
+    }
+  | {
+      op: 'addCustomFieldAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      attributeToSet: Record<string, unknown>;
+    }
+  | {
+      op: 'editCustomFieldAttribute';
+      forTarget: ForTarget;
+      targetUid: string;
+      name: string;
+      attributeToSet: Record<string, unknown>;
+    }
+  | { op: 'updateComponentUid'; uid: string; newComponentUID: string };
+
+export type CTBOperationsResult = {
+  operations: CTBOperation[];
+};

--- a/packages/core/content-type-builder/admin/src/components/AIChat/providers/ChatProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/providers/ChatProvider.tsx
@@ -18,12 +18,14 @@ import { FeedbackProvider } from '../FeedbackModal';
 import { useAIChat } from '../hooks/useAIFetch';
 import { useChatTitle } from '../hooks/useChatTitle';
 import { useLastSeenSchemas } from '../hooks/useLastSeenSchemas';
+import { isCtbAiOperationsV2Enabled } from '../lib/constants';
 import { transformCTBToChat } from '../lib/transforms/schemas/fromCTB';
 import { Attachment } from '../lib/types/attachments';
 import { Schema } from '../lib/types/schema';
 import { UploadProjectToChatProvider } from '../UploadCodeModal';
 import { UploadFigmaToChatProvider } from '../UploadFigmaModal';
 
+import { OperationsChatProvider } from './OperationsProvider';
 import { SchemaChatProvider } from './SchemaProvider';
 
 interface ChatContextType extends Omit<ReturnType<typeof useChat>, 'messages'> {
@@ -116,6 +118,7 @@ export const BaseChatProvider = ({
       body: {
         ...options?.body,
         schemas,
+        ...(isCtbAiOperationsV2Enabled() ? { ctbApiVersion: 2 as const } : {}),
         metadata: {
           lastSeenSchemas: lastSeenSchemas.map((schema) => schema.uid),
         },
@@ -232,11 +235,13 @@ export const ChatProvider = ({
   return (
     <BaseChatProvider defaultOpen={defaultOpen}>
       <SchemaChatProvider>
-        <UploadProjectToChatProvider>
-          <UploadFigmaToChatProvider>
-            <FeedbackProvider>{children}</FeedbackProvider>
-          </UploadFigmaToChatProvider>
-        </UploadProjectToChatProvider>
+        <OperationsChatProvider>
+          <UploadProjectToChatProvider>
+            <UploadFigmaToChatProvider>
+              <FeedbackProvider>{children}</FeedbackProvider>
+            </UploadFigmaToChatProvider>
+          </UploadProjectToChatProvider>
+        </OperationsChatProvider>
       </SchemaChatProvider>
     </BaseChatProvider>
   );

--- a/packages/core/content-type-builder/admin/src/components/AIChat/providers/OperationsProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/providers/OperationsProvider.tsx
@@ -1,0 +1,89 @@
+import { ReactNode, useEffect, useRef } from 'react';
+
+import { GUIDED_TOUR_REQUIRED_ACTIONS, useGuidedTour } from '@strapi/admin/strapi-admin';
+import { useDispatch } from 'react-redux';
+
+import { useDataManager } from '../../DataManager/useDataManager';
+import { applyCTBOperations } from '../lib/applyCTBOperations';
+import { isCtbAiOperationsV2Enabled } from '../lib/constants';
+import { AIMessage } from '../lib/types/messages';
+
+import { useStrapiChat } from './ChatProvider';
+
+import type { CTBOperation, CTBOperationsResult } from '../lib/types/ctbOperations';
+
+export function extractOperationsFromMessage(message: AIMessage): CTBOperation[] {
+  if (message.role !== 'assistant') return [];
+
+  const operations: CTBOperation[] = [];
+
+  message.parts?.forEach((part) => {
+    if (part && typeof part === 'object' && part.type === 'tool-schemaOperationsTool') {
+      const output = part.output as (CTBOperationsResult & { error?: unknown }) | undefined;
+      if (!output || output.error || !Array.isArray(output.operations)) return;
+
+      operations.push(...output.operations);
+    }
+  });
+
+  return operations;
+}
+
+export function messageHasOperationsToolPart(message: AIMessage): boolean {
+  if (message.role !== 'assistant') return false;
+
+  return (
+    message.parts?.some(
+      (part) => part && typeof part === 'object' && part.type === 'tool-schemaOperationsTool'
+    ) ?? false
+  );
+}
+
+/**
+ * Applies CTB AI v2 `schemaOperationsTool` output by dispatching ordered operations to
+ * DataManager. Active only when `STRAPI_AI_CTB_V2=true`.
+ */
+export const OperationsChatProvider = ({ children }: { children: ReactNode }) => {
+  const { messages, status } = useStrapiChat();
+  const dataManager = useDataManager();
+  const dispatch = useDispatch();
+  const guidedTourDispatch = useGuidedTour('OperationsChatProvider', (s) => s.dispatch);
+  const guidedTourState = useGuidedTour('OperationsChatProvider', (s) => s.state);
+  const lastAppliedMessageIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isCtbAiOperationsV2Enabled()) return;
+
+    const latestMessage = messages[messages.length - 1];
+    if (!latestMessage) return;
+    if (latestMessage.role !== 'assistant') return;
+    if (status !== 'ready') return;
+    if (lastAppliedMessageIdRef.current === latestMessage.id) return;
+
+    const operations = extractOperationsFromMessage(latestMessage);
+    if (operations.length === 0) return;
+
+    const isAddFieldCompleted = guidedTourState.completedActions.includes(
+      GUIDED_TOUR_REQUIRED_ACTIONS.contentTypeBuilder.addField
+    );
+
+    if (!isAddFieldCompleted && operations.some((operation) => operation.op === 'addAttribute')) {
+      guidedTourDispatch({
+        type: 'set_completed_actions',
+        payload: [GUIDED_TOUR_REQUIRED_ACTIONS.contentTypeBuilder.addField],
+      });
+    }
+
+    applyCTBOperations(operations, dataManager, { dispatch });
+    lastAppliedMessageIdRef.current = latestMessage.id;
+  }, [
+    messages,
+    status,
+    dataManager,
+    dispatch,
+    guidedTourDispatch,
+    guidedTourState.completedActions,
+  ]);
+
+  return children;
+};

--- a/packages/core/content-type-builder/admin/src/components/AIChat/providers/SchemaProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/providers/SchemaProvider.tsx
@@ -3,11 +3,13 @@ import { createContext, useContext, ReactNode, useEffect, useState } from 'react
 import { GUIDED_TOUR_REQUIRED_ACTIONS, useGuidedTour } from '@strapi/admin/strapi-admin';
 
 import { useDataManager } from '../../DataManager/useDataManager';
+import { isCtbAiOperationsV2Enabled } from '../lib/constants';
 import { transformChatToCTB } from '../lib/transforms/schemas/toCTB';
 import { SchemaChange } from '../lib/types/annotations';
 import { AIMessage } from '../lib/types/messages';
 
 import { useStrapiChat } from './ChatProvider';
+import { messageHasOperationsToolPart } from './OperationsProvider';
 
 interface SchemaContextType {
   lastRevisedId: string | null;
@@ -60,6 +62,11 @@ export const SchemaChatProvider = ({ children }: { children: ReactNode }) => {
     if (latestMessage.role !== 'assistant') return;
     // Wait until message streaming has finished
     if (status !== 'ready') return;
+
+    // v2 operations path handles this message — avoid double apply via applyChange
+    if (isCtbAiOperationsV2Enabled() && messageHasOperationsToolPart(latestMessage)) {
+      return;
+    }
 
     // const schemaChanges = latestMessage.schemaChanges;
     const schemaChanges = extractSchemaChangesFromMessage(latestMessage);

--- a/packages/core/content-type-builder/admin/src/components/AIChat/providers/tests/operationsProvider.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/providers/tests/operationsProvider.test.ts
@@ -1,0 +1,134 @@
+import { extractOperationsFromMessage, messageHasOperationsToolPart } from '../OperationsProvider';
+
+import type { CTBOperation } from '../../lib/types/ctbOperations';
+import type { AIMessage } from '../../lib/types/messages';
+
+const renameOp: CTBOperation = {
+  op: 'editAttribute',
+  forTarget: 'contentType',
+  targetUid: 'api::article.article',
+  name: 'title',
+  attributeToSet: { name: 'heading', type: 'string', required: true },
+};
+
+const assistantMessage = (parts: AIMessage['parts']): AIMessage =>
+  ({
+    id: 'msg-1',
+    role: 'assistant',
+    parts,
+  }) as AIMessage;
+
+describe('OperationsProvider extraction', () => {
+  describe('extractOperationsFromMessage', () => {
+    it('returns empty array for user messages', () => {
+      expect(
+        extractOperationsFromMessage({
+          id: 'u1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'hello' }],
+        } as AIMessage)
+      ).toEqual([]);
+    });
+
+    it('extracts operations from a completed tool-schemaOperationsTool part', () => {
+      const message = assistantMessage([
+        { type: 'text', text: 'Renaming the field.' },
+        {
+          type: 'tool-schemaOperationsTool',
+          toolCallId: 'call-1',
+          output: { operations: [renameOp] },
+        },
+      ]);
+
+      expect(extractOperationsFromMessage(message)).toEqual([renameOp]);
+    });
+
+    it('concatenates operations from multiple tool parts in order', () => {
+      const addOp: CTBOperation = {
+        op: 'addAttribute',
+        forTarget: 'contentType',
+        targetUid: 'api::article.article',
+        attributeToSet: { name: 'slug', type: 'uid', targetField: 'heading' },
+      };
+
+      const message = assistantMessage([
+        {
+          type: 'tool-schemaOperationsTool',
+          toolCallId: 'call-1',
+          output: { operations: [renameOp] },
+        },
+        {
+          type: 'tool-schemaOperationsTool',
+          toolCallId: 'call-2',
+          output: { operations: [addOp] },
+        },
+      ]);
+
+      expect(extractOperationsFromMessage(message)).toEqual([renameOp, addOp]);
+    });
+
+    it('ignores tool parts without output, with errors, or missing operations', () => {
+      expect(
+        extractOperationsFromMessage(
+          assistantMessage([{ type: 'tool-schemaOperationsTool', toolCallId: 'call-1' }])
+        )
+      ).toEqual([]);
+
+      expect(
+        extractOperationsFromMessage(
+          assistantMessage([
+            {
+              type: 'tool-schemaOperationsTool',
+              toolCallId: 'call-1',
+              output: { error: 'validation failed', operations: [renameOp] },
+            },
+          ])
+        )
+      ).toEqual([]);
+
+      expect(
+        extractOperationsFromMessage(
+          assistantMessage([
+            {
+              type: 'tool-schemaOperationsTool',
+              toolCallId: 'call-1',
+              output: { operations: 'not-an-array' as unknown as CTBOperation[] },
+            },
+          ])
+        )
+      ).toEqual([]);
+    });
+
+    it('ignores tool-schemaGenerationTool parts', () => {
+      const message = assistantMessage([
+        {
+          type: 'tool-schemaGenerationTool',
+          output: {
+            schemas: [{ action: 'update', uid: 'api::article.article', name: 'Article' }],
+          },
+        },
+      ]);
+
+      expect(extractOperationsFromMessage(message)).toEqual([]);
+    });
+  });
+
+  describe('messageHasOperationsToolPart', () => {
+    it('detects operations tool parts even before output is available', () => {
+      const message = assistantMessage([
+        { type: 'tool-schemaOperationsTool', toolCallId: 'call-1' },
+      ]);
+
+      expect(messageHasOperationsToolPart(message)).toBe(true);
+      expect(extractOperationsFromMessage(message)).toEqual([]);
+    });
+
+    it('returns false when no operations tool part is present', () => {
+      expect(
+        messageHasOperationsToolPart(
+          assistantMessage([{ type: 'tool-schemaGenerationTool', toolCallId: 'call-1' }])
+        )
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add operations-based AI chat client: `OperationsProvider` + `applyCTBOperations` dispatch `schemaOperationsTool` output to DataManager methods 1:1.
- Gate behind `STRAPI_AI_CTB_V2=true` (uses `/schemas/chat/v2` + `ctbApiVersion: 2`).
- Includes `CTB_AI_V2/` handoff docs for strapi-ai coordination.

Stacks on #26749 (`feat/ctb-rename-migration-builder`). That PR keeps the simpler v1 full-schema rename path (`toCTB` inference + explicit `previousName`/`renames[]`); this PR adds the operations API for complex renames (swaps, chains) once strapi-ai v2 is ready.

## Test plan

- [ ] `yarn workspace @strapi/content-type-builder test:front --testPathPattern="applyCTBOperations|operationsProvider"`
- [ ] With `STRAPI_AI_CTB_V2=true`, verify `editAttribute` rename op → `renames[]` in reducer state before save
- [ ] Live E2E with strapi-ai `feat/ctb-operations-v2` branch

## Related issue(s)/PR(s)

Depends on #26749
Fixes CMS-635 (AI chat portion)