### PR TITLE
chore(eslint): enforce zero warnings in package lint scripts

### DIFF
--- a/.github/actions/check-pr-status/package.json
+++ b/.github/actions/check-pr-status/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "NODE_ENV=production ncc build index.js -o dist --minify",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "watch": "NODE_ENV=production ncc build index.js -w -o dist --minify"
   },
   "dependencies": {

--- a/lint-staged.shared.mjs
+++ b/lint-staged.shared.mjs
@@ -10,7 +10,7 @@
  * @type {import('lint-staged').Configuration}
  */
 const config = {
-  '*.{js,ts,jsx,tsx}': ['eslint --cache --fix', 'prettier --cache --write'],
+  '*.{js,ts,jsx,tsx}': ['eslint --cache --fix --max-warnings=0', 'prettier --cache --write'],
   '!(*.js|*.ts|*.jsx|*.tsx)': ['prettier --cache --write --ignore-unknown'],
 };
 

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -73,7 +73,7 @@
     "watch:code": "run -T rollup -c -w",
     "watch:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly -w",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -43,7 +43,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest",
     "watch": "run -T rollup -c -w"
   },

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -46,7 +46,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc --noEmit",
     "watch": "run -T rollup -c -w"
   },

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -73,7 +73,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",
     "test:ts": "run -T tsc -p tsconfig.json",

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -57,7 +57,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:ts:back": "run -T tsc --noEmit -p server/tsconfig.json && run -T tsc --noEmit -p server/tsconfig.preview-script.json",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",

--- a/packages/core/content-releases/lint-staged.config.mjs
+++ b/packages/core/content-releases/lint-staged.config.mjs
@@ -7,7 +7,10 @@
  * @type {import('lint-staged').Configuration}
  */
 const config = {
-  '*.{js,ts,jsx,tsx}': ['yarn run -T eslint --cache --fix', 'prettier --cache --write'],
+  '*.{js,ts,jsx,tsx}': [
+    'yarn run -T eslint --cache --fix --max-warnings=0',
+    'prettier --cache --write',
+  ],
   '!(*.js|*.ts|*.jsx|*.tsx)': ['prettier --cache --write --ignore-unknown'],
 };
 

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -52,7 +52,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:front:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js",
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -53,7 +53,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:front:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js",
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -48,7 +48,7 @@
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "watch": "run -T rollup -c -w",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "prepublishOnly": "yarn clean && yarn build",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -45,7 +45,7 @@
     "build:code": "run -T rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "test:unit:vitest": "vitest run",

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -36,7 +36,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T tsc --noEmit && run -T eslint .",
+    "lint": "run -T tsc --noEmit && run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "test:unit:vitest": "vitest run",

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -52,7 +52,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:front:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js",
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -47,7 +47,7 @@
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "watch": "run -T rollup -c -w",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "prepublishOnly": "yarn clean && yarn build",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch"

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -36,7 +36,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc --noEmit",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -52,7 +52,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:ts:back": "run -T tsc --noEmit -p server/tsconfig.json",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -102,7 +102,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "watch": "run -T rollup -c -w"

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -39,7 +39,7 @@
     "clean": "run -T rimraf ./dist",
     "doc:ts": "typedoc",
     "doc:ts:watch": "typedoc --watch",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc --noEmit",
     "watch": "run -T tsc -p tsconfig.build.json -w"
   },

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -59,7 +59,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:unit": "run -T jest",
     "test:ts:back": "run -T tsc --noEmit -p server/tsconfig.json",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -40,7 +40,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc --noEmit",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -42,7 +42,7 @@
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
     "copy-files": "copyfiles -u 1 -a 'src/templates/**/*' 'src/files/**/*' dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc --noEmit",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -44,7 +44,7 @@
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
     "develop": "strapi-plugin watch",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
     "watch": "run -T rollup -c -w"
   },

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -52,7 +52,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:front:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js",
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -52,7 +52,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -52,7 +52,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest --passWithNoTests",
     "test:unit:watch": "run -T jest --watch",
     "watch": "run -T rollup -c -w"

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -52,7 +52,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
     "test:unit": "run -T jest",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -51,7 +51,7 @@
     "build:types:server": "run -T tsc -p server/tsconfig.build.json --emitDeclarationOnly",
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "watch": "run -T rollup -c -w"

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -43,7 +43,7 @@
     "build": "run -T npm-run-all clean build:code",
     "build:code": "run -T rollup -c",
     "clean": "run -T rimraf dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:front:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js",
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -37,7 +37,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit:vitest": "vitest run",
     "test:unit:vitest:watch": "vitest --watch",
     "watch": "run -T rollup -c -w"

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -41,7 +41,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "watch": "run -T rollup -c -w"

--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -67,7 +67,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest",
     "watch": "run -T rollup -c -w"
   },

--- a/packages/providers/email-sendgrid/package.json
+++ b/packages/providers/email-sendgrid/package.json
@@ -41,7 +41,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -40,7 +40,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest --watchman=false",
     "watch": "run -T rollup -c -w"
   },

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -42,7 +42,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "watch": "run -T rollup -c -w"

--- a/packages/providers/upload-cloudinary/package.json
+++ b/packages/providers/upload-cloudinary/package.json
@@ -41,7 +41,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -40,7 +40,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "watch": "run -T rollup -c -w"

--- a/packages/utils/logger/package.json
+++ b/packages/utils/logger/package.json
@@ -36,7 +36,7 @@
     "build:code": "run -T  rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc --noEmit",
     "watch": "run -T rollup -c -w"
   },

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -34,7 +34,7 @@
     "lib": "./lib"
   },
   "scripts": {
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "test": "run -T jest",
     "test:watch": "run -T jest --watch"
   },

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -57,7 +57,7 @@
     "build:code": "run -T rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint .",
+    "lint": "run -T eslint . --max-warnings=0",
     "prepublishOnly": "yarn clean && yarn build",
     "test:ts": "run -T tsc --noEmit",
     "test:unit": "run -T jest",


### PR DESCRIPTION
### What does it do?

Follow-up to [#26818](https://github.com/strapi/strapi/pull/26818), which drove the ESLint warning baseline to zero. This PR prevents that baseline from silently regressing:

Add `--max-warnings=0` to every package `lint` script (~38 packages) so ESLint fails when any warning is reintroduced. Warn-level rules stay at their inherited severity (`warn` / `off`); no tier-1 or tier-2 promotions in `eslint-config-custom`.

The CLI gate catches **all** warn regressions, not just a curated subset.

### Why is it needed?

#26818 eliminated ~2000 warnings, but nothing in CI stops them coming back. ESLint treats warnings as non-fatal; without `--max-warnings=0`, a new unused import or `any` annotation can land while `yarn lint` still passes. That undermines the zero-warning baseline we need before the Oxlint migration ([#26923](https://github.com/strapi/strapi/pull/26923)).

### How to test it?

```bash
yarn lint --skip-nx-cache
```

Must pass with zero warnings and zero errors across all nx lint targets.

Sanity check that the gate works: introduce a deliberate lint warning in a scratch file (e.g. unused import) and confirm `yarn nx lint <package> --skip-nx-cache` fails.

No product behaviour changes expected — config-only PR.

### Related issues / PRs

- [#26818](https://github.com/strapi/strapi/pull/26818) — zero-warning ESLint baseline this PR hardens
- [CMS-1381](https://linear.app/strapi/issue/CMS-1381/enforce-eslint-zero-warnings-and-promote-lint-rules-to-errors)
- Proposal: [lint-warn-to-error hardening proposal](https://github.com/strapi/strapi/blob/develop/.brain/personal/nico/context/2026-07-06-15:48-strapi-1-lint-warn-to-error/2026-07-06-15:48-lint-warn-to-error-proposal.md) (local context — not in repo)

---
_AI assisted_