### PR TITLE
fix(admin): prevent deprecated CJS Vite Node API warning on startup

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -164,7 +164,6 @@
     "@types/passport-local": "1.0.36",
     "@types/pluralize": "0.0.32",
     "@types/react-window": "1.8.8",
-    "@vitejs/plugin-react-swc": "3.11.0",
     "koa-body": "6.0.1",
     "msw": "2.13.4",
     "react": "18.3.1",

--- a/packages/core/strapi/src/node/vite/build.ts
+++ b/packages/core/strapi/src/node/vite/build.ts
@@ -6,6 +6,9 @@ const build = async (ctx: BuildContext) => {
   const config = await resolveProductionConfig(ctx);
   const finalConfig = await mergeConfigWithUserConfig(config, ctx);
 
+  // Imported dynamically so this file's CJS build resolves Vite's ESM Node API instead of
+  // its CJS entry, which emits "The CJS build of Vite's Node API is deprecated".
+  // https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated
   const { build: viteBuild } = await import('vite');
 
   ctx.logger.debug('Vite config', finalConfig);

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -1,5 +1,4 @@
 import type { InlineConfig, UserConfig } from 'vite';
-import react from '@vitejs/plugin-react-swc';
 
 import { getUserConfig } from '../core/config';
 import { ADMIN_VITE_DEDUPE_MODULES } from '../core/admin-vite-alias-modules';
@@ -15,6 +14,11 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
   const target = browserslistToEsbuild(ctx.target);
   const isMonorepoExampleApp = (ctx.strapi as any).internal_config?.uuid === 'getstarted';
   const designSystemLinked = isDesignSystemLinked();
+
+  // Imported dynamically so this file's CJS build resolves Vite's ESM Node API instead of
+  // its CJS entry, which emits "The CJS build of Vite's Node API is deprecated".
+  // https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated
+  const { default: react } = await import('@vitejs/plugin-react-swc');
 
   return {
     root: ctx.cwd,

--- a/packages/core/strapi/src/node/vite/watch.ts
+++ b/packages/core/strapi/src/node/vite/watch.ts
@@ -15,6 +15,9 @@ const watch = async (ctx: BuildContext): Promise<ViteWatcher> => {
 
   ctx.logger.debug('Vite config', finalConfig);
 
+  // Imported dynamically so this file's CJS build resolves Vite's ESM Node API instead of
+  // its CJS entry, which emits "The CJS build of Vite's Node API is deprecated".
+  // https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated
   const { createServer } = await import('vite');
 
   const vite = await createServer(finalConfig);

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -59,8 +59,8 @@
     "@types/fs-extra": "11.0.4",
     "@types/lodash": "^4.14.191",
     "@types/node": "20.19.41",
-    "eslint-config-custom": "5.50.0",
-    "tsconfig": "5.50.0"
+    "eslint-config-custom": "5.50.1",
+    "tsconfig": "5.50.1"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8936,7 +8936,6 @@ __metadata:
     "@types/passport-local": "npm:1.0.36"
     "@types/pluralize": "npm:0.0.32"
     "@types/react-window": "npm:1.8.8"
-    "@vitejs/plugin-react-swc": "npm:3.11.0"
     axios: "npm:1.18.1"
     bcryptjs: "npm:2.4.3"
     boxen: "npm:5.1.2"
@@ -10060,11 +10059,11 @@ __metadata:
     "@types/node": "npm:20.19.41"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
-    eslint-config-custom: "npm:5.50.0"
+    eslint-config-custom: "npm:5.50.1"
     fs-extra: "npm:11.3.4"
     lodash: "npm:4.18.1"
     prettier: "npm:3.3.3"
-    tsconfig: "npm:5.50.0"
+    tsconfig: "npm:5.50.1"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### What does it do?

The admin Vite config (`packages/core/strapi/src/node/vite/config.ts`) imported `@vitejs/plugin-react-swc` with a static `import`. In the CJS build of that config, the static require pulls in Vite's Node API through its CommonJS entry, which emits:

```
The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
```

Changes:
- Load `@vitejs/plugin-react-swc` via a dynamic `await import()` (same pattern already used for `browserslist-to-esbuild` in the same file) so its ESM entry is resolved even from the CJS build.
- Move the `@vitejs/plugin-react-swc` dependency declaration from `@strapi/admin` (which does not import it) to `@strapi/strapi` (which does).
- Document the existing dynamic `await import('vite')` calls in `build.ts` / `watch.ts` with the same rationale.

### Why is it needed?

Starting a Strapi project printed the deprecation warning on every startup. `@vitejs/plugin-react-swc` transitively loads Vite's Node API; resolving it as CJS triggers the warning. The dynamic import avoids the CJS path.

### How to test it?

1. `yarn build`
2. Start a Strapi app (e.g. `cd examples/getstarted && yarn develop`).
3. The "The CJS build of Vite's Node API is deprecated" warning no longer appears.

### Related issue(s)/PR(s)

- #26541 (chore(deps): upgrade vite to v8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)