### PR TITLE
fix(strapi): auto-exclude pre-built plugin UI libs from Vite optimizeDeps

### DIFF
--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
@@ -1,0 +1,185 @@
+import {
+  collectAdminOptimizeDepsExclude,
+  getPluginPackageName,
+  hasReactPeerDependency,
+  isEsmPackage,
+  shipsPreBuiltDist,
+  shouldExcludeFromOptimizeDeps,
+} from '../admin-vite-optimize-exclude';
+import { ADMIN_VITE_ALIAS_MODULES } from '../admin-vite-alias-modules';
+import { getModule } from '../dependencies';
+import type { PluginMeta } from '../plugins';
+
+jest.mock('../dependencies', () => ({
+  getModule: jest.fn(),
+}));
+
+jest.mock('read-pkg-up', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const readPkgUp = jest.requireMock('read-pkg-up').default as jest.Mock;
+
+const strapiDesignExtendedLike = {
+  name: 'strapi-design-extended',
+  type: 'module',
+  files: ['dist'],
+  module: './dist/index.js',
+  exports: {
+    '.': {
+      import: './dist/index.js',
+    },
+  },
+  peerDependencies: {
+    react: '^18.0.0',
+    'react-dom': '^18.0.0',
+    '@strapi/design-system': '^2.2.0',
+  },
+};
+
+describe('admin vite optimize exclude heuristics', () => {
+  it('matches pre-built ESM libraries with React peers', () => {
+    expect(shouldExcludeFromOptimizeDeps(strapiDesignExtendedLike)).toBe(true);
+  });
+
+  it('does not match CommonJS libraries with React peers', () => {
+    expect(
+      shouldExcludeFromOptimizeDeps({
+        name: 'formik',
+        main: 'dist/formik.cjs.production.min.js',
+        peerDependencies: {
+          react: '>=16.8.0',
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('does not match ESM React peers that ship source instead of dist', () => {
+    expect(
+      shouldExcludeFromOptimizeDeps({
+        name: 'react-intl',
+        type: 'module',
+        module: './lib/index.js',
+        peerDependencies: {
+          react: '^18.0.0',
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('does not match packages without React peers', () => {
+    expect(
+      shouldExcludeFromOptimizeDeps({
+        name: 'lodash',
+        type: 'module',
+        module: './dist/index.js',
+        files: ['dist'],
+      })
+    ).toBe(false);
+  });
+
+  it('extracts scoped plugin package names from admin entry paths', () => {
+    expect(getPluginPackageName('@org/my-plugin/strapi-admin')).toBe('@org/my-plugin');
+    expect(getPluginPackageName('my-plugin/strapi-admin')).toBe('my-plugin');
+  });
+
+  it('detects ESM via type module or exports.import', () => {
+    expect(isEsmPackage({ type: 'module' })).toBe(true);
+    expect(
+      isEsmPackage({
+        exports: {
+          '.': {
+            import: './dist/index.js',
+          },
+        },
+      })
+    ).toBe(true);
+    expect(isEsmPackage({ main: 'index.js' })).toBe(false);
+  });
+
+  it('detects React peer dependencies', () => {
+    expect(hasReactPeerDependency({ peerDependencies: { react: '^18.0.0' } })).toBe(true);
+    expect(hasReactPeerDependency({ peerDependencies: { 'styled-components': '^6.0.0' } })).toBe(
+      false
+    );
+  });
+
+  it('detects dist-based entry points', () => {
+    expect(shipsPreBuiltDist({ module: './dist/index.js' })).toBe(true);
+    expect(shipsPreBuiltDist({ files: ['dist'] })).toBe(true);
+    expect(shipsPreBuiltDist({ module: './lib/index.js' })).toBe(false);
+  });
+});
+
+describe('collectAdminOptimizeDepsExclude', () => {
+  const getModuleMock = getModule as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    readPkgUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          react: '^18.0.0',
+        },
+      },
+    });
+  });
+
+  it('excludes pre-built React peer libraries from plugin dependencies', async () => {
+    const plugins: PluginMeta[] = [
+      {
+        name: 'my-plugin',
+        importName: 'myPlugin',
+        type: 'module',
+        modulePath: '@org/my-plugin/strapi-admin',
+      },
+    ];
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === '@org/my-plugin') {
+        return {
+          dependencies: {
+            'strapi-design-extended': '^0.0.13',
+          },
+        };
+      }
+
+      if (name === 'strapi-design-extended') {
+        return strapiDesignExtendedLike;
+      }
+
+      return null;
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', plugins)).resolves.toEqual([
+      'strapi-design-extended',
+    ]);
+  });
+
+  it('never excludes pinned admin singleton modules', async () => {
+    readPkgUp.mockResolvedValue({
+      packageJson: {
+        dependencies: Object.fromEntries(ADMIN_VITE_ALIAS_MODULES.map((name) => [name, '1.0.0'])),
+      },
+    });
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (ADMIN_VITE_ALIAS_MODULES.includes(name as (typeof ADMIN_VITE_ALIAS_MODULES)[number])) {
+        return {
+          name,
+          type: 'module',
+          module: './dist/index.js',
+          files: ['dist'],
+          peerDependencies: {
+            react: '^18.0.0',
+          },
+        };
+      }
+
+      return null;
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', [])).resolves.toEqual([]);
+  });
+});

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -1,0 +1,174 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import readPkgUp from 'read-pkg-up';
+
+import { ADMIN_VITE_ALIAS_MODULES } from './admin-vite-alias-modules';
+import { getModule, type PackageJson } from './dependencies';
+import type { PluginMeta } from './plugins';
+
+const REACT_PEER_DEPENDENCIES = new Set(['react', 'react-dom']);
+
+/**
+ * Packages explicitly pre-bundled or aliased for the admin singleton contract.
+ * Never auto-exclude these — they must stay on the include/dedupe path.
+ */
+const PINNED_OPTIMIZE_MODULES = new Set<string>(ADMIN_VITE_ALIAS_MODULES);
+
+/**
+ * @internal exported for tests
+ */
+export const isEsmPackage = (pkg: PackageJson): boolean => {
+  if (pkg.type === 'module') {
+    return true;
+  }
+
+  const rootExport = pkg.exports?.['.'];
+
+  return (
+    typeof rootExport === 'object' &&
+    rootExport !== null &&
+    'import' in rootExport &&
+    typeof rootExport.import === 'string'
+  );
+};
+
+/**
+ * @internal exported for tests
+ */
+export const hasReactPeerDependency = (pkg: PackageJson): boolean =>
+  Object.keys(pkg.peerDependencies ?? {}).some((name) => REACT_PEER_DEPENDENCIES.has(name));
+
+/**
+ * Targets libraries that ship a pre-built dist bundle (e.g. plugin UI kits) rather than
+ * source packages like react-intl that still benefit from Vite's dep optimizer.
+ *
+ * @internal exported for tests
+ */
+export const shipsPreBuiltDist = (pkg: PackageJson): boolean => {
+  const rootExport = pkg.exports?.['.'];
+  const exportImport =
+    typeof rootExport === 'object' && rootExport !== null && 'import' in rootExport
+      ? rootExport.import
+      : undefined;
+
+  const entryPaths = [pkg.module, pkg.main, exportImport].filter(
+    (entry): entry is string => typeof entry === 'string'
+  );
+
+  if (
+    entryPaths.some(
+      (entry) =>
+        entry.includes('/dist/') || entry.startsWith('./dist/') || entry.startsWith('dist/')
+    )
+  ) {
+    return true;
+  }
+
+  return (
+    Array.isArray(pkg.files) &&
+    pkg.files.some((file) => file === 'dist' || file.startsWith('dist/'))
+  );
+};
+
+/**
+ * @internal exported for tests
+ */
+export const shouldExcludeFromOptimizeDeps = (pkg: PackageJson): boolean =>
+  hasReactPeerDependency(pkg) && isEsmPackage(pkg) && shipsPreBuiltDist(pkg);
+
+/**
+ * @internal exported for tests
+ */
+export const getPluginPackageName = (modulePath: string): string => {
+  if (modulePath.startsWith('@')) {
+    const [scope, name] = modulePath.split('/');
+
+    return `${scope}/${name}`;
+  }
+
+  return modulePath.split('/')[0] ?? modulePath;
+};
+
+const collectDependencyNames = (pkg: PackageJson): string[] => {
+  const names = new Set<string>();
+
+  for (const section of [pkg.dependencies, pkg.devDependencies] as const) {
+    if (section) {
+      for (const name of Object.keys(section)) {
+        names.add(name);
+      }
+    }
+  }
+
+  return [...names];
+};
+
+const getPluginPackageJson = async (
+  plugin: PluginMeta,
+  cwd: string
+): Promise<PackageJson | null> => {
+  if (plugin.type === 'local' && plugin.path) {
+    try {
+      const content = await fs.readFile(path.join(plugin.path, 'package.json'), 'utf8');
+
+      return JSON.parse(content) as PackageJson;
+    } catch {
+      return null;
+    }
+  }
+
+  return getModule(getPluginPackageName(plugin.modulePath), cwd);
+};
+
+const loadAppPackageJson = async (cwd: string): Promise<PackageJson | null> => {
+  const result = await readPkgUp({ cwd });
+
+  return result?.packageJson ?? null;
+};
+
+/**
+ * Pre-built ESM libraries with React peers (shared plugin UI kits) are incompatible with
+ * Strapi's React/design-system pre-bundling. Skip dep optimization so they resolve through
+ * the admin resolve aliases instead of being re-bundled by Vite.
+ *
+ * @internal
+ */
+export const collectAdminOptimizeDepsExclude = async (
+  cwd: string,
+  plugins: PluginMeta[]
+): Promise<string[]> => {
+  const candidateNames = new Set<string>();
+  const appPkg = await loadAppPackageJson(cwd);
+
+  if (appPkg) {
+    for (const name of collectDependencyNames(appPkg)) {
+      candidateNames.add(name);
+    }
+  }
+
+  for (const plugin of plugins) {
+    const pluginPkg = await getPluginPackageJson(plugin, cwd);
+
+    if (pluginPkg) {
+      for (const name of collectDependencyNames(pluginPkg)) {
+        candidateNames.add(name);
+      }
+    }
+  }
+
+  const exclude: string[] = [];
+
+  for (const name of candidateNames) {
+    if (PINNED_OPTIMIZE_MODULES.has(name)) {
+      continue;
+    }
+
+    const pkg = await getModule(name, cwd);
+
+    if (pkg && shouldExcludeFromOptimizeDeps(pkg)) {
+      exclude.push(name);
+    }
+  }
+
+  return exclude.sort();
+};

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -14,6 +14,24 @@ const REACT_PEER_DEPENDENCIES = new Set(['react', 'react-dom']);
  */
 const PINNED_OPTIMIZE_MODULES = new Set<string>(ADMIN_VITE_ALIAS_MODULES);
 
+type PackageExportEntry =
+  | string
+  | {
+      import?: string;
+      require?: string;
+      default?: string;
+    };
+
+const getRootPackageExport = (pkg: PackageJson): PackageExportEntry | undefined => {
+  const exportsField = pkg.exports as Record<string, PackageExportEntry> | string | undefined;
+
+  if (!exportsField || typeof exportsField === 'string') {
+    return undefined;
+  }
+
+  return exportsField['.'];
+};
+
 /**
  * @internal exported for tests
  */
@@ -22,7 +40,7 @@ export const isEsmPackage = (pkg: PackageJson): boolean => {
     return true;
   }
 
-  const rootExport = pkg.exports?.['.'];
+  const rootExport = getRootPackageExport(pkg);
 
   return (
     typeof rootExport === 'object' &&
@@ -45,7 +63,7 @@ export const hasReactPeerDependency = (pkg: PackageJson): boolean =>
  * @internal exported for tests
  */
 export const shipsPreBuiltDist = (pkg: PackageJson): boolean => {
-  const rootExport = pkg.exports?.['.'];
+  const rootExport = getRootPackageExport(pkg);
   const exportImport =
     typeof rootExport === 'object' && rootExport !== null && 'import' in rootExport
       ? rootExport.import

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react-swc';
 import { getUserConfig } from '../core/config';
 import { ADMIN_VITE_DEDUPE_MODULES } from '../core/admin-vite-alias-modules';
 import { buildAdminViteResolveAliases } from '../core/admin-vite-aliases';
+import { collectAdminOptimizeDepsExclude } from '../core/admin-vite-optimize-exclude';
 import { isDesignSystemLinked } from '../core/linked-packages';
 import { loadStrapiMonorepo } from '../core/monorepo';
 import { getMonorepoAliases } from '../core/aliases';
@@ -15,6 +16,11 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
   const target = browserslistToEsbuild(ctx.target);
   const isMonorepoExampleApp = (ctx.strapi as any).internal_config?.uuid === 'getstarted';
   const designSystemLinked = isDesignSystemLinked();
+  const pluginOptimizeDepsExclude = await collectAdminOptimizeDepsExclude(ctx.cwd, ctx.plugins);
+  const optimizeDepsExclude = [
+    ...(designSystemLinked ? ['@strapi/design-system'] : []),
+    ...pluginOptimizeDepsExclude,
+  ];
 
   return {
     root: ctx.cwd,
@@ -33,8 +39,9 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
     envPrefix: 'STRAPI_ADMIN_',
     optimizeDeps: {
       // When design-system is linked (portal:, file:, yarn link), exclude from pre-bundling
-      // so changes are reflected without clearing node_modules/.strapi/vite cache
-      ...(designSystemLinked && { exclude: ['@strapi/design-system'] }),
+      // so changes are reflected without clearing node_modules/.strapi/vite cache.
+      // Also skip pre-built ESM plugin UI libraries with React peers (see collectAdminOptimizeDepsExclude).
+      ...(optimizeDepsExclude.length > 0 && { exclude: optimizeDepsExclude }),
       include: [
         // pre-bundle React dependencies to avoid React duplicates,
         // even if React dependencies are not direct dependencies


### PR DESCRIPTION
## Summary

- Auto-exclude pre-built ESM plugin UI libraries that peer-depend on React from Vite `optimizeDeps` during admin dev
- Fixes dev-server failures for shared plugin design libraries (e.g. `strapi-design-extended`) after 5.48.x dependency re-optimization without reverting #26249
- Keeps pinned admin singletons (`react`, `@strapi/design-system`, `react-redux`, etc.) on the explicit include/dedupe path

## Context

After 5.48.1 expanded admin dep pre-bundling (#26249) and optionally cleared `node_modules/.strapi/vite` on upgrade, some plugin authors hit Vite dep optimizer errors when importing shared UI libraries that ship a fat pre-built `dist/` bundle with external React imports.

Users worked around this with `src/admin/vite.config.ts`:

```ts
optimizeDeps: { exclude: ['strapi-design-extended'] }
```

This PR applies that pattern automatically for matching packages found in plugin/app dependency trees.

## Safety constraints (why this should not flip-flop again)

- **Only excludes** packages that match **all** of:
  - `react` or `react-dom` in `peerDependencies`
  - ESM (`type: module` or `exports.import`)
  - pre-built dist output (`dist/` entry or `files: ['dist']`)
- **Never excludes** modules on the existing admin singleton list (`ADMIN_VITE_ALIAS_MODULES`) — so `@strapi/design-system`, `react-redux`, `@reduxjs/toolkit`, etc. stay pre-bundled
- **Does not** enable `optimizeDeps.noDiscovery` — CJS plugin deps still get discovered/optimized as before
- **Does not** change production `strapi build` (optimizeDeps is dev-only)

## Test plan

- [x] Unit tests for heuristics + collection (`admin-vite-optimize-exclude.test.ts`)
- [x] Existing admin Vite alias contract tests still pass
- [ ] Manual: project using `strapi-design-extended` in a plugin admin bundle starts with `strapi develop` without manual `optimizeDeps.exclude`

## Related issue(s)/PR(s)

Fixes CMS-1396
