### PR TITLE
fix(ci): use npm install in issue template checker workflow

### DIFF
--- a/.github/workflows/template-check-on-new-issue.yaml
+++ b/.github/workflows/template-check-on-new-issue.yaml
@@ -20,7 +20,7 @@ jobs:
           node-version: 24
 
       - name: Install scripts
-        run: cd .github/scripts && npm ci --ignore-scripts
+        run: cd .github/scripts && npm install --ignore-scripts
 
       - name: Check issue uses template
         run: node --experimental-strip-types .github/scripts/issue-template-check-action.ts


### PR DESCRIPTION
## Summary
Hotfix for #26955 — `template-check-on-new-issue.yaml` used `npm ci` but `.github/scripts/package-lock.json` is gitignored, so the workflow failed on every new issue (including TEST issues #26971–#26973).

## Test plan
- [x] Merge and re-run failed template-check workflow runs
- [x] Confirm valid TEST issues stay open without `flag: invalid template`