### PR TITLE
fix(upgrade): prompt to pin ranged @strapi/* dependencies before upgrading

### DIFF
--- a/packages/utils/upgrade/src/modules/project/__tests__/strapi-dependencies.test.ts
+++ b/packages/utils/upgrade/src/modules/project/__tests__/strapi-dependencies.test.ts
@@ -1,0 +1,112 @@
+import {
+  findUnpinnedStrapiDependencies,
+  getStrapiPinTargetVersion,
+  isPinnedSemVer,
+  pinStrapiDependencies,
+} from '../strapi-dependencies';
+import { semVerFactory } from '../../version';
+
+describe('strapi-dependencies', () => {
+  describe('isPinnedSemVer', () => {
+    it('accepts literal semver pins', () => {
+      expect(isPinnedSemVer('4.26.1')).toBe(true);
+      expect(isPinnedSemVer('5.0.0')).toBe(true);
+    });
+
+    it('rejects version ranges', () => {
+      expect(isPinnedSemVer('^4.26.1')).toBe(false);
+      expect(isPinnedSemVer('~4.26.1')).toBe(false);
+      expect(isPinnedSemVer('>=4.26.1 <5.0.0')).toBe(false);
+    });
+  });
+
+  describe('findUnpinnedStrapiDependencies', () => {
+    it('returns scoped @strapi packages that are not pinned', () => {
+      const unpinned = findUnpinnedStrapiDependencies(
+        {
+          '@strapi/strapi': '^4.26.1',
+          '@strapi/plugin-users-permissions': '4.26.1',
+          lodash: '^4.17.21',
+        },
+        {
+          '@strapi/types': '~4.26.1',
+        }
+      );
+
+      expect(unpinned).toEqual([
+        {
+          name: '@strapi/strapi',
+          declaredVersion: '^4.26.1',
+          section: 'dependencies',
+        },
+        {
+          name: '@strapi/types',
+          declaredVersion: '~4.26.1',
+          section: 'devDependencies',
+        },
+      ]);
+    });
+
+    it('returns an empty list when every @strapi package is pinned', () => {
+      const unpinned = findUnpinnedStrapiDependencies(
+        {
+          '@strapi/strapi': '4.26.1',
+          '@strapi/plugin-users-permissions': '4.26.1',
+        },
+        {
+          '@strapi/types': '4.26.1',
+        }
+      );
+
+      expect(unpinned).toEqual([]);
+    });
+  });
+
+  describe('pinStrapiDependencies', () => {
+    it('pins only the listed @strapi packages', () => {
+      const packageJSON = {
+        name: 'test-app',
+        version: '0.1.0',
+        dependencies: {
+          '@strapi/strapi': '^4.26.1',
+          '@strapi/plugin-users-permissions': '4.26.1',
+        },
+        devDependencies: {
+          '@strapi/types': '~4.26.1',
+        },
+      };
+
+      const unpinned = findUnpinnedStrapiDependencies(
+        packageJSON.dependencies,
+        packageJSON.devDependencies
+      );
+
+      const updated = pinStrapiDependencies(packageJSON, '4.26.1', unpinned);
+
+      expect(updated.dependencies).toEqual({
+        '@strapi/strapi': '4.26.1',
+        '@strapi/plugin-users-permissions': '4.26.1',
+      });
+      expect(updated.devDependencies).toEqual({
+        '@strapi/types': '4.26.1',
+      });
+    });
+  });
+
+  describe('getStrapiPinTargetVersion', () => {
+    it('uses the declared floor for ranged @strapi/strapi versions', () => {
+      const project = {
+        packageJSON: {
+          name: 'test-app',
+          version: '0.1.0',
+          dependencies: {
+            '@strapi/strapi': '^4.26.1',
+          },
+        },
+        getInstalledStrapiVersion: () => semVerFactory('4.26.2'),
+      } as const;
+
+      expect(getStrapiPinTargetVersion(project).raw).toBe('4.26.1');
+    });
+  });
+});

--- a/packages/utils/upgrade/src/modules/project/index.ts
+++ b/packages/utils/upgrade/src/modules/project/index.ts
@@ -4,3 +4,4 @@ export type { Project, AppProject, PluginProject } from './project';
 export { projectFactory } from './project';
 export * as constants from './constants';
 export * from './utils';
+export * from './strapi-dependencies';

--- a/packages/utils/upgrade/src/modules/project/project.ts
+++ b/packages/utils/upgrade/src/modules/project/project.ts
@@ -156,7 +156,16 @@ export class AppProject extends Project {
     return this;
   }
 
-  private refreshStrapiVersion(): void {
+  applyPackageJSON(packageJSON: MinimalPackageJSON): void {
+    this.packageJSON = packageJSON;
+    this.refreshStrapiVersion();
+  }
+
+  getInstalledStrapiVersion(): Version.SemVer {
+    return this.findLocallyInstalledStrapiVersion();
+  }
+
+  refreshStrapiVersion(): void {
     this.strapiVersion =
       // First try to get the strapi version from the package.json dependencies
       this.findStrapiVersionFromProjectPackageJSON() ??
@@ -184,18 +193,29 @@ export class AppProject extends Project {
     const packageSearchText = `${constants.STRAPI_DEPENDENCY_NAME}/package.json`;
 
     let strapiPackageJSONPath: string;
-    let strapiPackageJSON: MinimalPackageJSON;
 
     try {
       strapiPackageJSONPath = require.resolve(packageSearchText, { paths: [this.cwd] });
-      strapiPackageJSON = require(strapiPackageJSONPath);
-
-      assert(typeof strapiPackageJSON === 'object');
     } catch {
+      strapiPackageJSONPath = path.join(
+        this.cwd,
+        'node_modules',
+        constants.STRAPI_DEPENDENCY_NAME,
+        'package.json'
+      );
+    }
+
+    if (!fse.pathExistsSync(strapiPackageJSONPath)) {
       throw new Error(
         `Cannot resolve module "${constants.STRAPI_DEPENDENCY_NAME}" from paths [${this.cwd}]`
       );
     }
+
+    const strapiPackageJSON = JSON.parse(
+      fse.readFileSync(strapiPackageJSONPath, 'utf-8')
+    ) as MinimalPackageJSON;
+
+    assert(typeof strapiPackageJSON === 'object');
 
     const strapiVersion = strapiPackageJSON.version;
 

--- a/packages/utils/upgrade/src/modules/project/strapi-dependencies.ts
+++ b/packages/utils/upgrade/src/modules/project/strapi-dependencies.ts
@@ -15,6 +15,21 @@ export type UnpinnedStrapiDependency = {
   section: StrapiDependencySection;
 };
 
+const asDependencyRecord = (value: unknown): Record<string, string> | undefined => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, string>;
+};
+
+export const getPackageDependencyRecords = (packageJSON: MinimalPackageJSON) => {
+  return {
+    dependencies: asDependencyRecord(packageJSON.dependencies),
+    devDependencies: asDependencyRecord(packageJSON.devDependencies),
+  };
+};
+
 export const isPinnedSemVer = (version: string): boolean => {
   return isLiteralSemVer(version) && semver.valid(version) === version;
 };
@@ -74,25 +89,24 @@ export const pinStrapiDependencies = (
   pinVersion: string,
   unpinned: UnpinnedStrapiDependency[]
 ): MinimalPackageJSON => {
-  const updated: MinimalPackageJSON = {
-    ...packageJSON,
-    dependencies: packageJSON.dependencies ? { ...packageJSON.dependencies } : undefined,
-    devDependencies: packageJSON.devDependencies ? { ...packageJSON.devDependencies } : undefined,
+  const dependencies: Record<string, string> = {
+    ...asDependencyRecord(packageJSON.dependencies),
+  };
+  const devDependencies: Record<string, string> = {
+    ...asDependencyRecord(packageJSON.devDependencies),
   };
 
   for (const { name, section } of unpinned) {
     if (section === 'dependencies') {
-      updated.dependencies = {
-        ...updated.dependencies,
-        [name]: pinVersion,
-      };
+      dependencies[name] = pinVersion;
     } else {
-      updated.devDependencies = {
-        ...updated.devDependencies,
-        [name]: pinVersion,
-      };
+      devDependencies[name] = pinVersion;
     }
   }
 
-  return updated;
+  return {
+    ...packageJSON,
+    dependencies,
+    devDependencies,
+  };
 };

--- a/packages/utils/upgrade/src/modules/project/strapi-dependencies.ts
+++ b/packages/utils/upgrade/src/modules/project/strapi-dependencies.ts
@@ -1,0 +1,98 @@
+import semver from 'semver';
+
+import { isLiteralSemVer, semVerFactory } from '../version';
+import * as constants from './constants';
+
+import type { Version } from '../version';
+import type { AppProject } from './project';
+import type { MinimalPackageJSON } from './types';
+
+export type StrapiDependencySection = 'dependencies' | 'devDependencies';
+
+export type UnpinnedStrapiDependency = {
+  name: string;
+  declaredVersion: string;
+  section: StrapiDependencySection;
+};
+
+export const isPinnedSemVer = (version: string): boolean => {
+  return isLiteralSemVer(version) && semver.valid(version) === version;
+};
+
+export const findUnpinnedStrapiDependencies = (
+  dependencies: Record<string, string> | undefined,
+  devDependencies: Record<string, string> | undefined
+): UnpinnedStrapiDependency[] => {
+  const unpinned: UnpinnedStrapiDependency[] = [];
+
+  const sections: Array<[StrapiDependencySection, Record<string, string> | undefined]> = [
+    ['dependencies', dependencies],
+    ['devDependencies', devDependencies],
+  ];
+
+  for (const [section, deps] of sections) {
+    if (!deps) {
+      continue;
+    }
+
+    for (const [name, version] of Object.entries(deps)) {
+      const isScopedStrapiPackage = name.startsWith(constants.SCOPED_STRAPI_PACKAGE_PREFIX);
+
+      if (isScopedStrapiPackage && !isPinnedSemVer(version)) {
+        unpinned.push({ name, declaredVersion: version, section });
+      }
+    }
+  }
+
+  return unpinned;
+};
+
+export const getStrapiPinTargetVersion = (project: AppProject): Version.SemVer => {
+  const declared = project.packageJSON.dependencies?.[constants.STRAPI_DEPENDENCY_NAME];
+
+  if (!declared) {
+    throw new Error(
+      `No version of ${constants.STRAPI_DEPENDENCY_NAME} was found in ${project.packageJSON.name}`
+    );
+  }
+
+  if (isPinnedSemVer(declared)) {
+    return semVerFactory(declared);
+  }
+
+  const minVersion = semver.minVersion(declared);
+
+  if (minVersion) {
+    return semVerFactory(minVersion.version);
+  }
+
+  return project.getInstalledStrapiVersion();
+};
+
+export const pinStrapiDependencies = (
+  packageJSON: MinimalPackageJSON,
+  pinVersion: string,
+  unpinned: UnpinnedStrapiDependency[]
+): MinimalPackageJSON => {
+  const updated: MinimalPackageJSON = {
+    ...packageJSON,
+    dependencies: packageJSON.dependencies ? { ...packageJSON.dependencies } : undefined,
+    devDependencies: packageJSON.devDependencies ? { ...packageJSON.devDependencies } : undefined,
+  };
+
+  for (const { name, section } of unpinned) {
+    if (section === 'dependencies') {
+      updated.dependencies = {
+        ...updated.dependencies,
+        [name]: pinVersion,
+      };
+    } else {
+      updated.devDependencies = {
+        ...updated.devDependencies,
+        [name]: pinVersion,
+      };
+    }
+  }
+
+  return updated;
+};

--- a/packages/utils/upgrade/src/tasks/upgrade/prompts/__tests__/pin-versions.test.ts
+++ b/packages/utils/upgrade/src/tasks/upgrade/prompts/__tests__/pin-versions.test.ts
@@ -1,0 +1,155 @@
+import path from 'node:path';
+
+import { vol, fs } from 'memfs';
+
+import { AbortedError } from '../../../../modules/error';
+import { assertAppProject, projectFactory } from '../../../../modules/project';
+import { Version } from '../../../../modules/version';
+import { pinVersions } from '../pin-versions';
+
+jest.mock('fs', () => fs);
+
+describe('pinVersions prompt', () => {
+  const cwd = '/__pin_versions_tests__';
+
+  const logger = {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    raw: jest.fn(),
+    isSilent: false,
+    isDebug: false,
+    setSilent: jest.fn(),
+    setDebug: jest.fn(),
+    warnings: 0,
+    errors: 0,
+    stdout: undefined,
+    stderr: undefined,
+  };
+
+  const createProject = (packageJSON: Record<string, unknown>) => {
+    vol.fromNestedJSON(
+      {
+        'package.json': JSON.stringify(packageJSON, null, 2),
+        node_modules: {
+          '@strapi': {
+            strapi: {
+              'package.json': JSON.stringify({
+                name: '@strapi/strapi',
+                version: '4.26.2',
+              }),
+            },
+          },
+        },
+      },
+      cwd
+    );
+
+    return projectFactory(cwd);
+  };
+
+  beforeEach(() => {
+    vol.reset();
+    jest.clearAllMocks();
+  });
+
+  it('does nothing when all @strapi dependencies are pinned', async () => {
+    const project = createProject({
+      name: 'test-app',
+      version: '0.1.0',
+      dependencies: {
+        '@strapi/strapi': '4.26.1',
+      },
+    });
+
+    assertAppProject(project);
+
+    const confirm = jest.fn();
+
+    await pinVersions(project, {
+      logger,
+      confirm,
+      target: Version.RELEASE_TYPES.Minor,
+    });
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('pins ranged @strapi dependencies after confirmation', async () => {
+    const project = createProject({
+      name: 'test-app',
+      version: '0.1.0',
+      dependencies: {
+        '@strapi/strapi': '^4.26.1',
+      },
+      devDependencies: {
+        '@strapi/types': '^4.26.1',
+      },
+    });
+
+    assertAppProject(project);
+
+    await pinVersions(project, {
+      logger,
+      confirm: jest.fn().mockResolvedValue(true),
+      target: Version.RELEASE_TYPES.Minor,
+    });
+
+    const packageJSON = JSON.parse(
+      vol.readFileSync(path.join(cwd, 'package.json'), 'utf-8').toString()
+    );
+
+    expect(packageJSON.dependencies['@strapi/strapi']).toBe('4.26.1');
+    expect(packageJSON.devDependencies['@strapi/types']).toBe('4.26.1');
+    expect(project.strapiVersion.raw).toBe('4.26.1');
+  });
+
+  it('aborts when the user declines pinning', async () => {
+    const project = createProject({
+      name: 'test-app',
+      version: '0.1.0',
+      dependencies: {
+        '@strapi/strapi': '^4.26.1',
+      },
+    });
+
+    assertAppProject(project);
+
+    await expect(
+      pinVersions(project, {
+        logger,
+        confirm: jest.fn().mockResolvedValue(false),
+        target: Version.RELEASE_TYPES.Minor,
+      })
+    ).rejects.toBeInstanceOf(AbortedError);
+  });
+
+  it('pins in memory only during dry runs', async () => {
+    const project = createProject({
+      name: 'test-app',
+      version: '0.1.0',
+      dependencies: {
+        '@strapi/strapi': '^4.26.1',
+      },
+    });
+
+    assertAppProject(project);
+
+    await pinVersions(project, {
+      logger,
+      confirm: jest.fn().mockResolvedValue(true),
+      dry: true,
+      target: Version.RELEASE_TYPES.Minor,
+    });
+
+    const packageJSON = JSON.parse(
+      vol.readFileSync(path.join(cwd, 'package.json'), 'utf-8').toString()
+    );
+
+    expect(packageJSON.dependencies['@strapi/strapi']).toBe('^4.26.1');
+    expect(project.strapiVersion.raw).toBe('4.26.1');
+    expect(project.packageJSON.dependencies?.['@strapi/strapi']).toBe('4.26.1');
+  });
+});

--- a/packages/utils/upgrade/src/tasks/upgrade/prompts/index.ts
+++ b/packages/utils/upgrade/src/tasks/upgrade/prompts/index.ts
@@ -1,1 +1,2 @@
 export * from './latest';
+export * from './pin-versions';

--- a/packages/utils/upgrade/src/tasks/upgrade/prompts/pin-versions.ts
+++ b/packages/utils/upgrade/src/tasks/upgrade/prompts/pin-versions.ts
@@ -1,0 +1,68 @@
+import { AbortedError } from '../../../modules/error';
+import * as f from '../../../modules/format';
+import { saveJSON } from '../../../modules/json';
+import {
+  findUnpinnedStrapiDependencies,
+  getStrapiPinTargetVersion,
+  pinStrapiDependencies,
+} from '../../../modules/project/strapi-dependencies';
+import { assertAppProject } from '../../../modules/project/utils';
+
+import type { Project } from '../../../modules/project';
+import type { UpgradeOptions } from '../types';
+
+/**
+ * Detects ranged @strapi/* dependencies and offers to pin them before upgrading.
+ *
+ * The upgrade tool matches and bumps only exact semver pins. Ranges (e.g. ^4.26.1)
+ * make the current version ambiguous and can cause false "already up-to-date" errors.
+ */
+export const pinVersions = async (project: Project, options: UpgradeOptions) => {
+  assertAppProject(project);
+
+  const unpinned = findUnpinnedStrapiDependencies(
+    project.packageJSON.dependencies,
+    project.packageJSON.devDependencies
+  );
+
+  if (unpinned.length === 0) {
+    return;
+  }
+
+  const pinTarget = getStrapiPinTargetVersion(project);
+  const pinVersion = pinTarget.raw;
+
+  const unpinnedList = unpinned
+    .map(({ name, declaredVersion }) => `${name} (${f.highlight(declaredVersion)})`)
+    .join(', ');
+
+  options.logger.warn(
+    [
+      'Found @strapi/* dependencies using version ranges instead of pinned versions:',
+      unpinnedList,
+      `(will pin to ${f.version(pinTarget)} before upgrading)`,
+    ].join(' ')
+  );
+
+  const confirmed =
+    typeof options.confirm === 'function'
+      ? await options.confirm(
+          `Pin all @strapi/* dependencies to ${f.version(pinTarget)} before upgrading?`
+        )
+      : true;
+
+  if (!confirmed) {
+    throw new AbortedError();
+  }
+
+  const updatedPackageJSON = pinStrapiDependencies(project.packageJSON, pinVersion, unpinned);
+
+  if (options.dry) {
+    project.applyPackageJSON(updatedPackageJSON);
+    options.logger.warn('Pinned versions in memory only (dry mode).');
+    return;
+  }
+
+  await saveJSON(project.packageJSONPath, updatedPackageJSON);
+  project.refresh();
+};

--- a/packages/utils/upgrade/src/tasks/upgrade/prompts/pin-versions.ts
+++ b/packages/utils/upgrade/src/tasks/upgrade/prompts/pin-versions.ts
@@ -3,6 +3,7 @@ import * as f from '../../../modules/format';
 import { saveJSON } from '../../../modules/json';
 import {
   findUnpinnedStrapiDependencies,
+  getPackageDependencyRecords,
   getStrapiPinTargetVersion,
   pinStrapiDependencies,
 } from '../../../modules/project/strapi-dependencies';
@@ -20,10 +21,9 @@ import type { UpgradeOptions } from '../types';
 export const pinVersions = async (project: Project, options: UpgradeOptions) => {
   assertAppProject(project);
 
-  const unpinned = findUnpinnedStrapiDependencies(
-    project.packageJSON.dependencies,
-    project.packageJSON.devDependencies
-  );
+  const { dependencies, devDependencies } = getPackageDependencyRecords(project.packageJSON);
+
+  const unpinned = findUnpinnedStrapiDependencies(dependencies, devDependencies);
 
   if (unpinned.length === 0) {
     return;

--- a/packages/utils/upgrade/src/tasks/upgrade/upgrade.ts
+++ b/packages/utils/upgrade/src/tasks/upgrade/upgrade.ts
@@ -39,6 +39,9 @@ export const upgrade = async (options: UpgradeOptions) => {
   // Load all available versions from the NPM registry
   await npmPackage.refresh();
 
+  // Pin ranged @strapi/* dependencies before resolving upgrade targets
+  await prompts.pinVersions(project, options);
+
   // Initialize the upgrade instance
   // Throws during initialization if the provided target is incompatible with the current version
   const upgrader = upgraderFactory(project, options.target, npmPackage)


### PR DESCRIPTION
### What does it do?

Detects `@strapi/*` dependencies in `package.json` that use semver ranges (e.g. `^4.26.1`) instead of exact pins. Before resolving upgrade targets, the CLI warns and prompts to pin those dependencies to the declared floor version (`semver.minVersion`), then proceeds with the normal upgrade flow.

Also reads the installed `@strapi/strapi` version from disk when module resolution fails (improves testability and standard `node_modules` layouts).

### Why is it needed?

When projects declare ranged `@strapi/*` versions, the upgrade tool fell back to the installed version in `node_modules`. If install had already resolved to the latest release (e.g. `4.26.2`), `minor`/`patch` upgrades falsely reported "already up-to-date" even though `package.json` still used ranges.

Pinning first establishes a clear upgrade baseline and keeps sibling `@strapi/*` packages aligned — matching what the upgrader already expects.

Fixes CMS-1227

### How to test it?

1. Create a minimal Strapi app `package.json` with ranged deps:

```json
{
  "dependencies": {
    "@strapi/strapi": "^4.26.1"
  },
  "devDependencies": {
    "@strapi/types": "^4.26.1"
  }
}
```

2. Add `node_modules/@strapi/strapi/package.json` with `"version": "4.26.2"` (or run `npm install`).

3. Run `npx @strapi/upgrade minor --debug -y` from the project root.

4. Confirm:
   - Warning about unpinned `@strapi/*` dependencies
   - Prompt to pin (auto-confirmed with `-y`)
   - Upgrade proceeds from `4.26.1` → `4.26.2`
   - `package.json` dependencies are pinned

5. Unit tests: `yarn nx test:unit @strapi/upgrade`

### Related issue(s)/PR(s)

Fixes CMS-1227