### PR TITLE
fix(github): stop flagging valid bug reports as invalid template

### DIFF
--- a/.github/workflows/template-check-on-new-issue.yaml
+++ b/.github/workflows/template-check-on-new-issue.yaml
@@ -19,36 +19,24 @@ jobs:
             const issueBody = context.payload.issue.body || '';
             const issueNumber = context.payload.issue.number;
 
-            // Define the required checkboxes
+            // Grab every checked checkbox line so we can test it against loose,
+            // wording-agnostic keyword sets instead of brittle exact-phrase regexes.
+            const checkedBoxLines = issueBody.match(/-\s*\[x\][^\n]*/gi) || [];
+
+            // Define the required checkboxes. A checkbox is considered satisfied when
+            // at least one checked line contains ALL of its keywords, regardless of the
+            // exact surrounding wording (e.g. singular vs. plural, with or without the
+            // markdown link, paraphrased sentences, etc.).
             const requiredCheckboxes = [
               {
                 id: 'duplicateCheck',
                 text: 'I have checked the existing issues for duplicates.',
-                patterns: [
-                  /- \[x\]\s*I have checked the existing \[issues\]\([^)]+\) for duplicates\./i,
-                  /- \[x\]\s*I have checked the existing \[issues\]\([^)]+\) for duplicates/i,
-                  /- \[x\]\s*I have checked.*\[issues\].*duplicates/i,
-                  /\[x\].*I have checked.*\[issues\].*duplicates/i,
-                  /- \[x\]\s*I have checked the existing issues for duplicates\./i,
-                  /- \[x\]\s*I have checked the existing issues for duplicates/i,
-                  /- \[x\]\s*I have checked.*duplicates/i,
-                  /\[x\].*I have checked.*duplicates/i
-                ]
+                keywords: [/check/i, /duplicate/i]
               },
               {
                 id: 'codeOfConduct',
                 text: 'I agree to follow this project\'s Code of Conduct.',
-                patterns: [
-                  /- \[x\]\s*I agree to follow this project's \[Code of Conduct\]\([^)]+\)\./i,
-                  /- \[x\]\s*I agree to follow this project's \[Code of Conduct\]\([^)]+\)/i,
-                  /- \[x\]\s*I agree.*\[Code of Conduct\].*\./i,
-                  /\[x\].*I agree.*\[Code of Conduct\].*\./i,
-                  /- \[x\]\s*I agree to follow this project's Code of Conduct\./i,
-                  /- \[x\]\s*I agree to follow this project's Code of Conduct/i,
-                  /- \[x\]\s*I agree.*Code of Conduct/i,
-                  /\[x\].*I agree.*Code of Conduct/i,
-                  /- \[x\]\s*I agree to follow.*Code of Conduct/i
-                ]
+                keywords: [/code of conduct/i]
               }
             ];
 
@@ -75,16 +63,10 @@ jobs:
 
             // Check each required checkbox
             for (const checkbox of requiredCheckboxes) {
-              let found = false;
-              
-              // Check if any of the patterns match
-              for (const pattern of checkbox.patterns) {
-                if (pattern.test(issueBody)) {
-                  found = true;
-                  break;
-                }
-              }
-              
+              const found = checkedBoxLines.some((line) =>
+                checkbox.keywords.every((keyword) => keyword.test(line))
+              );
+
               if (!found) {
                 missingItems.push(checkbox.text);
               }
@@ -108,12 +90,14 @@ jobs:
               // Clean up the content
               content = content.trim();
               
-              // Check if content is empty or just placeholder text
-              if (!content || 
-                  content === 'No response' || 
+              // Check if content is empty or just placeholder text.
+              // Note: no minimum length check here — legitimate answers like a bare
+              // Node major version ("22", "24", ...) can be as short as 2 characters,
+              // so length alone is not a reliable signal of a missing answer.
+              if (!content ||
+                  content === 'No response' ||
                   content === 'N/A' ||
-                  content === 'None' ||
-                  content.length < 3) {
+                  content === 'None') {
                 missingItems.push(field.label);
               }
             }


### PR DESCRIPTION
### What does it do?

Fixes two bugs in `.github/workflows/template-check-on-new-issue.yaml` that caused it to mislabel valid, template-compliant bug reports with `flag: invalid template`:

1. **Version-field length heuristic**: the "is this field empty?" check included `content.length < 3`, which rejects perfectly valid answers like a bare Node major version (`22`, `24`, ...). Removed the length check — emptiness is already covered by the `!content` / placeholder-string checks.
2. **Overly rigid checkbox regexes**: the required-checkbox check relied on ~8-9 exact-phrase regex variants per checkbox, all requiring specific wording (e.g. plural "duplicates", markdown link syntax). Slightly reworded but semantically equivalent checked boxes (e.g. singular "duplicate") never matched. Replaced with loose keyword matching (`check` + `duplicate`, `code of conduct`) against any checked (`- [x]`) line, which still requires an actually-checked box but tolerates wording variation.

### Why is it needed?

The checker false-flagged at least three genuinely valid bug reports:
- #26951 and #26682 — flagged solely because the reporter answered `Node Version` with a 2-character major version (`22`/`24`), tripping the `length < 3` rule.
- #26813 — flagged because the reporter's checked-checkbox text ("I have checked the existing issues **and this is not a duplicate**.") didn't match any of the hardcoded exact-phrase regexes, despite satisfying the intent of the template.

These false positives add noise to triage and send well-meaning reporters a "please resubmit" comment for no real reason.

### How to test it?

Verified locally by extracting the real issue bodies for #26813, #26951, and #26682 and running the old vs. new validation logic against them in Node:
- Old logic: all three produce non-empty `missingItems` (false positive).
- New logic: all three produce an empty `missingItems` array (correctly recognized as valid).
- Sanity-checked that genuinely incomplete bodies (empty body, unchecked boxes, missing version field, `No response` placeholder) are still correctly flagged by the new logic.

### Related issue(s)/PR(s)

Fixes false positives reported on:
- #26813
- #26951
- #26682