### PR TITLE
fix(core): preserve published self-referential relation state

### DIFF
--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -584,13 +584,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       oldVersions: oldPublishedVersions,
     });
 
-    // Also pass the old published versions: independently publishing one side of a
-    // self-relation deletes those rows before the new version can reuse their order.
-    const selfRelationsToSync = await selfReferentialRelations.load(
-      uid,
-      draftsToPublish,
-      oldPublishedVersions
-    );
+    const selfRelationsToSync = await selfReferentialRelations.load(uid, draftsToPublish);
 
     // Delete old published versions
     await async.map(oldPublishedVersions, (entry: any) => entries.delete(entry.id));
@@ -695,13 +689,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       oldVersions: oldDrafts,
     });
 
-    // Also pass the old drafts so discardDraft can preserve rows attached to
-    // self-referential entries that are replaced but not part of the source side.
-    const selfRelationsToSync = await selfReferentialRelations.load(
-      uid,
-      versionsToDraft,
-      oldDrafts
-    );
+    const selfRelationsToSync = await selfReferentialRelations.load(uid, versionsToDraft);
 
     // Delete old drafts
     await async.map(oldDrafts, (entry: any) => entries.delete(entry.id));

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -584,7 +584,11 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       oldVersions: oldPublishedVersions,
     });
 
-    const selfRelationsToSync = await selfReferentialRelations.load(uid, draftsToPublish);
+    const selfRelationsToSync = await selfReferentialRelations.load(
+      uid,
+      draftsToPublish,
+      'published'
+    );
 
     // Delete old published versions
     await async.map(oldPublishedVersions, (entry: any) => entries.delete(entry.id));
@@ -689,7 +693,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       oldVersions: oldDrafts,
     });
 
-    const selfRelationsToSync = await selfReferentialRelations.load(uid, versionsToDraft);
+    const selfRelationsToSync = await selfReferentialRelations.load(uid, versionsToDraft, 'draft');
 
     // Delete old drafts
     await async.map(oldDrafts, (entry: any) => entries.delete(entry.id));

--- a/packages/core/core/src/services/document-service/utils/self-referential-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/self-referential-relations.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-continue */
 import { keyBy, omit } from 'lodash/fp';
 import type { Data, UID } from '@strapi/types';
-import type { JoinTable } from '@strapi/database';
+import type { Database, JoinTable } from '@strapi/database';
 
 interface VersionEntry {
   id: Data.ID;
@@ -17,15 +17,20 @@ interface RelationData {
   };
 }
 
+type TargetStatus = 'draft' | 'published';
+type DatabaseQueryBuilder = ReturnType<Database['getConnection']>;
+type DatabaseTransaction = Parameters<DatabaseQueryBuilder['transacting']>[0];
+
 const entryKey = (entry: { document_id: unknown; locale: unknown }) =>
   `${String(entry.document_id)}:${String(entry.locale)}`;
 
-const getPublishedCounterparts = async (
-  trx: any,
+const getCounterparts = async (
+  trx: DatabaseTransaction,
   tableName: string,
-  draftIds: unknown[]
+  idsToResolve: unknown[],
+  status: TargetStatus
 ): Promise<Record<string, Data.ID>> => {
-  const ids = [...new Set(draftIds.map((id) => String(id)))];
+  const ids = [...new Set(idsToResolve.map((id) => String(id)))];
 
   if (ids.length === 0) {
     return {};
@@ -42,27 +47,33 @@ const getPublishedCounterparts = async (
     return {};
   }
 
-  const documentIds = drafts.map((entry: { document_id: unknown }) => entry.document_id) as any[];
+  const documentIds = [
+    ...new Set(drafts.map((entry: { document_id: Data.ID }) => entry.document_id)),
+  ];
 
-  const publishedEntries = await strapi.db
+  const counterpartsQuery = strapi.db
     .getConnection()
     .select('id', 'document_id', 'locale')
     .from(tableName)
     .whereIn('document_id', documentIds)
-    .whereNotNull('published_at')
     .transacting(trx);
 
-  const publishedByDocument = keyBy(entryKey, publishedEntries);
+  const counterparts =
+    status === 'published'
+      ? await counterpartsQuery.whereNotNull('published_at')
+      : await counterpartsQuery.whereNull('published_at');
+
+  const counterpartByDocument = keyBy(entryKey, counterparts);
 
   return drafts.reduce(
     (
       acc: Record<string, Data.ID>,
       draft: { id: Data.ID; document_id: unknown; locale: unknown }
     ) => {
-      const published = publishedByDocument[entryKey(draft)];
+      const counterpart = counterpartByDocument[entryKey(draft)];
 
-      if (published) {
-        acc[String(draft.id)] = published.id;
+      if (counterpart) {
+        acc[String(draft.id)] = counterpart.id;
       }
 
       return acc;
@@ -93,7 +104,8 @@ const getPublishedCounterparts = async (
  */
 const load = async (
   uid: UID.ContentType,
-  sourceEntries: VersionEntry[]
+  sourceEntries: VersionEntry[],
+  targetStatus: TargetStatus
 ): Promise<RelationData[]> => {
   const updates: RelationData[] = [];
   const dbModel = strapi.db.metadata.get(uid);
@@ -139,9 +151,10 @@ const load = async (
         });
       }
 
-      // Use draft-side rows as the source of truth for one-sided self-relations. This covers
-      // first-published entries, where no old published row exists yet, and prevents stale old
-      // published rows from restoring relations that were removed from the draft.
+      // Use rows from the state being copied as the source of truth for one-sided
+      // self-relations. Publishing maps untouched targets to published counterparts and drops
+      // draft-only targets; discarding maps untouched targets to draft counterparts. This avoids
+      // restoring stale old rows that were removed from the copied state.
       const [sourceDraftRelations, targetDraftRelations] = await Promise.all([
         strapi.db
           .getConnection()
@@ -159,21 +172,31 @@ const load = async (
           .transacting(trx),
       ]);
 
-      if (sourceDraftRelations.length > 0) {
-        const publishedTargets = await getPublishedCounterparts(
+      const [targetCounterparts, sourceCounterparts] = await Promise.all([
+        getCounterparts(
           trx,
           dbModel.tableName,
-          sourceDraftRelations.map((relation) => relation[targetColumnName])
-        );
+          sourceDraftRelations.map((relation) => relation[targetColumnName]),
+          targetStatus
+        ),
+        getCounterparts(
+          trx,
+          dbModel.tableName,
+          targetDraftRelations.map((relation) => relation[sourceColumnName]),
+          targetStatus
+        ),
+      ]);
+
+      if (sourceDraftRelations.length > 0) {
         const relations = sourceDraftRelations
           .map((relation) => {
-            const publishedTarget = publishedTargets[String(relation[targetColumnName])];
+            const targetCounterpart = targetCounterparts[String(relation[targetColumnName])];
 
-            if (publishedTarget == null) {
+            if (targetCounterpart == null) {
               return null;
             }
 
-            return { ...relation, [targetColumnName]: publishedTarget };
+            return { ...relation, [targetColumnName]: targetCounterpart };
           })
           .filter(Boolean) as Record<string, unknown>[];
 
@@ -187,20 +210,15 @@ const load = async (
       }
 
       if (targetDraftRelations.length > 0) {
-        const publishedSources = await getPublishedCounterparts(
-          trx,
-          dbModel.tableName,
-          targetDraftRelations.map((relation) => relation[sourceColumnName])
-        );
         const relations = targetDraftRelations
           .map((relation) => {
-            const publishedSource = publishedSources[String(relation[sourceColumnName])];
+            const sourceCounterpart = sourceCounterparts[String(relation[sourceColumnName])];
 
-            if (publishedSource == null) {
+            if (sourceCounterpart == null) {
               return null;
             }
 
-            return { ...relation, [sourceColumnName]: publishedSource };
+            return { ...relation, [sourceColumnName]: sourceCounterpart };
           })
           .filter(Boolean) as Record<string, unknown>[];
 
@@ -213,10 +231,9 @@ const load = async (
         }
       }
 
-      // One-sided rows attached to replaced published entries are intentionally not restored
-      // from the old published state. The draft-side capture above represents the current
-      // logical relation set; restoring old rows here can resurrect relations removed from the
-      // draft before publishing.
+      // One-sided rows from the replaced state are intentionally not restored here. The rows
+      // captured above represent the current logical relation set; restoring stale old rows can
+      // resurrect relations that were removed before publishing or discarding.
     }
   });
 

--- a/packages/core/core/src/services/document-service/utils/self-referential-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/self-referential-relations.ts
@@ -17,6 +17,60 @@ interface RelationData {
   };
 }
 
+const entryKey = (entry: { document_id: unknown; locale: unknown }) =>
+  `${String(entry.document_id)}:${String(entry.locale)}`;
+
+const getPublishedCounterparts = async (
+  trx: any,
+  tableName: string,
+  draftIds: unknown[]
+): Promise<Record<string, Data.ID>> => {
+  const ids = [...new Set(draftIds.map((id) => String(id)))];
+
+  if (ids.length === 0) {
+    return {};
+  }
+
+  const drafts = await strapi.db
+    .getConnection()
+    .select('id', 'document_id', 'locale')
+    .from(tableName)
+    .whereIn('id', ids)
+    .transacting(trx);
+
+  if (drafts.length === 0) {
+    return {};
+  }
+
+  const documentIds = drafts.map((entry: { document_id: unknown }) => entry.document_id) as any[];
+
+  const publishedEntries = await strapi.db
+    .getConnection()
+    .select('id', 'document_id', 'locale')
+    .from(tableName)
+    .whereIn('document_id', documentIds)
+    .whereNotNull('published_at')
+    .transacting(trx);
+
+  const publishedByDocument = keyBy(entryKey, publishedEntries);
+
+  return drafts.reduce(
+    (
+      acc: Record<string, Data.ID>,
+      draft: { id: Data.ID; document_id: unknown; locale: unknown }
+    ) => {
+      const published = publishedByDocument[entryKey(draft)];
+
+      if (published) {
+        acc[String(draft.id)] = published.id;
+      }
+
+      return acc;
+    },
+    {}
+  );
+};
+
 /**
  * Preserves self-referential relations during publish/discard operations.
  *
@@ -39,8 +93,7 @@ interface RelationData {
  */
 const load = async (
   uid: UID.ContentType,
-  sourceEntries: VersionEntry[],
-  replacedEntries: VersionEntry[] = []
+  sourceEntries: VersionEntry[]
 ): Promise<RelationData[]> => {
   const updates: RelationData[] = [];
   const dbModel = strapi.db.metadata.get(uid);
@@ -66,7 +119,6 @@ const load = async (
       const { name: targetColumnName } = joinTable.inverseJoinColumn;
 
       const sourceIds = sourceEntries.map((entry) => String(entry.id));
-      const replacedIds = replacedEntries.map((entry) => String(entry.id));
 
       // Load relations where both source and target are among the entries being processed.
       // These are the self-referential relations that would be lost during the
@@ -87,45 +139,84 @@ const load = async (
         });
       }
 
-      if (replacedIds.length === 0) {
-        continue;
-      }
-
-      // When only one side of a self-relation is republished/discarded, the normal relation
-      // write recreates the row but assigns fresh order values. Capture those rows so sync()
-      // can restore the join-table payload after the replacement row exists.
-      const [sourceOnlyRelations, targetOnlyRelations] = await Promise.all([
+      // Use draft-side rows as the source of truth for one-sided self-relations. This covers
+      // first-published entries, where no old published row exists yet, and prevents stale old
+      // published rows from restoring relations that were removed from the draft.
+      const [sourceDraftRelations, targetDraftRelations] = await Promise.all([
         strapi.db
           .getConnection()
           .select('*')
           .from(joinTable.name)
-          .whereIn(sourceColumnName, replacedIds)
-          .whereNotIn(targetColumnName, replacedIds)
+          .whereIn(sourceColumnName, sourceIds)
+          .whereNotIn(targetColumnName, sourceIds)
           .transacting(trx),
         strapi.db
           .getConnection()
           .select('*')
           .from(joinTable.name)
-          .whereIn(targetColumnName, replacedIds)
-          .whereNotIn(sourceColumnName, replacedIds)
+          .whereIn(targetColumnName, sourceIds)
+          .whereNotIn(sourceColumnName, sourceIds)
           .transacting(trx),
       ]);
 
-      if (sourceOnlyRelations.length > 0) {
-        updates.push({
-          joinTable,
-          relations: sourceOnlyRelations,
-          remap: { source: true, target: false },
-        });
+      if (sourceDraftRelations.length > 0) {
+        const publishedTargets = await getPublishedCounterparts(
+          trx,
+          dbModel.tableName,
+          sourceDraftRelations.map((relation) => relation[targetColumnName])
+        );
+        const relations = sourceDraftRelations
+          .map((relation) => {
+            const publishedTarget = publishedTargets[String(relation[targetColumnName])];
+
+            if (publishedTarget == null) {
+              return null;
+            }
+
+            return { ...relation, [targetColumnName]: publishedTarget };
+          })
+          .filter(Boolean) as Record<string, unknown>[];
+
+        if (relations.length > 0) {
+          updates.push({
+            joinTable,
+            relations,
+            remap: { source: true, target: false },
+          });
+        }
       }
 
-      if (targetOnlyRelations.length > 0) {
-        updates.push({
-          joinTable,
-          relations: targetOnlyRelations,
-          remap: { source: false, target: true },
-        });
+      if (targetDraftRelations.length > 0) {
+        const publishedSources = await getPublishedCounterparts(
+          trx,
+          dbModel.tableName,
+          targetDraftRelations.map((relation) => relation[sourceColumnName])
+        );
+        const relations = targetDraftRelations
+          .map((relation) => {
+            const publishedSource = publishedSources[String(relation[sourceColumnName])];
+
+            if (publishedSource == null) {
+              return null;
+            }
+
+            return { ...relation, [sourceColumnName]: publishedSource };
+          })
+          .filter(Boolean) as Record<string, unknown>[];
+
+        if (relations.length > 0) {
+          updates.push({
+            joinTable,
+            relations,
+            remap: { source: false, target: true },
+          });
+        }
       }
+
+      // One-sided rows attached to replaced published entries are intentionally not restored
+      // from the old published state. The draft-side capture above represents the current
+      // logical relation set; restoring old rows here can resurrect relations removed from the
+      // draft before publishing.
     }
   });
 

--- a/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
+++ b/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
@@ -186,6 +186,21 @@ const getLocalizedRelationTargets = async (
   return res.body.results.map((result: { documentId: string }) => result.documentId);
 };
 
+const getCategoryVersionId = async (
+  documentId: string,
+  status: 'draft' | 'published'
+): Promise<number> => {
+  const [entry] = await strapi.db.query('api::category.category').findMany({
+    where: {
+      documentId,
+      publishedAt: status === 'published' ? { $notNull: true } : null,
+    },
+    select: ['id'],
+  });
+
+  return entry.id;
+};
+
 describe('CM API - Self-referential relations with Draft & Publish', () => {
   beforeAll(async () => {
     await builder.addContentTypes([category, localizedCategory]).build();
@@ -544,6 +559,108 @@ describe('CM API - Self-referential relations with Draft & Publish', () => {
     expect(await getRelationTargets(parent.documentId, 'children', 'published')).toEqual(
       remainingChildren.map((child) => child.documentId)
     );
+  });
+
+  test('regression: publish drops one-sided self-referential relations to draft-only targets', async () => {
+    const parent = await createCategory('Draft-only target Page 1');
+    const child = await createCategory('Draft-only target Page 1.1');
+
+    await updateCategory(parent.documentId, {
+      name: parent.name,
+      related: [{ documentId: child.documentId, locale: null }],
+    });
+
+    expect(await getRelationTargets(parent.documentId, 'related', 'draft')).toEqual([
+      child.documentId,
+    ]);
+
+    await publishCategory(parent.documentId);
+
+    expect(await getRelationTargets(parent.documentId, 'related', 'published')).toEqual([]);
+
+    const categoryMeta = strapi.db.metadata.get('api::category.category');
+    const {
+      name: joinTableName,
+      joinColumn,
+      inverseJoinColumn,
+    } = categoryMeta.attributes.related.joinTable;
+    const parentPublishedId = await getCategoryVersionId(parent.documentId, 'published');
+    const childDraftId = await getCategoryVersionId(child.documentId, 'draft');
+    const stalePublishedRows = await strapi.db
+      .getConnection()
+      .select('*')
+      .from(joinTableName)
+      .where({
+        [joinColumn.name]: parentPublishedId,
+        [inverseJoinColumn.name]: childDraftId,
+      });
+
+    expect(stalePublishedRows).toHaveLength(0);
+  });
+
+  test('regression: discarding parent draft preserves multi-entry self-referential relations without mixed-state rows', async () => {
+    const parent = await createCategory('Discard parent Page 1');
+    const childA = await createCategory('Discard parent Page 1.1');
+    const childB = await createCategory('Discard parent Page 1.2');
+    const childC = await createCategory('Discard parent Page 1.3');
+    const children = [childA, childB, childC];
+    const expectedOrder = children.map((child) => child.documentId);
+
+    await publishCategory(parent.documentId);
+
+    for (const child of children) {
+      await updateCategory(child.documentId, {
+        name: child.name,
+        parent: { documentId: parent.documentId, locale: null },
+      });
+      await publishCategory(child.documentId);
+    }
+
+    await updateCategory(parent.documentId, {
+      name: parent.name,
+      children: [...children].reverse().map((child) => ({
+        documentId: child.documentId,
+        locale: null,
+      })),
+    });
+    await publishCategory(parent.documentId);
+
+    await updateCategory(parent.documentId, { name: `${parent.name} - draft edit` });
+    await discardCategory(parent.documentId);
+
+    expect(await getRelationTargets(parent.documentId, 'children', 'draft')).toEqual(expectedOrder);
+    expect(await getRelationTargets(parent.documentId, 'children', 'published')).toEqual(
+      expectedOrder
+    );
+
+    const parentDraftId = await getCategoryVersionId(parent.documentId, 'draft');
+    const parentPublishedId = await getCategoryVersionId(parent.documentId, 'published');
+    const childVersionIds = await Promise.all(
+      children.map(async (child) => ({
+        draft: await getCategoryVersionId(child.documentId, 'draft'),
+        published: await getCategoryVersionId(child.documentId, 'published'),
+      }))
+    );
+
+    const categoryMeta = strapi.db.metadata.get('api::category.category');
+    const {
+      name: joinTableName,
+      joinColumn,
+      inverseJoinColumn,
+    } = categoryMeta.attributes.parent.joinTable;
+    const joinRows = await strapi.db.getConnection().select('*').from(joinTableName);
+    const pairCount = (sourceId: number, targetId: number) =>
+      joinRows.filter(
+        (row: Record<string, unknown>) =>
+          row[joinColumn.name] === sourceId && row[inverseJoinColumn.name] === targetId
+      ).length;
+
+    for (const childIds of childVersionIds) {
+      expect(pairCount(childIds.draft, parentDraftId)).toBe(1);
+      expect(pairCount(childIds.published, parentPublishedId)).toBe(1);
+      expect(pairCount(childIds.published, parentDraftId)).toBe(0);
+      expect(pairCount(childIds.draft, parentPublishedId)).toBe(0);
+    }
   });
 
   test('regression: self-referential manyToMany order and removals are preserved in published relations', async () => {

--- a/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
+++ b/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
@@ -378,6 +378,90 @@ describe('CM API - Self-referential relations with Draft & Publish', () => {
     await expectChildrenToPointToParent();
   });
 
+  test('regression: published self-referential oneToMany order is preserved when children are published after the parent', async () => {
+    const parent = await createCategory('Draft-child Page 1');
+    const childA = await createCategory('Draft-child Page 1.1');
+    const childB = await createCategory('Draft-child Page 1.2');
+    const childC = await createCategory('Draft-child Page 1.3');
+    const childD = await createCategory('Draft-child Page 1.4');
+    const children = [childA, childB, childC, childD];
+    const expectedOrder = children.map((child) => child.documentId);
+
+    for (const child of children) {
+      await updateCategory(child.documentId, {
+        name: child.name,
+        parent: { documentId: parent.documentId, locale: null },
+      });
+    }
+
+    await updateCategory(parent.documentId, {
+      name: parent.name,
+      children: [...children].reverse().map((child) => ({
+        documentId: child.documentId,
+        locale: null,
+      })),
+    });
+
+    expect(await getRelationTargets(parent.documentId, 'children', 'draft')).toEqual(expectedOrder);
+
+    await publishCategory(parent.documentId);
+
+    for (const [index, child] of children.entries()) {
+      await publishCategory(child.documentId);
+
+      expect({
+        publishedChild: child.name,
+        publishedOrder: await getRelationTargets(parent.documentId, 'children', 'published'),
+      }).toEqual({
+        publishedChild: child.name,
+        publishedOrder: expectedOrder.slice(0, index + 1),
+      });
+    }
+  });
+
+  test('regression: removed self-referential oneToMany relation stays removed after publishing the parent', async () => {
+    const parent = await createCategory('Removed-child Page 1');
+    const childA = await createCategory('Removed-child Page 1.1');
+    const childB = await createCategory('Removed-child Page 1.2');
+    const childC = await createCategory('Removed-child Page 1.3');
+    const children = [childA, childB, childC];
+
+    for (const child of children) {
+      await updateCategory(child.documentId, {
+        name: child.name,
+        parent: { documentId: parent.documentId, locale: null },
+      });
+      await publishCategory(child.documentId);
+    }
+
+    await updateCategory(parent.documentId, {
+      name: parent.name,
+      children: [...children].reverse().map((child) => ({
+        documentId: child.documentId,
+        locale: null,
+      })),
+    });
+    await publishCategory(parent.documentId);
+
+    expect(await getRelationTargets(parent.documentId, 'children', 'published')).toEqual(
+      children.map((child) => child.documentId)
+    );
+
+    const remainingChildren = [childA, childC];
+    await updateCategory(parent.documentId, {
+      name: `${parent.name} - removed child`,
+      children: [...remainingChildren].reverse().map((child) => ({
+        documentId: child.documentId,
+        locale: null,
+      })),
+    });
+    await publishCategory(parent.documentId);
+
+    expect(await getRelationTargets(parent.documentId, 'children', 'published')).toEqual(
+      remainingChildren.map((child) => child.documentId)
+    );
+  });
+
   // A single entry whose unidirectional relation points at itself must keep that relation in
   // its published version: during the delete-and-recreate publish cycle the self-link has to
   // be re-pointed to the entry's own published version rather than dropped. These cover the

--- a/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
+++ b/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
@@ -55,6 +55,34 @@ const category = {
   },
 } as const;
 
+const localizedCategory = {
+  displayName: 'localized category',
+  singularName: 'localized-category',
+  pluralName: 'localized-categories',
+  kind: 'collectionType',
+  draftAndPublish: true,
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  attributes: {
+    name: {
+      type: 'string',
+      pluginOptions: {
+        i18n: {
+          localized: true,
+        },
+      },
+    },
+    related: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'api::localized-category.localized-category',
+    },
+  },
+} as const;
+
 const getCategory = async (
   documentId: string,
   status: 'draft' | 'published' = 'draft'
@@ -77,10 +105,33 @@ const createCategory = async (name: string): Promise<CategoryEntry> => {
   return res.body.data as CategoryEntry;
 };
 
+const createLocalizedCategory = async (name: string, locale: string): Promise<CategoryEntry> => {
+  const res = await rq({
+    method: 'POST',
+    url: '/content-manager/collection-types/api::localized-category.localized-category',
+    qs: { locale },
+    body: { name },
+  });
+
+  return res.body.data as CategoryEntry;
+};
+
 const updateCategory = async (documentId: string, body: Record<string, unknown>) =>
   rq({
     method: 'PUT',
     url: `/content-manager/collection-types/api::category.category/${documentId}`,
+    body,
+  });
+
+const updateLocalizedCategory = async (
+  documentId: string,
+  locale: string,
+  body: Record<string, unknown>
+) =>
+  rq({
+    method: 'PUT',
+    url: `/content-manager/collection-types/api::localized-category.localized-category/${documentId}`,
+    qs: { locale },
     body,
   });
 
@@ -89,6 +140,13 @@ const publishCategory = async (documentId: string, body?: Record<string, unknown
     method: 'POST',
     url: `/content-manager/collection-types/api::category.category/${documentId}/actions/publish`,
     body,
+  });
+
+const publishLocalizedCategory = async (documentId: string, locale: string) =>
+  rq({
+    method: 'POST',
+    url: `/content-manager/collection-types/api::localized-category.localized-category/${documentId}/actions/publish`,
+    qs: { locale },
   });
 
 const discardCategory = async (documentId: string) =>
@@ -101,12 +159,28 @@ const discardCategory = async (documentId: string) =>
 const getRelationTargets = async (
   documentId: string,
   field: string,
-  status: 'draft' | 'published'
+  status: 'draft' | 'published',
+  locale?: string
 ): Promise<string[]> => {
   const res = await rq({
     method: 'GET',
     url: `/content-manager/relations/api::category.category/${documentId}/${field}`,
-    qs: { status },
+    qs: { status, locale },
+  });
+
+  return res.body.results.map((result: { documentId: string }) => result.documentId);
+};
+
+const getLocalizedRelationTargets = async (
+  documentId: string,
+  field: string,
+  status: 'draft' | 'published',
+  locale: string
+): Promise<string[]> => {
+  const res = await rq({
+    method: 'GET',
+    url: `/content-manager/relations/api::localized-category.localized-category/${documentId}/${field}`,
+    qs: { status, locale },
   });
 
   return res.body.results.map((result: { documentId: string }) => result.documentId);
@@ -114,10 +188,20 @@ const getRelationTargets = async (
 
 describe('CM API - Self-referential relations with Draft & Publish', () => {
   beforeAll(async () => {
-    await builder.addContentType(category).build();
+    await builder.addContentTypes([category, localizedCategory]).build();
 
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
+
+    await rq({
+      method: 'POST',
+      url: '/i18n/locales',
+      body: {
+        code: 'fr',
+        name: 'French',
+        isDefault: false,
+      },
+    });
 
     // Create two categories
     for (const name of ['Category A', 'Category B']) {
@@ -460,6 +544,83 @@ describe('CM API - Self-referential relations with Draft & Publish', () => {
     expect(await getRelationTargets(parent.documentId, 'children', 'published')).toEqual(
       remainingChildren.map((child) => child.documentId)
     );
+  });
+
+  test('regression: self-referential manyToMany order and removals are preserved in published relations', async () => {
+    const parent = await createCategory('ManyToMany Page 1');
+    const childA = await createCategory('ManyToMany Page 1.1');
+    const childB = await createCategory('ManyToMany Page 1.2');
+    const childC = await createCategory('ManyToMany Page 1.3');
+    const children = [childA, childB, childC];
+
+    for (const child of children) {
+      await publishCategory(child.documentId);
+    }
+
+    await updateCategory(parent.documentId, {
+      name: parent.name,
+      relatedMany: [...children].reverse().map((child) => ({
+        documentId: child.documentId,
+        locale: null,
+      })),
+    });
+    await publishCategory(parent.documentId);
+
+    expect(await getRelationTargets(parent.documentId, 'relatedMany', 'published')).toEqual(
+      children.map((child) => child.documentId)
+    );
+
+    const remainingChildren = [childA, childC];
+    await updateCategory(parent.documentId, {
+      name: `${parent.name} - removed child`,
+      relatedMany: [...remainingChildren].reverse().map((child) => ({
+        documentId: child.documentId,
+        locale: null,
+      })),
+    });
+    await publishCategory(parent.documentId);
+
+    expect(await getRelationTargets(parent.documentId, 'relatedMany', 'published')).toEqual(
+      remainingChildren.map((child) => child.documentId)
+    );
+  });
+
+  test('regression: localized self-referential relations map to the same locale on publish', async () => {
+    const parent = await createLocalizedCategory('Localized Page 1', 'fr');
+    const childA = await createLocalizedCategory('Localized Page 1.1', 'fr');
+    const childB = await createLocalizedCategory('Localized Page 1.2', 'fr');
+    const children = [childA, childB];
+
+    for (const child of children) {
+      await publishLocalizedCategory(child.documentId, 'fr');
+    }
+
+    await updateLocalizedCategory(parent.documentId, 'fr', {
+      name: parent.name,
+      related: [...children].reverse().map((child) => ({
+        documentId: child.documentId,
+        locale: 'fr',
+      })),
+    });
+    await publishLocalizedCategory(parent.documentId, 'fr');
+
+    expect(
+      await getLocalizedRelationTargets(parent.documentId, 'related', 'published', 'fr')
+    ).toEqual(children.map((child) => child.documentId));
+
+    const remainingChildren = [childA];
+    await updateLocalizedCategory(parent.documentId, 'fr', {
+      name: `${parent.name} - removed child`,
+      related: remainingChildren.map((child) => ({
+        documentId: child.documentId,
+        locale: 'fr',
+      })),
+    });
+    await publishLocalizedCategory(parent.documentId, 'fr');
+
+    expect(
+      await getLocalizedRelationTargets(parent.documentId, 'related', 'published', 'fr')
+    ).toEqual(remainingChildren.map((child) => child.documentId));
   });
 
   // A single entry whose unidirectional relation points at itself must keep that relation in


### PR DESCRIPTION
### What does it do?

Fixes self-referential relation sync during publish for Draft & Publish content types.

Technical changes:

- Uses draft-side self-referential relation rows as the source of truth when publishing.
- Maps the untouched side of a self-referential relation to its published counterpart when available.
- Stops restoring one-sided self-referential rows from the old published state, because those rows can be stale.
- Removes the now-unused old published entry argument from the self-referential relation loader.
- Adds API regressions for:
  - publishing a parent before publishing its children while preserving published relation order as children become published
  - removing a child relation and publishing the parent without the removed relation reappearing in the Published tab

### Why is it needed?

PR #26838 fixed one self-referential relation ordering case, but two publish flows were broken:

- When a parent was published before its child pages, publishing the child pages later could produce a different relation order in the Published tab.
- When a relation was removed from the draft and the parent was published, the removed relation could still appear in the Published tab.

The root cause was that publish sync could restore stale self-referential rows from the old published state instead of treating the current draft relation set as authoritative.

### How to test it?

Run:

```bash
yarn test:api tests/api/core/content-manager/api/self-referential-relations.test.api.ts
```

Manual path:

1. Create `Page 1`.
2. Create child pages without publishing them.
3. Add the child pages to `Page 1` in a chosen order.
4. Publish `Page 1`.
5. Publish the child pages.
6. Verify the Published tab preserves the expected relation order as each child becomes published.
7. Remove one child relation from `Page 1`, publish `Page 1`, and verify the removed relation no longer appears in the Published tab.

### Related issue(s)/PR(s)

Related to #26838.

