### PR TITLE
fix(content-manager): fix broken redirects to 403 and no-content-types pages

### DIFF
--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -57,12 +57,12 @@ const Layout = () => {
     supportedModelsToDisplay.length > 0 &&
     pathname !== '/content-manager/403'
   ) {
-    return <Navigate to="/403" />;
+    return <Navigate to="/content-manager/403" />;
   }
 
   // Redirect the user to the create content type page
-  if (supportedModelsToDisplay.length === 0 && pathname !== '/no-content-types') {
-    return <Navigate to="/no-content-types" />;
+  if (supportedModelsToDisplay.length === 0 && pathname !== '/content-manager/no-content-types') {
+    return <Navigate to="/content-manager/no-content-types" />;
   }
 
   // On /content-manager base route

--- a/packages/core/content-manager/admin/src/tests/Layout.test.tsx
+++ b/packages/core/content-manager/admin/src/tests/Layout.test.tsx
@@ -1,0 +1,95 @@
+import { render as renderRTL, screen } from '@tests/utils';
+import { Route, Routes } from 'react-router-dom';
+
+jest.mock('@strapi/admin/strapi-admin', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin'),
+  useIsMobile: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../hooks/useContentManagerInitData', () => ({
+  useContentManagerInitData: jest.fn(),
+}));
+
+import { useContentManagerInitData } from '../hooks/useContentManagerInitData';
+import { Layout } from '../layout';
+
+import type { ContentType } from '../../../shared/contracts/content-types';
+import type { ContentManagerLink } from '../hooks/useContentManagerInitData';
+import type { AppState } from '../modules/app';
+
+const mockUseContentManagerInitData = useContentManagerInitData as jest.MockedFunction<
+  typeof useContentManagerInitData
+>;
+
+const ARTICLE_MODEL = {
+  uid: 'api::article.article',
+  isDisplayed: true,
+  apiID: 'article',
+  kind: 'collectionType',
+  info: { displayName: 'Article' },
+} as unknown as ContentType;
+
+const ARTICLE_LINK: ContentManagerLink = {
+  permissions: [],
+  search: null,
+  kind: 'collectionType',
+  title: 'Article',
+  to: '/content-manager/collection-types/api::article.article',
+  uid: 'api::article.article',
+  name: 'api::article.article',
+  isDisplayed: true,
+};
+
+const mockAppState = (overrides: Partial<AppState>): AppState => ({
+  isLoading: false,
+  models: [],
+  collectionTypeLinks: [],
+  singleTypeLinks: [],
+  components: [],
+  fieldSizes: {},
+  ...overrides,
+});
+
+const render = (initialEntry: string) =>
+  renderRTL(
+    <Routes>
+      <Route path="content-manager/*" element={<Layout />}>
+        <Route path="403" element={<div>NoPermissions page</div>} />
+        <Route path="no-content-types" element={<div>NoContentType page</div>} />
+        <Route path="collection-types/:slug/:id" element={<div>EditView page</div>} />
+      </Route>
+    </Routes>,
+    { initialEntries: [initialEntry] }
+  );
+
+describe('Layout', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to the content-manager 403 page when the user has no authorised models for the active locale', () => {
+    mockUseContentManagerInitData.mockReturnValue(mockAppState({ models: [ARTICLE_MODEL] }));
+
+    render('/content-manager/collection-types/api::article.article/1');
+
+    expect(screen.getByText('NoPermissions page')).toBeInTheDocument();
+  });
+
+  it('redirects to the content-manager no-content-types page when there are no supported models at all', () => {
+    mockUseContentManagerInitData.mockReturnValue(mockAppState({ models: [] }));
+
+    render('/content-manager/collection-types/api::article.article/1');
+
+    expect(screen.getByText('NoContentType page')).toBeInTheDocument();
+  });
+
+  it('renders the authorised route without redirecting when the user has access', () => {
+    mockUseContentManagerInitData.mockReturnValue(
+      mockAppState({ models: [ARTICLE_MODEL], collectionTypeLinks: [ARTICLE_LINK] })
+    );
+
+    render('/content-manager/collection-types/api::article.article/1');
+
+    expect(screen.getByText('EditView page')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### What does it do?

`Layout` (`packages/core/content-manager/admin/src/layout.tsx`) redirected to the absolute paths `/403` and `/no-content-types` when the user had no authorised models or no supported content types. Both pages are registered as nested routes under `content-manager/*` in `router.tsx` (`/content-manager/403` and `/content-manager/no-content-types`), so the `Navigate` targets never matched any route and the admin's catch-all rendered the generic `NotFoundPage` instead.

This PR points both redirects at the correct nested path, matching the `pathname` comparisons already used in the same conditions (which already expected the `/content-manager/...` prefix).

### Why is it needed?

When an admin user's role is restricted to specific i18n locales, switching to a locale they don't have access to leaves them on `authorisedModels.length === 0`, which redirects to `/403`. Since no route exists there, the app shows "Page not found" instead of the intended "You don't have permissions" screen — turning a normal RBAC denial into a confusing dead end. The `no-content-types` redirect has the exact same bug for a different empty state.

### How to test it?

Unit test added in `packages/core/content-manager/admin/src/tests/Layout.test.tsx` reproduces both empty states by mocking `useContentManagerInitData` and asserts the correct nested route renders instead of falling through to a 404. Confirmed the tests fail against the old code (`/403`, `/no-content-types`) and pass with the fix.

Manual repro from the issue: restrict a role's Content Manager permissions to one locale, log in as that role, open a localized entry, and switch to a locale outside the role's allowed locales.

### Related issue(s)/PR(s)

Fix #26707