### PR TITLE
ci: fix typescript job condition and workflow cosmetics in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
     name: 'typescript (node: ${{ matrix.node }})'
     needs: [conditions, build]
     runs-on: ubuntu-latest
-    if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.backend == 'true'
+    if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true'
     strategy:
       matrix:
         node: [22, 24, 26]
@@ -404,10 +404,10 @@ jobs:
           jestOptions: '--shard=${{ matrix.shard }}'
 
   api_ce_mysql:
-    if: needs.conditions.outputs.global == 'true' ||  needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true'
+    if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true'
     runs-on: ubuntu-latest
     needs: [conditions, build]
-    name: '[CE] API Integration (mysql:latest, package: mysql2}, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    name: '[CE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     strategy:
       fail-fast: false
       matrix:
@@ -427,7 +427,7 @@ jobs:
           --health-timeout=5s
           --health-retries=3
         ports:
-          # Maps tcp port 5432 on service container to the host
+          # Maps tcp port 3306 on service container to the host
           - 3306:3306
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -538,7 +538,7 @@ jobs:
           --health-timeout=5s
           --health-retries=3
         ports:
-          # Maps tcp port 5432 on service container to the host
+          # Maps tcp port 3306 on service container to the host
           - 3306:3306
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -558,7 +558,7 @@ jobs:
   api_ee_sqlite:
     runs-on: ubuntu-latest
     needs: [conditions, build]
-    name: '[EE] API Integration (sqlite, client: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    name: '[EE] API Integration (sqlite, package: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     if: (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.api == 'true') && needs.conditions.outputs.is_local == 'true'
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}


### PR DESCRIPTION
## What does it do?

Cleans up a set of small defects in the `Tests` GitHub Actions workflow (`.github/workflows/tests.yml`):

- Fixes the `typescript` job's `if` condition, which listed `backend == 'true'` twice. The duplicated clause is replaced with `frontend == 'true'` so the job runs on frontend-only changes — which it should, since it type-checks the admin via `test:ts:front`.
- Removes a stray `}` in the `api_ce_mysql` job display name (`package: mysql2}` → `package: mysql2`).
- Removes a double space in the `api_ce_mysql` `if` expression.
- Corrects two misleading service-port comments on the MySQL jobs that read "Maps tcp port 5432" while the mapping is `3306:3306`.
- Aligns the `api_ee_sqlite` job name label with its CE counterpart (`client: better-sqlite3` → `package: better-sqlite3`).

No behavioural change to what the jobs run, aside from the `typescript` job now correctly triggering on frontend-only changes.

## Why is it needed?

The duplicated `backend` condition meant the `typescript` job's third clause was dead — frontend-only PRs would skip admin type-checking even though the job runs `test:ts:front`. The remaining items are cosmetic (typos, stale copy-paste comments, inconsistent labels) that make the workflow harder to read and audit.

## How to test it?

- Static review of the diff on `.github/workflows/tests.yml`.
- Validate the YAML parses (e.g. `actionlint`).
- On a frontend-only PR, confirm the `typescript` check now runs.

---
_AI assisted_