### PR TITLE
chore(typescript-utils): bump internal deps to 5.50.1

### DIFF
--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -59,8 +59,8 @@
     "@types/fs-extra": "11.0.4",
     "@types/lodash": "^4.14.191",
     "@types/node": "20.19.41",
-    "eslint-config-custom": "5.50.0",
-    "tsconfig": "5.50.0"
+    "eslint-config-custom": "5.50.1",
+    "tsconfig": "5.50.1"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10060,11 +10060,11 @@ __metadata:
     "@types/node": "npm:20.19.41"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
-    eslint-config-custom: "npm:5.50.0"
+    eslint-config-custom: "npm:5.50.1"
     fs-extra: "npm:11.3.4"
     lodash: "npm:4.18.1"
     prettier: "npm:3.3.3"
-    tsconfig: "npm:5.50.0"
+    tsconfig: "npm:5.50.1"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### What does it do?

Bumps the `@strapi/typescript-utils` internal dev dependencies `eslint-config-custom` and `tsconfig` from `5.50.0` to `5.50.1`, and updates `yarn.lock` accordingly.

### Why is it needed?

Aligns the package's internal dependency versions with the `5.50.1` release; they were left at `5.50.0` after the release bump.

### How to test it?

`yarn install` resolves cleanly with the `5.50.1` versions; no functional change.

### Related issue(s)/PR(s)

Follow-up to #26811

🤖 Generated with [Claude Code](https://claude.com/claude-code)