### PR TITLE
chore(data-transfer): clarify --exclude files CLI messaging

### DIFF
--- a/docs/docs/docs/01-core/data-transfer/01-engine/01-engine.mdx
+++ b/docs/docs/docs/01-core/data-transfer/01-engine/01-engine.mdx
@@ -197,6 +197,42 @@ Once the integrity check has passed, the transfer begins by opening streams from
 4. links - the relations between entities
 5. configuration - the Strapi project configuration data
 
+### Media library vs upload binaries
+
+Strapi stores media in two parts that transfer on different stages:
+
+- **entities** stage — media library database records (`plugin::upload.file`, `plugin::upload.folder`) are transferred as part of `content`, along with other entities
+- **assets** stage — the binary files on disk under `public/uploads`
+
+The CLI `--exclude files` (or `--only` without `files`) skips only the **assets** stage. Media library records are still transferred unless you exclude them programmatically.
+
+To exclude upload content types from the entities stage, use entity and link transform filters:
+
+```typescript
+const UPLOAD_TYPES = ['plugin::upload.file', 'plugin::upload.folder'];
+
+const options = {
+  transforms: {
+    entities: [
+      {
+        filter(entity) {
+          return !UPLOAD_TYPES.includes(entity.type);
+        },
+      },
+    ],
+    links: [
+      {
+        filter(link) {
+          return !UPLOAD_TYPES.includes(link.left.type) && !UPLOAD_TYPES.includes(link.right.type);
+        },
+      },
+    ],
+  },
+};
+```
+
+When skipping the assets stage, sync upload binaries separately — for example with `rsync -avz public/uploads/ user@host:/path/to/strapi/public/uploads/`.
+
 Once all stages have been completed, the transfer waits for all providers to close and then emits a finish event and the transfer completes.
 
 ## Setting up the transfer engine

--- a/packages/core/strapi/src/cli/commands/export/action.ts
+++ b/packages/core/strapi/src/cli/commands/export/action.ts
@@ -22,6 +22,7 @@ import {
   abortTransfer,
   getTransferTelemetryPayload,
   setSignalHandler,
+  logTransferFilterSummary,
 } from '../../utils/data-transfer';
 import { exitWith } from '../../utils/helpers';
 import { normalizeExportDirFormatOpts } from './validate-dir-format';
@@ -114,6 +115,7 @@ export default async (opts: CmdOptions) => {
 
   progress.on('transfer::start', async () => {
     console.log(`Starting export...`);
+    logTransferFilterSummary({ exclude: opts.exclude, only: opts.only });
 
     await strapi.telemetry.send('didDEITSProcessStart', getTransferTelemetryPayload(engine));
   });

--- a/packages/core/strapi/src/cli/commands/import/action.ts
+++ b/packages/core/strapi/src/cli/commands/import/action.ts
@@ -23,6 +23,7 @@ import {
   setSignalHandler,
   getDiffHandler,
   parseRestoreFromOptions,
+  logTransferFilterSummary,
 } from '../../utils/data-transfer';
 import { exitWith } from '../../utils/helpers';
 
@@ -136,6 +137,7 @@ export default async (opts: CmdOptions) => {
 
   progress.on('transfer::start', async () => {
     console.log('Starting import...');
+    logTransferFilterSummary({ exclude: opts.exclude, only: opts.only });
     await strapiInstance.telemetry.send(
       'didDEITSProcessStart',
       getTransferTelemetryPayload(engine)

--- a/packages/core/strapi/src/cli/commands/transfer/action.ts
+++ b/packages/core/strapi/src/cli/commands/transfer/action.ts
@@ -16,6 +16,7 @@ import {
   getDiffHandler,
   getAssetsBackupHandler,
   parseRestoreFromOptions,
+  logTransferFilterSummary,
 } from '../../utils/data-transfer';
 import {
   exitWith,
@@ -272,6 +273,7 @@ export default async (opts: CmdOptions) => {
   progress.on('transfer::start', async () => {
     transferPrepStartedAt = Date.now();
     prepStepDetail = null;
+    logTransferFilterSummary({ exclude: opts.exclude, only: opts.only });
     startingSpinner = ora(formatPrepSpinnerLine()).start();
     startingElapsedInterval = setInterval(() => {
       if (startingSpinner && transferPrepStartedAt != null) {

--- a/packages/core/strapi/src/cli/utils/__tests__/log-transfer-filter-summary.test.ts
+++ b/packages/core/strapi/src/cli/utils/__tests__/log-transfer-filter-summary.test.ts
@@ -43,4 +43,18 @@ describe('logTransferFilterSummary', () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('only content'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('plugin::upload.file'));
   });
+
+  test('does not print files note when content is also skipped via --only config', () => {
+    logTransferFilterSummary({ only: ['config'] });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('only config'));
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('plugin::upload.file'));
+  });
+
+  test('does not print files note when content is also skipped via --exclude files,content', () => {
+    logTransferFilterSummary({ exclude: ['files', 'content'] });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('excluding files, content'));
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('plugin::upload.file'));
+  });
 });

--- a/packages/core/strapi/src/cli/utils/__tests__/log-transfer-filter-summary.test.ts
+++ b/packages/core/strapi/src/cli/utils/__tests__/log-transfer-filter-summary.test.ts
@@ -1,0 +1,46 @@
+import { logTransferFilterSummary } from '../data-transfer';
+
+jest.mock('@strapi/core', () => ({
+  createStrapi: jest.fn(),
+  compileStrapi: jest.fn(),
+}));
+
+describe('logTransferFilterSummary', () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  test('does nothing when no exclude or only filters are set', () => {
+    logTransferFilterSummary({});
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  test('prints active filters when exclude is set', () => {
+    logTransferFilterSummary({ exclude: ['config'] });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('excluding config'));
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('plugin::upload.file'));
+  });
+
+  test('prints files note when assets stage is skipped via --exclude files', () => {
+    logTransferFilterSummary({ exclude: ['files'] });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('excluding files'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('plugin::upload.file'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('rsync'));
+  });
+
+  test('prints files note when assets stage is skipped via --only content', () => {
+    logTransferFilterSummary({ only: ['content'] });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('only content'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('plugin::upload.file'));
+  });
+});

--- a/packages/core/strapi/src/cli/utils/data-transfer.ts
+++ b/packages/core/strapi/src/cli/utils/data-transfer.ts
@@ -171,6 +171,20 @@ const createStrapiInstance = async (opts: { logLevel?: string } = {}): Promise<C
 
 const transferDataTypes = Object.keys(engineDataTransfer.TransferGroupPresets);
 
+const TRANSFER_FILTER_PRESET_DESCRIPTIONS: Record<engineDataTransfer.TransferFilterPreset, string> =
+  {
+    content: 'entities and links (incl. media library DB records)',
+    files: 'upload binaries in public/uploads (not media library DB records)',
+    config: 'core store and webhooks',
+  };
+
+const transferFilterPresetsHelp = transferDataTypes
+  .map(
+    (type) =>
+      `${type} (${TRANSFER_FILTER_PRESET_DESCRIPTIONS[type as engineDataTransfer.TransferFilterPreset]})`
+  )
+  .join('; ');
+
 const throttleOption = new Option(
   '--throttle <delay after each entity>',
   `Add a delay in milliseconds between each transferred entity`
@@ -180,12 +194,12 @@ const throttleOption = new Option(
 
 const excludeOption = new Option(
   '--exclude <comma-separated data types>',
-  `Exclude data using comma-separated types. Available types: ${transferDataTypes.join(',')}`
+  `Exclude data: ${transferFilterPresetsHelp}`
 ).argParser(getParseListWithChoices(transferDataTypes, 'Invalid options for "exclude"'));
 
 const onlyOption = new Option(
   '--only <command-separated data types>',
-  `Include only these types of data (plus schemas). Available types: ${transferDataTypes.join(',')}`
+  `Include only these types (plus schemas): ${transferFilterPresetsHelp}`
 ).argParser(getParseListWithChoices(transferDataTypes, 'Invalid options for "only"'));
 
 const validateExcludeOnly = (command: Command) => {
@@ -530,6 +544,31 @@ const shouldSkipStage = (
   return false;
 };
 
+const logTransferFilterSummary = (opts: Partial<engineDataTransfer.ITransferEngineOptions>) => {
+  const { exclude, only } = opts;
+  if (!exclude?.length && !only?.length) {
+    return;
+  }
+
+  const parts: string[] = [];
+  if (exclude?.length) {
+    parts.push(`excluding ${exclude.join(', ')}`);
+  }
+  if (only?.length) {
+    parts.push(`only ${only.join(', ')}`);
+  }
+
+  console.log(chalk.dim(`Transfer filters: ${parts.join('; ')}.`));
+
+  if (shouldSkipStage(opts, 'files')) {
+    console.log(
+      chalk.dim(
+        'Note: Media library records (plugin::upload.file, plugin::upload.folder) are still transferred via the content stage. Sync upload binaries separately (e.g. rsync public/uploads).'
+      )
+    );
+  }
+};
+
 type RestoreConfig = NonNullable<
   strapiDataTransfer.providers.ILocalStrapiDestinationProviderOptions['restore']
 >;
@@ -595,4 +634,5 @@ export {
   getAssetsBackupHandler,
   shouldSkipStage,
   parseRestoreFromOptions,
+  logTransferFilterSummary,
 };

--- a/packages/core/strapi/src/cli/utils/data-transfer.ts
+++ b/packages/core/strapi/src/cli/utils/data-transfer.ts
@@ -560,10 +560,10 @@ const logTransferFilterSummary = (opts: Partial<engineDataTransfer.ITransferEngi
 
   console.log(chalk.dim(`Transfer filters: ${parts.join('; ')}.`));
 
-  if (shouldSkipStage(opts, 'files')) {
+  if (shouldSkipStage(opts, 'files') && !shouldSkipStage(opts, 'content')) {
     console.log(
       chalk.dim(
-        'Note: Media library records (plugin::upload.file, plugin::upload.folder) are still transferred via the content stage. Sync upload binaries separately (e.g. rsync public/uploads).'
+        'Note: Media library records (plugin::upload.file, plugin::upload.folder) are still transferred with the rest of your content (the entities stage). Sync upload binaries separately (e.g. rsync public/uploads).'
       )
     );
   }


### PR DESCRIPTION
## What does it do?

Clarifies data-transfer CLI `--exclude` / `--only` filter presets and runtime messaging without changing transfer behavior:

- Expands `--help` descriptions for `content`, `files`, and `config` presets (notably that `files` = upload binaries in `public/uploads`, not media library DB records)
- Prints a brief filter summary at transfer start (export/import/transfer) via `logTransferFilterSummary`, including a note when the assets stage is skipped that `plugin::upload.file` / `plugin::upload.folder` records still transfer
- Adds contributor docs on the two-part media model, CLI `--exclude files` semantics, programmatic exclusion via transforms, and rsync for binaries

## Why is it needed?

Addresses confusion from #25008: users expect `--exclude files` to skip all media-related data, but it only skips the **assets** stage. Media library records are part of the **content** (entities) stage. This PR documents current behavior rather than changing semantics.

## How to test it?

- Run `yarn nx test:unit @strapi/strapi --testPathPattern=log-transfer-filter-summary`
- Run `strapi export --help` / `strapi import --help` / `strapi transfer --help` and confirm preset descriptions mention media library DB records vs upload binaries
- Run `strapi export --exclude files` (or import/transfer) and confirm the dim filter summary + media library note appear after "Starting …"
- Confirm a full transfer without filters shows no extra filter lines

## Related issue(s)/PR(s)

- Related to #25008
- Fixes CMS-1373
- Companion: #26915 adds `--exclude-content-types` / `--only-content-types` for the upload-record exclusion described here (merge #26914 first, then rebase #26915; small overlap in `data-transfer.ts` and action files)