### PR TITLE
fix: template checker strictness

### DIFF
--- a/.github/workflows/template-check-on-new-issue.yaml
+++ b/.github/workflows/template-check-on-new-issue.yaml
@@ -108,12 +108,14 @@ jobs:
               // Clean up the content
               content = content.trim();
               
-              // Check if content is empty or just placeholder text
-              if (!content || 
-                  content === 'No response' || 
+              // Check if content is empty or just placeholder text.
+              // Note: don't reject on length — valid version values can be
+              // short (e.g. Node "24", Package Manager "4").
+              if (!content ||
+                  content === '_No response_' ||
+                  content === 'No response' ||
                   content === 'N/A' ||
-                  content === 'None' ||
-                  content.length < 3) {
+                  content === 'None') {
                 missingItems.push(field.label);
               }
             }


### PR DESCRIPTION
### What does it do?

Lowers the strictness of the template checker
- Removed the content.length < 3 check
- Added _No response_ (with underscores) to the placeholder list

### Why is it needed?
Valid templates were being labelled as invalid

### How to test it?

Merge it and wait and see?
