### PR TITLE
ci(strapi): guard admin singleton deps and design-system bundle

### DIFF
--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
@@ -5,6 +5,7 @@ import {
   ADMIN_PINNED_ALIAS_MODULES,
   ADMIN_VITE_ALIAS_MODULES,
   ADMIN_VITE_DEDUPE_MODULES,
+  ADMIN_VITE_SINGLETON_MODULES,
 } from '../admin-vite-alias-modules';
 import { buildAdminViteResolveAliases } from '../admin-vite-aliases';
 import { getModulePath } from '../resolve-module';
@@ -20,8 +21,16 @@ describe('buildAdminViteResolveAliases', () => {
     }
   });
 
-  it('uses the same module list for aliases and vite resolve.dedupe', () => {
-    expect(ADMIN_VITE_DEDUPE_MODULES).toBe(ADMIN_VITE_ALIAS_MODULES);
+  it('includes all alias modules in vite resolve.dedupe', () => {
+    expect(ADMIN_VITE_DEDUPE_MODULES).toEqual(
+      expect.arrayContaining([...ADMIN_VITE_ALIAS_MODULES])
+    );
+  });
+
+  it('includes singleton modules in vite resolve.dedupe', () => {
+    expect(ADMIN_VITE_DEDUPE_MODULES).toEqual(
+      expect.arrayContaining([...ADMIN_VITE_SINGLETON_MODULES])
+    );
   });
 
   it.each(ADMIN_PINNED_ALIAS_MODULES)(

--- a/packages/core/strapi/src/node/core/__tests__/design-system-bundle-contract.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/design-system-bundle-contract.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import {
+  DESIGN_SYSTEM_BUNDLE_DIST_FILES,
+  DESIGN_SYSTEM_BUNDLE_MUST_BE_EXTERNAL,
+  DESIGN_SYSTEM_BUNDLE_MUST_NOT_CONTAIN,
+} from '../design-system-bundle-contract';
+import { getModulePath } from '../resolve-module';
+
+const externalImportPattern = (pkg: string) =>
+  new RegExp(`(?:from|require\\()\\s*["']${pkg.replace('/', '\\/')}["']`);
+
+/**
+ * Regression guard for strapi/strapi #26951 — installed design-system must not
+ * inline singleton deps that break CodeMirror in production admin builds.
+ */
+describe('@strapi/design-system published bundle contract', () => {
+  const packageRoot = getModulePath('@strapi/design-system');
+
+  describe.each(DESIGN_SYSTEM_BUNDLE_DIST_FILES)('%s', (relPath) => {
+    const content = readFileSync(resolve(packageRoot, relPath), 'utf-8');
+
+    it.each(DESIGN_SYSTEM_BUNDLE_MUST_NOT_CONTAIN)(
+      'does not inline forbidden marker: %s',
+      (marker) => {
+        expect(content).not.toContain(marker);
+      }
+    );
+
+    it.each(DESIGN_SYSTEM_BUNDLE_MUST_BE_EXTERNAL)('imports %s externally', (pkg) => {
+      expect(content).toMatch(externalImportPattern(pkg));
+    });
+  });
+});

--- a/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
@@ -4,6 +4,8 @@
  *
  * @internal
  */
+import { ADMIN_VITE_SINGLETON_MODULES } from './admin-vite-singleton-modules';
+
 export const ADMIN_VITE_ALIAS_MODULES = [
   'react',
   'react-dom',
@@ -18,8 +20,13 @@ export const ADMIN_VITE_ALIAS_MODULES = [
 
 export type AdminViteAliasModule = (typeof ADMIN_VITE_ALIAS_MODULES)[number];
 
-/** Same modules passed to Vite resolve.dedupe */
-export const ADMIN_VITE_DEDUPE_MODULES = ADMIN_VITE_ALIAS_MODULES;
+/** Alias modules plus singleton deps that must not be duplicated in the admin graph */
+export const ADMIN_VITE_DEDUPE_MODULES = [
+  ...ADMIN_VITE_ALIAS_MODULES,
+  ...ADMIN_VITE_SINGLETON_MODULES,
+] as const;
+
+export { ADMIN_VITE_SINGLETON_MODULES };
 
 /**
  * Alias modules with exact versions declared in @strapi/admin dependencies (not peers).

--- a/packages/core/strapi/src/node/core/admin-vite-singleton-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-singleton-modules.ts
@@ -1,0 +1,12 @@
+/**
+ * Singleton modules that must resolve to a single instance in the admin Vite graph.
+ * Extends {@link ADMIN_VITE_ALIAS_MODULES} with packages that break when duplicated
+ * (CodeMirror, etc.) — see strapi/strapi#26951.
+ */
+export const ADMIN_VITE_SINGLETON_MODULES = [
+  '@codemirror/state',
+  '@codemirror/view',
+  '@uiw/react-codemirror',
+] as const;
+
+export type AdminViteSingletonModule = (typeof ADMIN_VITE_SINGLETON_MODULES)[number];

--- a/packages/core/strapi/src/node/core/design-system-bundle-contract.ts
+++ b/packages/core/strapi/src/node/core/design-system-bundle-contract.ts
@@ -1,0 +1,17 @@
+/**
+ * Consumer-side contract for the published @strapi/design-system bundle.
+ * Mirrors design-system bundle-contract.config.json — update both when extending.
+ *
+ * @internal
+ */
+export const DESIGN_SYSTEM_BUNDLE_MUST_BE_EXTERNAL = [
+  '@codemirror/state',
+  '@codemirror/view',
+  '@tanstack/react-virtual',
+] as const;
+
+export const DESIGN_SYSTEM_BUNDLE_MUST_NOT_CONTAIN = [
+  'Unrecognized extension value in extension set',
+] as const;
+
+export const DESIGN_SYSTEM_BUNDLE_DIST_FILES = ['dist/index.mjs', 'dist/index.js'] as const;

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -1,7 +1,10 @@
 import type { InlineConfig, UserConfig } from 'vite';
 
 import { getUserConfig } from '../core/config';
-import { ADMIN_VITE_DEDUPE_MODULES } from '../core/admin-vite-alias-modules';
+import {
+  ADMIN_VITE_DEDUPE_MODULES,
+  ADMIN_VITE_SINGLETON_MODULES,
+} from '../core/admin-vite-alias-modules';
 import { buildAdminViteResolveAliases } from '../core/admin-vite-aliases';
 import { isDesignSystemLinked } from '../core/linked-packages';
 import { loadStrapiMonorepo } from '../core/monorepo';
@@ -64,6 +67,8 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
         // Pre-bundle prismjs so plugin chunks get a valid ESM namespace (prismjs is UMD and can
         // otherwise expose an empty object when bundled, causing "Prism is not defined" in admin).
         'prismjs',
+        // CodeMirror singletons — design-system JSONInput must share one @codemirror/state instance.
+        ...ADMIN_VITE_SINGLETON_MODULES,
         /**
          * Pre-bundle other dependencies that would otherwise cause a page reload when imported.
          * See "performance" section: https://vite.dev/guide/dep-pre-bundling.html#the-why

--- a/tests/e2e/tests/content-manager/edit-view/json-input-edit-view.spec.ts
+++ b/tests/e2e/tests/content-manager/edit-view/json-input-edit-view.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+import { login } from '../../../../utils/login';
+import { resetDatabaseAndImportDataFromPath } from '../../../../utils/dts-import';
+import { navToHeader } from '../../../../utils/shared';
+
+const CODEMIRROR_DUPLICATE_RE = /multiple instances of @codemirror\/state/i;
+
+test.describe('JSON field edit view', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetDatabaseAndImportDataFromPath('with-admin');
+    await page.goto('/admin');
+    await login({ page });
+  });
+
+  test('editing a JSON field does not crash with duplicate CodeMirror instances', async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await navToHeader(page, ['Content Manager', 'Complex Content'], 'Complex Content');
+    await page.getByRole('link', { name: 'Create new entry' }).click();
+    await page.waitForURL(/api::complex\.complex\/create/);
+
+    const editor = page.locator('.cm-editor .cm-content').first();
+    await expect(editor).toBeVisible();
+    await editor.click();
+    await editor.pressSequentially('{\n  "hello": "world"\n}');
+
+    await expect(page.getByText('Unrecognized extension value')).not.toBeVisible();
+    expect(consoleErrors.join('\n')).not.toMatch(CODEMIRROR_DUPLICATE_RE);
+  });
+});


### PR DESCRIPTION
## Summary

* Extends admin Vite `resolve.dedupe` and `optimizeDeps.include` with CodeMirror singleton modules (`@codemirror/state`, `@codemirror/view`, `@uiw/react-codemirror`) — belt-and-suspenders alongside the design-system bundle fix.
* Adds a **consumer-side unit test** that audits the installed `@strapi/design-system` dist for inlined singleton markers and missing external imports (mirrors design-system `bundle-contract.config.json`).
* Adds an **e2e smoke test** that opens the Complex Content JSON field edit view and asserts no CodeMirror duplicate-instance console errors.

## Why is it needed?

strapi/strapi#26951 — admin crashes when `@strapi/design-system` inlines `@codemirror/state`. Strapi-side dedupe and a dist audit catch regressions even when the bug originates upstream; the e2e test guards the JSON field UX path.

## How to test it?

```bash
yarn workspace @strapi/strapi test:unit --testPathPattern="admin-vite-aliases|design-system-bundle-contract"
yarn test:e2e --domains content-manager -- tests/e2e/tests/content-manager/edit-view/json-input-edit-view.spec.ts
```

## Merge order

**Draft — unit test is expected to fail until** `@strapi/design-system` **is bumped** to a release that includes strapi/design-system#2034 (externalized CodeMirror / react-virtual in dist).

Suggested sequence:

1. Merge & release design-system fix ([#2034](<https://github.com/strapi/strapi/issues/2034>))
2. Bump `@strapi/design-system` in this monorepo
3. Mark this PR ready and merge

## Related issue(s)/PR(s)

* strapi/strapi#26951
* strapi/design-system#2034
* [strapi/design-system#2032](<https://github.com/strapi/design-system/issues/2032>)