### PR TITLE
fix(content-manager): refraining from counting error draft relations …

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -793,7 +793,7 @@ const PublishAction: DocumentActionComponent = ({
   }, [components, formValues, model, schema]);
 
   const fetchDraftRelationsCount = React.useCallback(async () => {
-    if (!document?.documentId || isListView) {
+    if (!document?.documentId || isListView || !schema?.options?.draftAndPublish) {
       return;
     }
 
@@ -825,6 +825,7 @@ const PublishAction: DocumentActionComponent = ({
     documentId,
     isListView,
     model,
+    schema?.options?.draftAndPublish,
   ]);
 
   React.useEffect(() => {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/tests/DocumentActions.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/tests/DocumentActions.test.tsx
@@ -8,6 +8,9 @@ const mockUpdateParent = jest.fn();
 const mockDispatch = jest.fn();
 const mockCountDraftRelations = jest.fn();
 let parentInitialFormValues: Record<string, unknown> | undefined;
+let currentDocumentSchema: { options: { draftAndPublish: boolean } } = {
+  options: { draftAndPublish: true },
+};
 let relationModalState = {
   isModalOpen: true,
   fieldToConnect: 'relation',
@@ -63,7 +66,7 @@ jest.mock('../../../../hooks/useDocument', () => ({
 }));
 jest.mock('../../../../hooks/useDocumentContext', () => ({
   useDocumentContext: () => ({
-    currentDocument: { schema: { options: { draftAndPublish: true } }, components: {} },
+    currentDocument: { schema: currentDocumentSchema, components: {} },
     currentDocumentMeta: {
       documentId: undefined,
       model: 'api::child.child',
@@ -243,6 +246,36 @@ describe('relation parent updates', () => {
         disconnect: [],
       },
     });
+  });
+});
+
+describe('draft relations count fetching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCountDraftRelations.mockResolvedValue({
+      data: { unpublishedRelations: 0, draftM2mLinks: 0 },
+      error: undefined,
+    });
+  });
+
+  afterEach(() => {
+    currentDocumentSchema = { options: { draftAndPublish: true } };
+  });
+
+  it('fetches the draft relations count for a Draft & Publish content type', async () => {
+    currentDocumentSchema = { options: { draftAndPublish: true } };
+
+    render(<ActionHarness Action={PublishAction} label="Publish child" />);
+
+    await waitFor(() => expect(mockCountDraftRelations).toHaveBeenCalled());
+  });
+
+  it('does not fetch the draft relations count for a non Draft & Publish content type', async () => {
+    currentDocumentSchema = { options: { draftAndPublish: false } };
+
+    render(<ActionHarness Action={PublishAction} label="Publish child" />);
+
+    expect(mockCountDraftRelations).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/content-manager/server/src/controllers/__tests__/countDraftRelations.test.ts
+++ b/packages/core/content-manager/server/src/controllers/__tests__/countDraftRelations.test.ts
@@ -9,6 +9,7 @@ const createMocks = (overrides: Record<string, any> = {}) => {
   const buildPopulate = jest.fn().mockResolvedValue({ createdBy: true });
 
   const findOne = jest.fn().mockResolvedValue({ id: 1, createdBy: { id: 1 } });
+  const exists = jest.fn().mockResolvedValue(true);
   const countDraftRelations = jest.fn().mockResolvedValue({
     unpublishedRelations: 3,
     draftM2mLinks: 0,
@@ -22,6 +23,7 @@ const createMocks = (overrides: Record<string, any> = {}) => {
     populateFromQuery,
     buildPopulate,
     findOne,
+    exists,
     countDraftRelations,
     sanitizedQueryRead,
     cannotRead,
@@ -52,6 +54,7 @@ const setupStrapi = (mocks: ReturnType<typeof createMocks>) => {
           }),
           'document-manager': {
             findOne: mocks.findOne,
+            exists: mocks.exists,
             countDraftRelations: mocks.countDraftRelations,
           },
         },
@@ -118,14 +121,32 @@ describe('countDraftRelations', () => {
     expect(mocks.findOne).not.toHaveBeenCalled();
   });
 
-  it('returns 404 when the entity does not exist', async () => {
-    const mocks = createMocks({ findOne: jest.fn().mockResolvedValue(null) });
+  it('returns 404 when the document does not exist at all', async () => {
+    const mocks = createMocks({
+      findOne: jest.fn().mockResolvedValue(null),
+      exists: jest.fn().mockResolvedValue(false),
+    });
     setupStrapi(mocks);
 
     const ctx = createCtx();
     await controller.countDraftRelations(ctx);
 
     expect(ctx.status).toBe(404);
+    expect(mocks.countDraftRelations).not.toHaveBeenCalled();
+  });
+
+  it('returns zero counts when the document exists but not in the requested locale', async () => {
+    const mocks = createMocks({
+      findOne: jest.fn().mockResolvedValue(null),
+      exists: jest.fn().mockResolvedValue(true),
+    });
+    setupStrapi(mocks);
+
+    const ctx = createCtx();
+    const res = await controller.countDraftRelations(ctx);
+
+    expect(ctx.notFound).not.toHaveBeenCalled();
+    expect(res.data).toEqual({ unpublishedRelations: 0, draftM2mLinks: 0 });
     expect(mocks.countDraftRelations).not.toHaveBeenCalled();
   });
 

--- a/packages/core/content-manager/server/src/controllers/__tests__/countDraftRelations.test.ts
+++ b/packages/core/content-manager/server/src/controllers/__tests__/countDraftRelations.test.ts
@@ -9,6 +9,7 @@ const createMocks = (overrides: Record<string, any> = {}) => {
   const buildPopulate = jest.fn().mockResolvedValue({ createdBy: true });
 
   const findOne = jest.fn().mockResolvedValue({ id: 1, createdBy: { id: 1 } });
+  const findLocales = jest.fn().mockResolvedValue([]);
   const countDraftRelations = jest.fn().mockResolvedValue({
     unpublishedRelations: 3,
     draftM2mLinks: 0,
@@ -22,6 +23,7 @@ const createMocks = (overrides: Record<string, any> = {}) => {
     populateFromQuery,
     buildPopulate,
     findOne,
+    findLocales,
     countDraftRelations,
     sanitizedQueryRead,
     cannotRead,
@@ -52,6 +54,7 @@ const setupStrapi = (mocks: ReturnType<typeof createMocks>) => {
           }),
           'document-manager': {
             findOne: mocks.findOne,
+            findLocales: mocks.findLocales,
             countDraftRelations: mocks.countDraftRelations,
           },
         },
@@ -119,7 +122,10 @@ describe('countDraftRelations', () => {
   });
 
   it('returns 404 when the document does not exist at all', async () => {
-    const mocks = createMocks({ findOne: jest.fn().mockResolvedValue(null) });
+    const mocks = createMocks({
+      findOne: jest.fn().mockResolvedValue(null),
+      findLocales: jest.fn().mockResolvedValue([]),
+    });
     setupStrapi(mocks);
 
     const ctx = createCtx();
@@ -131,10 +137,8 @@ describe('countDraftRelations', () => {
 
   it('returns zero counts when the document exists but not in the requested locale', async () => {
     const mocks = createMocks({
-      findOne: jest
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValue({ id: 1, createdBy: { id: 1 } }),
+      findOne: jest.fn().mockResolvedValue(null),
+      findLocales: jest.fn().mockResolvedValue([{ id: 1, createdBy: { id: 1 } }]),
     });
     setupStrapi(mocks);
 
@@ -148,10 +152,8 @@ describe('countDraftRelations', () => {
 
   it('returns 403 when the requested locale is missing and entity-level RBAC denies the document', async () => {
     const mocks = createMocks({
-      findOne: jest
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValue({ id: 1, createdBy: { id: 2 } }),
+      findOne: jest.fn().mockResolvedValue(null),
+      findLocales: jest.fn().mockResolvedValue([{ id: 1, createdBy: { id: 2 } }]),
       cannotRead: jest.fn().mockImplementation((entity) => entity !== undefined),
     });
     setupStrapi(mocks);

--- a/packages/core/content-manager/server/src/controllers/__tests__/countDraftRelations.test.ts
+++ b/packages/core/content-manager/server/src/controllers/__tests__/countDraftRelations.test.ts
@@ -9,7 +9,6 @@ const createMocks = (overrides: Record<string, any> = {}) => {
   const buildPopulate = jest.fn().mockResolvedValue({ createdBy: true });
 
   const findOne = jest.fn().mockResolvedValue({ id: 1, createdBy: { id: 1 } });
-  const exists = jest.fn().mockResolvedValue(true);
   const countDraftRelations = jest.fn().mockResolvedValue({
     unpublishedRelations: 3,
     draftM2mLinks: 0,
@@ -23,7 +22,6 @@ const createMocks = (overrides: Record<string, any> = {}) => {
     populateFromQuery,
     buildPopulate,
     findOne,
-    exists,
     countDraftRelations,
     sanitizedQueryRead,
     cannotRead,
@@ -54,7 +52,6 @@ const setupStrapi = (mocks: ReturnType<typeof createMocks>) => {
           }),
           'document-manager': {
             findOne: mocks.findOne,
-            exists: mocks.exists,
             countDraftRelations: mocks.countDraftRelations,
           },
         },
@@ -122,10 +119,7 @@ describe('countDraftRelations', () => {
   });
 
   it('returns 404 when the document does not exist at all', async () => {
-    const mocks = createMocks({
-      findOne: jest.fn().mockResolvedValue(null),
-      exists: jest.fn().mockResolvedValue(false),
-    });
+    const mocks = createMocks({ findOne: jest.fn().mockResolvedValue(null) });
     setupStrapi(mocks);
 
     const ctx = createCtx();
@@ -137,8 +131,10 @@ describe('countDraftRelations', () => {
 
   it('returns zero counts when the document exists but not in the requested locale', async () => {
     const mocks = createMocks({
-      findOne: jest.fn().mockResolvedValue(null),
-      exists: jest.fn().mockResolvedValue(true),
+      findOne: jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue({ id: 1, createdBy: { id: 1 } }),
     });
     setupStrapi(mocks);
 
@@ -147,6 +143,23 @@ describe('countDraftRelations', () => {
 
     expect(ctx.notFound).not.toHaveBeenCalled();
     expect(res.data).toEqual({ unpublishedRelations: 0, draftM2mLinks: 0 });
+    expect(mocks.countDraftRelations).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the requested locale is missing and entity-level RBAC denies the document', async () => {
+    const mocks = createMocks({
+      findOne: jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue({ id: 1, createdBy: { id: 2 } }),
+      cannotRead: jest.fn().mockImplementation((entity) => entity !== undefined),
+    });
+    setupStrapi(mocks);
+
+    const ctx = createCtx();
+    await controller.countDraftRelations(ctx);
+
+    expect(ctx.status).toBe(403);
     expect(mocks.countDraftRelations).not.toHaveBeenCalled();
   });
 

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -1022,6 +1022,10 @@ export default {
       });
 
       if (!entity) {
+        if (await documentManager.exists(model, id)) {
+          return { data: { unpublishedRelations: 0, draftM2mLinks: 0 } };
+        }
+
         return ctx.notFound();
       }
 

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -1023,13 +1023,19 @@ export default {
       });
 
       if (!entity) {
-        const entityInAnyLocale = await documentManager.findOne(id, model, { populate });
+        // The document may simply not have a version in the requested locale yet.
+        // Check every existing locale/status version before deciding it truly doesn't exist —
+        // findLocales returns one row per locale AND per publication state.
+        const versions = await documentManager.findLocales(id, model, { populate });
 
-        if (!entityInAnyLocale) {
+        if (versions.length === 0) {
           return ctx.notFound();
         }
 
-        if (permissionChecker.cannot.read(entityInAnyLocale)) {
+        if (
+          permissionChecker.requiresEntity.read() &&
+          versions.every((version) => permissionChecker.cannot.read(version))
+        ) {
           return ctx.forbidden();
         }
 

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -17,6 +17,7 @@ import { getDocumentLocaleAndStatus } from './validation/dimensions';
 import { formatDocumentWithMetadata } from './utils/metadata';
 import { indexByDocumentId } from './utils/document-status';
 import { getPopulateForLocalizations, buildDeepPopulate } from '../services/utils/populate';
+import { EMPTY_DRAFT_RELATION_COUNTS } from '../services/utils/draft-relations';
 
 /**
  * Returns documentIds for (documentId, locale) that have both draft and published,
@@ -1022,11 +1023,17 @@ export default {
       });
 
       if (!entity) {
-        if (await documentManager.exists(model, id)) {
-          return { data: { unpublishedRelations: 0, draftM2mLinks: 0 } };
+        const entityInAnyLocale = await documentManager.findOne(id, model, { populate });
+
+        if (!entityInAnyLocale) {
+          return ctx.notFound();
         }
 
-        return ctx.notFound();
+        if (permissionChecker.cannot.read(entityInAnyLocale)) {
+          return ctx.forbidden();
+        }
+
+        return { data: EMPTY_DRAFT_RELATION_COUNTS };
       }
 
       if (permissionChecker.cannot.read(entity)) {

--- a/packages/core/content-manager/server/src/controllers/single-types.ts
+++ b/packages/core/content-manager/server/src/controllers/single-types.ts
@@ -336,7 +336,7 @@ export default {
 
     const document = await findDocument({}, model, { locale });
     if (!document) {
-      return ctx.notFound();
+      return { data: { unpublishedRelations: 0, draftM2mLinks: 0 } };
     }
 
     if (permissionChecker.cannot.read(document)) {

--- a/packages/core/content-manager/server/src/controllers/single-types.ts
+++ b/packages/core/content-manager/server/src/controllers/single-types.ts
@@ -329,22 +329,27 @@ export default {
     const documentManager = getService('document-manager');
     const permissionChecker = getService('permission-checker').create({ userAbility, model });
 
-    const { locale } = await getDocumentLocaleAndStatus(query, model);
-
     if (permissionChecker.cannot.read()) {
       return ctx.forbidden();
     }
 
-    const document = await findDocument({}, model, { locale });
+    const permissionQuery = await permissionChecker.sanitizedQuery.read(query);
+    const { locale } = await getDocumentLocaleAndStatus(query, model);
+
+    const document = await findDocument(permissionQuery, model, { locale });
 
     if (!document) {
-      const documentInAnyLocale = await findDocument({}, model);
+      // The single type may simply not have a version in the requested locale yet.
+      // Check every existing locale/status version — findLocales returns one row
+      // per locale AND per publication state — before deciding it truly doesn't exist.
+      const populate = await buildPopulateFromQuery(permissionQuery, model);
+      const versions = await documentManager.findLocales(undefined, model, { populate });
 
-      if (!documentInAnyLocale) {
+      if (versions.length === 0) {
         return ctx.notFound();
       }
 
-      if (permissionChecker.cannot.read(documentInAnyLocale)) {
+      if (versions.every((version) => permissionChecker.cannot.read(version))) {
         return ctx.forbidden();
       }
 

--- a/packages/core/content-manager/server/src/controllers/single-types.ts
+++ b/packages/core/content-manager/server/src/controllers/single-types.ts
@@ -5,6 +5,7 @@ import { getDocumentLocaleAndStatus } from './validation/dimensions';
 import { getService } from '../utils';
 import { formatDocumentWithMetadata } from './utils/metadata';
 import { getPopulateForLocalizations } from '../services/utils/populate';
+import { EMPTY_DRAFT_RELATION_COUNTS } from '../services/utils/draft-relations';
 
 type OptionsWithPopulate = Modules.Documents.Params.Pick<UID.ContentType, 'populate:object'>;
 
@@ -335,8 +336,19 @@ export default {
     }
 
     const document = await findDocument({}, model, { locale });
+
     if (!document) {
-      return { data: { unpublishedRelations: 0, draftM2mLinks: 0 } };
+      const documentInAnyLocale = await findDocument({}, model);
+
+      if (!documentInAnyLocale) {
+        return ctx.notFound();
+      }
+
+      if (permissionChecker.cannot.read(documentInAnyLocale)) {
+        return ctx.forbidden();
+      }
+
+      return { data: EMPTY_DRAFT_RELATION_COUNTS };
     }
 
     if (permissionChecker.cannot.read(document)) {

--- a/packages/core/content-manager/server/src/services/document-manager.ts
+++ b/packages/core/content-manager/server/src/services/document-manager.ts
@@ -1,6 +1,6 @@
 import { omit, pipe } from 'lodash/fp';
 
-import { contentTypes, errors, pagination } from '@strapi/utils';
+import { contentTypes, pagination } from '@strapi/utils';
 import type { Core, Modules, UID } from '@strapi/types';
 
 import { buildDeepPopulate, getDeepPopulate, getDeepPopulateDraftCount } from './utils/populate';
@@ -10,7 +10,6 @@ type DocService = Modules.Documents.ServiceInstance;
 type DocServiceParams<TAction extends keyof DocService> = Parameters<DocService[TAction]>[0];
 export type Document = Modules.Documents.Result<UID.ContentType>;
 
-const { ApplicationError } = errors;
 const { PUBLISHED_AT_ATTRIBUTE } = contentTypes.constants;
 
 const omitPublishedAtField = omit(PUBLISHED_AT_ATTRIBUTE);
@@ -249,9 +248,7 @@ const documentManager = ({ strapi }: { strapi: Core.Strapi }) => {
 
       const document = await strapi.documents(uid).findOne({ documentId: id, populate, locale });
       if (!document) {
-        throw new ApplicationError(
-          `Unable to count draft relations, document with id ${id} and locale ${locale} not found`
-        );
+        return { unpublishedRelations: 0, draftM2mLinks: 0 };
       }
 
       return sumDraftCounts(strapi, document, uid);

--- a/packages/core/content-manager/server/src/services/document-manager.ts
+++ b/packages/core/content-manager/server/src/services/document-manager.ts
@@ -4,6 +4,7 @@ import { contentTypes, pagination } from '@strapi/utils';
 import type { Core, Modules, UID } from '@strapi/types';
 
 import { buildDeepPopulate, getDeepPopulate, getDeepPopulateDraftCount } from './utils/populate';
+import { EMPTY_DRAFT_RELATION_COUNTS } from './utils/draft-relations';
 import { sumDraftCounts } from './utils/draft';
 
 type DocService = Modules.Documents.ServiceInstance;
@@ -243,12 +244,12 @@ const documentManager = ({ strapi }: { strapi: Core.Strapi }) => {
       const { populate, hasRelations } = getDeepPopulateDraftCount(uid);
 
       if (!hasRelations) {
-        return { unpublishedRelations: 0, draftM2mLinks: 0 };
+        return EMPTY_DRAFT_RELATION_COUNTS;
       }
 
       const document = await strapi.documents(uid).findOne({ documentId: id, populate, locale });
       if (!document) {
-        return { unpublishedRelations: 0, draftM2mLinks: 0 };
+        return EMPTY_DRAFT_RELATION_COUNTS;
       }
 
       return sumDraftCounts(strapi, document, uid);

--- a/tests/api/core/content-manager/api/draft-relations-non-dp-i18n.test.api.js
+++ b/tests/api/core/content-manager/api/draft-relations-non-dp-i18n.test.api.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createTestBuilder } = require('api-tests/builder');
+const { createAuthRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+
+const UID_PAGE = 'api::page.page';
+const UID_MENU = 'api::menu.menu';
+
+const nonDefaultLocale = 'fr';
+
+// Page: Draft & Publish + i18n (issue #26897)
+const pageModel = {
+  displayName: 'Page',
+  singularName: 'page',
+  pluralName: 'pages',
+  draftAndPublish: true,
+  pluginOptions: {
+    i18n: { localized: true },
+  },
+  attributes: {
+    title: {
+      type: 'string',
+      pluginOptions: { i18n: { localized: true } },
+    },
+  },
+};
+
+// Menu: NO Draft & Publish + i18n, one-way relation to Page (issue #26897)
+const menuModel = {
+  displayName: 'Menu',
+  singularName: 'menu',
+  pluralName: 'menus',
+  draftAndPublish: false,
+  pluginOptions: {
+    i18n: { localized: true },
+  },
+  attributes: {
+    page: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: UID_PAGE,
+    },
+  },
+};
+
+describe('CM API - countDraftRelations on a non-D&P i18n content type (issue #26897)', () => {
+  beforeAll(async () => {
+    await builder.addContentTypes([pageModel, menuModel]).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    await rq({
+      method: 'POST',
+      url: '/i18n/locales',
+      body: {
+        code: nonDefaultLocale,
+        name: `French (${nonDefaultLocale})`,
+        isDefault: false,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await strapi.db.query('plugin::i18n.locale').deleteMany({ code: { $ne: 'en' } });
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('does not error when counting draft relations in a non-default locale', async () => {
+    // 1. Page in default locale (en)
+    const {
+      body: { data: pageEn },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${UID_PAGE}`,
+      body: { title: 'Home' },
+    });
+
+    // 2. Page localized to fr
+    await rq({
+      method: 'PUT',
+      url: `/content-manager/collection-types/${UID_PAGE}/${pageEn.documentId}`,
+      qs: { locale: nonDefaultLocale },
+      body: { title: 'Accueil' },
+    });
+
+    // 3. Menu in default locale (en) with the page relation
+    const {
+      body: { data: menuEn },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${UID_MENU}`,
+      body: { page: pageEn.documentId },
+    });
+
+    // 4. Localize the menu to fr, also filling the page relation
+    const localizeRes = await rq({
+      method: 'PUT',
+      url: `/content-manager/collection-types/${UID_MENU}/${menuEn.documentId}`,
+      qs: { locale: nonDefaultLocale },
+      body: { page: pageEn.documentId },
+    });
+    expect(localizeRes.statusCode).toBe(200);
+
+    // 5. Count draft relations in the non-default locale -> must not 500
+    const countRes = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${UID_MENU}/${menuEn.documentId}/actions/countDraftRelations`,
+      qs: { locale: nonDefaultLocale },
+    });
+
+    expect(countRes.statusCode).toBe(200);
+  });
+
+  test('does not 500 when the requested locale has not been created yet', async () => {
+    // Menu exists only in the default locale (en)
+    const {
+      body: { data: menuEn },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${UID_MENU}`,
+      body: {},
+    });
+
+    // Switching to a locale that does not exist yet still triggers a count
+    const countRes = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${UID_MENU}/${menuEn.documentId}/actions/countDraftRelations`,
+      qs: { locale: nonDefaultLocale },
+    });
+
+    expect(countRes.statusCode).toBe(200);
+    expect(countRes.body.data).toMatchObject({ unpublishedRelations: 0, draftM2mLinks: 0 });
+  });
+
+  test('still returns a 404 when the document does not exist at all', async () => {
+    const countRes = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${UID_MENU}/does-not-exist/actions/countDraftRelations`,
+      qs: { locale: nonDefaultLocale },
+    });
+
+    expect(countRes.statusCode).toBe(404);
+  });
+});

--- a/tests/api/core/content-manager/api/draft-relations-non-dp-i18n.test.api.ts
+++ b/tests/api/core/content-manager/api/draft-relations-non-dp-i18n.test.api.ts
@@ -9,6 +9,7 @@ let rq: any;
 const UID_PAGE = 'api::page.page';
 const UID_MENU = 'api::menu.menu';
 const UID_HOMEPAGE = 'api::homepage.homepage';
+const UID_SETTINGS = 'api::settings.settings';
 
 const nonDefaultLocale = 'fr';
 
@@ -66,9 +67,29 @@ const homepageModel = {
   },
 };
 
+// Settings: single type, dedicated to the "only exists in a non-default locale" case
+// (Homepage already gets an 'en' version created by an earlier test in this file)
+const settingsModel = {
+  kind: 'singleType',
+  displayName: 'Settings',
+  singularName: 'settings',
+  pluralName: 'settings-entries',
+  draftAndPublish: false,
+  pluginOptions: {
+    i18n: { localized: true },
+  },
+  attributes: {
+    page: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: UID_PAGE,
+    },
+  },
+};
+
 describe('CM API - countDraftRelations on a non-D&P i18n content type (issue #26897)', () => {
   beforeAll(async () => {
-    await builder.addContentTypes([pageModel, menuModel, homepageModel]).build();
+    await builder.addContentTypes([pageModel, menuModel, homepageModel, settingsModel]).build();
 
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
@@ -171,6 +192,51 @@ describe('CM API - countDraftRelations on a non-D&P i18n content type (issue #26
       method: 'GET',
       url: `/content-manager/single-types/${UID_HOMEPAGE}/actions/countDraftRelations`,
       qs: { locale: nonDefaultLocale },
+    });
+
+    expect(countRes.statusCode).toBe(200);
+    expect(countRes.body.data).toMatchObject({ unpublishedRelations: 0, draftM2mLinks: 0 });
+  });
+
+  test('returns 200 with zero counts when the document exists only in a non-default locale', async () => {
+    // Menu created directly in fr, skipping the default 'en' locale entirely
+    const {
+      body: { data: menuFr },
+    } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${UID_MENU}`,
+      qs: { locale: nonDefaultLocale },
+      body: {},
+    });
+
+    // Requesting the DEFAULT locale (en), which was never created for this document.
+    // The document DOES exist (in fr), so this should be 200 with zero counts, not 404.
+    const countRes = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/${UID_MENU}/${menuFr.documentId}/actions/countDraftRelations`,
+      qs: { locale: 'en' },
+    });
+
+    expect(countRes.statusCode).toBe(200);
+    expect(countRes.body.data).toMatchObject({ unpublishedRelations: 0, draftM2mLinks: 0 });
+  });
+
+  test('returns 200 with zero counts for a single type that exists only in a non-default locale', async () => {
+    // Settings created directly in fr, skipping the default 'en' locale entirely
+    const createRes = await rq({
+      method: 'PUT',
+      url: `/content-manager/single-types/${UID_SETTINGS}`,
+      qs: { locale: nonDefaultLocale },
+      body: {},
+    });
+    expect(createRes.statusCode).toBe(200);
+
+    // Requesting the DEFAULT locale (en), which was never created for this single type.
+    // The document DOES exist (in fr), so this should be 200 with zero counts, not 404.
+    const countRes = await rq({
+      method: 'GET',
+      url: `/content-manager/single-types/${UID_SETTINGS}/actions/countDraftRelations`,
+      qs: { locale: 'en' },
     });
 
     expect(countRes.statusCode).toBe(200);

--- a/tests/api/core/content-manager/api/draft-relations-non-dp-i18n.test.api.ts
+++ b/tests/api/core/content-manager/api/draft-relations-non-dp-i18n.test.api.ts
@@ -1,15 +1,14 @@
-'use strict';
-
-const { createStrapiInstance } = require('api-tests/strapi');
-const { createTestBuilder } = require('api-tests/builder');
-const { createAuthRequest } = require('api-tests/request');
+import { createTestBuilder } from 'api-tests/builder';
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createAuthRequest } from 'api-tests/request';
 
 const builder = createTestBuilder();
-let strapi;
-let rq;
+let strapi: any;
+let rq: any;
 
 const UID_PAGE = 'api::page.page';
 const UID_MENU = 'api::menu.menu';
+const UID_HOMEPAGE = 'api::homepage.homepage';
 
 const nonDefaultLocale = 'fr';
 
@@ -48,9 +47,28 @@ const menuModel = {
   },
 };
 
+// Homepage: single type, same shape as Menu (issue #26897)
+const homepageModel = {
+  kind: 'singleType',
+  displayName: 'Homepage',
+  singularName: 'homepage',
+  pluralName: 'homepages',
+  draftAndPublish: false,
+  pluginOptions: {
+    i18n: { localized: true },
+  },
+  attributes: {
+    page: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: UID_PAGE,
+    },
+  },
+};
+
 describe('CM API - countDraftRelations on a non-D&P i18n content type (issue #26897)', () => {
   beforeAll(async () => {
-    await builder.addContentTypes([pageModel, menuModel]).build();
+    await builder.addContentTypes([pageModel, menuModel, homepageModel]).build();
 
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
@@ -72,7 +90,7 @@ describe('CM API - countDraftRelations on a non-D&P i18n content type (issue #26
     await builder.cleanup();
   });
 
-  test('does not error when counting draft relations in a non-default locale', async () => {
+  test('returns 200 with the draft relation count when counting in a non-default locale', async () => {
     // 1. Page in default locale (en)
     const {
       body: { data: pageEn },
@@ -108,7 +126,7 @@ describe('CM API - countDraftRelations on a non-D&P i18n content type (issue #26
     });
     expect(localizeRes.statusCode).toBe(200);
 
-    // 5. Count draft relations in the non-default locale -> must not 500
+    // 5. Count draft relations in the non-default locale -> the fr page is still a draft
     const countRes = await rq({
       method: 'GET',
       url: `/content-manager/collection-types/${UID_MENU}/${menuEn.documentId}/actions/countDraftRelations`,
@@ -116,9 +134,10 @@ describe('CM API - countDraftRelations on a non-D&P i18n content type (issue #26
     });
 
     expect(countRes.statusCode).toBe(200);
+    expect(countRes.body.data).toMatchObject({ unpublishedRelations: 1, draftM2mLinks: 0 });
   });
 
-  test('does not 500 when the requested locale has not been created yet', async () => {
+  test('returns 200 with zero counts when the requested locale does not exist yet', async () => {
     // Menu exists only in the default locale (en)
     const {
       body: { data: menuEn },
@@ -139,7 +158,26 @@ describe('CM API - countDraftRelations on a non-D&P i18n content type (issue #26
     expect(countRes.body.data).toMatchObject({ unpublishedRelations: 0, draftM2mLinks: 0 });
   });
 
-  test('still returns a 404 when the document does not exist at all', async () => {
+  test('returns 200 with zero counts for a single type whose requested locale does not exist yet', async () => {
+    // Homepage exists only in the default locale (en)
+    const createRes = await rq({
+      method: 'PUT',
+      url: `/content-manager/single-types/${UID_HOMEPAGE}`,
+      body: {},
+    });
+    expect(createRes.statusCode).toBe(200);
+
+    const countRes = await rq({
+      method: 'GET',
+      url: `/content-manager/single-types/${UID_HOMEPAGE}/actions/countDraftRelations`,
+      qs: { locale: nonDefaultLocale },
+    });
+
+    expect(countRes.statusCode).toBe(200);
+    expect(countRes.body.data).toMatchObject({ unpublishedRelations: 0, draftM2mLinks: 0 });
+  });
+
+  test('still returns 404 when the document does not exist in any locale', async () => {
     const countRes = await rq({
       method: 'GET',
       url: `/content-manager/collection-types/${UID_MENU}/does-not-exist/actions/countDraftRelations`,


### PR DESCRIPTION
…for missing locale

### What does it do?

Makes the Content Manager's "count draft relations" endpoint tolerant of a document version that does not exist for the requested locale.

* `document-manager.countDraftRelations` now returns `{ unpublishedRelations: 0, draftM2mLinks: 0 }` when the document version is not found, instead of throwing an `ApplicationError` (the unused `ApplicationError` import was removed).
* The `collection-types.countDraftRelations` controller returns zero counts when the requested locale version is missing but the document still exists in another locale; it keeps returning `404` only when the document does not exist at all.
* The `single-types.countDraftRelations` controller returns zero counts when the single type has no version in the requested locale.

### Why is it needed?

When editing an entry that has a relation and switching to a locale that has not been created yet, the admin panel showed the error toast **"An error occurred while fetching draft relations on this document."**

This happens for a localized content type without Draft & Publish that holds a relation to a localized Draft & Publish content type (issue strapi/strapi#26897). The `countDraftRelations` request looked up the document for the requested `(documentId, locale)`; when that locale version did not exist, the request failed (404 / thrown error), and the admin surfaced the generic error toast even though the entry itself was saved correctly.

Counting draft relations of a non-existent version should simply be zero — there is nothing to count — not an error.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

Automated:

```bash
# API regression test (fails before the fix with a 404, passes after)
yarn test:api draft-relations-non-dp-i18n

# Controller unit tests
yarn nx test @strapi/content-manager
```

### Related issue(s)/PR(s)

Fixes strapi/strapi#26897