### PR TITLE
fix(core): validate license registry responses with zod

### DIFF
--- a/packages/core/core/src/ee/__tests__/license.test.ts
+++ b/packages/core/core/src/ee/__tests__/license.test.ts
@@ -1,0 +1,168 @@
+import { fetchLicense, LicenseCheckError, LICENSE_REGISTRY_URI } from '../license';
+
+const VALIDATE_URL = `${LICENSE_REGISTRY_URI}/api/licenses/validate`;
+
+type ResponseOptions = {
+  status: number;
+  contentType?: string | null;
+  body?: unknown;
+};
+
+type FetchArgs = [url: string, init: unknown];
+type FetchMock = jest.Mock<Promise<Response>, FetchArgs>;
+
+const createResponse = ({
+  status,
+  contentType = 'application/json',
+  body,
+}: ResponseOptions): Response => {
+  // No Content-Type header at all: return a bodyless response so undici does not infer one.
+  if (contentType === null) {
+    return new Response(null, { status });
+  }
+
+  const payload = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Response(payload, { status, headers: { 'Content-Type': contentType } });
+};
+
+const mockFetch = (response: Response): FetchMock =>
+  jest.fn<Promise<Response>, FetchArgs>().mockResolvedValue(response);
+
+const createStrapi = (
+  fetchImpl: FetchMock,
+  { installId = 'install-id-from-package-json' }: { installId?: string } = {}
+) =>
+  ({
+    config: { installId },
+    fetch: fetchImpl,
+  }) as any;
+
+describe('fetchLicense', () => {
+  it('POSTs the license key, project id and device id as JSON to the license registry', async () => {
+    const fetchImpl = mockFetch(
+      createResponse({ status: 200, body: { data: { license: 'the-license' } } })
+    );
+    const strapi = createStrapi(fetchImpl, { installId: 'the-device-id' });
+
+    await fetchLicense({ strapi }, 'the-key', 'the-project-id');
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(VALIDATE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // installId is returned verbatim by generateInstallId when set
+      body: JSON.stringify({
+        key: 'the-key',
+        projectId: 'the-project-id',
+        deviceId: 'the-device-id',
+      }),
+    });
+  });
+
+  it('returns the license string on a 200 response', async () => {
+    const fetchImpl = mockFetch(
+      createResponse({ status: 200, body: { data: { license: 'the-license' } } })
+    );
+
+    const license = await fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+    expect(license).toBe('the-license');
+  });
+
+  it('throws a LicenseCheckError with the registry error message on a 400 response', async () => {
+    const fetchImpl = mockFetch(
+      createResponse({ status: 400, body: { error: { message: 'Invalid key.' } } })
+    );
+
+    const promise = fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+    await expect(promise).rejects.toBeInstanceOf(LicenseCheckError);
+    await expect(promise).rejects.toMatchObject({
+      message: 'Invalid key.',
+      shouldFallback: false,
+    });
+  });
+
+  it('throws a LicenseCheckError on a 404 response', async () => {
+    const fetchImpl = mockFetch(createResponse({ status: 404, body: {} }));
+
+    const promise = fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+    await expect(promise).rejects.toBeInstanceOf(LicenseCheckError);
+    await expect(promise).rejects.toMatchObject({
+      message: 'The license used does not exists.',
+      shouldFallback: false,
+    });
+  });
+
+  it('throws a fallback error on an unexpected status code', async () => {
+    const fetchImpl = mockFetch(createResponse({ status: 500, body: {} }));
+
+    const promise = fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+    await expect(promise).rejects.toMatchObject({
+      message: 'Could not proceed to the online validation of your license.',
+      shouldFallback: true,
+    });
+  });
+
+  it('throws a fallback error when the response is not JSON', async () => {
+    const fetchImpl = mockFetch(
+      createResponse({ status: 200, contentType: 'text/html', body: '<html></html>' })
+    );
+
+    const promise = fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+    await expect(promise).rejects.toMatchObject({
+      message: 'Could not proceed to the online validation of your license.',
+      shouldFallback: true,
+    });
+  });
+
+  it('throws a fallback error when the Content-Type header is missing', async () => {
+    const fetchImpl = mockFetch(createResponse({ status: 200, contentType: null }));
+
+    const promise = fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+    await expect(promise).rejects.toMatchObject({ shouldFallback: true });
+  });
+
+  it('throws a fallback error when the fetch call rejects', async () => {
+    const fetchImpl = jest
+      .fn<Promise<Response>, FetchArgs>()
+      .mockRejectedValue(new Error('network down'));
+
+    const promise = fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+    await expect(promise).rejects.toMatchObject({
+      message: 'Could not proceed to the online validation of your license.',
+      shouldFallback: true,
+    });
+  });
+
+  describe('response schema validation', () => {
+    it('throws a fallback error when a 200 response is missing data.license', async () => {
+      const fetchImpl = mockFetch(createResponse({ status: 200, body: { data: {} } }));
+
+      const promise = fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+      await expect(promise).rejects.toMatchObject({ shouldFallback: true });
+    });
+
+    it('throws a fallback error when a 200 response has a non-string license', async () => {
+      const fetchImpl = mockFetch(createResponse({ status: 200, body: { data: { license: 42 } } }));
+
+      const promise = fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+      await expect(promise).rejects.toMatchObject({ shouldFallback: true });
+    });
+
+    it('throws a fallback error when a 400 response is missing error.message', async () => {
+      const fetchImpl = mockFetch(createResponse({ status: 400, body: { error: {} } }));
+
+      const promise = fetchLicense({ strapi: createStrapi(fetchImpl) }, 'key', 'project');
+
+      await expect(promise).rejects.toMatchObject({ shouldFallback: true });
+    });
+  });
+});

--- a/packages/core/core/src/ee/license.ts
+++ b/packages/core/core/src/ee/license.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { join, resolve } from 'path';
 import crypto from 'crypto';
+import * as z from 'zod/v4';
 import type { Core } from '@strapi/types';
 
 import { generateInstallId } from '@strapi/utils';
@@ -31,6 +32,20 @@ const DEFAULT_FEATURES = {
 };
 
 const LICENSE_REGISTRY_URI = 'https://license.strapi.io';
+
+// Shape of a successful (200) response from the license registry.
+const licenseSuccessSchema = z.object({
+  data: z.object({
+    license: z.string(),
+  }),
+});
+
+// Shape of a bad-request (400) response from the license registry.
+const licenseErrorSchema = z.object({
+  error: z.object({
+    message: z.string(),
+  }),
+});
 
 const publicKey = fs.readFileSync(resolve(__dirname, '../../resources/key.pub'));
 
@@ -88,8 +103,12 @@ const verifyLicense = (license: string) => {
   return licenseInfo;
 };
 
-const throwError = () => {
-  throw new LicenseCheckError('Could not proceed to the online validation of your license.', true);
+const createShouldFallbackError = () => {
+  return new LicenseCheckError('Could not proceed to the online validation of your license.', true);
+};
+
+const throwShouldFallbackError = () => {
+  throw createShouldFallbackError();
 };
 
 const fetchLicense = async (
@@ -109,25 +128,31 @@ const fetchLicense = async (
         deviceId: generateInstallId(projectId, installIdFromPackageJson),
       }), // NOTE: Doing nothing on the LR with the installId
     })
-    .catch(throwError);
+    .catch(throwShouldFallbackError);
 
   const contentType = response.headers.get('Content-Type');
 
   if (contentType?.includes('application/json')) {
-    const { data, error } = await response.json();
+    const body = await response.json();
 
     switch (response.status) {
-      case 200:
-        return data.license;
-      case 400:
-        throw new LicenseCheckError(error.message);
+      case 200: {
+        const result = licenseSuccessSchema.safeParse(body);
+        if (!result.success) throw createShouldFallbackError();
+        return result.data.data.license;
+      }
+      case 400: {
+        const result = licenseErrorSchema.safeParse(body);
+        if (!result.success) throw createShouldFallbackError();
+        throw new LicenseCheckError(result.data.error.message);
+      }
       case 404:
         throw new LicenseCheckError('The license used does not exists.');
       default:
-        throwError();
+        throw createShouldFallbackError();
     }
   } else {
-    throwError();
+    throw createShouldFallbackError();
   }
 };
 


### PR DESCRIPTION
### What does it do?

Hardens `fetchLicense` in `packages/core/core/src/ee/license.ts` and adds unit coverage.

- Adds `zod` schema validation for the two responses `fetchLicense` reads from the license registry:
  - **200** must match `{ data: { license: string } }`
  - **400** must match `{ error: { message: string } }`
- When a response has the expected status but a malformed body, `fetchLicense` now throws the offline-fallback error (`shouldFallback: true`) instead of returning `undefined` (200 without a `license`) or throwing a `LicenseCheckError` with an `undefined` message (400 without an `error.message`).
- Adds a unit test suite for `fetchLicense` covering the request payload (url/method/headers/`deviceId`) and every response branch: 200, 400, 404, unexpected status, non-JSON, missing `Content-Type`, network error, and schema-invalid 200/400 bodies.

### Why is it needed?

`fetchLicense` previously trusted the shape of the registry JSON. A malformed 200 dereferenced `data.license` and silently returned `undefined`; a malformed 400 threw with an `undefined` message. Validating the payload makes the failure mode explicit and routes it through the existing offline fallback, and the new tests pin the exact behaviour of each branch.

### How to test it?

```bash
cd packages/core/core
yarn run -T jest src/ee/__tests__/license.test.ts
```

All 11 tests pass; `yarn test:ts` and `yarn lint` are clean for the changed files.

### Related issue(s)/PR(s)

Extracted from #26699 (`chore(typescript): scope tsconfig types per workspace`) — these license changes were unrelated to that PR's scope and are split out here.
