### PR TITLE
fix(content-manager): clear stale Blocks editor selection on external value change

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -140,7 +140,10 @@ const EditorDivider = styled(Divider)`
  * Why not use the entity id as the key, since it's unique for each locale?
  * Because it would not solve the problem when using the "fill in from other locale" feature
  */
-function useResetKey(value?: Schema.Attribute.BlocksValue): {
+function useResetKey(
+  editor: Editor,
+  value?: Schema.Attribute.BlocksValue
+): {
   key: number;
   incrementSlateUpdatesCount: () => void;
 } {
@@ -156,6 +159,10 @@ function useResetKey(value?: Schema.Attribute.BlocksValue): {
 
     // If the 2 refs are not equal, it means the value was updated from outside
     if (valueUpdatesCount.current !== slateUpdatesCount.current) {
+      if (editor.selection) {
+        Transforms.deselect(editor);
+      }
+
       // So we change the key to force a rerender of the Slate editor,
       // which will pick up the new value through its initialValue prop
       setKey((previousKey) => previousKey + 1);
@@ -163,7 +170,7 @@ function useResetKey(value?: Schema.Attribute.BlocksValue): {
       // Then bring the 2 refs back in sync
       slateUpdatesCount.current = valueUpdatesCount.current;
     }
-  }, [value]);
+  }, [editor, value]);
 
   const incrementSlateUpdatesCount = React.useCallback(() => {
     slateUpdatesCount.current += 1;
@@ -239,7 +246,7 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
       [editor]
     );
 
-    const { key, incrementSlateUpdatesCount } = useResetKey(value);
+    const { key, incrementSlateUpdatesCount } = useResetKey(editor, value);
 
     const debounceTimeout = React.useRef<NodeJS.Timeout | null>(null);
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/tests/BlocksEditor.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/tests/BlocksEditor.test.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable check-file/filename-naming-convention */
+import * as React from 'react';
+
+import { act, render, screen } from '@tests/utils';
+import { type Descendant, type Editor, createEditor, Transforms } from 'slate';
+import { ReactEditor } from 'slate-react';
+
+import { BlocksEditor } from '../BlocksEditor';
+import { defaultBlocksStore } from '../DefaultBlocksStore';
+
+jest.mock('slate', () => {
+  const actual = jest.requireActual('slate');
+
+  return {
+    ...actual,
+    createEditor: jest.fn(),
+  };
+});
+
+jest.mock('@strapi/admin/strapi-admin', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin'),
+  useStrapiApp: jest
+    .fn()
+    .mockImplementation((_name: string, selector: (state: unknown) => unknown) =>
+      selector({
+        plugins: {
+          'content-manager': {
+            apis: { getRichTextBlocks: () => ({ ...defaultBlocksStore }) },
+          },
+        },
+      })
+    ),
+  useIsMobile: jest.fn().mockReturnValue(false),
+}));
+
+const { createEditor: actualCreateEditor } = jest.requireActual('slate');
+
+const styledValue: Descendant[] = [
+  {
+    type: 'paragraph',
+    children: [
+      { type: 'text', text: 'answer ' },
+      { type: 'text', text: 'answer ', bold: true },
+      { type: 'text', text: 'answer ', italic: true },
+      { type: 'text', text: 'answer', underline: true },
+    ],
+  },
+];
+
+const collapsedValue: Descendant[] = [
+  {
+    type: 'paragraph',
+    children: [{ type: 'text', text: '' }],
+  },
+];
+
+let baseEditor: Editor;
+
+const ControlledEditor = () => {
+  const [value, setValue] = React.useState(styledValue);
+
+  return (
+    <>
+      <button type="button" onClick={() => setValue(collapsedValue)}>
+        collapse
+      </button>
+      <BlocksEditor
+        name="content"
+        // @ts-expect-error the styled test value is close enough to a BlocksValue for the editor
+        value={value}
+        onChange={jest.fn()}
+        ariaLabelId="label"
+      />
+    </>
+  );
+};
+
+const setup = () => {
+  baseEditor = actualCreateEditor();
+  (createEditor as jest.Mock).mockReturnValue(baseEditor);
+
+  return render(<ControlledEditor />);
+};
+
+describe('BlocksEditor', () => {
+  beforeAll(() => {
+    Range.prototype.getBoundingClientRect = () => ({}) as DOMRect;
+    Range.prototype.getClientRects = () =>
+      ({ length: 0, item: () => null, [Symbol.iterator]: [][Symbol.iterator] }) as DOMRectList;
+  });
+
+  beforeEach(() => {
+    jest.spyOn(ReactEditor, 'isFocused').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not crash when the value collapses to a shorter tree while a stale selection points past it', async () => {
+    const { user } = setup();
+
+    await act(async () => {
+      Transforms.select(baseEditor, { path: [0, 3], offset: 0 });
+    });
+    expect(baseEditor.selection).not.toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'collapse' }));
+
+    expect(baseEditor.selection).toBeNull();
+    expect(screen.getByRole('button', { name: 'collapse' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Clears the Slate selection before the Blocks editor remounts when the `value` prop is replaced from outside the editor.

`useResetKey` already forces a remount (via a key bump) whenever the field value changes from outside Slate, so the editor picks up the new `initialValue`. But Slate is not a controlled component — the editor instance is preserved across the remount, and so is its `selection`. When the incoming value is a shorter tree than what the editor currently holds, that stale selection can point at a path that no longer exists. On remount Slate tries to resolve it and throws.

The fix deselects the editor inside `useResetKey` right before the key bump, so there's no selection left to resolve against the new value. The pre-existing "sync after discard" effect already did this, but only when the editor is not focused — this covers the focused case that it skips.

### Why is it needed?

Creating a new related entry inline from a Single Type edit page crashes the admin when a Blocks field in the related entry contains styled text fragments. After applying inline formatting (bold/italic/underline) and hitting Save/Publish, the editor value collapses back to an empty paragraph while the selection still points into the old styled content, producing:

```
Cannot find a descendant at path [0,3] in node: ...
```

instead of saving the entry.


### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #26881 