### PR TITLE
fix(data-transfer): use exact on-disk size for remote assets on export

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/assets.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/assets.test.ts
@@ -129,3 +129,74 @@ describe('Local source assets stream warnings', () => {
     });
   });
 });
+
+describe('Local source assets stream — remote asset size', () => {
+  test('reports a size that matches the streamed bytes for a remote (cloud) file', async () => {
+    // A Cloudinary-hosted SVG in a subfolder. Its response has NO content-length
+    // header (chunked transfer) — common for cloud/CDN providers. The tar entry
+    // is built from stats.size, so if that doesn't match the streamed bytes the
+    // export crashes with "Failed to create an asset tar entry".
+    const body = Buffer.from('<svg data-note="chunked, no content-length" />');
+
+    const remoteFile = {
+      id: 7,
+      hash: 'New_Balance2_13004e51a8',
+      ext: '.svg',
+      url: 'https://res.cloudinary.com/demo/image/upload/cms/New_Balance2_13004e51a8.svg',
+      provider: 'cloudinary',
+      formats: undefined,
+    };
+
+    // Each fetch() must return a fresh response (a body stream is consumed once):
+    // once for getFileStatsForTransfer, once for getFileStream.
+    const fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+        headers: { get: () => null }, // no content-length (chunked)
+        body: Readable.toWeb(Readable.from([body])),
+      })
+    );
+
+    const strapi = {
+      db: {
+        queryBuilder: jest.fn(() => ({
+          select: jest.fn().mockReturnThis(),
+          stream: jest.fn(() => Readable.from([remoteFile])),
+        })),
+      },
+      dirs: { static: { public: '/tmp/unused' } },
+      log: { warn: jest.fn() },
+      fetch,
+      plugins: {
+        upload: { provider: { isPrivate: jest.fn().mockResolvedValue(false) } },
+      },
+      config: { get: jest.fn(() => ({ provider: 'cloudinary' })) },
+    } as any;
+
+    // Consume each asset's stream DURING iteration, exactly like the file
+    // destination does (it pipes the stream into the tar before pulling the next
+    // asset). This also matches how temp files are cleaned up as we advance.
+    const stream = createAssetsStream(strapi);
+    let assetCount = 0;
+    let declaredSize = -1;
+    let streamedBytes = -1;
+
+    for await (const asset of stream) {
+      assetCount += 1;
+      declaredSize = (asset as any).stats.size;
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of (asset as any).stream) {
+        chunks.push(chunk as Buffer);
+      }
+      streamedBytes = Buffer.concat(chunks).length;
+    }
+
+    expect(assetCount).toBe(1);
+
+    // The declared size (used for the tar entry header) MUST equal the streamed
+    // bytes. Before the fix it does not: content-length is missing, so stats.size
+    // is 0 while the stream carries the real bytes → the tar entry write fails.
+    expect(declaredSize).toBe(streamedBytes);
+  });
+});

--- a/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
@@ -1,46 +1,23 @@
 import { join } from 'path';
-import { Duplex, PassThrough, Readable } from 'stream';
-import { stat, createReadStream, ReadStream } from 'fs-extra';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+import { Duplex, Readable } from 'stream';
+import { pipeline } from 'stream/promises';
+import { stat, createReadStream, createWriteStream, mkdtemp, rm } from 'fs-extra';
 import * as webStream from 'stream/web';
 import type { Core } from '@strapi/types';
 
 import type { IAsset, IFile } from '../../../types';
 
-function getFileStream(
-  filepath: string,
-  strapi: Core.Strapi,
-  isLocal = false
-): PassThrough | ReadStream {
-  if (isLocal) {
-    // Todo: handle errors
-    return createReadStream(filepath);
-  }
-
-  const readableStream = new PassThrough();
-
-  // fetch the image from remote url and stream it
-  strapi
-    .fetch(filepath)
-    .then((res: Response) => {
-      if (res.status !== 200) {
-        readableStream.emit('error', new Error(`Request failed with status code ${res.status}`));
-        return;
-      }
-
-      if (res.body) {
-        // pipe the image data
-        Readable.fromWeb(res.body as webStream.ReadableStream<Uint8Array>).pipe(readableStream);
-      } else {
-        readableStream.emit('error', new Error('Empty data found for file'));
-      }
-    })
-    .catch((error: unknown) => {
-      readableStream.emit('error', error);
-    });
-
-  return readableStream;
-}
-
+/**
+ * Read the size of a file to transfer.
+ *
+ * For local files this is a plain `fs.stat`. For remote files it reads the
+ * `content-length` header — which is only an ESTIMATE for cloud providers (it
+ * can be missing on chunked responses, or reflect a compressed size). It is
+ * therefore used for progress estimation only; the actual transfer measures the
+ * real byte size on disk (see `createAssetsStream`).
+ */
 export function getFileStatsForTransfer(
   filepath: string,
   strapi: Core.Strapi,
@@ -95,6 +72,84 @@ const missingAssetWarningMessage = (file: IFile, filepath: string, format?: stri
   return `[Data transfer] Media item ${file.id} (hash: ${file.hash}) exists in database but no corresponding file was found to transfer${formatPart}. Path: ${filepath}`;
 };
 
+interface AssetSource {
+  size: number;
+  stream: Readable;
+}
+
+const isMissingFileError = (err: unknown): boolean =>
+  typeof err === 'object' &&
+  err !== null &&
+  'code' in err &&
+  (err as NodeJS.ErrnoException).code === 'ENOENT';
+
+/**
+ * Download a remote asset (e.g. Cloudinary/S3) to a temp file and return its
+ * real size + a stream that reads from disk.
+ *
+ * A tar entry needs the EXACT byte size before any bytes are written, and the
+ * remote `content-length` is unreliable for cloud providers (missing on chunked
+ * responses, or the compressed size while `fetch` yields the decompressed body).
+ * Downloading to a temp file lets us measure the real size with `fs.stat` and
+ * avoids buffering the whole asset in memory (important for large media).
+ *
+ * The temp file removes itself once its stream closes; the enclosing temp
+ * directory is removed when the export finishes (see `createAssetsStream`).
+ */
+async function openRemoteAssetToTemp(
+  filepath: string,
+  strapi: Core.Strapi,
+  tmpDir: string
+): Promise<AssetSource> {
+  const res = await strapi.fetch(filepath);
+  if (res.status !== 200) {
+    throw new Error(`Request failed with status code ${res.status}`);
+  }
+  if (!res.body) {
+    throw new Error('Empty data found for file');
+  }
+
+  const tmpFile = join(tmpDir, randomBytes(16).toString('hex'));
+
+  await pipeline(
+    Readable.fromWeb(res.body as webStream.ReadableStream<Uint8Array>),
+    createWriteStream(tmpFile)
+  );
+
+  const { size } = await stat(tmpFile);
+  const stream = createReadStream(tmpFile);
+
+  // Remove the temp file as soon as its stream is fully read (or errors). The
+  // whole temp dir is also removed when the export ends, as a safety net.
+  stream.on('close', () => {
+    rm(tmpFile, { force: true }).catch(() => {
+      /* best-effort */
+    });
+  });
+
+  return { size, stream };
+}
+
+/**
+ * Open an asset for transfer, returning its exact size and a readable stream.
+ * Local files are read straight from disk; remote files are downloaded to a
+ * temp file first so the size is exact (see `openRemoteAssetToTemp`).
+ */
+async function openAssetForTransfer(
+  filepath: string,
+  strapi: Core.Strapi,
+  isLocal: boolean,
+  ensureTmpDir: () => Promise<string>
+): Promise<AssetSource> {
+  if (isLocal) {
+    const { size } = await stat(filepath);
+    return { size, stream: createReadStream(filepath) };
+  }
+
+  const tmpDir = await ensureTmpDir();
+  return openRemoteAssetToTemp(filepath, strapi, tmpDir);
+}
+
 /**
  * Generate and consume assets streams in order to stream each file individually
  */
@@ -108,78 +163,93 @@ export const createAssetsStream = (
   };
 
   const generator: () => AsyncGenerator<IAsset, void> = async function* () {
-    const stream: Readable = strapi.db
-      .queryBuilder('plugin::upload.file')
-      // Create a query builder instance (default type is 'select')
-      // Fetch all columns
-      .select('*')
-      // Get a readable stream
-      .stream();
-
-    for await (const file of stream) {
-      const isLocalProvider = file.provider === 'local';
-      if (!isLocalProvider) {
-        await signUploadFileForTransfer(strapi, file);
+    // Remote assets are downloaded to a temp directory so their exact on-disk
+    // size can be used for the tar entry. It is created lazily (only when a
+    // remote asset is encountered) and removed in the `finally` below — which
+    // runs on normal completion, on error, and when the export is aborted
+    // mid-way (Duplex.from calls this generator's return()).
+    let tmpDir: string | undefined;
+    const ensureTmpDir = async (): Promise<string> => {
+      if (!tmpDir) {
+        tmpDir = await mkdtemp(join(tmpdir(), 'strapi-export-assets-'));
       }
-      const filepath = isLocalProvider ? join(strapi.dirs.static.public, file.url) : file.url;
-      let stats: { size: number };
-      try {
-        stats = await getFileStatsForTransfer(filepath, strapi, isLocalProvider);
-      } catch (err: unknown) {
-        const code =
-          err && typeof err === 'object' && 'code' in err
-            ? (err as NodeJS.ErrnoException).code
-            : undefined;
-        if (code === 'ENOENT') {
-          warnMissingAsset(missingAssetWarningMessage(file, filepath));
-          continue;
+      return tmpDir;
+    };
+
+    try {
+      const stream: Readable = strapi.db
+        .queryBuilder('plugin::upload.file')
+        // Create a query builder instance (default type is 'select')
+        // Fetch all columns
+        .select('*')
+        // Get a readable stream
+        .stream();
+
+      for await (const file of stream) {
+        const isLocalProvider = file.provider === 'local';
+        if (!isLocalProvider) {
+          await signUploadFileForTransfer(strapi, file);
         }
-        throw err;
-      }
-      const stream = getFileStream(filepath, strapi, isLocalProvider);
+        const filepath = isLocalProvider ? join(strapi.dirs.static.public, file.url) : file.url;
 
-      yield {
-        metadata: file,
-        filepath,
-        filename: file.hash + file.ext,
-        stream,
-        stats: { size: stats.size },
-      };
-
-      if (file.formats) {
-        for (const format of Object.keys(file.formats)) {
-          const fileFormat = file.formats[format];
-          const fileFormatFilepath = isLocalProvider
-            ? join(strapi.dirs.static.public, fileFormat.url)
-            : fileFormat.url;
-          let fileFormatStats: { size: number };
-          try {
-            fileFormatStats = await getFileStatsForTransfer(
-              fileFormatFilepath,
-              strapi,
-              isLocalProvider
-            );
-          } catch (err: unknown) {
-            const code =
-              err && typeof err === 'object' && 'code' in err
-                ? (err as NodeJS.ErrnoException).code
-                : undefined;
-            if (code === 'ENOENT') {
-              warnMissingAsset(missingAssetWarningMessage(file, fileFormatFilepath, format));
-              continue;
-            }
-            throw err;
+        let asset: AssetSource;
+        try {
+          asset = await openAssetForTransfer(filepath, strapi, isLocalProvider, ensureTmpDir);
+        } catch (err: unknown) {
+          if (isMissingFileError(err)) {
+            warnMissingAsset(missingAssetWarningMessage(file, filepath));
+            continue;
           }
-          const fileFormatStream = getFileStream(fileFormatFilepath, strapi, isLocalProvider);
-          const metadata = { ...fileFormat, type: format, id: file.id, mainHash: file.hash };
-          yield {
-            metadata,
-            filepath: fileFormatFilepath,
-            filename: fileFormat.hash + fileFormat.ext,
-            stream: fileFormatStream,
-            stats: { size: fileFormatStats.size },
-          };
+          throw err;
         }
+
+        yield {
+          metadata: file,
+          filepath,
+          filename: file.hash + file.ext,
+          stream: asset.stream,
+          stats: { size: asset.size },
+        };
+
+        if (file.formats) {
+          for (const format of Object.keys(file.formats)) {
+            const fileFormat = file.formats[format];
+            const fileFormatFilepath = isLocalProvider
+              ? join(strapi.dirs.static.public, fileFormat.url)
+              : fileFormat.url;
+
+            let fileFormatAsset: AssetSource;
+            try {
+              fileFormatAsset = await openAssetForTransfer(
+                fileFormatFilepath,
+                strapi,
+                isLocalProvider,
+                ensureTmpDir
+              );
+            } catch (err: unknown) {
+              if (isMissingFileError(err)) {
+                warnMissingAsset(missingAssetWarningMessage(file, fileFormatFilepath, format));
+                continue;
+              }
+              throw err;
+            }
+
+            const metadata = { ...fileFormat, type: format, id: file.id, mainHash: file.hash };
+            yield {
+              metadata,
+              filepath: fileFormatFilepath,
+              filename: fileFormat.hash + fileFormat.ext,
+              stream: fileFormatAsset.stream,
+              stats: { size: fileFormatAsset.size },
+            };
+          }
+        }
+      }
+    } finally {
+      if (tmpDir) {
+        await rm(tmpDir, { recursive: true, force: true }).catch(() => {
+          /* best-effort cleanup */
+        });
       }
     }
   };


### PR DESCRIPTION
### What does it do?

On `strapi export`, remote assets (e.g. Cloudinary/S3) are downloaded to a temp
file so their exact byte size can be measured with `fs.stat` and used for the
tar entry, instead of relying on the HTTP `content-length` header. Local files
are unchanged, and the progress estimate keeps using `content-length`
(approximate is fine there). Temp files are removed when their stream closes,
and the temp directory is cleaned up when the export ends — including mid-way
aborts (the async generator's `finally`).

This is a proposed approach to the size mismatch — happy to adjust the strategy
(e.g. only when `content-length` is missing, or a different temp-file scheme) if
you'd prefer.

### Why is it needed?

The file destination builds each asset's tar entry from `data.stats.size`, which
for remote files came from the `content-length` header. A tar entry needs the
exact byte size up front, and for cloud providers that header is unreliable —
missing on chunked responses (falls back to `0`), or reflecting a compressed size
while `fetch` returns the decompressed stream. When the streamed bytes didn't
match the declared size, the export crashed with "Failed to create an asset tar
entry".

### How to test it?

In `packages/core/data-transfer`: `npx jest local-source/__tests__/assets`.
Added a test that streams a remote asset whose response has no `content-length` —
before the change the declared size is `0` while the stream carries the real
bytes (reproducing the crash); after, they match. All existing local-source
tests still pass.

### Related issue(s)/PR(s)

Fix #26869


---
Fixes CPR-430