### PR TITLE
chore(ai-tooling): sync skills when cursor sets up a new worktree

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,3 +1,3 @@
 {
-  "setup-worktree": ["yarn install", "yarn build"]
+  "setup-worktree": ["yarn install", "yarn build", "yarn ai:sync"]
 }


### PR DESCRIPTION
### What does it do?

Adds `yarn ai:sync` to the Cursor worktree setup hook in `.cursor/worktrees.json`, so every new worktree runs install, build, and AI skill linking in one pass.

### Why is it needed?

Cursor worktrees already run `yarn install` and `yarn build` on creation, but contributors still had to run `yarn ai:sync` manually to populate `.agents/skills/`, `.claude/skills/`, and `.cursor/skills/` from `.ai/skills/`. Without that step, agent skills are missing in fresh worktrees and tooling hints in `AGENTS.md` / `CONTRIBUTING.md` are easy to miss.

### How to test it?

1. Create a new Cursor worktree from this branch (or edit `.cursor/worktrees.json` locally and trigger worktree setup).
2. After setup completes, confirm `.cursor/skills/`, `.claude/skills/`, and `.agents/skills/` contain symlinks to `.ai/skills/` entries (e.g. `git-conventions`).
3. Optionally run `yarn ai:status` — links should already be present without an extra manual sync.

### Related issue(s)/PR(s)

None.

---
_AI assisted_