### PR TITLE
fix(utils): return 400 instead of 500 for invalid sort order/params

### DIFF
--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -86,7 +86,46 @@ describe('convert-query-params', () => {
     test.todo('partial filtering works');
   });
 
-  test.todo('convertSortQueryParams');
+  describe('convertSortQueryParams', () => {
+    test.each<[string, unknown, object]>([
+      ['single field string', 'title:asc', [{ title: 'asc' }]],
+      ['defaults to asc when order is omitted', 'title', [{ title: 'asc' }]],
+      ['is case insensitive on order', 'title:DESC', [{ title: 'DESC' }]],
+      [
+        'array of field strings',
+        ['title:asc', 'createdAt:desc'],
+        [{ title: 'asc' }, { createdAt: 'desc' }],
+      ],
+      [
+        'comma-separated field string',
+        'title:asc,createdAt:desc',
+        [{ title: 'asc' }, { createdAt: 'desc' }],
+      ],
+      ['nested sort object', { title: 'asc' }, { title: 'asc' }],
+    ])('accepts: %s', (key, input, expectedOutput) => {
+      const res = transformer.private_convertSortQueryParams(input as never);
+      expect(res).toEqual(expectedOutput);
+    });
+
+    test.each<[string, unknown]>([
+      ['invalid order suffix', 'title:asc$'],
+      ['unsupported order value', 'title:ascending'],
+      ['unsupported order value on a nested sort object', { title: 'ascending' }],
+    ])('rejects with a ValidationError: %s', (key, input) => {
+      expect(() => transformer.private_convertSortQueryParams(input as never)).toThrow(
+        'Invalid order. order can only be one of asc|desc|ASC|DESC'
+      );
+    });
+
+    test.each<[string, unknown]>([
+      ['a number', 1234],
+      ['null', null],
+    ])('rejects with a ValidationError: %s', (key, input) => {
+      expect(() => transformer.private_convertSortQueryParams(input as never)).toThrow(
+        'Invalid sort parameter. Expected a string, an array of strings, a sort object or an array of sort objects'
+      );
+    });
+  });
 
   describe('convertStartQueryParams', () => {
     it('accepts valid non-negative integers', () => {

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -158,18 +158,17 @@ export interface Query {
   pageSize?: number;
 }
 
-class InvalidOrderError extends Error {
+class InvalidOrderError extends ValidationError {
   constructor() {
-    super();
-    this.message = 'Invalid order. order can only be one of asc|desc|ASC|DESC';
+    super('Invalid order. order can only be one of asc|desc|ASC|DESC');
   }
 }
 
-class InvalidSortError extends Error {
+class InvalidSortError extends ValidationError {
   constructor() {
-    super();
-    this.message =
-      'Invalid sort parameter. Expected a string, an array of strings, a sort object or an array of sort objects';
+    super(
+      'Invalid sort parameter. Expected a string, an array of strings, a sort object or an array of sort objects'
+    );
   }
 }
 


### PR DESCRIPTION
### What does it do?

`InvalidOrderError` and `InvalidSortError` in `packages/core/utils/src/convert-query-params.ts` extended the plain `Error` class instead of `ValidationError`. The core error middleware (`packages/core/core/src/middlewares/errors.ts`) only formats a proper HTTP response for errors that are an `instanceof errors.ApplicationError` (which `ValidationError` extends); anything else falls through to the generic 500 handler. This PR makes both classes extend `ValidationError` so they're recognized and returned as 400s with a useful message, and fills in the `convertSortQueryParams` `test.todo` with coverage for both the valid and invalid sort inputs.

### Why is it needed?

Requesting the REST API with a malformed `sort` query param (e.g. an invalid order suffix like `sort=title:asc$`, or an unsupported order value) throws a 500 Internal Server Error instead of a 400 Bad Request, hiding the actual problem from API consumers.

### How to test it?

1. Create a content-type with some fields and a few entries.
2. `GET /api/<plural-name>?sort=someField:asc$` (or any invalid order suffix/value).
3. Before this fix: 500 with an unhelpful "Invalid order..." message logged server-side only.
4. After this fix: 400 with `{"error":{"status":400,"name":"ValidationError","message":"Invalid order. order can only be one of asc|desc|ASC|DESC"}}`.

Unit tests added in `packages/core/utils/src/__tests__/convert-query-params.test.ts` cover this directly (`yarn jest --config packages/core/utils/jest.config.js convert-query-params`).

### Related issue(s)/PR(s)

Fix #25560

---
Fixes CPR-433