### PR TITLE
enhancement(admin): make admin auth cookie name configurable

### DIFF
--- a/docs/docs/docs/01-core/authentication/00-sessions-and-jwt.md
+++ b/docs/docs/docs/01-core/authentication/00-sessions-and-jwt.md
@@ -80,10 +80,11 @@ Configuration:
 **Deprecated:**
 
 - `admin.auth.options.*` — Use `admin.auth.sessions.options.*` instead
-- Cookie options (applied to `strapi_admin_refresh`):
-  - `admin.auth.cookie.domain` (or `admin.auth.domain`)
-  - `admin.auth.cookie.path` (default `/admin`)
-  - `admin.auth.cookie.sameSite` (default `lax`)
+- Cookie options:
+  - `admin.auth.cookie.name` (default `jwtToken`) — name of the non-httpOnly access-token cookie used for session logins (when `rememberMe` is false) and EE SSO handoff. Rename to avoid collisions with another app on a shared parent domain that sets a `jwtToken` cookie. Requires an admin rebuild after change (value is inlined into the admin bundle at build time).
+  - `admin.auth.cookie.domain` (or `admin.auth.domain`) — applied to `strapi_admin_refresh`
+  - `admin.auth.cookie.path` (default `/admin`) — applied to `strapi_admin_refresh`
+  - `admin.auth.cookie.sameSite` (default `lax`) — applied to `strapi_admin_refresh`
 
 Key files:
 

--- a/packages/core/admin/admin/src/reducer.ts
+++ b/packages/core/admin/admin/src/reducer.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import { PermissionMap } from './types/permissions';
-import { getCookieValue, setCookie, deleteCookie } from './utils/cookies';
+import { AUTH_COOKIE_NAME, getCookieValue, setCookie, deleteCookie } from './utils/cookies';
 
 import type { PayloadAction } from '@reduxjs/toolkit';
 
@@ -34,7 +34,7 @@ export const getStoredToken = (): string | null => {
     return JSON.parse(fromLocalStorage);
   }
 
-  const fromCookie = getCookieValue(STORAGE_KEYS.TOKEN);
+  const fromCookie = getCookieValue(AUTH_COOKIE_NAME);
   return fromCookie ?? null;
 };
 
@@ -75,7 +75,7 @@ const adminSlice = createSlice({
       const { token, persist } = action.payload;
 
       if (!persist) {
-        setCookie(STORAGE_KEYS.TOKEN, token);
+        setCookie(AUTH_COOKIE_NAME, token);
       } else {
         window.localStorage.setItem(STORAGE_KEYS.TOKEN, JSON.stringify(token));
       }
@@ -84,7 +84,7 @@ const adminSlice = createSlice({
     },
     logout(state) {
       state.token = null;
-      deleteCookie(STORAGE_KEYS.TOKEN);
+      deleteCookie(AUTH_COOKIE_NAME);
       window.localStorage.removeItem(STORAGE_KEYS.TOKEN);
       window.localStorage.removeItem(STORAGE_KEYS.STATUS);
     },

--- a/packages/core/admin/admin/src/tests/reducer.test.ts
+++ b/packages/core/admin/admin/src/tests/reducer.test.ts
@@ -10,6 +10,7 @@ import {
 import { setCookie, deleteCookie } from '../utils/cookies';
 
 jest.mock('../utils/cookies', () => ({
+  ...jest.requireActual('../utils/cookies'),
   setCookie: jest.fn(),
   deleteCookie: jest.fn(),
 }));

--- a/packages/core/admin/admin/src/utils/cookies.ts
+++ b/packages/core/admin/admin/src/utils/cookies.ts
@@ -1,3 +1,11 @@
+import { getAuthCookieName } from '../../../shared/utils/auth-cookie-name';
+
+/**
+ * Resolved once at module load: `STRAPI_ADMIN_AUTH_COOKIE_NAME` is inlined
+ * into the admin bundle at build time.
+ */
+export const AUTH_COOKIE_NAME = getAuthCookieName();
+
 /**
  * Retrieves the value of a specified cookie.
  *

--- a/packages/core/admin/admin/src/utils/cookies.ts
+++ b/packages/core/admin/admin/src/utils/cookies.ts
@@ -1,10 +1,10 @@
-import { getAuthCookieName } from '../../../shared/utils/auth-cookie-name';
+import { resolveAuthCookieName } from '../../../shared/utils/auth-cookie-name';
 
 /**
- * Resolved once at module load: `STRAPI_ADMIN_AUTH_COOKIE_NAME` is inlined
- * into the admin bundle at build time.
+ * Resolved once at module load: the build inlines `admin.auth.cookie.name`
+ * into the bundle as `STRAPI_ADMIN_AUTH_COOKIE_NAME`.
  */
-export const AUTH_COOKIE_NAME = getAuthCookieName();
+export const AUTH_COOKIE_NAME = resolveAuthCookieName(process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME);
 
 /**
  * Retrieves the value of a specified cookie.

--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -2,7 +2,7 @@ import pipe from 'lodash/fp/pipe';
 // eslint-disable-next-line import/default
 import qs from 'qs';
 
-import { getCookieValue, setCookie } from './cookies';
+import { AUTH_COOKIE_NAME, getCookieValue, setCookie } from './cookies';
 
 import type { errors } from '@strapi/utils';
 
@@ -102,7 +102,7 @@ const storeToken = (token: string): void => {
   if (wasPersistedToLocalStorage) {
     localStorage.setItem(STORAGE_KEYS.TOKEN, JSON.stringify(token));
   } else {
-    setCookie(STORAGE_KEYS.TOKEN, token);
+    setCookie(AUTH_COOKIE_NAME, token);
   }
 
   // Notify the app to update its state (e.g., Redux)
@@ -232,7 +232,7 @@ const getToken = (): string | null => {
     return JSON.parse(fromLocalStorage);
   }
 
-  const fromCookie = getCookieValue(STORAGE_KEYS.TOKEN);
+  const fromCookie = getCookieValue(AUTH_COOKIE_NAME);
   return fromCookie ?? null;
 };
 

--- a/packages/core/admin/admin/src/utils/tests/cookies.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/cookies.test.ts
@@ -39,4 +39,34 @@ describe('Cookie Utilities', () => {
       expect(getCookieValue('deleteMe')).toBeNull();
     });
   });
+
+  describe('AUTH_COOKIE_NAME', () => {
+    const ORIGINAL_ENV = process.env;
+
+    afterEach(() => {
+      process.env = ORIGINAL_ENV;
+    });
+
+    const loadAuthCookieName = (): string => {
+      let name = '';
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        name = require('../cookies').AUTH_COOKIE_NAME;
+      });
+      return name;
+    };
+
+    it('should default to jwtToken', () => {
+      process.env = { ...ORIGINAL_ENV };
+      delete process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME;
+
+      expect(loadAuthCookieName()).toBe('jwtToken');
+    });
+
+    it('should use STRAPI_ADMIN_AUTH_COOKIE_NAME when set', () => {
+      process.env = { ...ORIGINAL_ENV, STRAPI_ADMIN_AUTH_COOKIE_NAME: 'my_custom_auth_cookie' };
+
+      expect(loadAuthCookieName()).toBe('my_custom_auth_cookie');
+    });
+  });
 });

--- a/packages/core/admin/ee/admin/src/pages/AuthResponse.tsx
+++ b/packages/core/admin/ee/admin/src/pages/AuthResponse.tsx
@@ -6,7 +6,7 @@ import { useNavigate, useMatch } from 'react-router-dom';
 import { Page } from '../../../../admin/src/components/PageHelpers';
 import { useTypedDispatch } from '../../../../admin/src/core/store/hooks';
 import { login } from '../../../../admin/src/reducer';
-import { getCookieValue } from '../../../../admin/src/utils/cookies';
+import { AUTH_COOKIE_NAME, getCookieValue } from '../../../../admin/src/utils/cookies';
 
 const AuthResponse = () => {
   const match = useMatch('/auth/login/:authResponse');
@@ -32,7 +32,7 @@ const AuthResponse = () => {
     }
 
     if (match?.params.authResponse === 'success') {
-      const jwtToken = getCookieValue('jwtToken');
+      const jwtToken = getCookieValue(AUTH_COOKIE_NAME);
 
       if (jwtToken) {
         dispatch(

--- a/packages/core/admin/ee/admin/src/pages/tests/AuthResponse.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/tests/AuthResponse.test.tsx
@@ -34,6 +34,7 @@ jest.mock('../../../../../admin/src/reducer', () => ({
 }));
 
 jest.mock('../../../../../admin/src/utils/cookies', () => ({
+  ...jest.requireActual('../../../../../admin/src/utils/cookies'),
   getCookieValue: jest.fn(),
 }));
 

--- a/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
+++ b/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
@@ -5,10 +5,10 @@ import utils from './utils';
 import {
   REFRESH_COOKIE_NAME,
   buildCookieOptionsWithExpiry,
+  getAccessCookieName,
   getSessionManager,
   generateDeviceId,
 } from '../../../../../shared/utils/session-auth';
-import { getAuthCookieName } from '../../../../../shared/utils/auth-cookie-name';
 
 const defaultConnectionError = () => new Error('Invalid connection payload');
 
@@ -137,7 +137,7 @@ export const redirectWithAuth: Core.MiddlewareHandler = async (ctx) => {
     const isSecure = typeof configuredSecure === 'boolean' ? configuredSecure : isProduction;
 
     const domain: string | undefined = strapi.config.get('admin.auth.domain');
-    ctx.cookies.set(getAuthCookieName(), accessToken, {
+    ctx.cookies.set(getAccessCookieName(), accessToken, {
       httpOnly: false,
       secure: isSecure,
       overwrite: true,

--- a/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
+++ b/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
@@ -8,6 +8,7 @@ import {
   getSessionManager,
   generateDeviceId,
 } from '../../../../../shared/utils/session-auth';
+import { getAuthCookieName } from '../../../../../shared/utils/auth-cookie-name';
 
 const defaultConnectionError = () => new Error('Invalid connection payload');
 
@@ -136,7 +137,7 @@ export const redirectWithAuth: Core.MiddlewareHandler = async (ctx) => {
     const isSecure = typeof configuredSecure === 'boolean' ? configuredSecure : isProduction;
 
     const domain: string | undefined = strapi.config.get('admin.auth.domain');
-    ctx.cookies.set('jwtToken', accessToken, {
+    ctx.cookies.set(getAuthCookieName(), accessToken, {
       httpOnly: false,
       secure: isSecure,
       overwrite: true,

--- a/packages/core/admin/shared/utils/__tests__/auth-cookie-name.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/auth-cookie-name.test.ts
@@ -1,0 +1,48 @@
+import { DEFAULT_AUTH_COOKIE_NAME, getAuthCookieName } from '../auth-cookie-name';
+
+describe('getAuthCookieName', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME;
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.restoreAllMocks();
+  });
+
+  test('defaults to jwtToken', () => {
+    expect(getAuthCookieName()).toBe(DEFAULT_AUTH_COOKIE_NAME);
+  });
+
+  test('uses STRAPI_ADMIN_AUTH_COOKIE_NAME when set', () => {
+    process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME = 'my_custom_auth_cookie';
+
+    expect(getAuthCookieName()).toBe('my_custom_auth_cookie');
+  });
+
+  test('trims surrounding whitespace', () => {
+    process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME = ' my_custom_auth_cookie ';
+
+    expect(getAuthCookieName()).toBe('my_custom_auth_cookie');
+  });
+
+  test('falls back to the default when the variable is empty or blank', () => {
+    process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME = '   ';
+
+    expect(getAuthCookieName()).toBe(DEFAULT_AUTH_COOKIE_NAME);
+  });
+
+  test.each(['bad name', 'bad;name', 'bad=name', 'bad,name'])(
+    'warns and falls back to the default for the invalid name "%s"',
+    (invalidName) => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME = invalidName;
+
+      expect(getAuthCookieName()).toBe(DEFAULT_AUTH_COOKIE_NAME);
+      expect(warn).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/packages/core/admin/shared/utils/__tests__/auth-cookie-name.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/auth-cookie-name.test.ts
@@ -1,47 +1,30 @@
-import { DEFAULT_AUTH_COOKIE_NAME, getAuthCookieName } from '../auth-cookie-name';
+import { DEFAULT_AUTH_COOKIE_NAME, resolveAuthCookieName } from '../auth-cookie-name';
 
-describe('getAuthCookieName', () => {
-  const ORIGINAL_ENV = process.env;
-
-  beforeEach(() => {
-    process.env = { ...ORIGINAL_ENV };
-    delete process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME;
-  });
-
+describe('resolveAuthCookieName', () => {
   afterEach(() => {
-    process.env = ORIGINAL_ENV;
     jest.restoreAllMocks();
   });
 
-  test('defaults to jwtToken', () => {
-    expect(getAuthCookieName()).toBe(DEFAULT_AUTH_COOKIE_NAME);
+  test('defaults to jwtToken for undefined, empty, and blank values', () => {
+    expect(resolveAuthCookieName(undefined)).toBe(DEFAULT_AUTH_COOKIE_NAME);
+    expect(resolveAuthCookieName('')).toBe(DEFAULT_AUTH_COOKIE_NAME);
+    expect(resolveAuthCookieName('   ')).toBe(DEFAULT_AUTH_COOKIE_NAME);
   });
 
-  test('uses STRAPI_ADMIN_AUTH_COOKIE_NAME when set', () => {
-    process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME = 'my_custom_auth_cookie';
-
-    expect(getAuthCookieName()).toBe('my_custom_auth_cookie');
+  test('returns the configured name', () => {
+    expect(resolveAuthCookieName('my_custom_auth_cookie')).toBe('my_custom_auth_cookie');
   });
 
   test('trims surrounding whitespace', () => {
-    process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME = ' my_custom_auth_cookie ';
-
-    expect(getAuthCookieName()).toBe('my_custom_auth_cookie');
-  });
-
-  test('falls back to the default when the variable is empty or blank', () => {
-    process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME = '   ';
-
-    expect(getAuthCookieName()).toBe(DEFAULT_AUTH_COOKIE_NAME);
+    expect(resolveAuthCookieName(' my_custom_auth_cookie ')).toBe('my_custom_auth_cookie');
   });
 
   test.each(['bad name', 'bad;name', 'bad=name', 'bad,name'])(
     'warns and falls back to the default for the invalid name "%s"',
     (invalidName) => {
       const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME = invalidName;
 
-      expect(getAuthCookieName()).toBe(DEFAULT_AUTH_COOKIE_NAME);
+      expect(resolveAuthCookieName(invalidName)).toBe(DEFAULT_AUTH_COOKIE_NAME);
       expect(warn).toHaveBeenCalledTimes(1);
     }
   );

--- a/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
@@ -1,0 +1,35 @@
+import { getAccessCookieName } from '../session-auth';
+import { DEFAULT_AUTH_COOKIE_NAME } from '../auth-cookie-name';
+
+describe('getAccessCookieName', () => {
+  beforeEach(() => {
+    global.strapi = {
+      config: {
+        get: jest.fn(() => undefined),
+      },
+    } as any;
+  });
+
+  test('defaults to jwtToken', () => {
+    expect(getAccessCookieName()).toBe(DEFAULT_AUTH_COOKIE_NAME);
+  });
+
+  test('uses the admin.auth.cookie.name config', () => {
+    global.strapi.config.get = jest.fn((key: string) =>
+      key === 'admin.auth.cookie.name' ? 'config_cookie_name' : undefined
+    ) as any;
+
+    expect(getAccessCookieName()).toBe('config_cookie_name');
+  });
+
+  test('does not read the STRAPI_ADMIN_AUTH_COOKIE_NAME environment variable', () => {
+    const ORIGINAL_ENV = process.env;
+    process.env = { ...ORIGINAL_ENV, STRAPI_ADMIN_AUTH_COOKIE_NAME: 'env_cookie_name' };
+
+    try {
+      expect(getAccessCookieName()).toBe(DEFAULT_AUTH_COOKIE_NAME);
+    } finally {
+      process.env = ORIGINAL_ENV;
+    }
+  });
+});

--- a/packages/core/admin/shared/utils/auth-cookie-name.ts
+++ b/packages/core/admin/shared/utils/auth-cookie-name.ts
@@ -1,34 +1,33 @@
 /**
- * Name of the cookie holding the admin auth (access) token.
+ * Name of the cookie holding the admin auth (access) token, configurable
+ * through `admin.auth.cookie.name` so it cannot collide with a same-named
+ * cookie set by another application on a shared parent domain.
  *
- * Configurable through the `STRAPI_ADMIN_AUTH_COOKIE_NAME` environment
- * variable so the cookie cannot collide with a same-named cookie set by
- * another application on a shared parent domain.
- *
- * This module is browser-safe and is the single source of truth for both
- * sides of the SSO handoff: the admin panel inlines the variable at build
- * time, the server reads it at runtime. The variable must therefore be set
- * both when the admin panel is built and when the server runs, otherwise the
- * two sides disagree on the cookie name.
+ * Browser-safe single source for both sides of the SSO handoff: the admin
+ * panel cannot read server config, so the build transports the config value
+ * into the bundle through the internal `STRAPI_ADMIN_AUTH_COOKIE_NAME`
+ * variable (see create-build-context.ts in @strapi/strapi); the server
+ * resolves the same config at runtime. Renaming the cookie requires an admin
+ * rebuild, like any other admin config change.
  */
 export const DEFAULT_AUTH_COOKIE_NAME = 'jwtToken';
 
 // RFC 6265 cookie-name token characters.
 const VALID_COOKIE_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
-export const getAuthCookieName = (): string => {
-  const configured = (process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME || '').trim();
+export const resolveAuthCookieName = (configuredName?: string): string => {
+  const cookieName = (configuredName || '').trim();
 
-  if (!configured) {
+  if (!cookieName) {
     return DEFAULT_AUTH_COOKIE_NAME;
   }
 
-  if (!VALID_COOKIE_NAME.test(configured)) {
+  if (!VALID_COOKIE_NAME.test(cookieName)) {
     console.warn(
-      `Ignoring invalid STRAPI_ADMIN_AUTH_COOKIE_NAME "${configured}" (must only contain RFC 6265 cookie-name characters); using "${DEFAULT_AUTH_COOKIE_NAME}" instead.`
+      `Ignoring invalid admin auth cookie name "${cookieName}" (must only contain RFC 6265 cookie-name characters); using "${DEFAULT_AUTH_COOKIE_NAME}" instead.`
     );
     return DEFAULT_AUTH_COOKIE_NAME;
   }
 
-  return configured;
+  return cookieName;
 };

--- a/packages/core/admin/shared/utils/auth-cookie-name.ts
+++ b/packages/core/admin/shared/utils/auth-cookie-name.ts
@@ -1,0 +1,34 @@
+/**
+ * Name of the cookie holding the admin auth (access) token.
+ *
+ * Configurable through the `STRAPI_ADMIN_AUTH_COOKIE_NAME` environment
+ * variable so the cookie cannot collide with a same-named cookie set by
+ * another application on a shared parent domain.
+ *
+ * This module is browser-safe and is the single source of truth for both
+ * sides of the SSO handoff: the admin panel inlines the variable at build
+ * time, the server reads it at runtime. The variable must therefore be set
+ * both when the admin panel is built and when the server runs, otherwise the
+ * two sides disagree on the cookie name.
+ */
+export const DEFAULT_AUTH_COOKIE_NAME = 'jwtToken';
+
+// RFC 6265 cookie-name token characters.
+const VALID_COOKIE_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+export const getAuthCookieName = (): string => {
+  const configured = (process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME || '').trim();
+
+  if (!configured) {
+    return DEFAULT_AUTH_COOKIE_NAME;
+  }
+
+  if (!VALID_COOKIE_NAME.test(configured)) {
+    console.warn(
+      `Ignoring invalid STRAPI_ADMIN_AUTH_COOKIE_NAME "${configured}" (must only contain RFC 6265 cookie-name characters); using "${DEFAULT_AUTH_COOKIE_NAME}" instead.`
+    );
+    return DEFAULT_AUTH_COOKIE_NAME;
+  }
+
+  return configured;
+};

--- a/packages/core/admin/shared/utils/session-auth.ts
+++ b/packages/core/admin/shared/utils/session-auth.ts
@@ -1,7 +1,14 @@
 import crypto from 'crypto';
 import type { Modules } from '@strapi/types';
 
+import { resolveAuthCookieName } from './auth-cookie-name';
+
 export const REFRESH_COOKIE_NAME = 'strapi_admin_refresh';
+
+export const getAccessCookieName = (): string => {
+  const configured: string | undefined = strapi.config.get('admin.auth.cookie.name');
+  return resolveAuthCookieName(configured);
+};
 
 export const DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN = 30 * 24 * 60 * 60;
 export const DEFAULT_IDLE_REFRESH_TOKEN_LIFESPAN = 14 * 24 * 60 * 60;

--- a/packages/core/strapi/src/node/__tests__/create-build-context.test.ts
+++ b/packages/core/strapi/src/node/__tests__/create-build-context.test.ts
@@ -1,0 +1,112 @@
+import type { Core } from '@strapi/types';
+
+import { createBuildContext } from '../create-build-context';
+
+jest.mock('../core/env', () => ({
+  ...jest.requireActual('../core/env'),
+  loadEnv: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../core/plugins', () => ({
+  getEnabledPlugins: jest.fn().mockResolvedValue({}),
+  getMapOfPluginsWithAdmin: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../core/admin-customisations', () => ({
+  loadUserAppFile: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('node:fs/promises', () => ({
+  rm: jest.fn().mockResolvedValue(undefined),
+}));
+
+const buildStrapiMock = (cookieName?: string): Core.Strapi =>
+  ({
+    config: {
+      get: jest.fn((key: string, def?: unknown) => {
+        if (key === 'server.absoluteUrl') {
+          return 'http://localhost:1337';
+        }
+        if (key === 'admin.absoluteUrl') {
+          return 'http://localhost:1337/admin';
+        }
+        if (key === 'admin.path') {
+          return '/admin';
+        }
+        if (key === 'admin.auth.cookie.name') {
+          return cookieName;
+        }
+        if (key === 'features') {
+          return undefined;
+        }
+        return def;
+      }),
+    },
+    dirs: {
+      app: { root: '/app' },
+      dist: { root: '/app/dist' },
+    },
+    telemetry: { isDisabled: true },
+  }) as unknown as Core.Strapi;
+
+const buildArgs = (strapi: Core.Strapi) => ({
+  cwd: '/app',
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  strapi,
+});
+
+describe('createBuildContext', () => {
+  const ORIGINAL_ENV = process.env;
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.clearAllMocks();
+  });
+
+  it('transports admin.auth.cookie.name into STRAPI_ADMIN_AUTH_COOKIE_NAME', async () => {
+    const strapi = buildStrapiMock('my_admin_jwt');
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_NAME).toBe('my_admin_jwt');
+  });
+
+  it('sets an empty STRAPI_ADMIN_AUTH_COOKIE_NAME when config is unset', async () => {
+    const strapi = buildStrapiMock(undefined);
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_NAME).toBe('');
+  });
+
+  it('overrides ambient STRAPI_ADMIN_AUTH_COOKIE_NAME from process.env with config', async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      STRAPI_ADMIN_AUTH_COOKIE_NAME: 'env_cookie_name',
+    };
+
+    const strapi = buildStrapiMock('config_cookie_name');
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_NAME).toBe('config_cookie_name');
+  });
+
+  it('clears ambient STRAPI_ADMIN_AUTH_COOKIE_NAME when config is unset', async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      STRAPI_ADMIN_AUTH_COOKIE_NAME: 'env_cookie_name',
+    };
+
+    const strapi = buildStrapiMock(undefined);
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_NAME).toBe('');
+  });
+});

--- a/packages/core/strapi/src/node/create-build-context.ts
+++ b/packages/core/strapi/src/node/create-build-context.ts
@@ -99,6 +99,11 @@ const createBuildContext = async <TOptions extends BaseOptions>({
     STRAPI_ANALYTICS_URL: process.env.STRAPI_ANALYTICS_URL || 'https://analytics.strapi.io',
   });
 
+  // NOTE: Transports `admin.auth.cookie.name` into the bundle; always assigned so an
+  // ambient STRAPI_ADMIN_AUTH_COOKIE_NAME cannot make the bundle disagree with the server.
+  env.STRAPI_ADMIN_AUTH_COOKIE_NAME =
+    strapiInstance.config.get<string | undefined>('admin.auth.cookie.name') || '';
+
   const envKeys = Object.keys(env);
 
   if (envKeys.length > 0) {

--- a/packages/core/types/src/core/config/admin.ts
+++ b/packages/core/types/src/core/config/admin.ts
@@ -15,6 +15,7 @@ export interface AuthSessions {
 }
 
 export interface AuthCookie {
+  name?: string;
   secure?: boolean;
   domain?: string;
   path?: string;


### PR DESCRIPTION
### What does it do?

Adds an `admin.auth.cookie.name` config option to control the name of the admin access-token cookie. Default unchanged (`jwtToken`).

- `packages/core/admin/shared/utils/auth-cookie-name.ts` is the single source for the two sides that must agree: the admin panel (the build inlines the config value into the bundle, same mechanism as `STRAPI_ADMIN_BACKEND_URL`) and the EE SSO redirect handler (resolves the config at runtime).
- Client cookie operations (`reducer.ts`, `getFetchClient.ts`, `AuthResponse.tsx`) and the SSO cookie write resolve the name from it instead of the hardcoded `'jwtToken'`.
- Value is trimmed and validated against RFC 6265 cookie-name characters; invalid values warn and fall back to the default.
- localStorage keys untouched (per-origin, cannot collide).

### Why is it needed?

Since 5.12.0 (#23188), session logins store the token in a cookie named `jwtToken`. When another application on a shared parent domain sets `jwtToken` with `Domain=.example.com`, it is visible to `document.cookie` on the admin origin: `getStoredToken` reads the foreign JWT, every request 401s, and the admin panel is unusable. No workaround exists — the collision happens in client-side JS, and deleting the shared cookie logs the user out of the other application. The refresh cookie is already namespaced (`strapi_admin_refresh`); the access cookie was not.

### How to test it?

1. In `examples/getstarted/config/admin.js`, add:
   ```js
   auth: {
     cookie: { name: 'my_admin_jwt' },
   }
   ```
2. `yarn develop`, log in without "Remember me" → cookie is named `my_admin_jwt`
3. In the browser console, run:
   ```js
   document.cookie = 'jwtToken=FOREIGN.GARBAGE.TOKEN; Path=/'
   ```
   then reload → session survives (simulates a parent-domain cookie from another app — client-side JS cannot distinguish the two)
4. Without the option, the cookie stays `jwtToken`

Unit tests: `packages/core/admin/shared/utils/__tests__/auth-cookie-name.test.ts` and `session-auth.test.ts`, plus updated cookie/reducer/AuthResponse tests.

### Related issue(s)/PR(s)

#23188 (moved the token from sessionStorage into the `jwtToken` cookie).

---
Fixes CPR-435
