### PR TITLE
chore(types): per-client database connection types

### DIFF
--- a/examples/complex/config/database.ts
+++ b/examples/complex/config/database.ts
@@ -1,10 +1,18 @@
 import type { Core } from '@strapi/strapi';
+import { isDatabaseClientKind } from '@strapi/database';
 
 export default ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database => {
   const client = env('DATABASE_CLIENT', 'postgres');
 
-  const connections = {
+  if (!isDatabaseClientKind(client)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  const connections: Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']> = {
     mysql: {
+      client: 'mysql',
       connection: {
         host: env('DATABASE_HOST', 'localhost'),
         port: env.int('DATABASE_PORT', 3306),
@@ -23,6 +31,7 @@ export default ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     postgres: {
+      client: 'postgres',
       connection: {
         connectionString: env('DATABASE_URL'),
         host: env('DATABASE_HOST', 'localhost'),
@@ -43,6 +52,7 @@ export default ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     sqlite: {
+      client: 'sqlite',
       connection: {
         filename: env('DATABASE_FILENAME', '.tmp/data.db'),
       },
@@ -50,19 +60,10 @@ export default ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     },
   };
 
-  if (!(client in connections)) {
-    throw new Error(
-      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
-    );
-  }
-
-  type DatabaseClient = keyof typeof connections;
-
   return {
     connection: {
-      client: client as DatabaseClient,
-      ...connections[client as DatabaseClient],
+      ...connections[client],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  } as Core.Config.Database;
+  };
 };

--- a/examples/empty/config/database.ts
+++ b/examples/empty/config/database.ts
@@ -1,11 +1,19 @@
 import path from 'path';
 import type { Core } from '@strapi/strapi';
+import { isDatabaseClientKind } from '@strapi/database';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
-  const connections = {
+  if (!isDatabaseClientKind(client)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  const connections: Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']> = {
     mysql: {
+      client: 'mysql',
       connection: {
         host: env('DATABASE_HOST', 'localhost'),
         port: env.int('DATABASE_PORT', 3306),
@@ -24,6 +32,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     postgres: {
+      client: 'postgres',
       connection: {
         connectionString: env('DATABASE_URL'),
         host: env('DATABASE_HOST', 'localhost'),
@@ -44,6 +53,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     sqlite: {
+      client: 'sqlite',
       connection: {
         filename: path.join(__dirname, '..', '..', env('DATABASE_FILENAME', '.tmp/data.db')),
       },
@@ -51,21 +61,12 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     },
   };
 
-  if (!(client in connections)) {
-    throw new Error(
-      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
-    );
-  }
-
-  type DatabaseClient = keyof typeof connections;
-
   return {
     connection: {
-      client: client as DatabaseClient,
-      ...connections[client as DatabaseClient],
+      ...connections[client],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  } as Core.Config.Database;
+  };
 };
 
 export default config;

--- a/examples/getstarted/config/database.js
+++ b/examples/getstarted/config/database.js
@@ -1,3 +1,6 @@
+/** @import { Core } from '@strapi/strapi' */
+
+/** @type {Core.Config.Database<'sqlite'>['connection']} */
 const sqlite = {
   client: 'sqlite',
   connection: {
@@ -6,6 +9,7 @@ const sqlite = {
   useNullAsDefault: true,
 };
 
+/** @type {Core.Config.Database<'postgres'>['connection']} */
 const postgres = {
   client: 'postgres',
   connection: {
@@ -17,6 +21,7 @@ const postgres = {
   },
 };
 
+/** @type {Core.Config.Database<'mysql'>['connection']} */
 const mysql = {
   client: 'mysql',
   connection: {
@@ -28,6 +33,7 @@ const mysql = {
   },
 };
 
+/** @type {Core.Config.Database<'mysql'>['connection']} */
 const mariadb = {
   client: 'mysql',
   connection: {

--- a/examples/kitchensink-ts/config/database.ts
+++ b/examples/kitchensink-ts/config/database.ts
@@ -1,14 +1,18 @@
 import path from 'path';
 import type { Core } from '@strapi/strapi';
 
-const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database<'sqlite'> => ({
-  connection: {
+const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database<'sqlite'> => {
+  const connection: Core.Config.Database<'sqlite'>['connection'] = {
     client: 'sqlite',
     connection: {
       filename: path.join(__dirname, '..', '..', env('DATABASE_FILENAME', '.tmp/data.db')),
     },
     useNullAsDefault: true,
-  },
-});
+  };
+
+  return {
+    connection,
+  };
+};
 
 export default config;

--- a/examples/kitchensink/config/database.js
+++ b/examples/kitchensink/config/database.js
@@ -1,11 +1,18 @@
+/** @import { Core } from '@strapi/strapi' */
+
 const path = require('path');
 
-module.exports = ({ env }) => ({
-  connection: {
+module.exports = ({ env }) => {
+  /** @type {Core.Config.Database<'sqlite'>['connection']} */
+  const connection = {
     client: 'sqlite',
     connection: {
       filename: path.join(__dirname, '..', env('DATABASE_FILENAME', '.tmp/data.db')),
     },
     useNullAsDefault: true,
-  },
-});
+  };
+
+  return {
+    connection,
+  };
+};

--- a/packages/cli/create-strapi-app/.eslintrc.cjs
+++ b/packages/cli/create-strapi-app/.eslintrc.cjs
@@ -13,6 +13,7 @@ const config = {
     'dist/',
     'bin/',
     'templates/',
+    'jest.config.js',
     'rollup.config.mjs',
     'lint-staged.config.mjs',
   ],

--- a/packages/cli/create-strapi-app/jest.config.js
+++ b/packages/cli/create-strapi-app/jest.config.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  preset: '../../../jest-preset.unit.js',
+  displayName: 'Create Strapi App',
+};

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -48,6 +48,7 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc -p tsconfig.json",
+    "test:unit": "run -T jest",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
@@ -67,6 +68,8 @@
     "tar": "7.5.18"
   },
   "devDependencies": {
+    "@strapi/database": "5.50.1",
+    "@strapi/utils": "5.50.1",
     "@types/async-retry": "^1",
     "@types/fs-extra": "11.0.4",
     "@types/inquirer": "9.0.9",

--- a/packages/cli/create-strapi-app/src/__tests__/templates-database.test.ts
+++ b/packages/cli/create-strapi-app/src/__tests__/templates-database.test.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+import { env } from '@strapi/utils';
+
+/**
+ * Every scaffolded template ships a `config/database` file that validates the
+ * `DATABASE_CLIENT` env var against the clients Strapi actually supports. These
+ * tests load each template's database config (using the real `env` helper the
+ * generated app runs with) and assert it fails loudly when an unsupported
+ * client is provided, rather than silently building an invalid connection.
+ */
+
+const templatesDir = path.resolve(__dirname, '..', '..', 'templates');
+
+const templates = fs
+  .readdirSync(templatesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+const loadDatabaseConfig = (template: string) => {
+  const configDir = path.join(templatesDir, template, 'config');
+  const file = ['database.ts', 'database.js']
+    .map((name) => path.join(configDir, name))
+    .find((candidate) => fs.existsSync(candidate));
+
+  if (!file) {
+    throw new Error(`No database config found for template "${template}"`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mod = require(file);
+
+  return (mod.default ?? mod) as (ctx: { env: typeof env }) => unknown;
+};
+
+describe('create-strapi-app templates database config', () => {
+  const originalClient = process.env.DATABASE_CLIENT;
+
+  afterEach(() => {
+    if (originalClient === undefined) {
+      delete process.env.DATABASE_CLIENT;
+    } else {
+      process.env.DATABASE_CLIENT = originalClient;
+    }
+  });
+
+  it('discovers at least one template', () => {
+    expect(templates.length).toBeGreaterThan(0);
+  });
+
+  it.each(templates)('%s throws on an unsupported DATABASE_CLIENT', (template) => {
+    process.env.DATABASE_CLIENT = 'oracle';
+    const config = loadDatabaseConfig(template);
+
+    expect(() => config({ env })).toThrow('Unsupported DATABASE_CLIENT');
+  });
+
+  it.each(templates)('%s builds a config for a supported DATABASE_CLIENT', (template) => {
+    process.env.DATABASE_CLIENT = 'sqlite';
+    const config = loadDatabaseConfig(template);
+
+    expect(() => config({ env })).not.toThrow();
+  });
+});

--- a/packages/cli/create-strapi-app/templates/example-js/config/database.js
+++ b/packages/cli/create-strapi-app/templates/example-js/config/database.js
@@ -1,10 +1,21 @@
+/** @import { Core } from '@strapi/strapi' */
+
 const path = require('path');
+const { isDatabaseClientKind } = require('@strapi/database');
 
 module.exports = ({ env }) => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
+  if (!isDatabaseClientKind(client)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  /** @type {Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']>} */
   const connections = {
     mysql: {
+      client: 'mysql',
       connection: {
         host: env('DATABASE_HOST', 'localhost'),
         port: env.int('DATABASE_PORT', 3306),
@@ -23,6 +34,7 @@ module.exports = ({ env }) => {
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     postgres: {
+      client: 'postgres',
       connection: {
         connectionString: env('DATABASE_URL'),
         host: env('DATABASE_HOST', 'localhost'),
@@ -43,6 +55,7 @@ module.exports = ({ env }) => {
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     sqlite: {
+      client: 'sqlite',
       connection: {
         filename: path.join(__dirname, '..', env('DATABASE_FILENAME', '.tmp/data.db')),
       },
@@ -52,7 +65,6 @@ module.exports = ({ env }) => {
 
   return {
     connection: {
-      client,
       ...connections[client],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },

--- a/packages/cli/create-strapi-app/templates/example-js/jsconfig.json
+++ b/packages/cli/create-strapi-app/templates/example-js/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "target": "ES2021",
     "checkJs": true,

--- a/packages/cli/create-strapi-app/templates/example/config/database.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/database.ts
@@ -1,11 +1,19 @@
 import path from 'path';
 import type { Core } from '@strapi/strapi';
+import { isDatabaseClientKind } from '@strapi/database';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
-  const connections = {
+  if (!isDatabaseClientKind(client)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  const connections: Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']> = {
     mysql: {
+      client: 'mysql',
       connection: {
         host: env('DATABASE_HOST', 'localhost'),
         port: env.int('DATABASE_PORT', 3306),
@@ -24,6 +32,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     postgres: {
+      client: 'postgres',
       connection: {
         connectionString: env('DATABASE_URL'),
         host: env('DATABASE_HOST', 'localhost'),
@@ -44,6 +53,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     sqlite: {
+      client: 'sqlite',
       connection: {
         filename: path.join(__dirname, '..', '..', env('DATABASE_FILENAME', '.tmp/data.db')),
       },
@@ -51,21 +61,12 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     },
   };
 
-  if (!(client in connections)) {
-    throw new Error(
-      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
-    );
-  }
-
-  type DatabaseClient = keyof typeof connections;
-
   return {
     connection: {
-      client: client as DatabaseClient,
-      ...connections[client as DatabaseClient],
+      ...connections[client],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  } as Core.Config.Database;
+  };
 };
 
 export default config;

--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/database.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/database.js
@@ -1,10 +1,21 @@
+/** @import { Core } from '@strapi/strapi' */
+
 const path = require('path');
+const { isDatabaseClientKind } = require('@strapi/database');
 
 module.exports = ({ env }) => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
+  if (!isDatabaseClientKind(client)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  /** @type {Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']>} */
   const connections = {
     mysql: {
+      client: 'mysql',
       connection: {
         host: env('DATABASE_HOST', 'localhost'),
         port: env.int('DATABASE_PORT', 3306),
@@ -23,6 +34,7 @@ module.exports = ({ env }) => {
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     postgres: {
+      client: 'postgres',
       connection: {
         connectionString: env('DATABASE_URL'),
         host: env('DATABASE_HOST', 'localhost'),
@@ -43,6 +55,7 @@ module.exports = ({ env }) => {
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     sqlite: {
+      client: 'sqlite',
       connection: {
         filename: path.join(__dirname, '..', env('DATABASE_FILENAME', '.tmp/data.db')),
       },
@@ -52,7 +65,6 @@ module.exports = ({ env }) => {
 
   return {
     connection: {
-      client,
       ...connections[client],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },

--- a/packages/cli/create-strapi-app/templates/vanilla-js/jsconfig.json
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "target": "ES2021",
     "checkJs": true,

--- a/packages/cli/create-strapi-app/templates/vanilla/config/database.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/database.ts
@@ -1,11 +1,19 @@
 import path from 'path';
 import type { Core } from '@strapi/strapi';
+import { isDatabaseClientKind } from '@strapi/database';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
-  const connections = {
+  if (!isDatabaseClientKind(client)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  const connections: Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']> = {
     mysql: {
+      client: 'mysql',
       connection: {
         host: env('DATABASE_HOST', 'localhost'),
         port: env.int('DATABASE_PORT', 3306),
@@ -24,6 +32,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     postgres: {
+      client: 'postgres',
       connection: {
         connectionString: env('DATABASE_URL'),
         host: env('DATABASE_HOST', 'localhost'),
@@ -44,6 +53,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     sqlite: {
+      client: 'sqlite',
       connection: {
         filename: path.join(__dirname, '..', '..', env('DATABASE_FILENAME', '.tmp/data.db')),
       },
@@ -51,21 +61,12 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     },
   };
 
-  if (!(client in connections)) {
-    throw new Error(
-      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
-    );
-  }
-
-  type DatabaseClient = keyof typeof connections;
-
   return {
     connection: {
-      client: client as DatabaseClient,
-      ...connections[client as DatabaseClient],
+      ...connections[client],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  } as Core.Config.Database;
+  };
 };
 
 export default config;

--- a/packages/cli/create-strapi-app/tsconfig.json
+++ b/packages/cli/create-strapi-app/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "include": ["src"]
 }

--- a/packages/core/database/src/connection.ts
+++ b/packages/core/database/src/connection.ts
@@ -7,16 +7,18 @@ const clientMap = {
   postgres: 'pg',
 };
 
-function isClientValid(config: { client?: unknown }): config is { client: keyof typeof clientMap } {
-  return Object.keys(clientMap).includes(config.client as string);
+type ClientKind = keyof typeof clientMap;
+
+export function isDatabaseClientKind(client: unknown): client is ClientKind {
+  return (client as string) in clientMap;
 }
 
 export const createConnection = (userConfig: Knex.Config, strapiConfig?: Partial<Knex.Config>) => {
-  if (!isClientValid(userConfig)) {
+  if (!isDatabaseClientKind(userConfig.client)) {
     throw new Error(`Unsupported database client ${userConfig.client}`);
   }
 
-  const knexConfig: Knex.Config = { ...userConfig, client: (clientMap as any)[userConfig.client] };
+  const knexConfig: Knex.Config = { ...userConfig, client: clientMap[userConfig.client] };
 
   // initialization code to run upon opening a new connection
   if (strapiConfig?.pool?.afterCreate) {

--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -18,6 +18,7 @@ import type { Identifiers } from './utils/identifiers';
 import { createRepairManager, type RepairManager } from './repairs';
 
 export { isKnexQuery } from './utils/knex';
+export { isDatabaseClientKind } from './connection';
 
 interface Settings {
   forceMigration?: boolean;

--- a/packages/core/types/src/core/config/database.ts
+++ b/packages/core/types/src/core/config/database.ts
@@ -1,12 +1,7 @@
-import type { If, StrictEqual } from '../../utils';
-
-export type ClientKind = 'mysql' | 'postgres' | 'sqlite';
-
-type IfClientIs<TClient extends ClientKind, TClientKind extends ClientKind, TOnTrue, TOnFalse> = If<
-  StrictEqual<TClient, TClientKind>,
-  TOnTrue,
-  TOnFalse
->;
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Database {
+  export type ClientKind = 'mysql' | 'postgres' | 'sqlite';
+}
 
 type SSLConfig = {
   rejectUnauthorized?: boolean;
@@ -30,7 +25,7 @@ type PoolConfig = {
   afterCreate?: (conn: unknown, done: (err?: Error, conn?: unknown) => void) => void;
 };
 
-type Connection<TClient extends ClientKind> = {
+type SharedConnection = {
   database: string;
   user: string;
   password: string;
@@ -39,28 +34,33 @@ type Connection<TClient extends ClientKind> = {
   ssl?: SSLConfig | boolean;
   connectionString?: string;
   timezone?: string;
-} & { [key: string]: unknown } & IfClientIs<TClient, 'postgres', { schema?: string }, unknown>;
+};
 
-type SqliteConnection = {
-  filename: string;
-} & { [key: string]: unknown };
+type Connection<TClient extends Database.ClientKind> = {
+  mysql: SharedConnection;
+  postgres: SharedConnection & { schema?: string };
+  sqlite: { filename: string };
+}[TClient] & { [key: string]: unknown };
 
-export interface Database<TClient extends ClientKind = ClientKind> {
-  connection: {
-    client: TClient;
-    connection:
-      | IfClientIs<TClient, 'sqlite', SqliteConnection, Connection<TClient>>
-      | (() => Promise<IfClientIs<TClient, 'sqlite', SqliteConnection, Connection<TClient>>>)
-      | (() => IfClientIs<TClient, 'sqlite', SqliteConnection, Connection<TClient>>);
-    debug?: boolean;
-    pool?: PoolConfig;
-    acquireConnectionTimeout?: number;
-  } & { [key: string]: unknown } & IfClientIs<
-      TClient,
-      'sqlite',
-      { useNullAsDefault?: boolean },
-      unknown
-    >;
+type SharedDatabaseConnection<TClient extends Database.ClientKind> = {
+  client: TClient;
+  connection:
+    | Connection<TClient>
+    | (() => Promise<Connection<TClient>>)
+    | (() => Connection<TClient>);
+  debug?: boolean;
+  pool?: PoolConfig;
+  acquireConnectionTimeout?: number;
+};
+
+type DatabaseConnection<TClient extends Database.ClientKind> = {
+  mysql: SharedDatabaseConnection<'mysql'>;
+  postgres: SharedDatabaseConnection<'postgres'>;
+  sqlite: SharedDatabaseConnection<'sqlite'> & { useNullAsDefault?: boolean };
+}[TClient] & { [key: string]: unknown };
+
+export interface Database<TClient extends Database.ClientKind = Database.ClientKind> {
+  connection: DatabaseConnection<TClient>;
   settings?: {
     forceMigration?: boolean;
     runMigrations?: boolean;

--- a/packages/core/utils/src/env-helper.ts
+++ b/packages/core/utils/src/env-helper.ts
@@ -4,7 +4,7 @@ export type Env = typeof envFn & typeof utils;
 
 function envFn(key: string): string | undefined;
 function envFn(key: string, defaultValue: string): string;
-function envFn<T>(key: string, defaultValue: T): string | T;
+function envFn<T>(key: string, defaultValue: T): (string & Record<never, never>) | T;
 function envFn(key: string, defaultValue?: any): any {
   return _.has(process.env, key) ? process.env[key] : defaultValue;
 }

--- a/templates/website/config/database.ts
+++ b/templates/website/config/database.ts
@@ -1,11 +1,19 @@
 import path from 'path';
 import type { Core } from '@strapi/strapi';
+import { isDatabaseClientKind } from '@strapi/database';
 
 const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
-  const connections = {
+  if (!isDatabaseClientKind(client)) {
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
+  }
+
+  const connections: Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']> = {
     mysql: {
+      client: 'mysql',
       connection: {
         host: env('DATABASE_HOST', 'localhost'),
         port: env.int('DATABASE_PORT', 3306),
@@ -24,6 +32,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     postgres: {
+      client: 'postgres',
       connection: {
         connectionString: env('DATABASE_URL'),
         host: env('DATABASE_HOST', 'localhost'),
@@ -44,6 +53,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
     sqlite: {
+      client: 'sqlite',
       connection: {
         filename: path.join(__dirname, '..', '..', env('DATABASE_FILENAME', '.tmp/data.db')),
       },
@@ -51,21 +61,12 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     },
   };
 
-  if (!(client in connections)) {
-    throw new Error(
-      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
-    );
-  }
-
-  type DatabaseClient = keyof typeof connections;
-
   return {
     connection: {
-      client: client as DatabaseClient,
-      ...connections[client as DatabaseClient],
+      ...connections[client],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
-  } as Core.Config.Database;
+  };
 };
 
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15724,6 +15724,8 @@ __metadata:
   resolution: "create-strapi-app@workspace:packages/cli/create-strapi-app"
   dependencies:
     "@strapi/cloud-cli": "npm:5.50.1"
+    "@strapi/database": "npm:5.50.1"
+    "@strapi/utils": "npm:5.50.1"
     "@types/async-retry": "npm:^1"
     "@types/fs-extra": "npm:11.0.4"
     "@types/inquirer": "npm:9.0.9"


### PR DESCRIPTION
### What does it do?

Improves the typing of the Strapi database config and propagates it to the create-strapi-app templates, the `examples/` sandboxes, and the website template.

**Core types (`@strapi/types`):**
- Refactors `Core.Config.Database<TClient>` so each client resolves to its own connection shape via indexed mapped-type lookups instead of the previous `IfClientIs` conditionals. `postgres` gets `schema`, `sqlite` gets `filename` + `useNullAsDefault`, `mysql` gets the shared shape; invalid combinations (e.g. `filename` on a postgres connection) no longer type-check.
- Drops the `If` / `StrictEqual` helper indirection.
- Moves `ClientKind` under a `Database` namespace, reachable as `Core.Config.Database.ClientKind`.

**Runtime guard (`@strapi/database`):**
- Exports a new `isDatabaseClientKind(client): client is ClientKind` type guard. The existing internal `isClientValid` now delegates to it, so the runtime client allow-list (`clientMap`) is the single source of truth.

**Env helper (`@strapi/utils`):**
- Refines `envFn`'s return type to `(string & Record<never, never>) | T` so a raw `env('DATABASE_CLIENT', ...)` value stays narrowable through `isDatabaseClientKind` without widening to a plain `string`.

**Templates / examples / website:**
- Validate `DATABASE_CLIENT` with `isDatabaseClientKind(client)` + an explicit `throw`, replacing the manual `in`-check and the `as` casts.
- Move `client` into each entry of the `connections` map so `connections[client]` carries its own discriminant, and type the map by `Core.Config.Database.ClientKind`.
- JS examples/templates: annotate with a single `@import { Core } from '@strapi/strapi'` JSDoc tag plus per-value `@type`, and add `"module": "nodenext"` to the `jsconfig.json` files so `checkJs` resolves the import.

### Why is it needed?

The previous `Database` type used conditional types to bolt sqlite-only / postgres-only fields onto a shared shape, which let invalid combinations type-check, and the example configs relied on an untyped `connections` object + `connection: { client, ...connections[client] }` that only worked because the inner objects carried no `client` field. That pattern didn't benefit from `Database<TClient>` discrimination and silently produced `undefined` when `DATABASE_CLIENT` was an unknown value.

Per-client mapped types give correct discriminated shapes out of the box, and a shared `isDatabaseClientKind` guard means the templates validate the client against the same allow-list the database layer uses — no hand-rolled `in`/`includes` checks, no casts. No runtime behaviour change: an invalid `DATABASE_CLIENT` still fails fast, now with a clear `Unsupported DATABASE_CLIENT` error.

### How to test it?

1. `yarn nx run @strapi/database:build` and `yarn nx run @strapi/types:build` — packages compile.
2. `yarn nx run @strapi/database:lint` — passes.
3. In a TS template's `config/database.ts`, change a branch's `client` (e.g. `'mysql'` → `'sqlite'`) without updating its `connection` — TS should error on the mismatched discriminated shape; likewise assigning `filename` under `postgres` or `schema` under `sqlite` should error.
4. Run an example (`cd examples/getstarted && yarn develop`) or scaffold from a template with `DATABASE_CLIENT` set to `postgres` / `mysql` / `sqlite`; an unsupported value throws `Unsupported DATABASE_CLIENT`.
5. `yarn test:ts` for the type surface.

### Related issue(s)/PR(s)

Extracted from #25992 — this PR carries only the `Database<TClient>` type refactor, the `isDatabaseClientKind` guard, and the database-config template/example changes. The remaining pieces of #25992 (`Features` config export, `logger.config` winston typing, `PreviewConfig.handler` uid typing, non-database example annotations) are not included here.