### PR TITLE
fix(utils): align remaining convert-query-params errors with ValidationError

### DIFF
--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -1,4 +1,5 @@
 import { createTransformer, type Params } from '../convert-query-params';
+import { ValidationError } from '../errors';
 import { Model } from '../types';
 
 const models = {
@@ -113,14 +114,33 @@ describe('convert-query-params', () => {
       ['unsupported order value on a nested sort object', { title: 'ascending' }],
     ])('rejects with a ValidationError: %s', (key, input) => {
       expect(() => transformer.private_convertSortQueryParams(input as never)).toThrow(
+        ValidationError
+      );
+      expect(() => transformer.private_convertSortQueryParams(input as never)).toThrow(
         'Invalid order. order can only be one of asc|desc|ASC|DESC'
       );
+    });
+
+    test.each<[string, unknown, string]>([
+      [
+        'invalid nested sort value type',
+        { title: 123 },
+        'Invalid sort type expected object or string got number',
+      ],
+    ])('rejects with a ValidationError: %s', (key, input, message) => {
+      expect(() => transformer.private_convertSortQueryParams(input as never)).toThrow(
+        ValidationError
+      );
+      expect(() => transformer.private_convertSortQueryParams(input as never)).toThrow(message);
     });
 
     test.each<[string, unknown]>([
       ['a number', 1234],
       ['null', null],
     ])('rejects with a ValidationError: %s', (key, input) => {
+      expect(() => transformer.private_convertSortQueryParams(input as never)).toThrow(
+        ValidationError
+      );
       expect(() => transformer.private_convertSortQueryParams(input as never)).toThrow(
         'Invalid sort parameter. Expected a string, an array of strings, a sort object or an array of sort objects'
       );
@@ -214,6 +234,21 @@ describe('convert-query-params', () => {
   });
 
   describe('convertPopulateQueryParams', () => {
+    test.each<[string, unknown]>([
+      ['a number', 1234],
+      ['null', null],
+      ['an array with a non-string entry', ['title', 1234]],
+    ])('rejects with a ValidationError: %s', (key, input) => {
+      expect(() =>
+        transformer.private_convertPopulateQueryParams(input as never, models['api::dog.dog'])
+      ).toThrow(ValidationError);
+      expect(() =>
+        transformer.private_convertPopulateQueryParams(input as never, models['api::dog.dog'])
+      ).toThrow(
+        'Invalid populate parameter. Expected a string, an array of strings, a populate object'
+      );
+    });
+
     describe('Fields selection', () => {
       test('should not select documentId when selecting fields for components', () => {
         const populate = {

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -172,6 +172,12 @@ class InvalidSortError extends ValidationError {
   }
 }
 
+class InvalidPopulateError extends ValidationError {
+  constructor() {
+    super('Invalid populate parameter. Expected a string, an array of strings, a populate object');
+  }
+}
+
 function validateOrder(order: string): asserts order is SortOrder {
   if (!isString(order) || !['asc', 'desc'].includes(order.toLocaleLowerCase())) {
     throw new InvalidOrderError();
@@ -231,7 +237,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     }
 
     if (!isString(trimmed)) {
-      throw new Error('Invalid sort query');
+      throw new ValidationError('Invalid sort query');
     }
 
     // split field and order param with default order to ascending
@@ -239,7 +245,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     const field = rawField.trim();
 
     if (field.length === 0) {
-      throw new Error('Field cannot be empty');
+      throw new ValidationError('Field cannot be empty');
     }
 
     validateOrder(order.trim());
@@ -269,7 +275,9 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
           transformedSort[field] = trimmedOrder;
         }
       } else {
-        throw Error(`Invalid sort type expected object or string got ${typeof order}`);
+        throw new ValidationError(
+          `Invalid sort type expected object or string got ${typeof order}`
+        );
       }
     }
 
@@ -362,14 +370,6 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
       );
     }
   };
-
-  class InvalidPopulateError extends Error {
-    constructor() {
-      super();
-      this.message =
-        'Invalid populate parameter. Expected a string, an array of strings, a populate object';
-    }
-  }
 
   // NOTE: we could support foo.* or foo.bar.* etc later on
   const convertPopulateQueryParams = (


### PR DESCRIPTION
## Summary

Follow-up to strapi/strapi#26907 (fixes strapi/strapi#25560). With `InvalidOrderError` / `InvalidSortError` already on `develop`, this PR closes the same 500-vs-400 gap for the remaining malformed query-param paths in `convert-query-params`:

* `InvalidPopulateError` now extends `ValidationError` (bad populate type / shape)
* Remaining sort conversion throws (`Invalid sort query`, empty field, invalid nested sort value type) use `ValidationError` instead of plain `Error`
* Unit tests assert `instanceof ValidationError`, not only message strings (so they actually guard the HTTP semantics)

Rebased onto current `develop` so the diff is only this follow-up.

## Test plan

- [X] `yarn jest --config packages/core/utils/jest.config.js convert-query-params` (95 tests, all pass)

## Related issue(s)/PR(s)

Fixes strapi/strapi#25560<br>Fixes [CMS-1416](https://linear.app/strapi/issue/CMS-1416/pr-26908-fixutils-align-remaining-convert-query-params-errors-with)