### PR TITLE
fix(admin): pre-commit fails when staging files ignored by ESLint

### DIFF
--- a/lint-staged.shared.mjs
+++ b/lint-staged.shared.mjs
@@ -1,5 +1,7 @@
 // @ts-check
 
+import { ESLint } from 'eslint';
+
 /**
  * Shared lint-staged task map, re-exported by each workspace's
  * `lint-staged.config.mjs`.
@@ -7,10 +9,33 @@
  * lint-staged runs these with the cwd set to the package containing the matched
  * config file, so eslint resolves that package's own tsconfig / .eslintrc.cjs.
  *
+ * Some files are intentionally excluded via a package's ESLint `ignorePatterns`
+ * (e.g. `shared/**` in `@strapi/admin`, `jest.config.js` in several packages,
+ * `bin/**` in `@strapi/upgrade`). Passing an ignored file to the ESLint CLI
+ * still emits a "file ignored because of a matching ignore pattern" warning,
+ * which `--max-warnings=0` turns into a hard failure and blocks the commit —
+ * see https://github.com/strapi/strapi/issues/26952. `ESLint#isPathIgnored`
+ * mirrors the CLI's own ignore resolution, so ESLint only runs on files it
+ * actually lints; Prettier still formats everything.
+ *
  * @type {import('lint-staged').Configuration}
  */
 const config = {
-  '*.{js,ts,jsx,tsx}': ['eslint --cache --fix --max-warnings=0', 'prettier --cache --write'],
+  async '*.{js,ts,jsx,tsx}'(files) {
+    const eslint = new ESLint();
+    const ignored = await Promise.all(files.map((file) => eslint.isPathIgnored(file)));
+    const lintable = files.filter((_file, index) => !ignored[index]);
+
+    const quote = (list) => list.map((file) => `"${file}"`).join(' ');
+
+    const commands = [];
+    if (lintable.length > 0) {
+      commands.push(`eslint --cache --fix --max-warnings=0 ${quote(lintable)}`);
+    }
+    commands.push(`prettier --cache --write ${quote(files)}`);
+
+    return commands;
+  },
   '!(*.js|*.ts|*.jsx|*.tsx)': ['prettier --cache --write --ignore-unknown'],
 };
 


### PR DESCRIPTION
### What does it do?

Filters staged files through ESLint's own `isPathIgnored` API before invoking the ESLint CLI in the shared `lint-staged.shared.mjs` config used by every workspace, so ESLint only runs on files it actually lints. Prettier still runs on every staged file, including the ignored ones.

### Why is it needed?

`lint-staged` passes staged file paths directly to ESLint with `--max-warnings=0`. Files matched by a package's ESLint `ignorePatterns` still trigger a "file ignored because of a matching ignore pattern" warning when passed explicitly to the CLI, and that warning fails the zero-warning gate — blocking commits to files the package intentionally excludes from linting. CI's `yarn lint` is unaffected since it lints via globs, never explicit ignored paths.

Originally scoped to `@strapi/admin`'s `shared/**/*`, but the same bug affects any tracked file matched by both the lint-staged glob and a package's `ignorePatterns`. Fixed once at the shared-config level instead of per-package.

`--no-warn-ignored` was considered but only works with ESLint's flat config (`eslint.config.js`); this repo is still on the legacy `.eslintrc.cjs` format, so that option isn't available here.

### How to test it?

For each package below: on this branch, edit the listed file (e.g. add a one-line comment), `git add` it, then commit. The pre-commit hook should pass, and its output should show only a `prettier --write` step for that file — no `eslint` step runs. Revert the test edit afterward (`git reset --hard HEAD~1`).

<!-- linear:table-colwidths:400,400 -->
| Package | File to edit |
| -- | -- |
| `@strapi/admin` | `packages/core/admin/shared/utils/session-auth.ts` |
| `@strapi/core` | `packages/core/core/jest.config.js` |
| `@strapi/data-transfer` | `packages/core/data-transfer/jest.config.js` |
| `@strapi/provider-upload-aws-s3` | `packages/providers/upload-aws-s3/jest.config.js` |
| `@strapi/generators` | `packages/generators/generators/jest.config.js` |
| `@strapi/openapi` | `packages/core/openapi/jest.config.js` |
| `@strapi/cloud-cli` | `packages/cli/cloud/bin/index.js` |
| `@strapi/upgrade` | `packages/utils/upgrade/bin/upgrade.js` |
| `create-strapi-app` | `packages/cli/create-strapi-app/templates/example-js/config/admin.js` |

Regression check (should still be blocked as before): add `console.log(...)` to a normally-linted file, e.g. `packages/core/admin/admin/src/index.ts`, stage, and commit — ESLint should still fail with `no-console` and block the commit.

### Related issue(s)/PR(s)

Fixes strapi/strapi#26952