### PR TITLE
enhancement(ci): selective API and E2E tests on test-only PRs

### DIFF
--- a/.github/actions/run-api-tests/action.yml
+++ b/.github/actions/run-api-tests/action.yml
@@ -6,6 +6,12 @@ inputs:
     required: true
   runEE:
     description: 'Should run EE or CE tests'
+  scope:
+    description: 'Test scope: full (default) or selective (changed files only)'
+    default: 'full'
+  testFiles:
+    description: 'Space-separated API test file paths (selective scope only)'
+    default: ''
   jestOptions:
     description: 'Jest options'
 runs:
@@ -15,5 +21,7 @@ runs:
       env:
         DB_OPTIONS: ${{ inputs.dbOptions }}
         RUN_EE: ${{ inputs.runEE }}
+        SCOPE: ${{ inputs.scope }}
+        TEST_FILES: ${{ inputs.testFiles }}
         JEST_OPTIONS: ${{ inputs.jestOptions }}
       shell: bash

--- a/.github/actions/run-api-tests/script.sh
+++ b/.github/actions/run-api-tests/script.sh
@@ -1,5 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 ## disable EE if options not set
-if [[ -z "$RUN_EE" ]]; then
+if [[ -z "${RUN_EE:-}" ]]; then
   export STRAPI_DISABLE_EE=true
 else
   export STRAPI_DISABLE_LICENSE_PING=true
@@ -9,7 +12,18 @@ export ENV_PATH="$(pwd)/test-apps/api/.env"
 export JWT_SECRET="aSecret"
 
 opts=($DB_OPTIONS)
-jestOptions=($JEST_OPTIONS)
+
+if [[ "${SCOPE:-full}" == 'selective' && -n "${TEST_FILES:-}" ]]; then
+  jestOptions=($TEST_FILES)
+  echo "Running selective API tests: ${TEST_FILES}"
+else
+  jestOptions=($JEST_OPTIONS)
+fi
+
+if [[ "${SCOPE:-full}" == 'selective' && ${#jestOptions[@]} -eq 0 ]]; then
+  echo 'Selective API scope requested but no test files were provided.'
+  exit 1
+fi
 
 yarn run test:generate-app:no-build --appPath=test-apps/api "${opts[@]}"
 yarn run test:api --no-generate-app "${jestOptions[@]}"

--- a/.github/actions/run-cli-tests/action.yml
+++ b/.github/actions/run-cli-tests/action.yml
@@ -1,0 +1,21 @@
+name: 'Run CLI tests'
+description: 'Run CLI tests'
+inputs:
+  scope:
+    description: 'Test scope: full (default) or selective (changed files only)'
+    default: 'full'
+  testFiles:
+    description: 'Space-separated CLI test file paths (selective scope only)'
+    default: ''
+  cliDomains:
+    description: 'Space-separated CLI domain names (selective scope only)'
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - run: $GITHUB_ACTION_PATH/script.sh
+      env:
+        SCOPE: ${{ inputs.scope }}
+        TEST_FILES: ${{ inputs.testFiles }}
+        CLI_DOMAINS: ${{ inputs.cliDomains }}
+      shell: bash

--- a/.github/actions/run-cli-tests/script.sh
+++ b/.github/actions/run-cli-tests/script.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${SCOPE:-full}" == 'selective' && -n "${TEST_FILES:-}" ]]; then
+  runnerArgs=(--setup --concurrency=1)
+
+  if [[ -n "${CLI_DOMAINS:-}" ]]; then
+    for domain in $CLI_DOMAINS; do
+      runnerArgs+=(-d "$domain")
+    done
+  fi
+
+  # shellcheck disable=SC2206
+  fileArgs=($TEST_FILES)
+  echo "Running selective CLI tests: ${TEST_FILES}"
+  yarn test:cli "${runnerArgs[@]}" -- "${fileArgs[@]}"
+elif [[ "${SCOPE:-full}" == 'selective' ]]; then
+  echo 'Selective CLI scope requested but no test files were provided.'
+  exit 1
+else
+  yarn test:cli
+fi

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -3,6 +3,15 @@ description: 'Run e2e tests'
 inputs:
   runEE:
     description: 'Should run EE or CE e2e tests'
+  scope:
+    description: 'Test scope: full (default) or selective (changed files only)'
+    default: 'full'
+  testFiles:
+    description: 'Space-separated E2E spec file paths (selective scope only)'
+    default: ''
+  e2eDomains:
+    description: 'Space-separated E2E domain names (selective scope only)'
+    default: ''
   jestOptions:
     description: 'Jest options'
 runs:
@@ -11,6 +20,9 @@ runs:
     - run: $GITHUB_ACTION_PATH/script.sh
       env:
         RUN_EE: ${{ inputs.runEE }}
+        SCOPE: ${{ inputs.scope }}
+        TEST_FILES: ${{ inputs.testFiles }}
+        E2E_DOMAINS: ${{ inputs.e2eDomains }}
         JEST_OPTIONS: ${{ inputs.jestOptions }}
         STRAPI_FEATURES_UNSTABLE_PREVIEW_SIDE_EDITOR: true
       shell: bash

--- a/.github/actions/run-e2e-tests/script.sh
+++ b/.github/actions/run-e2e-tests/script.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 ## Align with `tests/utils/e2e-edition.ts`: explicit CE vs EE for the whole e2e run.
 if [[ "${RUN_EE:-}" == "true" ]]; then
   export STRAPI_E2E_EDITION=ee
@@ -7,6 +9,24 @@ else
   export STRAPI_E2E_EDITION=ce
 fi
 
-jestOptions=($JEST_OPTIONS)
+if [[ "${SCOPE:-full}" == 'selective' && -n "${TEST_FILES:-}" ]]; then
+  jestOptions=(--project=chromium)
+
+  if [[ -n "${E2E_DOMAINS:-}" ]]; then
+    for domain in $E2E_DOMAINS; do
+      jestOptions+=(-d "$domain")
+    done
+  fi
+
+  # shellcheck disable=SC2206
+  fileArgs=($TEST_FILES)
+  jestOptions+=("${fileArgs[@]}")
+  echo "Running selective E2E tests: ${TEST_FILES}"
+elif [[ "${SCOPE:-full}" == 'selective' ]]; then
+  echo 'Selective E2E scope requested but no test files were provided.'
+  exit 1
+else
+  jestOptions=($JEST_OPTIONS)
+fi
 
 yarn test:e2e --setup --concurrency=1 -- "${jestOptions[@]}"

--- a/.github/scripts/classify-ci-test-scope.sh
+++ b/.github/scripts/classify-ci-test-scope.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Classify PR diffs for selective API / E2E CI on test-only pull requests.
-# Writes api_scope, e2e_scope, and related outputs to GITHUB_OUTPUT.
+# Classify PR diffs for selective API / E2E / CLI CI on test-only pull requests.
+# Writes *_scope and test file outputs to GITHUB_OUTPUT.
 set -euo pipefail
 
 write_default_full_scope() {
@@ -11,11 +11,33 @@ write_default_full_scope() {
     echo 'e2e_scope=full'
     echo 'e2e_test_files='
     echo 'e2e_domains='
+    echo 'cli_scope=full'
+    echo 'cli_test_files='
+    echo 'cli_domains='
+  } >>"$GITHUB_OUTPUT"
+}
+
+force_full_scope() {
+  {
+    echo 'test_only=true'
+    echo 'api_scope=full'
+    echo 'api_test_files='
+    echo 'e2e_scope=full'
+    echo 'e2e_test_files='
+    echo 'e2e_domains='
+    echo 'cli_scope=full'
+    echo 'cli_test_files='
+    echo 'cli_domains='
   } >>"$GITHUB_OUTPUT"
 }
 
 if [[ "${GITHUB_EVENT_NAME:-}" != 'pull_request' ]]; then
   write_default_full_scope
+  exit 0
+fi
+
+if [[ "${FORCE_FULL_CI:-false}" == 'true' ]]; then
+  force_full_scope
   exit 0
 fi
 
@@ -68,6 +90,8 @@ fi
 api_test_files=()
 e2e_test_files=()
 e2e_domains=()
+cli_test_files=()
+cli_domains=()
 
 for file in "${changed_files[@]}"; do
   if [[ "$file" =~ ^tests/api/.+\.test\.api\.(js|ts)$ ]]; then
@@ -87,6 +111,24 @@ for file in "${changed_files[@]}"; do
     domain="${file#tests/e2e/tests/}"
     domain="${domain%%/*}"
     e2e_domains+=("$domain")
+    continue
+  fi
+
+  if [[ "$file" =~ ^tests/cli/tests/.+\.test\.cli\.(js|ts)$ ]]; then
+    cli_test_files+=("$file")
+    domain="${file#tests/cli/tests/}"
+    domain="${domain%%/*}"
+    cli_domains+=("$domain")
+    continue
+  fi
+
+  if [[ "$file" =~ ^tests/cli/tests/.+/__snapshots__/(.+)\.(snap)$ ]]; then
+    snapshot_test_file="${BASH_REMATCH[1]}"
+    cli_dir="${file%/__snapshots__/*}"
+    cli_test_files+=("${cli_dir}/${snapshot_test_file}")
+    domain="${cli_dir#tests/cli/tests/}"
+    domain="${domain%%/*}"
+    cli_domains+=("$domain")
   fi
 done
 
@@ -102,6 +144,8 @@ unique_space_list() {
 api_test_files_output="$(unique_space_list "${api_test_files[@]}")"
 e2e_test_files_output="$(unique_space_list "${e2e_test_files[@]}")"
 e2e_domains_output="$(unique_space_list "${e2e_domains[@]}")"
+cli_test_files_output="$(unique_space_list "${cli_test_files[@]}")"
+cli_domains_output="$(unique_space_list "${cli_domains[@]}")"
 
 if [[ -n "$api_test_files_output" ]]; then
   api_scope='selective'
@@ -115,6 +159,12 @@ else
   e2e_scope='full'
 fi
 
+if [[ -n "$cli_test_files_output" ]]; then
+  cli_scope='selective'
+else
+  cli_scope='full'
+fi
+
 {
   echo 'test_only=true'
   echo "api_scope=${api_scope}"
@@ -122,4 +172,7 @@ fi
   echo "e2e_scope=${e2e_scope}"
   echo "e2e_test_files=${e2e_test_files_output}"
   echo "e2e_domains=${e2e_domains_output}"
+  echo "cli_scope=${cli_scope}"
+  echo "cli_test_files=${cli_test_files_output}"
+  echo "cli_domains=${cli_domains_output}"
 } >>"$GITHUB_OUTPUT"

--- a/.github/scripts/classify-ci-test-scope.sh
+++ b/.github/scripts/classify-ci-test-scope.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Classify PR diffs for selective API / E2E CI on test-only pull requests.
+# Writes api_scope, e2e_scope, and related outputs to GITHUB_OUTPUT.
+set -euo pipefail
+
+write_default_full_scope() {
+  {
+    echo 'test_only=false'
+    echo 'api_scope=full'
+    echo 'api_test_files='
+    echo 'e2e_scope=full'
+    echo 'e2e_test_files='
+    echo 'e2e_domains='
+  } >>"$GITHUB_OUTPUT"
+}
+
+if [[ "${GITHUB_EVENT_NAME:-}" != 'pull_request' ]]; then
+  write_default_full_scope
+  exit 0
+fi
+
+BASE_SHA="${GITHUB_EVENT_PULL_REQUEST_BASE_SHA:?}"
+HEAD_SHA="${GITHUB_EVENT_PULL_REQUEST_HEAD_SHA:?}"
+
+changed_files=()
+while IFS= read -r file; do
+  [[ -n "$file" ]] && changed_files+=("$file")
+done < <(git diff --name-only --diff-filter=ACMR "${BASE_SHA}" "${HEAD_SHA}")
+
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+  write_default_full_scope
+  exit 0
+fi
+
+is_test_only_path() {
+  local file="$1"
+
+  case "$file" in
+    tests/api/* | tests/e2e/* | tests/cli/* | */__snapshots__/* | *.snap)
+      return 0
+      ;;
+  esac
+
+  if [[ "$file" =~ \.(test|spec)\.(js|ts|jsx|tsx)$ ]]; then
+    return 0
+  fi
+
+  if [[ "$file" =~ \.test\.api\.(js|ts)$ ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+test_only=true
+for file in "${changed_files[@]}"; do
+  if ! is_test_only_path "$file"; then
+    test_only=false
+    break
+  fi
+done
+
+if [[ "$test_only" != 'true' ]]; then
+  write_default_full_scope
+  exit 0
+fi
+
+api_test_files=()
+e2e_test_files=()
+e2e_domains=()
+
+for file in "${changed_files[@]}"; do
+  if [[ "$file" =~ ^tests/api/.+\.test\.api\.(js|ts)$ ]]; then
+    api_test_files+=("$file")
+    continue
+  fi
+
+  if [[ "$file" =~ ^tests/api/.+/__snapshots__/(.+)\.(snap)$ ]]; then
+    snapshot_test_file="${BASH_REMATCH[1]}"
+    api_dir="${file%/__snapshots__/*}"
+    api_test_files+=("${api_dir}/${snapshot_test_file}")
+    continue
+  fi
+
+  if [[ "$file" =~ ^tests/e2e/tests/[^/]+/.+\.spec\.ts$ ]]; then
+    e2e_test_files+=("$file")
+    domain="${file#tests/e2e/tests/}"
+    domain="${domain%%/*}"
+    e2e_domains+=("$domain")
+  fi
+done
+
+unique_space_list() {
+  if [[ $# -eq 0 ]]; then
+    echo ''
+    return
+  fi
+
+  printf '%s\n' "$@" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+}
+
+api_test_files_output="$(unique_space_list "${api_test_files[@]}")"
+e2e_test_files_output="$(unique_space_list "${e2e_test_files[@]}")"
+e2e_domains_output="$(unique_space_list "${e2e_domains[@]}")"
+
+if [[ -n "$api_test_files_output" ]]; then
+  api_scope='selective'
+else
+  api_scope='full'
+fi
+
+if [[ -n "$e2e_test_files_output" ]]; then
+  e2e_scope='selective'
+else
+  e2e_scope='full'
+fi
+
+{
+  echo 'test_only=true'
+  echo "api_scope=${api_scope}"
+  echo "api_test_files=${api_test_files_output}"
+  echo "e2e_scope=${e2e_scope}"
+  echo "e2e_test_files=${e2e_test_files_output}"
+  echo "e2e_domains=${e2e_domains_output}"
+} >>"$GITHUB_OUTPUT"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,9 @@ jobs:
       e2e_scope: ${{ steps.classify.outputs.e2e_scope }}
       e2e_test_files: ${{ steps.classify.outputs.e2e_test_files }}
       e2e_domains: ${{ steps.classify.outputs.e2e_domains }}
+      cli_scope: ${{ steps.classify.outputs.cli_scope }}
+      cli_test_files: ${{ steps.classify.outputs.cli_test_files }}
+      cli_domains: ${{ steps.classify.outputs.cli_domains }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -53,6 +56,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FORCE_FULL_CI: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full') }}
         run: bash .github/scripts/classify-ci-test-scope.sh
 
   # Always run build in case an unrecognized file change could affect it
@@ -273,7 +277,12 @@ jobs:
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: |
+          if [[ "${{ needs.conditions.outputs.e2e_scope }}" == "selective" ]]; then
+            npx playwright install --with-deps chromium
+          else
+            npx playwright install --with-deps
+          fi
       - name: Monorepo build
         uses: ./.github/actions/run-build
 
@@ -329,7 +338,12 @@ jobs:
         uses: ./.github/actions/yarn-nm-install
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: |
+          if [[ "${{ needs.conditions.outputs.e2e_scope }}" == "selective" ]]; then
+            npx playwright install --with-deps chromium
+          else
+            npx playwright install --with-deps
+          fi
 
       - name: Monorepo build
         uses: ./.github/actions/run-build
@@ -360,7 +374,9 @@ jobs:
         continue-on-error: true
 
   cli:
-    if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.cli == 'true'
+    if: >-
+      (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.cli == 'true')
+      && (needs.conditions.outputs.cli_scope == 'full' || matrix.node == 24)
     timeout-minutes: 60
     needs: [conditions, build]
     name: 'CLI Tests (node: ${{ matrix.node }})'
@@ -383,7 +399,11 @@ jobs:
         uses: ./.github/actions/run-build
 
       - name: Run CLI tests
-        run: yarn test:cli
+        uses: ./.github/actions/run-cli-tests
+        with:
+          scope: ${{ needs.conditions.outputs.cli_scope }}
+          testFiles: ${{ needs.conditions.outputs.cli_test_files }}
+          cliDomains: ${{ needs.conditions.outputs.cli_domains }}
 
   api_ce_pg:
     if: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,14 +33,27 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       global: ${{ steps.filter.outputs.global }}
       is_local: ${{ github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
+      test_only: ${{ steps.classify.outputs.test_only }}
+      api_scope: ${{ steps.classify.outputs.api_scope }}
+      api_test_files: ${{ steps.classify.outputs.api_test_files }}
+      e2e_scope: ${{ steps.classify.outputs.e2e_scope }}
+      e2e_test_files: ${{ steps.classify.outputs.e2e_test_files }}
+      e2e_domains: ${{ steps.classify.outputs.e2e_domains }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 2 # need to check out previous 2 commits to see what has changed
+          fetch-depth: 0
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: .github/filters.yaml
+      - name: Classify test-only PR scope
+        id: classify
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/scripts/classify-ci-test-scope.sh
 
   # Always run build in case an unrecognized file change could affect it
   # Build must complete before any other step that uses build, so that it gets cached here and doesn't build multiple times
@@ -240,7 +253,9 @@ jobs:
           retention-days: 1
 
   e2e_ce:
-    if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true' || needs.conditions.outputs.e2e == 'true'
+    if: >-
+      (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true' || needs.conditions.outputs.e2e == 'true')
+      && (needs.conditions.outputs.e2e_scope == 'full' || (matrix.project == 'chromium' && matrix.shard == '1/4'))
     timeout-minutes: 60
     needs: [conditions, build]
     name: '[CE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
@@ -266,6 +281,9 @@ jobs:
         uses: ./.github/actions/run-e2e-tests
         with:
           runEE: false
+          scope: ${{ needs.conditions.outputs.e2e_scope }}
+          testFiles: ${{ needs.conditions.outputs.e2e_test_files }}
+          e2eDomains: ${{ needs.conditions.outputs.e2e_domains }}
           jestOptions: '--project=${{ matrix.project }} --shard=${{ matrix.shard }}'
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -286,7 +304,9 @@ jobs:
         continue-on-error: true
 
   e2e_ee:
-    if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true' || needs.conditions.outputs.e2e == 'true'
+    if: >-
+      (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true' || needs.conditions.outputs.e2e == 'true')
+      && (needs.conditions.outputs.e2e_scope == 'full' || (matrix.project == 'chromium' && matrix.shard == '1/4'))
     timeout-minutes: 60
     needs: [conditions, build]
     name: '[EE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
@@ -317,6 +337,9 @@ jobs:
         uses: ./.github/actions/run-e2e-tests
         with:
           runEE: true
+          scope: ${{ needs.conditions.outputs.e2e_scope }}
+          testFiles: ${{ needs.conditions.outputs.e2e_test_files }}
+          e2eDomains: ${{ needs.conditions.outputs.e2e_domains }}
           jestOptions: '--project=${{ matrix.project }} --shard=${{ matrix.shard }}'
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -363,7 +386,9 @@ jobs:
         run: yarn test:cli
 
   api_ce_pg:
-    if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true'
+    if: >-
+      (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true')
+      && needs.conditions.outputs.api_scope != 'selective'
     runs-on: ubuntu-latest
     needs: [conditions, build]
     name: '[CE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
@@ -404,7 +429,9 @@ jobs:
           jestOptions: '--shard=${{ matrix.shard }}'
 
   api_ce_mysql:
-    if: needs.conditions.outputs.global == 'true' ||  needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true'
+    if: >-
+      (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true')
+      && needs.conditions.outputs.api_scope != 'selective'
     runs-on: ubuntu-latest
     needs: [conditions, build]
     name: '[CE] API Integration (mysql:latest, package: mysql2}, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
@@ -444,7 +471,9 @@ jobs:
           jestOptions: '--shard=${{ matrix.shard }}'
 
   api_ce_sqlite:
-    if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true'
+    if: >-
+      (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true')
+      && (needs.conditions.outputs.api_scope == 'full' || (matrix.node == 24 && matrix.shard == '1/4'))
     runs-on: ubuntu-latest
     needs: [conditions, build]
     name: '[CE] API Integration (sqlite, package: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
@@ -465,6 +494,8 @@ jobs:
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=sqlite --dbfile=./tmp/data.db'
+          scope: ${{ needs.conditions.outputs.api_scope }}
+          testFiles: ${{ needs.conditions.outputs.api_test_files }}
           jestOptions: '--shard=${{ matrix.shard }}'
 
   # EE
@@ -472,7 +503,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [conditions, build]
     name: '[EE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    if: (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true') && needs.conditions.outputs.is_local == 'true'
+    if: >-
+      (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true')
+      && needs.conditions.outputs.is_local == 'true'
+      && needs.conditions.outputs.api_scope != 'selective'
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
     strategy:
@@ -516,7 +550,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [conditions, build]
     name: '[EE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    if: (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true') && needs.conditions.outputs.is_local == 'true'
+    if: >-
+      (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true')
+      && needs.conditions.outputs.is_local == 'true'
+      && needs.conditions.outputs.api_scope != 'selective'
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
     strategy:
@@ -559,7 +596,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [conditions, build]
     name: '[EE] API Integration (sqlite, client: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    if: (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true') && needs.conditions.outputs.is_local == 'true'
+    if: >-
+      (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true')
+      && needs.conditions.outputs.is_local == 'true'
+      && (needs.conditions.outputs.api_scope == 'full' || (matrix.node == 24 && matrix.shard == '1/4'))
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
     strategy:
@@ -580,6 +620,8 @@ jobs:
         with:
           dbOptions: '--dbclient=sqlite --dbfile=./tmp/data.db'
           runEE: true
+          scope: ${{ needs.conditions.outputs.api_scope }}
+          testFiles: ${{ needs.conditions.outputs.api_test_files }}
           jestOptions: '--shard=${{ matrix.shard }}'
   sonarqube:
     name: SonarQube Analysis


### PR DESCRIPTION
## Summary

- Adds a `classify-ci-test-scope.sh` step to the existing `conditions` job that detects **test-only pull requests** (all changed files are tests, snapshots, or test fixtures under `tests/api`, `tests/e2e`, or `tests/cli`).
- Extends `run-api-tests`, `run-e2e-tests`, and `run-cli-tests` composite actions with `scope` (`full` | `selective`) and `testFiles` inputs.
- When selective:
  - **API**: skips postgres/mysql and EE DB matrices; runs only **SQLite + Node 24** with the changed `*.test.api.*` files (snapshot-only changes map back to their parent test file).
  - **E2E**: collapses to **chromium only** (single shard slot), installs **Chromium only** via Playwright, and runs only changed `*.spec.ts` files in their affected domains.
  - **CLI**: collapses to **Node 24** and runs only changed `*.test.cli.*` files in their affected domains.
- Add the **`ci:full` label** to any test-only PR to opt out of selective mode and run the full API/E2E/CLI matrices.
- Path filters (`filters.yaml`) are unchanged — jobs still trigger the same way; only the runner scope and matrix collapse differ on test-only PRs.
- Pushes to `develop`/`main` and mixed PRs (test + production code) always use **full** scope.

## Test plan

- [ ] Open a draft PR that changes only a single `tests/api/**/*.test.api.*` file → verify only `[CE] API Integration (sqlite, node: 24, shard: 1/4)` runs and executes that file.
- [ ] Open a PR that changes only a `tests/e2e/tests/**/**.spec.ts` file → verify only one `[CE] e2e (browser: chromium) (shard: 1/4)` job runs with that spec (Chromium install only).
- [ ] Open a PR that changes only a `tests/cli/**/*.test.cli.*` file → verify only `CLI Tests (node: 24)` runs with that file.
- [ ] Add `ci:full` label to a test-only PR → verify full API/E2E/CLI matrices run.
- [ ] Open a PR that changes a test file **and** a production file → verify full API/E2E/CLI matrices still run.
- [ ] Push to `develop` → verify full matrices run (no selective collapse).
- [ ] Update only an API snapshot under `__snapshots__/` → verify the parent `.test.api.*` file is selected.