### PR TITLE
fix(ci): grace period for invalid template issues

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -4,10 +4,10 @@ TypeScript helpers used by workflows under `.github/workflows/`.
 
 ## Scripts
 
-| File                        | Workflow                           | Description                                             |
-| --------------------------- | ---------------------------------- | ------------------------------------------------------- |
-| `community-pr-lifecycle.ts` | `community-pr-lifecycle.yml`       | Syncs community PR "waiting on author" → stale → closed |
-| `issue-template-check.ts`   | `template-check-on-new-issue.yaml` | Validates new bug reports against `BUG_REPORT.yml`      |
+| File                        | Workflow                                                                             | Description                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| `community-pr-lifecycle.ts` | `community-pr-lifecycle.yml`                                                         | Syncs community PR "waiting on author" → stale → closed         |
+| `issue-template-check.ts`   | `template-check-on-new-issue.yaml`, `issues_handleLabel.yml`, `issues_dailyCron.yml` | Validates bug reports and manages invalid-template grace period |
 
 ## Tests
 

--- a/.github/scripts/issue-template-check-action.ts
+++ b/.github/scripts/issue-template-check-action.ts
@@ -1,7 +1,12 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { buildInvalidTemplateComment, validateIssueTemplate } from './issue-template-check.ts';
+import {
+  INVALID_TEMPLATE_LABEL,
+  buildInvalidTemplateComment,
+  buildInvalidTemplateFixedComment,
+  validateIssueTemplate,
+} from './issue-template-check.ts';
 
 async function run() {
   const issue = github.context.payload.issue;
@@ -15,33 +20,68 @@ async function run() {
   const { owner, repo } = github.context.repo;
   const issueBody = issue.body || '';
   const issueNumber = issue.number;
+  const action = github.context.payload.action ?? 'opened';
+  const labels = (issue.labels ?? []).map((label) =>
+    typeof label === 'string' ? label : label.name
+  );
+  const hasInvalidTemplateLabel = labels.includes(INVALID_TEMPLATE_LABEL);
   const { valid, missingItems } = validateIssueTemplate(issueBody);
 
   if (!valid) {
-    core.info(`Missing required items: ${missingItems.join(', ')}`);
+    if (action === 'opened' || !hasInvalidTemplateLabel) {
+      core.info(`Missing required items: ${missingItems.join(', ')}`);
 
-    await octokit.rest.issues.addLabels({
-      owner,
-      repo,
-      issue_number: issueNumber,
-      labels: ['flag: invalid template'],
-    });
+      if (!hasInvalidTemplateLabel) {
+        await octokit.rest.issues.addLabels({
+          owner,
+          repo,
+          issue_number: issueNumber,
+          labels: [INVALID_TEMPLATE_LABEL],
+        });
+      }
 
-    const comment = buildInvalidTemplateComment(
-      issue.user?.login ?? 'user',
-      owner,
-      repo,
-      missingItems
-    );
+      const comment = buildInvalidTemplateComment(
+        issue.user?.login ?? 'user',
+        owner,
+        repo,
+        missingItems
+      );
+
+      await octokit.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body: comment,
+      });
+
+      core.info(`Flagged issue #${issueNumber} as invalid template`);
+      return;
+    }
+
+    core.info(`Issue #${issueNumber} is still invalid; grace period continues`);
+    return;
+  }
+
+  if (hasInvalidTemplateLabel) {
+    try {
+      await octokit.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        name: INVALID_TEMPLATE_LABEL,
+      });
+    } catch {
+      // Label may have been removed concurrently — not fatal
+    }
 
     await octokit.rest.issues.createComment({
       owner,
       repo,
       issue_number: issueNumber,
-      body: comment,
+      body: buildInvalidTemplateFixedComment(),
     });
 
-    core.info(`Added "flag: invalid template" label and comment on issue #${issueNumber}`);
+    core.info(`Removed invalid template label from issue #${issueNumber}`);
     return;
   }
 

--- a/.github/scripts/issue-template-check.test.ts
+++ b/.github/scripts/issue-template-check.test.ts
@@ -182,23 +182,23 @@ describe('issue-template-check', () => {
 
   it('removes label when an issue becomes valid before grace period ends', () => {
     const now = new Date('2026-07-09T12:00:00Z');
-    const updatedAt = new Date('2026-07-08T12:00:00Z');
+    const labelAppliedAt = new Date('2026-07-08T12:00:00Z');
 
-    assert.equal(resolveInvalidTemplateAction(true, updatedAt, now), 'remove_label');
+    assert.equal(resolveInvalidTemplateAction(true, labelAppliedAt, now), 'remove_label');
   });
 
   it('skips closing while grace period is active', () => {
     const now = new Date('2026-07-09T12:00:00Z');
-    const updatedAt = new Date('2026-07-09T06:00:00Z');
+    const labelAppliedAt = new Date('2026-07-09T06:00:00Z');
 
-    assert.equal(resolveInvalidTemplateAction(false, updatedAt, now), 'skip');
+    assert.equal(resolveInvalidTemplateAction(false, labelAppliedAt, now), 'skip');
   });
 
   it('closes issues that stay invalid beyond the grace period', () => {
     const now = new Date('2026-07-09T12:00:00Z');
-    const updatedAt = new Date('2026-06-20T12:00:00Z');
+    const labelAppliedAt = new Date('2026-06-20T12:00:00Z');
 
-    assert.equal(resolveInvalidTemplateAction(false, updatedAt, now), 'close');
+    assert.equal(resolveInvalidTemplateAction(false, labelAppliedAt, now), 'close');
   });
 
   it('plans label removal when a flagged issue is fixed', () => {
@@ -207,7 +207,7 @@ describe('issue-template-check', () => {
         {
           number: 123,
           body: VALID_ISSUE_BODY,
-          updated_at: '2026-07-01T00:00:00Z',
+          label_applied_at: '2026-07-01T00:00:00Z',
         },
       ],
       now: new Date('2026-07-09T00:00:00Z'),

--- a/.github/scripts/issue-template-check.test.ts
+++ b/.github/scripts/issue-template-check.test.ts
@@ -5,6 +5,8 @@ import {
   buildInvalidTemplateComment,
   isPlaceholderContent,
   parseIssueSections,
+  planInvalidTemplateProcessing,
+  resolveInvalidTemplateAction,
   validateIssueTemplate,
 } from './issue-template-check.ts';
 
@@ -175,5 +177,42 @@ describe('issue-template-check', () => {
     assert.match(comment, /Section: Node Version/);
     assert.match(comment, /Duplicate issues checkbox/);
     assert.match(comment, /BUG_REPORT\.yml/);
+    assert.match(comment, /1 day/);
+  });
+
+  it('removes label when an issue becomes valid before grace period ends', () => {
+    const now = new Date('2026-07-09T12:00:00Z');
+    const updatedAt = new Date('2026-07-08T12:00:00Z');
+
+    assert.equal(resolveInvalidTemplateAction(true, updatedAt, now), 'remove_label');
+  });
+
+  it('skips closing while grace period is active', () => {
+    const now = new Date('2026-07-09T12:00:00Z');
+    const updatedAt = new Date('2026-07-09T06:00:00Z');
+
+    assert.equal(resolveInvalidTemplateAction(false, updatedAt, now), 'skip');
+  });
+
+  it('closes issues that stay invalid beyond the grace period', () => {
+    const now = new Date('2026-07-09T12:00:00Z');
+    const updatedAt = new Date('2026-06-20T12:00:00Z');
+
+    assert.equal(resolveInvalidTemplateAction(false, updatedAt, now), 'close');
+  });
+
+  it('plans label removal when a flagged issue is fixed', () => {
+    const plans = planInvalidTemplateProcessing({
+      issues: [
+        {
+          number: 123,
+          body: VALID_ISSUE_BODY,
+          updated_at: '2026-07-01T00:00:00Z',
+        },
+      ],
+      now: new Date('2026-07-09T00:00:00Z'),
+    });
+
+    assert.deepEqual(plans, [{ number: 123, action: 'remove_label' }]);
   });
 });

--- a/.github/scripts/issue-template-check.ts
+++ b/.github/scripts/issue-template-check.ts
@@ -210,7 +210,7 @@ export function buildInvalidTemplateComment(
 
 export function resolveInvalidTemplateAction(
   valid: boolean,
-  updatedAt: Date,
+  labelAppliedAt: Date,
   now: Date = new Date(),
   graceDays: number = INVALID_TEMPLATE_GRACE_DAYS
 ): InvalidTemplateAction {
@@ -220,7 +220,7 @@ export function resolveInvalidTemplateAction(
 
   const cutoff = new Date(now.getTime() - graceDays * 24 * 60 * 60 * 1000);
 
-  if (updatedAt > cutoff) {
+  if (labelAppliedAt > cutoff) {
     return 'skip';
   }
 
@@ -248,7 +248,7 @@ export function buildInvalidTemplateFixedComment() {
 interface IssueSummary {
   number: number;
   body: string | null;
-  updated_at: string;
+  label_applied_at: string;
 }
 
 interface ProcessInvalidTemplateOptions {
@@ -269,7 +269,12 @@ export function planInvalidTemplateProcessing({
 }: ProcessInvalidTemplateOptions): InvalidTemplateProcessPlan[] {
   return issues.map((issue) => {
     const { valid } = validateIssueTemplate(issue.body ?? '');
-    const action = resolveInvalidTemplateAction(valid, new Date(issue.updated_at), now, graceDays);
+    const action = resolveInvalidTemplateAction(
+      valid,
+      new Date(issue.label_applied_at),
+      now,
+      graceDays
+    );
 
     return { number: issue.number, action };
   });
@@ -282,6 +287,30 @@ interface ProcessInvalidTemplateIssuesArgs {
   graceDays?: number;
   dryRun?: boolean;
   log?: (message: string) => void;
+}
+
+export async function getInvalidTemplateLabelAppliedAt(
+  github: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number
+): Promise<Date | null> {
+  let latest: Date | null = null;
+
+  for await (const response of github.paginate.iterator(github.rest.issues.listEventsForRepo, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  })) {
+    for (const event of response.data) {
+      if (event.event === 'labeled' && event.label?.name === INVALID_TEMPLATE_LABEL) {
+        latest = new Date(event.created_at);
+      }
+    }
+  }
+
+  return latest;
 }
 
 export async function processInvalidTemplateIssues({
@@ -309,12 +338,31 @@ export async function processInvalidTemplateIssues({
     per_page: 100,
   })) {
     const openIssues = response.data.filter((issue) => !issue.pull_request);
-    const plans = planInvalidTemplateProcessing({
-      issues: openIssues.map((issue) => ({
+    const issueSummaries = [];
+
+    for (const issue of openIssues) {
+      const labelAppliedAt = await getInvalidTemplateLabelAppliedAt(
+        github,
+        owner,
+        repo,
+        issue.number
+      );
+
+      if (!labelAppliedAt) {
+        log(`Issue #${issue.number}: missing label event, skipping`);
+        skipped += 1;
+        continue;
+      }
+
+      issueSummaries.push({
         number: issue.number,
         body: issue.body,
-        updated_at: issue.updated_at,
-      })),
+        label_applied_at: labelAppliedAt.toISOString(),
+      });
+    }
+
+    const plans = planInvalidTemplateProcessing({
+      issues: issueSummaries,
       now,
       graceDays,
     });

--- a/.github/scripts/issue-template-check.ts
+++ b/.github/scripts/issue-template-check.ts
@@ -5,6 +5,10 @@
  * short but valid values (e.g. Node "20", yarn version "1") are accepted.
  */
 
+import type { getOctokit } from '@actions/github';
+
+type Octokit = ReturnType<typeof getOctokit>;
+
 /**
  * Values GitHub issue forms insert when a field is left empty — not intentional answers.
  * We do not reject NA/N/A, "-", etc.; content quality is for humans to triage.
@@ -172,11 +176,21 @@ export function validateIssueTemplate(body: string): TemplateValidationResult {
   };
 }
 
+function formatGracePeriod(graceDays: number): string {
+  return graceDays === 1 ? '1 day' : `${graceDays} days`;
+}
+
+export const INVALID_TEMPLATE_LABEL = 'flag: invalid template';
+export const INVALID_TEMPLATE_GRACE_DAYS = 1;
+
+export type InvalidTemplateAction = 'remove_label' | 'close' | 'skip';
+
 export function buildInvalidTemplateComment(
   login: string,
   owner: string,
   repo: string,
-  missingItems: string[]
+  missingItems: string[],
+  graceDays = INVALID_TEMPLATE_GRACE_DAYS
 ) {
   const missingList = missingItems.map((item) => `- ${item}`).join('\n');
 
@@ -189,6 +203,174 @@ export function buildInvalidTemplateComment(
     `${missingList}\n\n` +
     'Please update this issue to include the missing information, or create a new issue and completely fill out the issue template [here](https://github.com/' +
     `${owner}/${repo}/issues/new?template=BUG_REPORT.yml).\n\n` +
+    `If this issue is still incomplete after **${formatGracePeriod(graceDays)}**, it will be closed automatically.\n\n` +
     'Thank you.'
   );
+}
+
+export function resolveInvalidTemplateAction(
+  valid: boolean,
+  updatedAt: Date,
+  now: Date = new Date(),
+  graceDays: number = INVALID_TEMPLATE_GRACE_DAYS
+): InvalidTemplateAction {
+  if (valid) {
+    return 'remove_label';
+  }
+
+  const cutoff = new Date(now.getTime() - graceDays * 24 * 60 * 60 * 1000);
+
+  if (updatedAt > cutoff) {
+    return 'skip';
+  }
+
+  return 'close';
+}
+
+export function buildInvalidTemplateCloseComment(graceDays = INVALID_TEMPLATE_GRACE_DAYS) {
+  return (
+    '> This is a templated message\n\n' +
+    'Hello!\n\n' +
+    `This issue has had the **${INVALID_TEMPLATE_LABEL}** label for more than ${formatGracePeriod(graceDays)} without being updated to follow the bug report template, so it is being closed.\n\n` +
+    'If you still want to report this bug, please [open a new issue](https://github.com/strapi/strapi/issues/new?template=BUG_REPORT.yml) and fill out the template completely.\n\n' +
+    'Thank you!'
+  );
+}
+
+export function buildInvalidTemplateFixedComment() {
+  return (
+    '> This is a templated message\n\n' +
+    'Thanks for updating this issue — it now follows the bug report template. The **flag: invalid template** label has been removed automatically.\n\n' +
+    'A team member will triage it when they can. Thank you!'
+  );
+}
+
+interface IssueSummary {
+  number: number;
+  body: string | null;
+  updated_at: string;
+}
+
+interface ProcessInvalidTemplateOptions {
+  issues: IssueSummary[];
+  now?: Date;
+  graceDays?: number;
+}
+
+export interface InvalidTemplateProcessPlan {
+  number: number;
+  action: InvalidTemplateAction;
+}
+
+export function planInvalidTemplateProcessing({
+  issues,
+  now = new Date(),
+  graceDays = INVALID_TEMPLATE_GRACE_DAYS,
+}: ProcessInvalidTemplateOptions): InvalidTemplateProcessPlan[] {
+  return issues.map((issue) => {
+    const { valid } = validateIssueTemplate(issue.body ?? '');
+    const action = resolveInvalidTemplateAction(valid, new Date(issue.updated_at), now, graceDays);
+
+    return { number: issue.number, action };
+  });
+}
+
+interface ProcessInvalidTemplateIssuesArgs {
+  github: Octokit;
+  owner: string;
+  repo: string;
+  graceDays?: number;
+  dryRun?: boolean;
+  log?: (message: string) => void;
+}
+
+export async function processInvalidTemplateIssues({
+  github,
+  owner,
+  repo,
+  graceDays = INVALID_TEMPLATE_GRACE_DAYS,
+  dryRun = false,
+  log = () => {},
+}: ProcessInvalidTemplateIssuesArgs): Promise<{
+  relabeled: number;
+  closed: number;
+  skipped: number;
+}> {
+  const now = new Date();
+  let relabeled = 0;
+  let closed = 0;
+  let skipped = 0;
+
+  for await (const response of github.paginate.iterator(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state: 'open',
+    labels: INVALID_TEMPLATE_LABEL,
+    per_page: 100,
+  })) {
+    const openIssues = response.data.filter((issue) => !issue.pull_request);
+    const plans = planInvalidTemplateProcessing({
+      issues: openIssues.map((issue) => ({
+        number: issue.number,
+        body: issue.body,
+        updated_at: issue.updated_at,
+      })),
+      now,
+      graceDays,
+    });
+
+    for (const plan of plans) {
+      if (plan.action === 'skip') {
+        skipped += 1;
+        log(`Issue #${plan.number}: still invalid, within ${graceDays}-day grace period`);
+        continue;
+      }
+
+      if (plan.action === 'remove_label') {
+        log(`Issue #${plan.number}: now valid, removing label`);
+        if (!dryRun) {
+          try {
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: plan.number,
+              name: INVALID_TEMPLATE_LABEL,
+            });
+          } catch {
+            // Label may have been removed concurrently — not fatal
+          }
+
+          await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: plan.number,
+            body: buildInvalidTemplateFixedComment(),
+          });
+        }
+        relabeled += 1;
+        continue;
+      }
+
+      log(`Issue #${plan.number}: still invalid after ${graceDays} days, closing`);
+      if (!dryRun) {
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: plan.number,
+          body: buildInvalidTemplateCloseComment(graceDays),
+        });
+
+        await github.rest.issues.update({
+          owner,
+          repo,
+          issue_number: plan.number,
+          state: 'closed',
+          state_reason: 'not_planned',
+        });
+      }
+      closed += 1;
+    }
+  }
+
+  return { relabeled, closed, skipped };
 }

--- a/.github/workflows/issues_dailyCron.yml
+++ b/.github/workflows/issues_dailyCron.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
   statuses: read
 
@@ -13,6 +14,30 @@ jobs:
   cron-tasks:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+
+      - name: Install and build scripts
+        run: cd .github/scripts && npm install --ignore-scripts && npx tsup issue-template-check.ts --format cjs --target node20 --out-dir dist --no-splitting
+
+      - name: Reconcile invalid template issues
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { processInvalidTemplateIssues } = require('./.github/scripts/dist/issue-template-check.js');
+            const { owner, repo } = context.repo;
+
+            const { relabeled, closed, skipped } = await processInvalidTemplateIssues({
+              github,
+              owner,
+              repo,
+              log: (message) => core.info(message),
+            });
+
+            core.info(
+              `Invalid template sweep: ${relabeled} label(s) removed, ${closed} issue(s) closed, ${skipped} skipped (grace period)`
+            );
+
       - name: Close inactive "can not reproduce" issues
         uses: actions/github-script@v9
         with:

--- a/.github/workflows/issues_handleLabel.yml
+++ b/.github/workflows/issues_handleLabel.yml
@@ -5,21 +5,34 @@ on:
     types: [labeled]
 
 permissions:
+  contents: read
   issues: write
   pull-requests: write
   actions: read
   checks: read
-  contents: read
   statuses: read
 
 jobs:
   issue-labeled:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+
+      - name: Install and build scripts
+        run: cd .github/scripts && npm install --ignore-scripts && npx tsup issue-template-check.ts --format cjs --target node20 --out-dir dist --no-splitting
+
       - name: Handle issue label automation
         uses: actions/github-script@v9
         with:
           script: |
+            const {
+              INVALID_TEMPLATE_LABEL,
+              buildInvalidTemplateComment,
+              buildInvalidTemplateFixedComment,
+              validateIssueTemplate,
+            } = require('./.github/scripts/dist/issue-template-check.js');
+
             const { owner, repo } = context.repo;
             const issue_number = context.payload.issue.number;
             const login = context.payload.issue.user.login;
@@ -126,19 +139,28 @@ jobs:
               },
 
               'flag: invalid template': async () => {
+                const body = context.payload.issue.body || '';
+                const { valid, missingItems } = validateIssueTemplate(body);
+
+                if (valid) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner,
+                      repo,
+                      issue_number,
+                      name: INVALID_TEMPLATE_LABEL,
+                    });
+                  } catch {
+                    // Label may have been removed concurrently — not fatal
+                  }
+
+                  await comment(buildInvalidTemplateFixedComment());
+                  return;
+                }
+
                 await comment(
-                  `> This is a templated message
-
-            Hello @${login},
-
-            We ask that you please follow the issue template.
-            A proper issue submission let's us better understand the origin of your bug and therefore help you. You can see the template guidelines for bug reports [here](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md#reporting-an-issue).
-
-            Please create a new issue and completely fill out the issue template, you can [open a new issue here](https://github.com/strapi/strapi/issues/new?template=BUG_REPORT.yml).
-
-            Thank you.`
+                  buildInvalidTemplateComment(login, owner, repo, missingItems)
                 );
-                await close('not_planned');
               },
 
               'flag: question': async () => {

--- a/.github/workflows/template-check-on-new-issue.yaml
+++ b/.github/workflows/template-check-on-new-issue.yaml
@@ -2,7 +2,7 @@ name: Check Required Checkboxes
 
 on:
   issues:
-    types: [opened]
+    types: [opened, edited]
 
 permissions:
   contents: read
@@ -23,4 +23,6 @@ jobs:
         run: cd .github/scripts && npm install --ignore-scripts
 
       - name: Check issue uses template
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node --experimental-strip-types .github/scripts/issue-template-check-action.ts


### PR DESCRIPTION
### What does it do?

Follow-up to strapi/strapi#26955. Makes invalid-template handling verify before closing and less close-happy:

<!-- linear:table-colwidths:400,400 -->
| When | What happens |
| -- | -- |
| **Issue opened** (invalid) | Label + comment listing missing items; mentions 1-day grace; **stays open** |
| **Issue edited** (now valid) | Label removed immediately + thank-you comment |
| **Issue edited** (still invalid) | No spam — grace period continues |
| `flag: invalid template` **labeled** (any actor, e.g. dosubot) | Re-validates body; **removes label if valid**; if still invalid, posts our comment with missing items — **does not close** |
| **Daily cron** | Re-validates all flagged open issues: valid → remove label; invalid + inactive 1d → close |

Also includes the [#26976](<https://github.com/strapi/strapi/issues/26976>) hotfix (`GITHUB_TOKEN` wiring for the template checker run step).

### Why is it needed?

strapi/strapi#26955 only fixed false-positive detection. On `develop` today, `issues_handleLabel.yml` still **instantly closes** any issue labeled `flag: invalid template` — including labels added by dosubot — without re-checking the body. That defeated the whole point for cases like strapi/strapi#26973.

### How to test it?

```bash
cd .github/scripts && npm install && npm test
```

After merge:

1. Open a valid bug report with Node `22` → no `flag: invalid template`, stays open
2. Open a stack-trace-only issue → gets label + grace comment, stays open
3. Manually add `flag: invalid template` to a valid issue → label removed automatically
4. Wait 1 day (or run `issues_dailyCron` via workflow_dispatch) on a still-invalid flagged issue → closes

### Related issue(s)/PR(s)

Follow-up to strapi/strapi#26955, supersedes [#26976](<https://github.com/strapi/strapi/issues/26976>)