### PR TITLE
fix(types): correct ForgotPassword.emailTemplate type from string to object

### DIFF
--- a/packages/core/types/src/core/config/admin.ts
+++ b/packages/core/types/src/core/config/admin.ts
@@ -61,7 +61,7 @@ export interface History {
 }
 
 export interface ForgotPassword {
-  emailTemplate?: string;
+  emailTemplate?: { subject: string; text: string; html?: string };
   from?: string;
   replyTo?: string;
 }


### PR DESCRIPTION
### What does it do?

Changes the `emailTemplate` property type in the `ForgotPassword` interface from `string` to `{ subject: string; text: string; html?: string }` in `packages/core/types/src/core/config/admin.ts`.

### Why is it needed?

The `ForgotPassword.emailTemplate` type is declared as `string`, but both the default value and the runtime consumer require an object:

- **Default value** — `packages/core/admin/server/src/config/email-templates/forgot-password.ts` exports `{ subject, text, html }`.
- **Runtime** — `sendTemplatedEmail()` in the email plugin validates that `emailTemplate` has `subject`, `text`, and `html` keys, and throws if any are missing.

This means TypeScript users who follow the declared type get a runtime error, and users who provide the correct object shape must suppress the type error with a cast.

### How to test it?

1. In a TypeScript Strapi project, configure `config/admin.ts` with a custom email template object:
   ```ts
   forgotPassword: {
     emailTemplate: { subject: 'Reset', text: '<%= url %>', html: '<p><%= url %></p>' },
   },
   ```
2. Verify `tsc` accepts it without errors (previously required an `as unknown as string` cast).
3. Run `yarn test:ts` — all type checks pass.

### Related issue(s)/PR(s)

Fix #26918