### PR TITLE
fix(core): preserve duplicate form relation edits when cloning

### DIFF
--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -43,6 +43,46 @@ const MAX_LOCALE_LENGTH = 35;
 /** Treat as "param not provided": null, undefined, or empty string (e.g. from query/JSON). */
 const isParamEmpty = (v: unknown): boolean => v === undefined || v === null || v === '';
 
+const RELATION_OPERATIONS = ['connect', 'disconnect', 'set'] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+};
+
+const isRelationAttribute = (attribute: unknown): attribute is { type: 'relation' } => {
+  return isRecord(attribute) && attribute.type === 'relation';
+};
+
+const isRelationOperationPayload = (value: unknown): value is Record<string, unknown> => {
+  return (
+    isRecord(value) &&
+    RELATION_OPERATIONS.some((operation) => Object.prototype.hasOwnProperty.call(value, operation))
+  );
+};
+
+const mergeCloneData = (
+  originalData: Record<string, unknown>,
+  submittedData: Record<string, unknown> | undefined,
+  contentType: { attributes: Record<string, unknown> }
+) => {
+  const mergedData = merge(originalData, submittedData ?? {}) as Record<string, unknown>;
+
+  if (!submittedData) {
+    return mergedData;
+  }
+
+  for (const [attributeName, attribute] of Object.entries(contentType.attributes)) {
+    if (
+      isRelationAttribute(attribute) &&
+      isRelationOperationPayload(submittedData[attributeName])
+    ) {
+      mergedData[attributeName] = submittedData[attributeName];
+    }
+  }
+
+  return mergedData;
+};
+
 export const createContentTypeRepository: RepositoryFactoryMethod = (
   uid,
   validator = entityValidator
@@ -454,7 +494,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
         // assign new documentId
         assoc('documentId', createDocumentId()),
         // Merge new data into it
-        (data) => merge(data, queryParams.data),
+        (data) => mergeCloneData(data, queryParams.data, contentType),
         (data) => entries.create({ ...queryParams, data, status: 'draft' })
       )
     );

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -458,10 +458,11 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
           string,
           unknown
         >;
-        const { data, relationsToCopy } = prepareCloneData(
+        const { data, relationsToCopy } = await prepareCloneData(
           originalData,
           queryParams.data,
-          contentType
+          contentType,
+          (modelUid) => strapi.getModel(modelUid as UID.Schema)
         );
         const dataWithDocumentId = assoc('documentId', newDocumentId, data);
         const doc = await entries.create({

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -49,8 +49,16 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 };
 
-const isRelationAttribute = (attribute: unknown): attribute is { type: 'relation' } => {
-  return isRecord(attribute) && attribute.type === 'relation';
+type RelationAttribute = {
+  type: 'relation';
+  relation: string;
+  useJoinTable?: boolean;
+};
+
+const isRelationAttribute = (attribute: unknown): attribute is RelationAttribute => {
+  return (
+    isRecord(attribute) && attribute.type === 'relation' && typeof attribute.relation === 'string'
+  );
 };
 
 const isRelationOperationPayload = (value: unknown): value is Record<string, unknown> => {
@@ -58,6 +66,10 @@ const isRelationOperationPayload = (value: unknown): value is Record<string, unk
     isRecord(value) &&
     RELATION_OPERATIONS.some((operation) => Object.prototype.hasOwnProperty.call(value, operation))
   );
+};
+
+const canTransformRelationOperationPayload = (attribute: RelationAttribute) => {
+  return attribute.useJoinTable !== false && attribute.relation !== 'morphToOne';
 };
 
 const mergeCloneData = (
@@ -74,6 +86,7 @@ const mergeCloneData = (
   for (const [attributeName, attribute] of Object.entries(contentType.attributes)) {
     if (
       isRelationAttribute(attribute) &&
+      canTransformRelationOperationPayload(attribute) &&
       isRelationOperationPayload(submittedData[attributeName])
     ) {
       mergedData[attributeName] = submittedData[attributeName];

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -1,4 +1,4 @@
-import { omit, assoc, merge, curry, isEmpty, pick } from 'lodash/fp';
+import { omit, assoc, curry, isEmpty, pick } from 'lodash/fp';
 
 import {
   async,
@@ -28,6 +28,7 @@ import * as selfReferentialRelations from './utils/self-referential-relations';
 import entityValidator from '../entity-validator';
 import { addFirstPublishedAtToDraft, filterDataFirstPublishedAt } from './first-published-at';
 import { runParallelWithOrderedErrors } from './utils/ordered-parallel';
+import { copyCloneRelationRows, prepareCloneData } from './utils/clone-relations';
 
 const { validators } = validate;
 
@@ -42,59 +43,6 @@ const MAX_LOCALE_LENGTH = 35;
 
 /** Treat as "param not provided": null, undefined, or empty string (e.g. from query/JSON). */
 const isParamEmpty = (v: unknown): boolean => v === undefined || v === null || v === '';
-
-const RELATION_OPERATIONS = ['connect', 'disconnect', 'set'] as const;
-
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-};
-
-type RelationAttribute = {
-  type: 'relation';
-  relation: string;
-  useJoinTable?: boolean;
-};
-
-const isRelationAttribute = (attribute: unknown): attribute is RelationAttribute => {
-  return (
-    isRecord(attribute) && attribute.type === 'relation' && typeof attribute.relation === 'string'
-  );
-};
-
-const isRelationOperationPayload = (value: unknown): value is Record<string, unknown> => {
-  return (
-    isRecord(value) &&
-    RELATION_OPERATIONS.some((operation) => Object.prototype.hasOwnProperty.call(value, operation))
-  );
-};
-
-const canTransformRelationOperationPayload = (attribute: RelationAttribute) => {
-  return attribute.useJoinTable !== false && attribute.relation !== 'morphToOne';
-};
-
-const mergeCloneData = (
-  originalData: Record<string, unknown>,
-  submittedData: Record<string, unknown> | undefined,
-  contentType: { attributes: Record<string, unknown> }
-) => {
-  const mergedData = merge(originalData, submittedData ?? {}) as Record<string, unknown>;
-
-  if (!submittedData) {
-    return mergedData;
-  }
-
-  for (const [attributeName, attribute] of Object.entries(contentType.attributes)) {
-    if (
-      isRelationAttribute(attribute) &&
-      canTransformRelationOperationPayload(attribute) &&
-      isRelationOperationPayload(submittedData[attributeName])
-    ) {
-      mergedData[attributeName] = submittedData[attributeName];
-    }
-  }
-
-  return mergedData;
-};
 
 export const createContentTypeRepository: RepositoryFactoryMethod = (
   uid,
@@ -500,16 +448,41 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       populate: getDeepPopulate(uid, { relationalFields: ['id'] }),
     });
 
+    const newDocumentId = createDocumentId();
+
     const clonedEntries = await async.map(
       entriesToClone,
-      async.pipe(
-        omit(['id', 'createdAt', 'updatedAt']),
-        // assign new documentId
-        assoc('documentId', createDocumentId()),
-        // Merge new data into it
-        (data) => mergeCloneData(data, queryParams.data, contentType),
-        (data) => entries.create({ ...queryParams, data, status: 'draft' })
-      )
+      async (entryToClone: Record<string, unknown>) => {
+        const sourceEntryId = entryToClone.id as number;
+        const originalData = omit(['id', 'createdAt', 'updatedAt'], entryToClone) as Record<
+          string,
+          unknown
+        >;
+        const { data, relationsToCopy } = prepareCloneData(
+          originalData,
+          queryParams.data,
+          contentType
+        );
+        const dataWithDocumentId = assoc('documentId', newDocumentId, data);
+        const doc = await entries.create({
+          ...queryParams,
+          data: dataWithDocumentId,
+          status: 'draft',
+        });
+
+        await copyCloneRelationRows(strapi, uid, sourceEntryId, doc.id, relationsToCopy);
+
+        if (relationsToCopy.length === 0) {
+          return doc;
+        }
+
+        const selectionQuery = transformParamsToQuery(
+          uid,
+          pickSelectionParams({ ...queryParams, status: 'draft' }) as any
+        );
+
+        return strapi.db.query(uid).findOne({ ...selectionQuery, where: { id: doc.id } });
+      }
     );
 
     clonedEntries.forEach(emitEvent('entry.create'));

--- a/packages/core/core/src/services/document-service/utils/clone-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/clone-relations.ts
@@ -1,0 +1,146 @@
+import { merge } from 'lodash/fp';
+
+import type { Core, Schema, UID } from '@strapi/types';
+
+const RELATION_OPERATIONS = ['connect', 'disconnect', 'set'] as const;
+
+type CloneRelationAttribute = Schema.Attribute.Relation & {
+  targetAttribute?: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+};
+
+const isRelationAttribute = (attribute: unknown): attribute is CloneRelationAttribute => {
+  return (
+    isRecord(attribute) && attribute.type === 'relation' && typeof attribute.relation === 'string'
+  );
+};
+
+const isRelationOperationPayload = (value: unknown): value is Record<string, unknown> => {
+  return (
+    isRecord(value) &&
+    RELATION_OPERATIONS.some((operation) => Object.prototype.hasOwnProperty.call(value, operation))
+  );
+};
+
+const hasMeaningfulRelationOperations = (value: Record<string, unknown>) => {
+  if (Object.prototype.hasOwnProperty.call(value, 'set')) {
+    return true;
+  }
+
+  return ['connect', 'disconnect'].some((operation) => {
+    const operationValue = value[operation];
+    return Array.isArray(operationValue) ? operationValue.length > 0 : operationValue != null;
+  });
+};
+
+const canTransformRelationOperationPayload = (attribute: Schema.Attribute.Relation) => {
+  return attribute.useJoinTable !== false && attribute.relation !== 'morphToOne';
+};
+
+const isBidirectionalOneToOne = (attribute: CloneRelationAttribute) => {
+  return (
+    attribute.relation === 'oneToOne' &&
+    [attribute.inversedBy, attribute.mappedBy, attribute.targetAttribute].some(
+      (inverseAttribute) => inverseAttribute != null
+    )
+  );
+};
+
+const hasPopulatedRelation = (value: unknown) => {
+  return isRecord(value) && ('id' in value || 'documentId' in value);
+};
+
+export const prepareCloneData = (
+  originalData: Record<string, unknown>,
+  submittedData: Record<string, unknown> | undefined,
+  contentType: Schema.ContentType
+) => {
+  const submitted = submittedData ?? {};
+  const data = merge(originalData, submitted) as Record<string, unknown>;
+  const relationsToCopy: string[] = [];
+
+  for (const [attributeName, attribute] of Object.entries(contentType.attributes)) {
+    if (!isRelationAttribute(attribute) || !canTransformRelationOperationPayload(attribute)) {
+      continue;
+    }
+
+    const relationWasSubmitted = Object.prototype.hasOwnProperty.call(submitted, attributeName);
+    const submittedValue = submitted[attributeName];
+    const isOperationPayload = isRelationOperationPayload(submittedValue);
+    const hasMeaningfulOperations =
+      isOperationPayload && hasMeaningfulRelationOperations(submittedValue);
+
+    if (hasMeaningfulOperations) {
+      data[attributeName] = submittedValue;
+    }
+
+    const relationIsUnchanged =
+      !relationWasSubmitted || (isOperationPayload && !hasMeaningfulOperations);
+
+    if (
+      relationIsUnchanged &&
+      isBidirectionalOneToOne(attribute) &&
+      hasPopulatedRelation(originalData[attributeName])
+    ) {
+      // Normal relation attachment enforces oneToOne ownership by removing the source link.
+      // Leave unchanged relations out of create and copy their join row after the clone exists.
+      delete data[attributeName];
+      relationsToCopy.push(attributeName);
+    }
+  }
+
+  return { data, relationsToCopy };
+};
+
+export const copyCloneRelationRows = async (
+  strapi: Core.Strapi,
+  uid: UID.ContentType,
+  sourceEntryId: number,
+  targetEntryId: number,
+  attributeNames: string[]
+) => {
+  if (attributeNames.length === 0) {
+    return;
+  }
+
+  const { attributes } = strapi.db.metadata.get(uid);
+  const idColumn = strapi.db.metadata.identifiers.ID_COLUMN;
+  const batchSize = strapi.db.dialect.getBatchInsertSize();
+
+  await strapi.db.transaction(async ({ trx }) => {
+    for (const attributeName of attributeNames) {
+      const attribute = attributes[attributeName];
+
+      if (attribute?.type !== 'relation' || !('joinTable' in attribute) || !attribute.joinTable) {
+        continue;
+      }
+
+      const { joinTable } = attribute;
+      const { joinColumn } = joinTable;
+      const rows = (await strapi.db
+        .connection(joinTable.name)
+        .where({
+          [joinColumn.name]: sourceEntryId,
+          ...(('on' in joinTable && joinTable.on) || {}),
+        })
+        .select('*')
+        .transacting(trx)) as Record<string, unknown>[];
+
+      const rowsToCopy = rows.map((row) => {
+        const copiedRow = { ...row, [joinColumn.name]: targetEntryId };
+        delete copiedRow[idColumn];
+        return copiedRow;
+      });
+
+      for (let index = 0; index < rowsToCopy.length; index += batchSize) {
+        await strapi.db
+          .connection(joinTable.name)
+          .insert(rowsToCopy.slice(index, index + batchSize))
+          .transacting(trx);
+      }
+    }
+  });
+};

--- a/packages/core/core/src/services/document-service/utils/clone-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/clone-relations.ts
@@ -1,8 +1,11 @@
-import { merge } from 'lodash/fp';
+import { merge, set } from 'lodash/fp';
 
 import type { Core, Schema, UID } from '@strapi/types';
+import type { traverseEntity } from '@strapi/utils';
+import { traverseEntityRelations } from '../transform/relations/utils/map-relation';
 
 const RELATION_OPERATIONS = ['connect', 'disconnect', 'set'] as const;
+type TraversableData = Parameters<typeof traverseEntity>[2];
 
 type CloneRelationAttribute = Schema.Attribute.Relation & {
   targetAttribute?: string;
@@ -53,13 +56,41 @@ const hasPopulatedRelation = (value: unknown) => {
   return isRecord(value) && ('id' in value || 'documentId' in value);
 };
 
-export const prepareCloneData = (
+const collectRelationOperationOverrides = async (
+  submittedData: Record<string, unknown>,
+  contentType: Schema.ContentType,
+  getModel: (uid: string) => Schema.Schema
+) => {
+  const overrides = new Map<string, Record<string, unknown>>();
+
+  await traverseEntityRelations(
+    ({ path, value }) => {
+      if (isRelationOperationPayload(value) && hasMeaningfulRelationOperations(value)) {
+        overrides.set(path.rawWithIndices!, value);
+      }
+    },
+    { schema: contentType, getModel },
+    submittedData as TraversableData
+  );
+
+  return [...overrides.entries()].sort(([leftPath], [rightPath]) =>
+    leftPath.localeCompare(rightPath)
+  );
+};
+
+export const prepareCloneData = async (
   originalData: Record<string, unknown>,
   submittedData: Record<string, unknown> | undefined,
-  contentType: Schema.ContentType
+  contentType: Schema.ContentType,
+  getModel: (uid: string) => Schema.Schema
 ) => {
   const submitted = submittedData ?? {};
-  const data = merge(originalData, submitted) as Record<string, unknown>;
+  const relationOperationOverrides = await collectRelationOperationOverrides(
+    submitted,
+    contentType,
+    getModel
+  );
+  let data = merge(originalData, submitted) as Record<string, unknown>;
   const relationsToCopy: string[] = [];
 
   for (const [attributeName, attribute] of Object.entries(contentType.attributes)) {
@@ -72,10 +103,6 @@ export const prepareCloneData = (
     const isOperationPayload = isRelationOperationPayload(submittedValue);
     const hasMeaningfulOperations =
       isOperationPayload && hasMeaningfulRelationOperations(submittedValue);
-
-    if (hasMeaningfulOperations) {
-      data[attributeName] = submittedValue;
-    }
 
     const relationIsUnchanged =
       !relationWasSubmitted || (isOperationPayload && !hasMeaningfulOperations);
@@ -90,6 +117,10 @@ export const prepareCloneData = (
       delete data[attributeName];
       relationsToCopy.push(attributeName);
     }
+  }
+
+  for (const [path, value] of relationOperationOverrides) {
+    data = set(path, value, data) as Record<string, unknown>;
   }
 
   return { data, relationsToCopy };

--- a/tests/api/core/strapi/document-service/relations/clone-nested-relation-operations.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/clone-nested-relation-operations.test.api.ts
@@ -1,0 +1,438 @@
+/**
+ * Duplicate-form relation operations nested in components and dynamic zones must override the
+ * source entry's populated relation data when cloning.
+ */
+import type { Core, UID } from '@strapi/types';
+
+import { testInTransaction } from '../../../../utils';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+
+let strapi: Core.Strapi;
+const builder = createTestBuilder();
+
+const PRODUCT_UID = 'api::product.product' as UID.ContentType;
+const TAG_UID = 'api::tag.tag' as UID.ContentType;
+const RELATION_CONTAINER_UID = 'default.relation-container' as UID.Component;
+
+type RelationContainer = {
+  label?: string;
+  tag?: {
+    documentId?: string;
+  } | null;
+};
+
+type ProductWithNestedRelations = {
+  details?: RelationContainer | null;
+  relatedItems?: RelationContainer[];
+  sections?: Array<RelationContainer & { __component?: string }>;
+};
+
+const relationContainerModel = {
+  collectionName: 'components_relation_containers',
+  attributes: {
+    label: { type: 'string' },
+    tag: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: TAG_UID,
+    },
+  },
+  displayName: 'relation-container',
+};
+
+const productModel = {
+  attributes: {
+    name: { type: 'string' },
+    details: {
+      type: 'component',
+      component: RELATION_CONTAINER_UID,
+    },
+    relatedItems: {
+      type: 'component',
+      repeatable: true,
+      component: RELATION_CONTAINER_UID,
+    },
+    sections: {
+      type: 'dynamiczone',
+      components: [RELATION_CONTAINER_UID],
+    },
+  },
+  draftAndPublish: true,
+  displayName: 'Product',
+  singularName: 'product',
+  pluralName: 'products',
+  description: '',
+  collectionName: '',
+};
+
+const tagModel = {
+  attributes: {
+    name: { type: 'string' },
+  },
+  draftAndPublish: true,
+  displayName: 'Tag',
+  singularName: 'tag',
+  pluralName: 'tags',
+  description: '',
+  collectionName: '',
+};
+
+const populate = {
+  details: {
+    populate: { tag: true },
+  },
+  relatedItems: {
+    populate: { tag: true },
+  },
+  sections: {
+    on: {
+      [RELATION_CONTAINER_UID]: {
+        populate: { tag: true },
+      },
+    },
+  },
+} as const;
+
+const createTag = (name: string) => strapi.documents(TAG_UID).create({ data: { name } });
+
+const findProduct = (documentId: string) =>
+  strapi.documents(PRODUCT_UID).findOne({
+    documentId,
+    status: 'draft',
+    populate,
+  });
+
+const nestedTagDocumentId = (container: RelationContainer | null | undefined) =>
+  container?.tag?.documentId ?? null;
+
+describe('Document Service clone nested relation operation payloads', () => {
+  beforeAll(async () => {
+    await builder
+      .addContentType(tagModel)
+      .addComponent(relationContainerModel)
+      .addContentType(productModel)
+      .build();
+
+    strapi = await createStrapiInstance();
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  testInTransaction(
+    'clone applies duplicate-form selected target for a relation inside a component',
+    async () => {
+      const originalTag = await createTag('Component Original Tag');
+      const selectedTag = await createTag('Component Selected Tag');
+      const product = await strapi.documents(PRODUCT_UID).create({
+        data: {
+          name: 'Component Source Product',
+          details: {
+            label: 'Source details',
+            tag: { documentId: originalTag.documentId },
+          },
+        },
+        populate,
+      });
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        data: {
+          name: 'Component Clone Product',
+          details: {
+            label: 'Cloned details',
+            tag: {
+              connect: [{ documentId: selectedTag.documentId }],
+              disconnect: [{ documentId: originalTag.documentId }],
+            },
+          },
+        },
+        populate,
+      });
+
+      const originalProduct = (await findProduct(
+        product.documentId
+      )) as ProductWithNestedRelations | null;
+      const clonedProduct = result.entries[0] as ProductWithNestedRelations;
+
+      expect({
+        cloneTagDocumentId: nestedTagDocumentId(clonedProduct.details),
+        originalTagDocumentId: nestedTagDocumentId(originalProduct?.details),
+      }).toEqual({
+        cloneTagDocumentId: selectedTag.documentId,
+        originalTagDocumentId: originalTag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone applies duplicate-form selected target for a relation inside a repeatable component',
+    async () => {
+      const originalTag = await createTag('Repeatable Component Original Tag');
+      const selectedTag = await createTag('Repeatable Component Selected Tag');
+      const product = await strapi.documents(PRODUCT_UID).create({
+        data: {
+          name: 'Repeatable Component Source Product',
+          relatedItems: [
+            {
+              label: 'Source related item',
+              tag: { documentId: originalTag.documentId },
+            },
+          ],
+        },
+        populate,
+      });
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        data: {
+          name: 'Repeatable Component Clone Product',
+          relatedItems: [
+            {
+              label: 'Cloned related item',
+              tag: {
+                connect: [{ documentId: selectedTag.documentId }],
+                disconnect: [{ documentId: originalTag.documentId }],
+              },
+            },
+          ],
+        },
+        populate,
+      });
+
+      const originalProduct = (await findProduct(
+        product.documentId
+      )) as ProductWithNestedRelations | null;
+      const clonedProduct = result.entries[0] as ProductWithNestedRelations;
+
+      expect({
+        cloneTagDocumentId: nestedTagDocumentId(clonedProduct.relatedItems?.[0]),
+        originalTagDocumentId: nestedTagDocumentId(originalProduct?.relatedItems?.[0]),
+      }).toEqual({
+        cloneTagDocumentId: selectedTag.documentId,
+        originalTagDocumentId: originalTag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone applies duplicate-form selected target for a relation inside a dynamic-zone block',
+    async () => {
+      const originalTag = await createTag('Dynamic Zone Original Tag');
+      const selectedTag = await createTag('Dynamic Zone Selected Tag');
+      const product = await strapi.documents(PRODUCT_UID).create({
+        data: {
+          name: 'Dynamic Zone Source Product',
+          sections: [
+            {
+              __component: RELATION_CONTAINER_UID,
+              label: 'Source section',
+              tag: { documentId: originalTag.documentId },
+            },
+          ],
+        },
+        populate,
+      });
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        data: {
+          name: 'Dynamic Zone Clone Product',
+          sections: [
+            {
+              __component: RELATION_CONTAINER_UID,
+              label: 'Cloned section',
+              tag: {
+                connect: [{ documentId: selectedTag.documentId }],
+                disconnect: [{ documentId: originalTag.documentId }],
+              },
+            },
+          ],
+        },
+        populate,
+      });
+
+      const originalProduct = (await findProduct(
+        product.documentId
+      )) as ProductWithNestedRelations | null;
+      const clonedProduct = result.entries[0] as ProductWithNestedRelations;
+
+      expect({
+        cloneTagDocumentId: nestedTagDocumentId(clonedProduct.sections?.[0]),
+        originalTagDocumentId: nestedTagDocumentId(originalProduct?.sections?.[0]),
+      }).toEqual({
+        cloneTagDocumentId: selectedTag.documentId,
+        originalTagDocumentId: originalTag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone applies duplicate-form selected targets for relations inside a component and dynamic-zone block in one request',
+    async () => {
+      const originalComponentTag = await createTag('Combined Component Original Tag');
+      const selectedComponentTag = await createTag('Combined Component Selected Tag');
+      const originalDynamicZoneTag = await createTag('Combined Dynamic Zone Original Tag');
+      const selectedDynamicZoneTag = await createTag('Combined Dynamic Zone Selected Tag');
+      const product = await strapi.documents(PRODUCT_UID).create({
+        data: {
+          name: 'Combined Source Product',
+          details: {
+            label: 'Source details',
+            tag: { documentId: originalComponentTag.documentId },
+          },
+          sections: [
+            {
+              __component: RELATION_CONTAINER_UID,
+              label: 'Source section',
+              tag: { documentId: originalDynamicZoneTag.documentId },
+            },
+          ],
+        },
+        populate,
+      });
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        data: {
+          name: 'Combined Clone Product',
+          details: {
+            label: 'Cloned details',
+            tag: {
+              connect: [{ documentId: selectedComponentTag.documentId }],
+              disconnect: [{ documentId: originalComponentTag.documentId }],
+            },
+          },
+          sections: [
+            {
+              __component: RELATION_CONTAINER_UID,
+              label: 'Cloned section',
+              tag: {
+                connect: [{ documentId: selectedDynamicZoneTag.documentId }],
+                disconnect: [{ documentId: originalDynamicZoneTag.documentId }],
+              },
+            },
+          ],
+        },
+        populate,
+      });
+
+      const originalProduct = (await findProduct(
+        product.documentId
+      )) as ProductWithNestedRelations | null;
+      const clonedProduct = result.entries[0] as ProductWithNestedRelations;
+
+      expect({
+        cloneComponentTagDocumentId: nestedTagDocumentId(clonedProduct.details),
+        cloneDynamicZoneTagDocumentId: nestedTagDocumentId(clonedProduct.sections?.[0]),
+        originalComponentTagDocumentId: nestedTagDocumentId(originalProduct?.details),
+        originalDynamicZoneTagDocumentId: nestedTagDocumentId(originalProduct?.sections?.[0]),
+      }).toEqual({
+        cloneComponentTagDocumentId: selectedComponentTag.documentId,
+        cloneDynamicZoneTagDocumentId: selectedDynamicZoneTag.documentId,
+        originalComponentTagDocumentId: originalComponentTag.documentId,
+        originalDynamicZoneTagDocumentId: originalDynamicZoneTag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone preserves a relation inside a component for empty duplicate-form operations',
+    async () => {
+      const originalTag = await createTag('Empty Component Operations Original Tag');
+      const product = await strapi.documents(PRODUCT_UID).create({
+        data: {
+          name: 'Empty Component Operations Source Product',
+          details: {
+            label: 'Source details',
+            tag: { documentId: originalTag.documentId },
+          },
+        },
+        populate,
+      });
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        data: {
+          name: 'Empty Component Operations Clone Product',
+          details: {
+            label: 'Cloned details',
+            tag: {
+              connect: [],
+              disconnect: [],
+            },
+          },
+        },
+        populate,
+      });
+
+      const originalProduct = (await findProduct(
+        product.documentId
+      )) as ProductWithNestedRelations | null;
+      const clonedProduct = result.entries[0] as ProductWithNestedRelations;
+
+      expect({
+        cloneTagDocumentId: nestedTagDocumentId(clonedProduct.details),
+        originalTagDocumentId: nestedTagDocumentId(originalProduct?.details),
+      }).toEqual({
+        cloneTagDocumentId: originalTag.documentId,
+        originalTagDocumentId: originalTag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone preserves a relation inside a dynamic-zone block for empty duplicate-form operations',
+    async () => {
+      const originalTag = await createTag('Empty Dynamic Zone Operations Original Tag');
+      const product = await strapi.documents(PRODUCT_UID).create({
+        data: {
+          name: 'Empty Dynamic Zone Operations Source Product',
+          sections: [
+            {
+              __component: RELATION_CONTAINER_UID,
+              label: 'Source section',
+              tag: { documentId: originalTag.documentId },
+            },
+          ],
+        },
+        populate,
+      });
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        data: {
+          name: 'Empty Dynamic Zone Operations Clone Product',
+          sections: [
+            {
+              __component: RELATION_CONTAINER_UID,
+              label: 'Cloned section',
+              tag: {
+                connect: [],
+                disconnect: [],
+              },
+            },
+          ],
+        },
+        populate,
+      });
+
+      const originalProduct = (await findProduct(
+        product.documentId
+      )) as ProductWithNestedRelations | null;
+      const clonedProduct = result.entries[0] as ProductWithNestedRelations;
+
+      expect({
+        cloneTagDocumentId: nestedTagDocumentId(clonedProduct.sections?.[0]),
+        originalTagDocumentId: nestedTagDocumentId(originalProduct?.sections?.[0]),
+      }).toEqual({
+        cloneTagDocumentId: originalTag.documentId,
+        originalTagDocumentId: originalTag.documentId,
+      });
+    }
+  );
+});

--- a/tests/api/core/strapi/document-service/relations/clone-relation-operations.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/clone-relation-operations.test.api.ts
@@ -15,8 +15,11 @@ const builder = createTestBuilder();
 const PRODUCT_UID = 'api::product.product' as UID.ContentType;
 const TAG_UID = 'api::tag.tag' as UID.ContentType;
 
-type ProductWithTag = {
+type ProductWithTags = {
   tag?: {
+    documentId?: string;
+  } | null;
+  legacyTag?: {
     documentId?: string;
   } | null;
 };
@@ -31,6 +34,12 @@ const productModel = {
       relation: 'oneToOne',
       target: TAG_UID,
       targetAttribute: 'product',
+    },
+    legacyTag: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: TAG_UID,
+      useJoinTable: false,
     },
   },
   pluginOptions: {
@@ -60,7 +69,10 @@ const tagModel = {
 
 const createTag = (name: string) => strapi.documents(TAG_UID).create({ data: { name } });
 
-const tagDocumentId = (product?: ProductWithTag) => product?.tag?.documentId ?? null;
+const relationDocumentId = (
+  product: ProductWithTags | undefined,
+  attribute: keyof ProductWithTags
+) => product?.[attribute]?.documentId ?? null;
 
 const createTaggedProduct = async (productName: string, tagName: string) => {
   const tag = await createTag(tagName);
@@ -74,16 +86,33 @@ const createTaggedProduct = async (productName: string, tagName: string) => {
     populate: { tag: true },
   });
 
-  expect((product as ProductWithTag).tag).toMatchObject({ documentId: tag.documentId });
+  expect((product as ProductWithTags).tag).toMatchObject({ documentId: tag.documentId });
 
   return { product, tag };
 };
 
-const findProductWithTag = (documentId: string) =>
+const createLegacyTaggedProduct = async (productName: string, tagName: string) => {
+  const tag = await createTag(tagName);
+
+  const product = await strapi.documents(PRODUCT_UID).create({
+    locale: 'en',
+    data: {
+      name: productName,
+      legacyTag: tag.id,
+    },
+    populate: { legacyTag: true },
+  });
+
+  expect((product as ProductWithTags).legacyTag).toMatchObject({ documentId: tag.documentId });
+
+  return { product, tag };
+};
+
+const findProductWithTags = (documentId: string) =>
   strapi.documents(PRODUCT_UID).findOne({
     documentId,
     locale: 'en',
-    populate: { tag: true },
+    populate: { tag: true, legacyTag: true },
   });
 
 describe('Document Service clone relation operation payloads', () => {
@@ -119,11 +148,11 @@ describe('Document Service clone relation operation payloads', () => {
         populate: { tag: true },
       });
 
-      const originalProduct = await findProductWithTag(product.documentId);
+      const originalProduct = await findProductWithTags(product.documentId);
 
       expect({
-        cloneTagDocumentId: tagDocumentId(result.entries[0] as ProductWithTag),
-        originalTagDocumentId: tagDocumentId(originalProduct as ProductWithTag),
+        cloneTagDocumentId: relationDocumentId(result.entries[0] as ProductWithTags, 'tag'),
+        originalTagDocumentId: relationDocumentId(originalProduct as ProductWithTags, 'tag'),
       }).toEqual({
         cloneTagDocumentId: null,
         originalTagDocumentId: tag.documentId,
@@ -153,14 +182,53 @@ describe('Document Service clone relation operation payloads', () => {
         populate: { tag: true },
       });
 
-      const originalProduct = await findProductWithTag(product.documentId);
+      const originalProduct = await findProductWithTags(product.documentId);
 
       expect({
-        cloneTagDocumentId: tagDocumentId(result.entries[0] as ProductWithTag),
-        originalTagDocumentId: tagDocumentId(originalProduct as ProductWithTag),
+        cloneTagDocumentId: relationDocumentId(result.entries[0] as ProductWithTags, 'tag'),
+        originalTagDocumentId: relationDocumentId(originalProduct as ProductWithTags, 'tag'),
       }).toEqual({
         cloneTagDocumentId: selectedTag.documentId,
         originalTagDocumentId: originalTag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone preserves useJoinTable:false relation data when submitted operations are not transformable',
+    async () => {
+      const { product, tag } = await createLegacyTaggedProduct(
+        'Legacy Source Product',
+        'Legacy Original Tag'
+      );
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        locale: 'en',
+        data: {
+          name: 'Legacy Clone',
+          legacyTag: {
+            connect: [],
+            disconnect: [{ documentId: tag.documentId }],
+          },
+        },
+        populate: { legacyTag: true },
+      });
+
+      const originalProduct = await findProductWithTags(product.documentId);
+
+      expect({
+        cloneLegacyTagDocumentId: relationDocumentId(
+          result.entries[0] as ProductWithTags,
+          'legacyTag'
+        ),
+        originalLegacyTagDocumentId: relationDocumentId(
+          originalProduct as ProductWithTags,
+          'legacyTag'
+        ),
+      }).toEqual({
+        cloneLegacyTagDocumentId: tag.documentId,
+        originalLegacyTagDocumentId: tag.documentId,
       });
     }
   );

--- a/tests/api/core/strapi/document-service/relations/clone-relation-operations.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/clone-relation-operations.test.api.ts
@@ -1,0 +1,167 @@
+/**
+ * Clone must treat user-submitted relation operation payloads as replacements for the
+ * original entry's populated relation data.
+ */
+import type { Core, UID } from '@strapi/types';
+
+import { testInTransaction } from '../../../../utils';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+
+let strapi: Core.Strapi;
+const builder = createTestBuilder();
+
+const PRODUCT_UID = 'api::product.product' as UID.ContentType;
+const TAG_UID = 'api::tag.tag' as UID.ContentType;
+
+type ProductWithTag = {
+  tag?: {
+    documentId?: string;
+  } | null;
+};
+
+const productModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    tag: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: TAG_UID,
+      targetAttribute: 'product',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  draftAndPublish: true,
+  displayName: 'Product',
+  singularName: 'product',
+  pluralName: 'products',
+  description: '',
+  collectionName: '',
+};
+
+const tagModel = {
+  attributes: {
+    name: { type: 'string' },
+  },
+  draftAndPublish: true,
+  displayName: 'Tag',
+  singularName: 'tag',
+  pluralName: 'tags',
+  description: '',
+  collectionName: '',
+};
+
+const createTag = (name: string) => strapi.documents(TAG_UID).create({ data: { name } });
+
+const tagDocumentId = (product?: ProductWithTag) => product?.tag?.documentId ?? null;
+
+const createTaggedProduct = async (productName: string, tagName: string) => {
+  const tag = await createTag(tagName);
+
+  const product = await strapi.documents(PRODUCT_UID).create({
+    locale: 'en',
+    data: {
+      name: productName,
+      tag: { documentId: tag.documentId },
+    },
+    populate: { tag: true },
+  });
+
+  expect((product as ProductWithTag).tag).toMatchObject({ documentId: tag.documentId });
+
+  return { product, tag };
+};
+
+const findProductWithTag = (documentId: string) =>
+  strapi.documents(PRODUCT_UID).findOne({
+    documentId,
+    locale: 'en',
+    populate: { tag: true },
+  });
+
+describe('Document Service clone relation operation payloads', () => {
+  beforeAll(async () => {
+    await builder.addContentTypes([tagModel, productModel]).build();
+
+    strapi = await createStrapiInstance();
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  testInTransaction(
+    'clone applies duplicate-form disconnect for a top-level oneToOne relation',
+    async () => {
+      const { product, tag } = await createTaggedProduct(
+        'CMS-557 Source Product',
+        'CMS-557 Original Tag'
+      );
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        locale: 'en',
+        data: {
+          name: 'CMS-557 Clone without tag',
+          tag: {
+            connect: [],
+            disconnect: [{ documentId: tag.documentId }],
+          },
+        },
+        populate: { tag: true },
+      });
+
+      const originalProduct = await findProductWithTag(product.documentId);
+
+      expect({
+        cloneTagDocumentId: tagDocumentId(result.entries[0] as ProductWithTag),
+        originalTagDocumentId: tagDocumentId(originalProduct as ProductWithTag),
+      }).toEqual({
+        cloneTagDocumentId: null,
+        originalTagDocumentId: tag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone applies duplicate-form selected target for a top-level oneToOne relation',
+    async () => {
+      const { product, tag: originalTag } = await createTaggedProduct(
+        'CMS-562 Source Product',
+        'CMS-562 Original Tag'
+      );
+      const selectedTag = await createTag('CMS-562 Selected Tag');
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        locale: 'en',
+        data: {
+          name: 'CMS-562 Clone with selected tag',
+          tag: {
+            connect: [{ documentId: selectedTag.documentId }],
+            disconnect: [{ documentId: originalTag.documentId }],
+          },
+        },
+        populate: { tag: true },
+      });
+
+      const originalProduct = await findProductWithTag(product.documentId);
+
+      expect({
+        cloneTagDocumentId: tagDocumentId(result.entries[0] as ProductWithTag),
+        originalTagDocumentId: tagDocumentId(originalProduct as ProductWithTag),
+      }).toEqual({
+        cloneTagDocumentId: selectedTag.documentId,
+        originalTagDocumentId: originalTag.documentId,
+      });
+    }
+  );
+});

--- a/tests/api/core/strapi/document-service/relations/clone-relation-operations.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/clone-relation-operations.test.api.ts
@@ -195,6 +195,144 @@ describe('Document Service clone relation operation payloads', () => {
   );
 
   testInTransaction(
+    'clone preserves a top-level oneToOne relation for empty duplicate-form operations',
+    async () => {
+      const { product, tag } = await createTaggedProduct(
+        'Empty Operations Source Product',
+        'Empty Operations Original Tag'
+      );
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        locale: 'en',
+        data: {
+          name: 'Empty Operations Clone',
+          tag: {
+            connect: [],
+            disconnect: [],
+          },
+        },
+        populate: { tag: true },
+      });
+
+      const originalProduct = await findProductWithTags(product.documentId);
+
+      expect({
+        cloneTagDocumentId: relationDocumentId(result.entries[0] as ProductWithTags, 'tag'),
+        originalTagDocumentId: relationDocumentId(originalProduct as ProductWithTags, 'tag'),
+      }).toEqual({
+        cloneTagDocumentId: tag.documentId,
+        originalTagDocumentId: tag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone preserves an omitted top-level oneToOne relation when changing scalar data',
+    async () => {
+      const { product, tag } = await createTaggedProduct(
+        'Omitted Relation Source Product',
+        'Omitted Relation Original Tag'
+      );
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        locale: 'en',
+        data: {
+          name: 'Omitted Relation Clone',
+        },
+        populate: { tag: true },
+      });
+
+      const originalProduct = await findProductWithTags(product.documentId);
+
+      expect({
+        cloneTagDocumentId: relationDocumentId(result.entries[0] as ProductWithTags, 'tag'),
+        originalTagDocumentId: relationDocumentId(originalProduct as ProductWithTags, 'tag'),
+      }).toEqual({
+        cloneTagDocumentId: tag.documentId,
+        originalTagDocumentId: tag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone returns the draft with an unchanged oneToOne relation when status is published',
+    async () => {
+      const { product, tag } = await createTaggedProduct(
+        'Published Status Source Product',
+        'Published Status Original Tag'
+      );
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        locale: 'en',
+        status: 'published',
+        data: {
+          name: 'Published Status Clone',
+        },
+        populate: { tag: true },
+      });
+
+      const clonedProduct = result.entries[0] as ProductWithTags | null;
+      const persistedDraft = result.documentId
+        ? await strapi.documents(PRODUCT_UID).findOne({
+            documentId: result.documentId,
+            locale: 'en',
+            status: 'draft',
+            populate: { tag: true },
+          })
+        : undefined;
+      const originalProduct = await findProductWithTags(product.documentId);
+
+      expect({
+        cloneDocumentId: result.documentId ?? null,
+        cloneTagDocumentId: relationDocumentId(clonedProduct ?? undefined, 'tag'),
+        persistedDraftTagDocumentId: relationDocumentId(persistedDraft as ProductWithTags, 'tag'),
+        originalTagDocumentId: relationDocumentId(originalProduct as ProductWithTags, 'tag'),
+      }).toEqual({
+        cloneDocumentId: expect.any(String),
+        cloneTagDocumentId: tag.documentId,
+        persistedDraftTagDocumentId: tag.documentId,
+        originalTagDocumentId: tag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
+    'clone applies set for a top-level oneToOne relation without changing the original',
+    async () => {
+      const { product, tag: originalTag } = await createTaggedProduct(
+        'Set Operation Source Product',
+        'Set Operation Original Tag'
+      );
+      const selectedTag = await createTag('Set Operation Selected Tag');
+
+      const result = await strapi.documents(PRODUCT_UID).clone({
+        documentId: product.documentId,
+        locale: 'en',
+        data: {
+          name: 'Set Operation Clone',
+          tag: {
+            set: [{ documentId: selectedTag.documentId }],
+          },
+        },
+        populate: { tag: true },
+      });
+
+      const originalProduct = await findProductWithTags(product.documentId);
+
+      expect({
+        cloneTagDocumentId: relationDocumentId(result.entries[0] as ProductWithTags, 'tag'),
+        originalTagDocumentId: relationDocumentId(originalProduct as ProductWithTags, 'tag'),
+      }).toEqual({
+        cloneTagDocumentId: selectedTag.documentId,
+        originalTagDocumentId: originalTag.documentId,
+      });
+    }
+  );
+
+  testInTransaction(
     'clone preserves useJoinTable:false relation data when submitted operations are not transformable',
     async () => {
       const { product, tag } = await createLegacyTaggedProduct(


### PR DESCRIPTION
### What does it do?

Fixes Document Service clone data merging so relation edits submitted from the duplicate form override stale populated relation data from the source entry.

This applies to:

- top-level relations;
- relations inside single and repeatable components;
- relations inside dynamic-zone blocks;
- meaningful `connect`, `disconnect`, and `set` operations.

Empty relation operations preserve the source relation on the clone, and cloning does not change the original entry's relation.

### Why is it needed?

Previously, populated relation data from the source entry could survive the clone merge and override duplicate-form edits. A clone could therefore retain the original target after the relation was removed or changed.

For bidirectional one-to-one relations, normal relation attachment could also move the relation from the original entry to the clone. The clone now receives the submitted relation state while the original entry keeps its relation.

### How to test it?

- Automated:
  - `yarn test:api tests/api/core/strapi/document-service/relations/clone-relation-operations.test.api.ts`
  - `yarn test:api tests/api/core/strapi/document-service/relations/clone-nested-relation-operations.test.api.ts`
  - `yarn test:api tests/api/core/strapi/document-service/clone.test.api.ts`
- Manual validation:
  1. Create a source entry related to Target A through a bidirectional one-to-one relation.
  2. Duplicate it, remove the relation, and save. Confirm the clone has no relation and the original still points to Target A.
  3. Duplicate it again, change the relation from Target A to Target B, and save. Confirm the clone points to Target B and the original still points to Target A.
  4. Repeat the target-change scenario for a relation inside a component, repeatable component, and dynamic-zone block.

### Related issue(s)/PR(s)

fixes #23680
fixes #25749
