### PR TITLE
fix(users-permissions): use correct translation ID for role edit and add missing created ID

### DIFF
--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.jsx
@@ -66,7 +66,7 @@ export const EditPage = () => {
       toggleNotification({
         type: 'success',
         message: formatMessage({
-          id: getTrad('Settings.roles.created'),
+          id: getTrad('Settings.roles.edited'),
           defaultMessage: 'Role edited',
         }),
       });

--- a/packages/plugins/users-permissions/admin/src/translations/en.json
+++ b/packages/plugins/users-permissions/admin/src/translations/en.json
@@ -58,6 +58,7 @@
   "Providers.status": "Status",
   "Roles.empty": "You don't have any roles yet.",
   "Roles.empty.search": "No roles match the search.",
+  "Settings.roles.created": "Role created",
   "Settings.roles.deleted": "Role deleted",
   "Settings.roles.edited": "Role edited",
   "Settings.section-label": "Users & Permissions plugin",


### PR DESCRIPTION
Fixes #26917

- Uses the correct `Settings.roles.edited` translation ID in `EditPage.jsx`.
- Adds the missing `Settings.roles.created` key to `en.json` so it can be translated in `CreatePage.jsx`.

---
Fixes CPR-446