### PR TITLE
fix(openapi): add bearerAuth and bracket pagination query params

### DIFF
--- a/packages/core/openapi/__tests__/document-assemblers.test.ts
+++ b/packages/core/openapi/__tests__/document-assemblers.test.ts
@@ -1,0 +1,49 @@
+import type { Core } from '@strapi/types';
+
+import { DocumentSecurityAssembler } from '../src/assemblers/document/security';
+import { DocumentContextFactory } from '../src/context';
+import { ComponentsWriter } from '../src/post-processor/component-writer';
+
+const createStrapiMock = (config: Record<string, unknown> = {}): Pick<Core.Strapi, 'config'> => ({
+  config: {
+    get(path: string) {
+      return config[path];
+    },
+  } as Core.Strapi['config'],
+});
+
+describe('OpenAPI document assemblers', () => {
+  const createDocumentContext = () => {
+    const factory = new DocumentContextFactory();
+    return factory.create({ strapi: createStrapiMock() as Core.Strapi, routes: [] });
+  };
+
+  describe('DocumentSecurityAssembler', () => {
+    it('includes default bearerAuth in components.securitySchemes', () => {
+      const assembler = new DocumentSecurityAssembler();
+      const context = createDocumentContext();
+
+      assembler.assemble(context);
+
+      expect(context.output.data.components?.securitySchemes?.bearerAuth).toEqual({
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'JWT Bearer token for authentication',
+      });
+      expect(context.output.data.security).toEqual([{ bearerAuth: [] }]);
+    });
+
+    it('preserves bearerAuth after ComponentsWriter post-processing', () => {
+      const assembler = new DocumentSecurityAssembler();
+      const postProcessor = new ComponentsWriter();
+      const context = createDocumentContext();
+
+      assembler.assemble(context);
+      postProcessor.postProcess(context);
+
+      expect(context.output.data.components?.securitySchemes?.bearerAuth).toBeDefined();
+      expect(context.output.data.components?.schemas).toBeDefined();
+    });
+  });
+});

--- a/packages/core/openapi/__tests__/document-assemblers.test.ts
+++ b/packages/core/openapi/__tests__/document-assemblers.test.ts
@@ -1,6 +1,7 @@
 import type { Core } from '@strapi/types';
 
 import { DocumentSecurityAssembler } from '../src/assemblers/document/security';
+import { DocumentServerAssembler } from '../src/assemblers/document/server';
 import { DocumentContextFactory } from '../src/context';
 import { ComponentsWriter } from '../src/post-processor/component-writer';
 
@@ -44,6 +45,52 @@ describe('OpenAPI document assemblers', () => {
 
       expect(context.output.data.components?.securitySchemes?.bearerAuth).toBeDefined();
       expect(context.output.data.components?.schemas).toBeDefined();
+    });
+  });
+
+  describe('DocumentServerAssembler', () => {
+    it('includes a default server from server.url', () => {
+      const assembler = new DocumentServerAssembler();
+      const factory = new DocumentContextFactory();
+      const context = factory.create({
+        strapi: createStrapiMock({ 'server.url': 'https://api.example.com' }) as Core.Strapi,
+        routes: [],
+      });
+
+      assembler.assemble(context);
+
+      expect(context.output.data.servers).toEqual([
+        { url: 'https://api.example.com', description: 'Default server' },
+      ]);
+    });
+
+    it('prefers openapi.servers over server.url', () => {
+      const assembler = new DocumentServerAssembler();
+      const factory = new DocumentContextFactory();
+      const context = factory.create({
+        strapi: createStrapiMock({
+          'openapi.servers': [{ url: 'https://staging.example.com', description: 'Staging' }],
+          'server.url': 'https://api.example.com',
+        }) as Core.Strapi,
+        routes: [],
+      });
+
+      assembler.assemble(context);
+
+      expect(context.output.data.servers).toEqual([
+        { url: 'https://staging.example.com', description: 'Staging' },
+      ]);
+    });
+
+    it('falls back to localhost when no server config is set', () => {
+      const assembler = new DocumentServerAssembler();
+      const context = createDocumentContext();
+
+      assembler.assemble(context);
+
+      expect(context.output.data.servers).toEqual([
+        { url: 'http://localhost:1337', description: 'Default server' },
+      ]);
     });
   });
 });

--- a/packages/core/openapi/__tests__/document-assemblers.test.ts
+++ b/packages/core/openapi/__tests__/document-assemblers.test.ts
@@ -46,6 +46,53 @@ describe('OpenAPI document assemblers', () => {
       expect(context.output.data.components?.securitySchemes?.bearerAuth).toBeDefined();
       expect(context.output.data.components?.schemas).toBeDefined();
     });
+
+    it('uses openapi.security schemes when configured', () => {
+      const assembler = new DocumentSecurityAssembler();
+      const factory = new DocumentContextFactory();
+      const customBearerAuth = {
+        type: 'http' as const,
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'Project JWT',
+      };
+      const apiKey = {
+        type: 'apiKey' as const,
+        name: 'X-API-Key',
+        in: 'header' as const,
+        description: 'Service API key',
+      };
+      const context = factory.create({
+        strapi: createStrapiMock({
+          'openapi.security': {
+            bearerAuth: customBearerAuth,
+            apiKey,
+          },
+        }) as Core.Strapi,
+        routes: [],
+      });
+
+      assembler.assemble(context);
+
+      expect(context.output.data.components?.securitySchemes?.bearerAuth).toEqual(customBearerAuth);
+      expect(context.output.data.components?.securitySchemes?.apiKey).toEqual(apiKey);
+    });
+
+    it('uses openapi.globalSecurity when configured', () => {
+      const assembler = new DocumentSecurityAssembler();
+      const factory = new DocumentContextFactory();
+      const globalSecurity = [{ apiKey: [] }];
+      const context = factory.create({
+        strapi: createStrapiMock({
+          'openapi.globalSecurity': globalSecurity,
+        }) as Core.Strapi,
+        routes: [],
+      });
+
+      assembler.assemble(context);
+
+      expect(context.output.data.security).toEqual(globalSecurity);
+    });
   });
 
   describe('DocumentServerAssembler', () => {

--- a/packages/core/openapi/__tests__/operation-assemblers.test.ts
+++ b/packages/core/openapi/__tests__/operation-assemblers.test.ts
@@ -207,6 +207,26 @@ describe('OpenAPI operation assemblers – params added via addQueryParams / add
       expect(filtersParam?.schema).toMatchObject({ type: 'object' });
       expect(parameters.some((p) => p.name.startsWith('filters['))).toBe(false);
     });
+
+    it('keeps obscure query params when allOf merge yields no properties', () => {
+      const obscureSchema = z.intersection(z.object({}), z.object({})).optional();
+
+      const route = contentAPIRoute({
+        handler: 'api::article.article.findMany',
+        request: {
+          query: {
+            obscure: obscureSchema,
+          },
+        },
+      });
+
+      const assembler = new OperationParametersAssembler();
+      const context = createOperationContext();
+      assembler.assemble(context, route);
+
+      const parameters = context.output.data.parameters ?? [];
+      expect(parameters.some((p) => p.name === 'obscure' && p.in === 'query')).toBe(true);
+    });
   });
 
   describe('BodyAssembler', () => {

--- a/packages/core/openapi/__tests__/operation-assemblers.test.ts
+++ b/packages/core/openapi/__tests__/operation-assemblers.test.ts
@@ -136,6 +136,49 @@ describe('OpenAPI operation assemblers – params added via addQueryParams / add
       assembler.assemble(context, contentAPIRoute({ handler: 'api::article.article.findMany' }));
       expect(context.output.data.parameters).toEqual([]);
     });
+
+    it('expands nested pagination object into bracket notation query params', () => {
+      const paginationSchema = z
+        .intersection(
+          z.object({
+            withCount: z.boolean().optional(),
+          }),
+          z.union([
+            z.object({
+              page: z.number().int().positive(),
+              pageSize: z.number().int().positive(),
+            }),
+            z.object({
+              start: z.number().int().min(0),
+              limit: z.number().int().positive(),
+            }),
+          ])
+        )
+        .optional();
+
+      const route = contentAPIRoute({
+        handler: 'api::article.article.findMany',
+        request: {
+          query: {
+            pagination: paginationSchema,
+          },
+        },
+      });
+
+      const assembler = new OperationParametersAssembler();
+      const context = createOperationContext();
+      assembler.assemble(context, route);
+
+      const parameters = context.output.data.parameters ?? [];
+      const names = parameters.map((p) => p.name);
+
+      expect(names).toContain('pagination[page]');
+      expect(names).toContain('pagination[pageSize]');
+      expect(names).toContain('pagination[start]');
+      expect(names).toContain('pagination[limit]');
+      expect(names).toContain('pagination[withCount]');
+      expect(names).not.toContain('pagination');
+    });
   });
 
   describe('BodyAssembler', () => {

--- a/packages/core/openapi/__tests__/operation-assemblers.test.ts
+++ b/packages/core/openapi/__tests__/operation-assemblers.test.ts
@@ -179,6 +179,34 @@ describe('OpenAPI operation assemblers – params added via addQueryParams / add
       expect(names).toContain('pagination[withCount]');
       expect(names).not.toContain('pagination');
     });
+
+    it('describes filters as a deepObject query param', () => {
+      const filtersSchema = z.record(z.string(), z.any()).optional();
+
+      const route = contentAPIRoute({
+        handler: 'api::article.article.findMany',
+        request: {
+          query: {
+            filters: filtersSchema,
+          },
+        },
+      });
+
+      const assembler = new OperationParametersAssembler();
+      const context = createOperationContext();
+      assembler.assemble(context, route);
+
+      const parameters = context.output.data.parameters ?? [];
+      const filtersParam = parameters.find(
+        (p): p is typeof p & { name: string } => p.name === 'filters' && p.in === 'query'
+      );
+
+      expect(filtersParam).toBeDefined();
+      expect(filtersParam?.style).toBe('deepObject');
+      expect(filtersParam?.explode).toBe(true);
+      expect(filtersParam?.schema).toMatchObject({ type: 'object' });
+      expect(parameters.some((p) => p.name.startsWith('filters['))).toBe(false);
+    });
   });
 
   describe('BodyAssembler', () => {

--- a/packages/core/openapi/__tests__/query-param-styles.test.ts
+++ b/packages/core/openapi/__tests__/query-param-styles.test.ts
@@ -1,0 +1,18 @@
+import type { OpenAPIV3_1 } from 'openapi-types';
+
+import {
+  hasExpandableObjectProperties,
+  shouldUseDeepObjectStyle,
+} from '../src/assemblers/document/query-param-styles';
+
+describe('query param styles', () => {
+  it('does not treat filters as bracket-expandable', () => {
+    const filtersSchema: OpenAPIV3_1.SchemaObject = {
+      type: 'object',
+      additionalProperties: true,
+    };
+
+    expect(hasExpandableObjectProperties(filtersSchema)).toBe(false);
+    expect(shouldUseDeepObjectStyle('filters', filtersSchema)).toBe(true);
+  });
+});

--- a/packages/core/openapi/src/assemblers/document/factory.ts
+++ b/packages/core/openapi/src/assemblers/document/factory.ts
@@ -6,12 +6,14 @@ import { DocumentInfoAssembler } from './info';
 import { DocumentMetadataAssembler } from './metadata';
 import { DocumentPathsAssembler, PathAssemblerFactory } from './path';
 import { DocumentSecurityAssembler } from './security';
+import { DocumentServerAssembler } from './server';
 
 export class DocumentAssemblerFactory {
   createAll(): Assembler.Document[] {
     return [
       this._createMetadataAssembler(),
       this._createInfoAssembler(),
+      this._createServerAssembler(),
       this._createSecurityAssembler(),
       this._createPathsAssembler(),
     ];
@@ -27,6 +29,10 @@ export class DocumentAssemblerFactory {
 
   private _createSecurityAssembler() {
     return new DocumentSecurityAssembler();
+  }
+
+  private _createServerAssembler() {
+    return new DocumentServerAssembler();
   }
 
   private _createPathsAssembler(

--- a/packages/core/openapi/src/assemblers/document/factory.ts
+++ b/packages/core/openapi/src/assemblers/document/factory.ts
@@ -5,12 +5,14 @@ import type { Assembler } from '..';
 import { DocumentInfoAssembler } from './info';
 import { DocumentMetadataAssembler } from './metadata';
 import { DocumentPathsAssembler, PathAssemblerFactory } from './path';
+import { DocumentSecurityAssembler } from './security';
 
 export class DocumentAssemblerFactory {
   createAll(): Assembler.Document[] {
     return [
       this._createMetadataAssembler(),
       this._createInfoAssembler(),
+      this._createSecurityAssembler(),
       this._createPathsAssembler(),
     ];
   }
@@ -21,6 +23,10 @@ export class DocumentAssemblerFactory {
 
   private _createMetadataAssembler() {
     return new DocumentMetadataAssembler();
+  }
+
+  private _createSecurityAssembler() {
+    return new DocumentSecurityAssembler();
   }
 
   private _createPathsAssembler(

--- a/packages/core/openapi/src/assemblers/document/path/path-item/operation/parameters.ts
+++ b/packages/core/openapi/src/assemblers/document/path/path-item/operation/parameters.ts
@@ -58,15 +58,110 @@ export class OperationParametersAssembler implements Assembler.Operation {
     for (const [name, zodSchema] of Object.entries(query)) {
       const required = !zodSchema.isOptional();
       const schema = zodToOpenAPI(zodSchema) as any;
-      const param: QueryParameterObject = { name, in: 'query', required, schema };
 
-      // In Strapi, query params are always interpreted as query strings, which isn't supported by the specification
-      // TODO: Make that configurable somehow
-      Object.assign(param, { 'x-strapi-serialize': 'querystring' });
+      const resolvedSchema = this._resolveSchema(schema);
+      if (resolvedSchema.type === 'object' && resolvedSchema.properties) {
+        for (const [propName, propSchema] of Object.entries(resolvedSchema.properties)) {
+          const isRequired = resolvedSchema.required?.includes(propName) ?? false;
 
-      queryParams.push(param);
+          const param: QueryParameterObject = {
+            name: `${name}[${propName}]`,
+            in: 'query',
+            required: isRequired,
+            schema: propSchema as any,
+          };
+
+          Object.assign(param, { 'x-strapi-serialize': 'querystring' });
+          queryParams.push(param);
+        }
+      } else {
+        const param: QueryParameterObject = { name, in: 'query', required, schema };
+        Object.assign(param, { 'x-strapi-serialize': 'querystring' });
+        queryParams.push(param);
+      }
     }
 
     return queryParams;
+  }
+
+  /**
+   * Resolve composite OpenAPI schemas (allOf/anyOf/oneOf) into a flat object shape
+   * so nested Strapi query params can be emitted as bracket notation (e.g. pagination[page]).
+   */
+  private _resolveSchema(schema: OpenAPIV3_1.SchemaObject): OpenAPIV3_1.SchemaObject {
+    if (schema.type === 'object' && schema.properties) {
+      return schema;
+    }
+
+    if (schema.allOf && Array.isArray(schema.allOf)) {
+      const mergedSchema: OpenAPIV3_1.SchemaObject = {
+        type: 'object',
+        properties: {},
+        required: [],
+      };
+
+      for (const subSchema of schema.allOf) {
+        if (!('$ref' in subSchema)) {
+          const hasAnyOfOneOf = Boolean(subSchema.anyOf || subSchema.oneOf);
+          const resolved = this._resolveSchema(subSchema);
+
+          if (resolved.type === 'object' && resolved.properties) {
+            Object.assign(mergedSchema.properties!, resolved.properties);
+            if (resolved.required && !hasAnyOfOneOf) {
+              mergedSchema.required = [
+                ...(mergedSchema.required ?? []),
+                ...(resolved.required as string[]),
+              ];
+            }
+          }
+        }
+      }
+
+      return mergedSchema.properties ? mergedSchema : schema;
+    }
+
+    if (schema.anyOf && Array.isArray(schema.anyOf)) {
+      return this._extractCommonProperties(schema.anyOf, false);
+    }
+
+    if (schema.oneOf && Array.isArray(schema.oneOf)) {
+      return this._extractCommonProperties(schema.oneOf, false);
+    }
+
+    return schema;
+  }
+
+  private _extractCommonProperties(
+    schemas: OpenAPIV3_1.SchemaObject[],
+    preserveRequired = true
+  ): OpenAPIV3_1.SchemaObject {
+    const objectSchemas = schemas
+      .filter((s): s is OpenAPIV3_1.SchemaObject => !('$ref' in s))
+      .map((s) => this._resolveSchema(s))
+      .filter((s) => s.type === 'object' && s.properties);
+
+    if (objectSchemas.length === 0) {
+      return schemas[0] as OpenAPIV3_1.SchemaObject;
+    }
+
+    const allProperties: Record<string, OpenAPIV3_1.SchemaObject> = {};
+    let allRequired: string[] = [];
+
+    for (const objSchema of objectSchemas) {
+      Object.assign(allProperties, objSchema.properties);
+      if (preserveRequired && objSchema.required) {
+        allRequired.push(...(objSchema.required as string[]));
+      }
+    }
+
+    if (!preserveRequired) {
+      allRequired = [];
+    }
+
+    return {
+      type: 'object',
+      properties: allProperties,
+      required: allRequired,
+    };
   }
 }

--- a/packages/core/openapi/src/assemblers/document/path/path-item/operation/parameters.ts
+++ b/packages/core/openapi/src/assemblers/document/path/path-item/operation/parameters.ts
@@ -84,7 +84,7 @@ export class OperationParametersAssembler implements Assembler.Operation {
           name,
           in: 'query',
           required,
-          schema: resolvedSchema,
+          schema: resolvedSchema as any,
           style: 'deepObject',
           explode: true,
         };

--- a/packages/core/openapi/src/assemblers/document/path/path-item/operation/parameters.ts
+++ b/packages/core/openapi/src/assemblers/document/path/path-item/operation/parameters.ts
@@ -134,7 +134,7 @@ export class OperationParametersAssembler implements Assembler.Operation {
         }
       }
 
-      return mergedSchema.properties ? mergedSchema : schema;
+      return hasExpandableObjectProperties(mergedSchema) ? mergedSchema : schema;
     }
 
     if (schema.anyOf && Array.isArray(schema.anyOf)) {
@@ -173,6 +173,10 @@ export class OperationParametersAssembler implements Assembler.Operation {
 
     if (!preserveRequired) {
       allRequired = [];
+    }
+
+    if (Object.keys(allProperties).length === 0) {
+      return schemas[0] as OpenAPIV3_1.SchemaObject;
     }
 
     return {

--- a/packages/core/openapi/src/assemblers/document/path/path-item/operation/parameters.ts
+++ b/packages/core/openapi/src/assemblers/document/path/path-item/operation/parameters.ts
@@ -4,6 +4,10 @@ import type { Assembler } from '../../../..';
 
 import type { OperationContext } from '../../../../../types';
 import { createDebugger, zodToOpenAPI } from '../../../../../utils';
+import {
+  hasExpandableObjectProperties,
+  shouldUseDeepObjectStyle,
+} from '../../../query-param-styles';
 
 const debug = createDebugger('assembler:parameters');
 
@@ -60,8 +64,9 @@ export class OperationParametersAssembler implements Assembler.Operation {
       const schema = zodToOpenAPI(zodSchema) as any;
 
       const resolvedSchema = this._resolveSchema(schema);
-      if (resolvedSchema.type === 'object' && resolvedSchema.properties) {
-        for (const [propName, propSchema] of Object.entries(resolvedSchema.properties)) {
+
+      if (hasExpandableObjectProperties(resolvedSchema)) {
+        for (const [propName, propSchema] of Object.entries(resolvedSchema.properties!)) {
           const isRequired = resolvedSchema.required?.includes(propName) ?? false;
 
           const param: QueryParameterObject = {
@@ -74,6 +79,18 @@ export class OperationParametersAssembler implements Assembler.Operation {
           Object.assign(param, { 'x-strapi-serialize': 'querystring' });
           queryParams.push(param);
         }
+      } else if (shouldUseDeepObjectStyle(name, resolvedSchema)) {
+        const param: QueryParameterObject = {
+          name,
+          in: 'query',
+          required,
+          schema: resolvedSchema,
+          style: 'deepObject',
+          explode: true,
+        };
+
+        Object.assign(param, { 'x-strapi-serialize': 'querystring' });
+        queryParams.push(param);
       } else {
         const param: QueryParameterObject = { name, in: 'query', required, schema };
         Object.assign(param, { 'x-strapi-serialize': 'querystring' });

--- a/packages/core/openapi/src/assemblers/document/query-param-styles.ts
+++ b/packages/core/openapi/src/assemblers/document/query-param-styles.ts
@@ -1,0 +1,30 @@
+import type { OpenAPIV3_1 } from 'openapi-types';
+
+/**
+ * Query params whose values are open-ended records parsed from bracket notation
+ * (e.g. filters[title][$eq]=hello). These are described as deepObject in OpenAPI
+ * rather than expanded into fixed sub-keys.
+ */
+export const DEEP_OBJECT_QUERY_PARAMS = new Set(['filters']);
+
+export const shouldUseDeepObjectStyle = (
+  name: string,
+  schema: OpenAPIV3_1.SchemaObject
+): boolean => {
+  if (DEEP_OBJECT_QUERY_PARAMS.has(name)) {
+    return true;
+  }
+
+  return (
+    schema.type === 'object' &&
+    (!schema.properties || Object.keys(schema.properties).length === 0) &&
+    schema.additionalProperties !== undefined &&
+    schema.additionalProperties !== false
+  );
+};
+
+export const hasExpandableObjectProperties = (schema: OpenAPIV3_1.SchemaObject): boolean => {
+  return Boolean(
+    schema.type === 'object' && schema.properties && Object.keys(schema.properties).length > 0
+  );
+};

--- a/packages/core/openapi/src/assemblers/document/security.ts
+++ b/packages/core/openapi/src/assemblers/document/security.ts
@@ -1,0 +1,61 @@
+import type { Core } from '@strapi/types';
+import type { OpenAPIV3_1 } from 'openapi-types';
+
+import type { DocumentContext } from '../../types';
+
+import type { Assembler } from '..';
+
+const DEFAULT_BEARER_AUTH: OpenAPIV3_1.HttpSecurityScheme = {
+  type: 'http',
+  scheme: 'bearer',
+  bearerFormat: 'JWT',
+  description: 'JWT Bearer token for authentication',
+};
+
+export class DocumentSecurityAssembler implements Assembler.Document {
+  assemble(context: DocumentContext): void {
+    const { strapi } = context;
+
+    const securitySchemes = this._getSecuritySchemes(strapi);
+    const security = this._getGlobalSecurity(strapi);
+
+    if (context.output.data.components === undefined) {
+      context.output.data.components = {};
+    }
+
+    context.output.data.components.securitySchemes = securitySchemes;
+    context.output.data.security = security;
+  }
+
+  private _getSecuritySchemes(
+    strapi: Core.Strapi
+  ): Record<string, OpenAPIV3_1.SecuritySchemeObject> {
+    const securityConfig =
+      strapi.config.get<
+        Record<string, OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.SecuritySchemeObject>
+      >('openapi.security') ?? {};
+
+    const schemes: Record<string, OpenAPIV3_1.SecuritySchemeObject> = {};
+
+    if (!securityConfig.bearerAuth) {
+      schemes.bearerAuth = DEFAULT_BEARER_AUTH;
+    }
+
+    for (const [name, config] of Object.entries(securityConfig)) {
+      schemes[name] = config as OpenAPIV3_1.SecuritySchemeObject;
+    }
+
+    return schemes;
+  }
+
+  private _getGlobalSecurity(strapi: Core.Strapi): OpenAPIV3_1.Document['security'] {
+    const globalSecurity =
+      strapi.config.get<OpenAPIV3_1.Document['security']>('openapi.globalSecurity');
+
+    if (globalSecurity) {
+      return globalSecurity;
+    }
+
+    return [{ bearerAuth: [] }];
+  }
+}

--- a/packages/core/openapi/src/assemblers/document/server.ts
+++ b/packages/core/openapi/src/assemblers/document/server.ts
@@ -1,0 +1,39 @@
+import type { OpenAPIV3_1 } from 'openapi-types';
+
+import type { Core } from '@strapi/types';
+import type { DocumentContext } from '../../types';
+
+import type { Assembler } from '..';
+
+export interface ServerConfig {
+  url: string;
+  description?: string;
+  variables?: Record<string, OpenAPIV3_1.ServerVariableObject>;
+}
+
+const DEFAULT_SERVER_URL = 'http://localhost:1337';
+
+export class DocumentServerAssembler implements Assembler.Document {
+  assemble(context: DocumentContext): void {
+    const { strapi } = context;
+
+    context.output.data.servers = this._getServers(strapi);
+  }
+
+  private _getServers(strapi: Core.Strapi): OpenAPIV3_1.ServerObject[] {
+    const serverConfig = strapi.config.get<ServerConfig[]>('openapi.servers') ?? [];
+
+    if (serverConfig.length > 0) {
+      return serverConfig;
+    }
+
+    const serverUrl = strapi.config.get<string>('server.url') ?? DEFAULT_SERVER_URL;
+
+    return [
+      {
+        url: serverUrl,
+        description: 'Default server',
+      },
+    ];
+  }
+}

--- a/packages/core/openapi/src/post-processor/component-writer.ts
+++ b/packages/core/openapi/src/post-processor/component-writer.ts
@@ -12,6 +12,11 @@ export class ComponentsWriter implements PostProcessor {
       uri: toComponentsPath,
     }) as OpenAPIV3_1.ComponentsObject;
 
-    output.data.components = { schemas };
+    const existingComponents = output.data.components ?? {};
+
+    output.data.components = {
+      ...existingComponents,
+      schemas,
+    };
   }
 }

--- a/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
@@ -742,6 +742,136 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
         ],
         "type": "object",
       },
+      "ApiRelationLabRelationLabDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiRelationLabRelationLabDocument",
+        "properties": {
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "manyToMany": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            },
+            "type": "array",
+          },
+          "manyToManyBi": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            },
+            "type": "array",
+          },
+          "manyToOne": {
+            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            "description": "A relational field",
+          },
+          "oneToMany": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            },
+            "type": "array",
+          },
+          "oneToOne": {
+            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+            "description": "A relational field",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "title": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "title",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiRelationTargetRelationTargetDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiRelationTargetRelationTargetDocument",
+        "properties": {
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "name": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "relationLabs": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+            },
+            "type": "array",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "name",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
       "ApiShopShopDocument": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -18037,6 +18167,3120 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
         },
         "tags": [
           "product",
+        ],
+      },
+    },
+    "/relation-labs": {
+      "get": {
+        "operationId": "relation-lab/get/relation_labs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "explode": true,
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "style": "deepObject",
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[withCount]",
+            "required": false,
+            "schema": {
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "title",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "title",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "title",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "title",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "manyToMany": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            },
+                            "type": "array",
+                          },
+                          "manyToManyBi": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            },
+                            "type": "array",
+                          },
+                          "manyToOne": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            "description": "A relational field",
+                          },
+                          "oneToMany": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            },
+                            "type": "array",
+                          },
+                          "oneToOne": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                            "description": "A relational field",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "title": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "title",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+      "post": {
+        "operationId": "relation-lab/post/relation_labs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "manyToMany": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "manyToManyBi": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "manyToOne": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "oneToMany": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "oneToOne": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "title": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "title",
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "manyToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToManyBi": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "oneToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "oneToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+    },
+    "/relation-labs/{id}": {
+      "delete": {
+        "operationId": "relation-lab/delete/relation_labs_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "explode": true,
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "style": "deepObject",
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "manyToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToManyBi": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "oneToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "oneToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+      "get": {
+        "operationId": "relation-lab/get/relation_labs_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "explode": true,
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "style": "deepObject",
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "title",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "title",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "title",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "title",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "manyToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToManyBi": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "oneToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "oneToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+      "put": {
+        "operationId": "relation-lab/put/relation_labs_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "manyToOne",
+                    "oneToOne",
+                    "oneToMany",
+                    "manyToMany",
+                    "manyToManyBi",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "manyToOne",
+                      "oneToOne",
+                      "oneToMany",
+                      "manyToMany",
+                      "manyToManyBi",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "manyToMany": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "manyToManyBi": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "manyToOne": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "oneToMany": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "oneToOne": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "title": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "manyToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToManyBi": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "manyToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "oneToMany": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          },
+                          "type": "array",
+                        },
+                        "oneToOne": {
+                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-lab",
+        ],
+      },
+    },
+    "/relation-targets": {
+      "get": {
+        "operationId": "relation-target/get/relation_targets",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "explode": true,
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "style": "deepObject",
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[withCount]",
+            "required": false,
+            "schema": {
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "name": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "relationLabs": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                            },
+                            "type": "array",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "name",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
+        ],
+      },
+      "post": {
+        "operationId": "relation-target/post/relation_targets",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "relationLabs": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "relationLabs": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                          },
+                          "type": "array",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
+        ],
+      },
+    },
+    "/relation-targets/{id}": {
+      "delete": {
+        "operationId": "relation-target/delete/relation_targets_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "explode": true,
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "style": "deepObject",
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "relationLabs": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                          },
+                          "type": "array",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
+        ],
+      },
+      "get": {
+        "operationId": "relation-target/get/relation_targets_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "explode": true,
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "style": "deepObject",
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "relationLabs": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                          },
+                          "type": "array",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
+        ],
+      },
+      "put": {
+        "operationId": "relation-target/put/relation_targets_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "relationLabs",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "relationLabs",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "publicationFilter",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
+              "enum": [
+                "never-published",
+                "has-published-version",
+                "modified",
+                "unmodified",
+                "never-published-document",
+                "has-published-version-document",
+                "published-without-draft",
+                "published-with-draft",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "relationLabs": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "relationLabs": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
+                          },
+                          "type": "array",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "relation-target",
         ],
       },
     },

--- a/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
@@ -742,136 +742,6 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
         ],
         "type": "object",
       },
-      "ApiRelationLabRelationLabDocument": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "additionalProperties": false,
-        "id": "ApiRelationLabRelationLabDocument",
-        "properties": {
-          "createdAt": {
-            "description": "A datetime field",
-            "type": "string",
-          },
-          "documentId": {
-            "description": "The document ID, represented by a UUID",
-            "format": "uuid",
-            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-            "type": "string",
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "number",
-              },
-            ],
-          },
-          "manyToMany": {
-            "description": "A relational field",
-            "items": {
-              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-            },
-            "type": "array",
-          },
-          "manyToManyBi": {
-            "description": "A relational field",
-            "items": {
-              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-            },
-            "type": "array",
-          },
-          "manyToOne": {
-            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-            "description": "A relational field",
-          },
-          "oneToMany": {
-            "description": "A relational field",
-            "items": {
-              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-            },
-            "type": "array",
-          },
-          "oneToOne": {
-            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-            "description": "A relational field",
-          },
-          "publishedAt": {
-            "default": "<generated-at-runtime>",
-            "description": "A datetime field",
-            "type": "string",
-          },
-          "title": {
-            "description": "A string field",
-            "type": "string",
-          },
-          "updatedAt": {
-            "description": "A datetime field",
-            "type": "string",
-          },
-        },
-        "required": [
-          "documentId",
-          "id",
-          "title",
-          "publishedAt",
-        ],
-        "type": "object",
-      },
-      "ApiRelationTargetRelationTargetDocument": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "additionalProperties": false,
-        "id": "ApiRelationTargetRelationTargetDocument",
-        "properties": {
-          "createdAt": {
-            "description": "A datetime field",
-            "type": "string",
-          },
-          "documentId": {
-            "description": "The document ID, represented by a UUID",
-            "format": "uuid",
-            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-            "type": "string",
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "number",
-              },
-            ],
-          },
-          "name": {
-            "description": "A string field",
-            "type": "string",
-          },
-          "publishedAt": {
-            "default": "<generated-at-runtime>",
-            "description": "A datetime field",
-            "type": "string",
-          },
-          "relationLabs": {
-            "description": "A relational field",
-            "items": {
-              "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
-            },
-            "type": "array",
-          },
-          "updatedAt": {
-            "description": "A datetime field",
-            "type": "string",
-          },
-        },
-        "required": [
-          "documentId",
-          "id",
-          "name",
-          "publishedAt",
-        ],
-        "type": "object",
-      },
       "ApiShopShopDocument": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -1694,6 +1564,14 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
         "type": "object",
       },
     },
+    "securitySchemes": {
+      "bearerAuth": {
+        "bearerFormat": "JWT",
+        "description": "JWT Bearer token for authentication",
+        "scheme": "bearer",
+        "type": "http",
+      },
+    },
   },
   "info": {
     "description": "API documentation for test-app-0 v0.1.0",
@@ -1731,6 +1609,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -1752,6 +1631,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -1766,73 +1646,59 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
             },
             "x-strapi-serialize": "querystring",
           },
@@ -2541,6 +2407,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -2562,6 +2429,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -2828,6 +2696,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -2849,6 +2718,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -4679,6 +4549,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -4697,6 +4568,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -4711,73 +4583,59 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
             },
             "x-strapi-serialize": "querystring",
           },
@@ -5382,6 +5240,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -5400,6 +5259,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -5628,6 +5488,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -5646,6 +5507,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -6170,6 +6032,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -6189,6 +6052,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -6203,73 +6067,59 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
             },
             "x-strapi-serialize": "querystring",
           },
@@ -6803,6 +6653,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -6822,6 +6673,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -7012,6 +6864,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -7031,6 +6884,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -7503,6 +7357,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -7542,6 +7397,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -7556,73 +7412,59 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
             },
             "x-strapi-serialize": "querystring",
           },
@@ -8759,6 +8601,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -8798,6 +8641,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -9163,6 +9007,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -9202,6 +9047,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -10199,6 +10045,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -10218,6 +10065,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -10232,73 +10080,59 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
             },
             "x-strapi-serialize": "querystring",
           },
@@ -10968,6 +10802,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -10987,6 +10822,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -11232,6 +11068,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -11251,6 +11088,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -13670,6 +13508,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -13691,6 +13530,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -13705,73 +13545,59 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
             },
             "x-strapi-serialize": "querystring",
           },
@@ -14373,6 +14199,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -14394,6 +14221,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -14602,6 +14430,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -14623,6 +14452,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -15505,6 +15335,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -15525,6 +15356,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -16120,6 +15952,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -16144,6 +15977,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -16158,73 +15992,59 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
             },
             "x-strapi-serialize": "querystring",
           },
@@ -17102,6 +16922,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -17126,6 +16947,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -17444,6 +17266,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -17468,6 +17291,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -18216,3136 +18040,6 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
         ],
       },
     },
-    "/relation-labs": {
-      "get": {
-        "operationId": "relation-lab/get/relation_labs",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "title",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "filters",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "additionalProperties": {},
-              "description": "Filters to apply to the query",
-              "propertyNames": {
-                "enum": [
-                  "title",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "type": "object",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "_q",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "pagination",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "sort",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "enum": [
-                    "title",
-                    "createdAt",
-                    "updatedAt",
-                    "publishedAt",
-                  ],
-                  "type": "string",
-                },
-                {
-                  "items": {
-                    "enum": [
-                      "title",
-                      "createdAt",
-                      "updatedAt",
-                      "publishedAt",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                {
-                  "additionalProperties": {
-                    "enum": [
-                      "asc",
-                      "desc",
-                    ],
-                    "type": "string",
-                  },
-                  "propertyNames": {
-                    "enum": [
-                      "title",
-                      "createdAt",
-                      "updatedAt",
-                      "publishedAt",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "object",
-                },
-                {
-                  "items": {
-                    "additionalProperties": {
-                      "enum": [
-                        "asc",
-                        "desc",
-                      ],
-                      "type": "string",
-                    },
-                    "propertyNames": {
-                      "enum": [
-                        "title",
-                        "createdAt",
-                        "updatedAt",
-                        "publishedAt",
-                      ],
-                      "type": "string",
-                    },
-                    "type": "object",
-                  },
-                  "type": "array",
-                },
-              ],
-              "description": "Sort the result",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "manyToOne",
-                    "oneToOne",
-                    "oneToMany",
-                    "manyToMany",
-                    "manyToManyBi",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "manyToOne",
-                      "oneToOne",
-                      "oneToMany",
-                      "manyToMany",
-                      "manyToManyBi",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "createdAt": {
-                            "description": "A datetime field",
-                            "type": "string",
-                          },
-                          "documentId": {
-                            "description": "The document ID, represented by a UUID",
-                            "format": "uuid",
-                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                            "type": "string",
-                          },
-                          "id": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "type": "number",
-                              },
-                            ],
-                          },
-                          "manyToMany": {
-                            "description": "A relational field",
-                            "items": {
-                              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                            },
-                            "type": "array",
-                          },
-                          "manyToManyBi": {
-                            "description": "A relational field",
-                            "items": {
-                              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                            },
-                            "type": "array",
-                          },
-                          "manyToOne": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                            "description": "A relational field",
-                          },
-                          "oneToMany": {
-                            "description": "A relational field",
-                            "items": {
-                              "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                            },
-                            "type": "array",
-                          },
-                          "oneToOne": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                            "description": "A relational field",
-                          },
-                          "publishedAt": {
-                            "default": "<generated-at-runtime>",
-                            "description": "A datetime field",
-                            "type": "string",
-                          },
-                          "title": {
-                            "description": "A string field",
-                            "type": "string",
-                          },
-                          "updatedAt": {
-                            "description": "A datetime field",
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "documentId",
-                          "id",
-                          "title",
-                          "publishedAt",
-                        ],
-                        "type": "object",
-                      },
-                      "type": "array",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-lab",
-        ],
-      },
-      "post": {
-        "operationId": "relation-lab/post/relation_labs",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "title",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "manyToOne",
-                    "oneToOne",
-                    "oneToMany",
-                    "manyToMany",
-                    "manyToManyBi",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "manyToOne",
-                      "oneToOne",
-                      "oneToMany",
-                      "manyToMany",
-                      "manyToManyBi",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "additionalProperties": false,
-                "properties": {
-                  "data": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "manyToMany": {
-                        "description": "A relational field",
-                        "items": {
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                      "manyToManyBi": {
-                        "description": "A relational field",
-                        "items": {
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                      "manyToOne": {
-                        "description": "A relational field",
-                        "format": "uuid",
-                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                        "type": "string",
-                      },
-                      "oneToMany": {
-                        "description": "A relational field",
-                        "items": {
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                      "oneToOne": {
-                        "description": "A relational field",
-                        "format": "uuid",
-                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                        "type": "string",
-                      },
-                      "publishedAt": {
-                        "default": "<generated-at-runtime>",
-                        "description": "A datetime field",
-                        "type": "string",
-                      },
-                      "title": {
-                        "description": "A string field",
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "title",
-                      "publishedAt",
-                    ],
-                    "type": "object",
-                  },
-                },
-                "required": [
-                  "data",
-                ],
-                "type": "object",
-              },
-            },
-          },
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "createdAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "documentId": {
-                          "description": "The document ID, represented by a UUID",
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "id": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                          ],
-                        },
-                        "manyToMany": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "manyToManyBi": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "manyToOne": {
-                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          "description": "A relational field",
-                        },
-                        "oneToMany": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "oneToOne": {
-                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          "description": "A relational field",
-                        },
-                        "publishedAt": {
-                          "default": "<generated-at-runtime>",
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "title": {
-                          "description": "A string field",
-                          "type": "string",
-                        },
-                        "updatedAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "documentId",
-                        "id",
-                        "title",
-                        "publishedAt",
-                      ],
-                      "type": "object",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-lab",
-        ],
-      },
-    },
-    "/relation-labs/{id}": {
-      "delete": {
-        "operationId": "relation-lab/delete/relation_labs_by_id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The document ID, represented by a UUID",
-              "format": "uuid",
-              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-              "type": "string",
-            },
-          },
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "title",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "manyToOne",
-                    "oneToOne",
-                    "oneToMany",
-                    "manyToMany",
-                    "manyToManyBi",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "manyToOne",
-                      "oneToOne",
-                      "oneToMany",
-                      "manyToMany",
-                      "manyToManyBi",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "filters",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "additionalProperties": {},
-              "description": "Filters to apply to the query",
-              "propertyNames": {
-                "enum": [
-                  "title",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "type": "object",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "createdAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "documentId": {
-                          "description": "The document ID, represented by a UUID",
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "id": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                          ],
-                        },
-                        "manyToMany": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "manyToManyBi": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "manyToOne": {
-                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          "description": "A relational field",
-                        },
-                        "oneToMany": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "oneToOne": {
-                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          "description": "A relational field",
-                        },
-                        "publishedAt": {
-                          "default": "<generated-at-runtime>",
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "title": {
-                          "description": "A string field",
-                          "type": "string",
-                        },
-                        "updatedAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "documentId",
-                        "id",
-                        "title",
-                        "publishedAt",
-                      ],
-                      "type": "object",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-lab",
-        ],
-      },
-      "get": {
-        "operationId": "relation-lab/get/relation_labs_by_id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The document ID, represented by a UUID",
-              "format": "uuid",
-              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-              "type": "string",
-            },
-          },
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "title",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "manyToOne",
-                    "oneToOne",
-                    "oneToMany",
-                    "manyToMany",
-                    "manyToManyBi",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "manyToOne",
-                      "oneToOne",
-                      "oneToMany",
-                      "manyToMany",
-                      "manyToManyBi",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "filters",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "additionalProperties": {},
-              "description": "Filters to apply to the query",
-              "propertyNames": {
-                "enum": [
-                  "title",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "type": "object",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "sort",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "enum": [
-                    "title",
-                    "createdAt",
-                    "updatedAt",
-                    "publishedAt",
-                  ],
-                  "type": "string",
-                },
-                {
-                  "items": {
-                    "enum": [
-                      "title",
-                      "createdAt",
-                      "updatedAt",
-                      "publishedAt",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                {
-                  "additionalProperties": {
-                    "enum": [
-                      "asc",
-                      "desc",
-                    ],
-                    "type": "string",
-                  },
-                  "propertyNames": {
-                    "enum": [
-                      "title",
-                      "createdAt",
-                      "updatedAt",
-                      "publishedAt",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "object",
-                },
-                {
-                  "items": {
-                    "additionalProperties": {
-                      "enum": [
-                        "asc",
-                        "desc",
-                      ],
-                      "type": "string",
-                    },
-                    "propertyNames": {
-                      "enum": [
-                        "title",
-                        "createdAt",
-                        "updatedAt",
-                        "publishedAt",
-                      ],
-                      "type": "string",
-                    },
-                    "type": "object",
-                  },
-                  "type": "array",
-                },
-              ],
-              "description": "Sort the result",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "createdAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "documentId": {
-                          "description": "The document ID, represented by a UUID",
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "id": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                          ],
-                        },
-                        "manyToMany": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "manyToManyBi": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "manyToOne": {
-                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          "description": "A relational field",
-                        },
-                        "oneToMany": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "oneToOne": {
-                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          "description": "A relational field",
-                        },
-                        "publishedAt": {
-                          "default": "<generated-at-runtime>",
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "title": {
-                          "description": "A string field",
-                          "type": "string",
-                        },
-                        "updatedAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "documentId",
-                        "id",
-                        "title",
-                        "publishedAt",
-                      ],
-                      "type": "object",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-lab",
-        ],
-      },
-      "put": {
-        "operationId": "relation-lab/put/relation_labs_by_id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The document ID, represented by a UUID",
-              "format": "uuid",
-              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-              "type": "string",
-            },
-          },
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "title",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "manyToOne",
-                    "oneToOne",
-                    "oneToMany",
-                    "manyToMany",
-                    "manyToManyBi",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "manyToOne",
-                      "oneToOne",
-                      "oneToMany",
-                      "manyToMany",
-                      "manyToManyBi",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "additionalProperties": false,
-                "properties": {
-                  "data": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "manyToMany": {
-                        "description": "A relational field",
-                        "items": {
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                      "manyToManyBi": {
-                        "description": "A relational field",
-                        "items": {
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                      "manyToOne": {
-                        "description": "A relational field",
-                        "format": "uuid",
-                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                        "type": "string",
-                      },
-                      "oneToMany": {
-                        "description": "A relational field",
-                        "items": {
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                      "oneToOne": {
-                        "description": "A relational field",
-                        "format": "uuid",
-                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                        "type": "string",
-                      },
-                      "publishedAt": {
-                        "default": "<generated-at-runtime>",
-                        "description": "A datetime field",
-                        "type": "string",
-                      },
-                      "title": {
-                        "description": "A string field",
-                        "type": "string",
-                      },
-                    },
-                    "type": "object",
-                  },
-                },
-                "required": [
-                  "data",
-                ],
-                "type": "object",
-              },
-            },
-          },
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "createdAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "documentId": {
-                          "description": "The document ID, represented by a UUID",
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "id": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                          ],
-                        },
-                        "manyToMany": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "manyToManyBi": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "manyToOne": {
-                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          "description": "A relational field",
-                        },
-                        "oneToMany": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          },
-                          "type": "array",
-                        },
-                        "oneToOne": {
-                          "$ref": "#/components/schemas/ApiRelationTargetRelationTargetDocument",
-                          "description": "A relational field",
-                        },
-                        "publishedAt": {
-                          "default": "<generated-at-runtime>",
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "title": {
-                          "description": "A string field",
-                          "type": "string",
-                        },
-                        "updatedAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "documentId",
-                        "id",
-                        "title",
-                        "publishedAt",
-                      ],
-                      "type": "object",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-lab",
-        ],
-      },
-    },
-    "/relation-targets": {
-      "get": {
-        "operationId": "relation-target/get/relation_targets",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "name",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "filters",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "additionalProperties": {},
-              "description": "Filters to apply to the query",
-              "propertyNames": {
-                "enum": [
-                  "name",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "type": "object",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "_q",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "pagination",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "sort",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "enum": [
-                    "name",
-                    "createdAt",
-                    "updatedAt",
-                    "publishedAt",
-                  ],
-                  "type": "string",
-                },
-                {
-                  "items": {
-                    "enum": [
-                      "name",
-                      "createdAt",
-                      "updatedAt",
-                      "publishedAt",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                {
-                  "additionalProperties": {
-                    "enum": [
-                      "asc",
-                      "desc",
-                    ],
-                    "type": "string",
-                  },
-                  "propertyNames": {
-                    "enum": [
-                      "name",
-                      "createdAt",
-                      "updatedAt",
-                      "publishedAt",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "object",
-                },
-                {
-                  "items": {
-                    "additionalProperties": {
-                      "enum": [
-                        "asc",
-                        "desc",
-                      ],
-                      "type": "string",
-                    },
-                    "propertyNames": {
-                      "enum": [
-                        "name",
-                        "createdAt",
-                        "updatedAt",
-                        "publishedAt",
-                      ],
-                      "type": "string",
-                    },
-                    "type": "object",
-                  },
-                  "type": "array",
-                },
-              ],
-              "description": "Sort the result",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "relationLabs",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "relationLabs",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "createdAt": {
-                            "description": "A datetime field",
-                            "type": "string",
-                          },
-                          "documentId": {
-                            "description": "The document ID, represented by a UUID",
-                            "format": "uuid",
-                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                            "type": "string",
-                          },
-                          "id": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "type": "number",
-                              },
-                            ],
-                          },
-                          "name": {
-                            "description": "A string field",
-                            "type": "string",
-                          },
-                          "publishedAt": {
-                            "default": "<generated-at-runtime>",
-                            "description": "A datetime field",
-                            "type": "string",
-                          },
-                          "relationLabs": {
-                            "description": "A relational field",
-                            "items": {
-                              "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
-                            },
-                            "type": "array",
-                          },
-                          "updatedAt": {
-                            "description": "A datetime field",
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "documentId",
-                          "id",
-                          "name",
-                          "publishedAt",
-                        ],
-                        "type": "object",
-                      },
-                      "type": "array",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-target",
-        ],
-      },
-      "post": {
-        "operationId": "relation-target/post/relation_targets",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "name",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "relationLabs",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "relationLabs",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "additionalProperties": false,
-                "properties": {
-                  "data": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "name": {
-                        "description": "A string field",
-                        "type": "string",
-                      },
-                      "publishedAt": {
-                        "default": "<generated-at-runtime>",
-                        "description": "A datetime field",
-                        "type": "string",
-                      },
-                      "relationLabs": {
-                        "description": "A relational field",
-                        "items": {
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                    },
-                    "required": [
-                      "name",
-                      "publishedAt",
-                    ],
-                    "type": "object",
-                  },
-                },
-                "required": [
-                  "data",
-                ],
-                "type": "object",
-              },
-            },
-          },
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "createdAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "documentId": {
-                          "description": "The document ID, represented by a UUID",
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "id": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                          ],
-                        },
-                        "name": {
-                          "description": "A string field",
-                          "type": "string",
-                        },
-                        "publishedAt": {
-                          "default": "<generated-at-runtime>",
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "relationLabs": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
-                          },
-                          "type": "array",
-                        },
-                        "updatedAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "documentId",
-                        "id",
-                        "name",
-                        "publishedAt",
-                      ],
-                      "type": "object",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-target",
-        ],
-      },
-    },
-    "/relation-targets/{id}": {
-      "delete": {
-        "operationId": "relation-target/delete/relation_targets_by_id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The document ID, represented by a UUID",
-              "format": "uuid",
-              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-              "type": "string",
-            },
-          },
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "name",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "relationLabs",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "relationLabs",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "filters",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "additionalProperties": {},
-              "description": "Filters to apply to the query",
-              "propertyNames": {
-                "enum": [
-                  "name",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "type": "object",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "createdAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "documentId": {
-                          "description": "The document ID, represented by a UUID",
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "id": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                          ],
-                        },
-                        "name": {
-                          "description": "A string field",
-                          "type": "string",
-                        },
-                        "publishedAt": {
-                          "default": "<generated-at-runtime>",
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "relationLabs": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
-                          },
-                          "type": "array",
-                        },
-                        "updatedAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "documentId",
-                        "id",
-                        "name",
-                        "publishedAt",
-                      ],
-                      "type": "object",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-target",
-        ],
-      },
-      "get": {
-        "operationId": "relation-target/get/relation_targets_by_id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The document ID, represented by a UUID",
-              "format": "uuid",
-              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-              "type": "string",
-            },
-          },
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "name",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "relationLabs",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "relationLabs",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "filters",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "additionalProperties": {},
-              "description": "Filters to apply to the query",
-              "propertyNames": {
-                "enum": [
-                  "name",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "type": "object",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "sort",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "enum": [
-                    "name",
-                    "createdAt",
-                    "updatedAt",
-                    "publishedAt",
-                  ],
-                  "type": "string",
-                },
-                {
-                  "items": {
-                    "enum": [
-                      "name",
-                      "createdAt",
-                      "updatedAt",
-                      "publishedAt",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                {
-                  "additionalProperties": {
-                    "enum": [
-                      "asc",
-                      "desc",
-                    ],
-                    "type": "string",
-                  },
-                  "propertyNames": {
-                    "enum": [
-                      "name",
-                      "createdAt",
-                      "updatedAt",
-                      "publishedAt",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "object",
-                },
-                {
-                  "items": {
-                    "additionalProperties": {
-                      "enum": [
-                        "asc",
-                        "desc",
-                      ],
-                      "type": "string",
-                    },
-                    "propertyNames": {
-                      "enum": [
-                        "name",
-                        "createdAt",
-                        "updatedAt",
-                        "publishedAt",
-                      ],
-                      "type": "string",
-                    },
-                    "type": "object",
-                  },
-                  "type": "array",
-                },
-              ],
-              "description": "Sort the result",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "createdAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "documentId": {
-                          "description": "The document ID, represented by a UUID",
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "id": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                          ],
-                        },
-                        "name": {
-                          "description": "A string field",
-                          "type": "string",
-                        },
-                        "publishedAt": {
-                          "default": "<generated-at-runtime>",
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "relationLabs": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
-                          },
-                          "type": "array",
-                        },
-                        "updatedAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "documentId",
-                        "id",
-                        "name",
-                        "publishedAt",
-                      ],
-                      "type": "object",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-target",
-        ],
-      },
-      "put": {
-        "operationId": "relation-target/put/relation_targets_by_id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The document ID, represented by a UUID",
-              "format": "uuid",
-              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-              "type": "string",
-            },
-          },
-          {
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
-              "items": {
-                "enum": [
-                  "name",
-                  "createdAt",
-                  "updatedAt",
-                  "publishedAt",
-                ],
-                "type": "string",
-              },
-              "readOnly": true,
-              "type": "array",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "populate",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "const": "*",
-                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a single relation, component, file, or dynamic zone",
-                  "enum": [
-                    "relationLabs",
-                  ],
-                  "readOnly": true,
-                  "type": "string",
-                },
-                {
-                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
-                  "items": {
-                    "enum": [
-                      "relationLabs",
-                    ],
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-              ],
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Fetch documents based on their status. Default to "published" if not specified.",
-              "enum": [
-                "draft",
-                "published",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "publicationFilter",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "description": "Derived publication cohort: pair-scoped (per documentId+locale), document-scoped variants (-document), or published-slice diagnostics (published-without-draft / published-with-draft)",
-              "enum": [
-                "never-published",
-                "has-published-version",
-                "modified",
-                "unmodified",
-                "never-published-document",
-                "has-published-version-document",
-                "published-without-draft",
-                "published-with-draft",
-              ],
-              "type": "string",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-          {
-            "in": "query",
-            "name": "hasPublishedVersion",
-            "required": false,
-            "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "enum": [
-                    "true",
-                    "false",
-                  ],
-                  "type": "string",
-                },
-              ],
-              "description": "[Deprecated: prefer publicationFilter] Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
-            },
-            "x-strapi-serialize": "querystring",
-          },
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "additionalProperties": false,
-                "properties": {
-                  "data": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "name": {
-                        "description": "A string field",
-                        "type": "string",
-                      },
-                      "publishedAt": {
-                        "default": "<generated-at-runtime>",
-                        "description": "A datetime field",
-                        "type": "string",
-                      },
-                      "relationLabs": {
-                        "description": "A relational field",
-                        "items": {
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                    },
-                    "type": "object",
-                  },
-                },
-                "required": [
-                  "data",
-                ],
-                "type": "object",
-              },
-            },
-          },
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "additionalProperties": false,
-                  "properties": {
-                    "data": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "createdAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "documentId": {
-                          "description": "The document ID, represented by a UUID",
-                          "format": "uuid",
-                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-                          "type": "string",
-                        },
-                        "id": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                          ],
-                        },
-                        "name": {
-                          "description": "A string field",
-                          "type": "string",
-                        },
-                        "publishedAt": {
-                          "default": "<generated-at-runtime>",
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                        "relationLabs": {
-                          "description": "A relational field",
-                          "items": {
-                            "$ref": "#/components/schemas/ApiRelationLabRelationLabDocument",
-                          },
-                          "type": "array",
-                        },
-                        "updatedAt": {
-                          "description": "A datetime field",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "documentId",
-                        "id",
-                        "name",
-                        "publishedAt",
-                      ],
-                      "type": "object",
-                    },
-                  },
-                  "required": [
-                    "data",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "OK",
-          },
-          "400": {
-            "description": "Bad request",
-          },
-          "401": {
-            "description": "Unauthorized",
-          },
-          "403": {
-            "description": "Forbidden",
-          },
-          "404": {
-            "description": "Not found",
-          },
-          "500": {
-            "description": "Internal server error",
-          },
-        },
-        "tags": [
-          "relation-target",
-        ],
-      },
-    },
     "/shop": {
       "delete": {
         "operationId": "shop/delete/shop",
@@ -21651,6 +18345,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -21670,6 +18365,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -22358,6 +19054,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -22377,6 +19074,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -22897,6 +19595,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -22915,6 +19614,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
         ],
@@ -23392,6 +20092,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -23410,6 +20111,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
         ],
@@ -23693,6 +20395,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -23713,6 +20416,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -23727,73 +20431,59 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
             },
             "x-strapi-serialize": "querystring",
           },
@@ -24438,6 +21128,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -24458,6 +21149,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -24704,6 +21396,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -24724,6 +21417,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -25294,6 +21988,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -25317,6 +22012,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -25331,73 +22027,59 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
             },
             "x-strapi-serialize": "querystring",
           },
@@ -26144,6 +22826,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -26167,6 +22850,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -26445,6 +23129,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -26468,6 +23153,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -27365,6 +24051,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
             "x-strapi-serialize": "querystring",
           },
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -27385,6 +24072,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
           {
@@ -28209,77 +24897,64 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
             },
             "x-strapi-serialize": "querystring",
           },
           {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -28292,6 +24967,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
         ],
@@ -28566,77 +25242,64 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
             },
             "x-strapi-serialize": "querystring",
           },
           {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -28649,6 +25312,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
         ],
@@ -29402,77 +26066,64 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
           },
           {
             "in": "query",
-            "name": "pagination",
+            "name": "pagination[withCount]",
             "required": false,
             "schema": {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "allOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "withCount": {
-                      "description": "Include total count in response",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "description": "Page-based pagination",
-                      "properties": {
-                        "page": {
-                          "description": "Page number (1-based)",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "pageSize": {
-                          "description": "Number of entries per page",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "page",
-                        "pageSize",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "description": "Offset-based pagination",
-                      "properties": {
-                        "limit": {
-                          "description": "Maximum number of entries to return",
-                          "exclusiveMinimum": 0,
-                          "maximum": 9007199254740991,
-                          "type": "integer",
-                        },
-                        "start": {
-                          "description": "Number of entries to skip",
-                          "maximum": 9007199254740991,
-                          "minimum": 0,
-                          "type": "integer",
-                        },
-                      },
-                      "required": [
-                        "start",
-                        "limit",
-                      ],
-                      "type": "object",
-                    },
-                  ],
-                },
-              ],
-              "description": "Pagination parameters",
+              "description": "Include total count in response",
+              "type": "boolean",
             },
             "x-strapi-serialize": "querystring",
           },
           {
+            "in": "query",
+            "name": "pagination[page]",
+            "required": false,
+            "schema": {
+              "description": "Page number (1-based)",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[pageSize]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries per page",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[start]",
+            "required": false,
+            "schema": {
+              "description": "Number of entries to skip",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination[limit]",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of entries to return",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -29485,6 +26136,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
         ],
@@ -30430,6 +27082,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
         "operationId": "users-permissions/get/users_count",
         "parameters": [
           {
+            "explode": true,
             "in": "query",
             "name": "filters",
             "required": false,
@@ -30442,6 +27095,7 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
               },
               "type": "object",
             },
+            "style": "deepObject",
             "x-strapi-serialize": "querystring",
           },
         ],
@@ -31208,6 +27862,17 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
       },
     },
   },
+  "security": [
+    {
+      "bearerAuth": [],
+    },
+  ],
+  "servers": [
+    {
+      "description": "Default server",
+      "url": "",
+    },
+  ],
   "x-powered-by": "strapi",
   "x-strapi-version": "<current-strapi-version>",
 }


### PR DESCRIPTION
### What does it do?

Fixes two gaps in the experimental `@strapi/openapi` generator that made generated specs unusable in Swagger UI:

1. **Security** — adds a `DocumentSecurityAssembler` that emits default `components.securitySchemes.bearerAuth` (JWT) and top-level `security: [{ bearerAuth: [] }]`, overridable via `openapi.security` / `openapi.globalSecurity` in project config.
2. **Pagination query params** — expands nested object query schemas (e.g. `pagination`) into bracket notation (`pagination[page]`, `pagination[pageSize]`, etc.), matching how Strapi parses Content API queries and how the documentation plugin already describes them.
3. **Components merge** — `ComponentsWriter` now merges into existing `components` instead of replacing them, so `securitySchemes` survive post-processing.

### Why is it needed?

Fixes #25103

`strapi openapi generate` produced specs missing `bearerAuth`, and paginated list endpoints failed in Swagger UI with:

```
PaginationError: Invalid pagination attributes. The page parameters are incorrect and must be in the pagination object
```

Swagger UI sent flat `page`/`pageSize` keys because the spec described `pagination` as a single nested object, while Strapi expects `pagination[page]` / `pagination[pageSize]` bracket notation.

### How to test it?

1. Run unit tests:
   ```bash
   cd packages/core/openapi && yarn test:unit
   ```
2. In a Strapi app with content types, generate a spec:
   ```bash
   npx strapi openapi generate -o public/swagger-spec.json
   ```
3. Confirm `swagger-spec.json` contains `components.securitySchemes.bearerAuth` and list endpoints expose `pagination[page]` / `pagination[pageSize]` query parameters.
4. Serve the spec in Swagger UI and try a paginated list endpoint — it should no longer return `PaginationError`.

### Related issue(s)/PR(s)

- Fixes #25103
- Fixes CMS-1413
- Related (closed, not merged): #25109