### PR TITLE
chore(types): drop CommonJS tsconfig overrides, build JS via rollup

### DIFF
--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -30,12 +30,24 @@
   "main": "./dist/index.js",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "files": [
     "dist/"
   ],
   "scripts": {
-    "build": "run -T run-s clean build:types",
-    "build:types": "run -T tsc -p tsconfig.build.json",
+    "build": "run -T npm-run-all clean --parallel build:code build:types",
+    "build:code": "run -T rollup -c",
+    "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
     "doc:ts": "typedoc",
     "doc:ts:watch": "typedoc --watch",

--- a/packages/core/types/rollup.config.mjs
+++ b/packages/core/types/rollup.config.mjs
@@ -1,0 +1,5 @@
+import { baseConfig } from '../../../rollup.utils.mjs';
+
+export default baseConfig({
+  rootDir: './src',
+});

--- a/packages/core/types/tsconfig.json
+++ b/packages/core/types/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "moduleResolution": "node",
     "noEmit": true
   },
   "include": ["src"],


### PR DESCRIPTION
## What does it do?

Removes the `module: CommonJS` and `moduleResolution: node` overrides from `@strapi/types` `tsconfig.json` so the package inherits the shared base config, and wires up rollup for JS bundling.

- Drop the `module` / `moduleResolution` overrides from `tsconfig.json`.
- Add a `build:code` script running `rollup -c` (new `rollup.config.mjs` uses the shared `baseConfig`).
- Extend `build` to run `clean build:types build:code`.
- Switch `build:types` to `tsc --emitDeclarationOnly`.
- Add an `exports` map exposing `types` / `source` / `import` / `require` / `default` plus `./package.json` and `./*`.

## Why is it needed?

The main goal is removing the CommonJS tsconfig overrides so the package aligns with the shared base config — a prerequisite for enabling `verbatimModuleSyntax` across the type package later.

`@strapi/types` exports only types, so the rollup output is effectively empty today. The `build:code` step and exports map are added for consistency with the other core packages and to leave the package ready should it ever ship runtime values — they are not producing meaningful JS right now.

## How to test it?

```bash
yarn nx build @strapi/types
# dist/index.d.ts is emitted; JS output is empty (types-only package)
yarn test:ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)