### PR TITLE
test(e2e): add release review-workflows full-lifecycle test (#22)

### DIFF
--- a/tests/e2e/tests/review-workflows/content-manager.spec.ts
+++ b/tests/e2e/tests/review-workflows/content-manager.spec.ts
@@ -123,6 +123,36 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     await expect(page.getByRole('combobox', { name: 'Review stage' })).toHaveText('In progress');
   });
 
+  // Critical path #22 (workflows.review-stages): a full review lifecycle — assign a reviewer and
+  // move the document forward through every stage of the Default workflow, confirming each update
+  // persists and the list view reflects the final stage + assignee.
+  test(
+    'a reviewer can be assigned and the document moved through every review stage',
+    { tag: ['@release'] },
+    async ({ page }) => {
+      await page.getByRole('link', { name: 'Content Manager' }).click();
+      await page.getByRole('gridcell', { name: 'West Ham post match analysis' }).click();
+
+      // Assign a reviewer.
+      await checkAssignee(page);
+
+      // Move through each subsequent stage of the Default workflow in order.
+      for (const stage of ['Ready to review', 'In progress', 'Reviewed']) {
+        await page.getByRole('combobox', { name: 'Review stage' }).click();
+        const stageUpdated = waitForStageUpdate(page);
+        await page.getByRole('option', { name: stage }).click();
+        await stageUpdated;
+        await findAndClose(page, 'Review stage updated');
+        await expect(page.getByRole('combobox', { name: 'Review stage' })).toHaveText(stage);
+      }
+
+      // The list view reflects the final stage and the assignee.
+      await goBackToArticleList(page);
+      await expect(page.getByRole('gridcell', { name: 'Reviewed' })).toBeVisible();
+      await expect(page.getByRole('gridcell', { name: 'editor testing' })).toBeVisible();
+    }
+  );
+
   describeOnCondition(process.env.STRAPI_FEATURES_UNSTABLE_PREVIEW_SIDE_EDITOR === 'true')(
     'Unstable Preview',
     () => {


### PR DESCRIPTION
### What does it do?
Adds a `@release`, EE-gated E2E test for **critical path #22 (`workflows.review-stages`)** in `review-workflows/content-manager.spec.ts`. It exercises a full review lifecycle: assigns a reviewer, then moves the document forward through every stage of the Default workflow (**Ready to review → In progress → Reviewed**), asserting each update persists and that the list view reflects the final stage and assignee.

It reuses the file's existing helpers (`checkAssignee`, `waitForStageUpdate`, `goBackToArticleList`) so it matches the proven selectors/flow.

### Why is it needed?
The existing review-workflows specs cover a single assignee change and a single stage hop. #22 asks for a *full* stage transition with assignees — this closes that gap at the `@release` tier.

### How to test it?
EE-only. It's gated by `describeOnCondition(edition === 'EE')`, so:
- **CE** (`yarn test:e2e` with no license) → skipped
- **EE** (CI `[EE] e2e` job, or `STRAPI_LICENSE` set locally) → runs
```
STRAPI_LICENSE=… yarn test:e2e:ee --domains review-workflows -- content-manager.spec.ts
```
Validated locally with `playwright --list` (parses + registers across chromium/firefox/webkit). Behaviour is verified by the **`[EE] e2e`** CI job — no EE license is available locally.

### Related issue(s)/PR(s)
E2E coverage focus — Phase 3 (@release). https://app.notion.com/p/strapi/E2E-coverage-focus-3738f35980748111a75bcc596272f8d7

> Note: the "permissions" dimension of #22 (stage role-permissions) is a distinct EE feature — recommend a separate follow-up rather than bundling it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
