### PR TITLE
feat(database): add postgres reader/writer endpoint splitting

### DIFF
--- a/packages/core/admin/server/src/register.ts
+++ b/packages/core/admin/server/src/register.ts
@@ -16,6 +16,20 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
   strapi.get('auth').register('admin', adminTokenAuthStrategy);
   strapi.get('auth').register('content-api', contentApiTokenAuthStrategy);
 
+  // Auth-sensitive models: their reads must always hit the writer so a revoked
+  // credential/permission isn't evaluated from a lagging read replica (incl.
+  // on `auth: false` routes like login/refresh that bypass the auth phase).
+  strapi.db.routing.registerWriterModels([
+    'admin::user',
+    'admin::role',
+    'admin::permission',
+    'admin::api-token',
+    'admin::api-token-permission',
+    'admin::transfer-token',
+    'admin::transfer-token-permission',
+    'admin::session',
+  ]);
+
   strapi.add('ai.admin', () => createAiAdminService({ strapi }));
 
   const shouldServeAdminPanel = strapi.config.get('admin.serveAdminPanel');

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -281,7 +281,7 @@ class Strapi extends Container implements Core.Strapi {
     this.add('config', () => config)
       .add('query-params', createQueryParamService(this))
       .add('content-api', createContentAPI(this))
-      .add('auth', createAuth())
+      .add('auth', () => createAuth(this))
       .add('server', () => createServer(this))
       .add('fs', () => createStrapiFs(this))
       .add('eventHub', () => createEventHub())

--- a/packages/core/core/src/services/auth/index.ts
+++ b/packages/core/core/src/services/auth/index.ts
@@ -42,7 +42,7 @@ const validStrategy = (strategy: Strategy) => {
   }
 };
 
-const createAuthentication = (): Authentication => {
+const createAuthentication = (strapi: Core.Strapi): Authentication => {
   const strategies: Record<string, Strategy[]> = {};
 
   return {
@@ -97,7 +97,10 @@ const createAuthentication = (): Authentication => {
       );
 
       for (const strategy of strategiesToUse) {
-        const result = await strategy.authenticate(ctx);
+        // Pin the whole authentication phase to the writer so auth/RBAC reads
+        // are never served stale from a lagging replica. Inert when no read
+        // replica is configured.
+        const result = await strapi.db.routing.withWriterOnly(() => strategy.authenticate(ctx));
 
         const { authenticated = false, credentials, ability = null, error = null } = result || {};
 

--- a/packages/core/core/src/services/server/index.ts
+++ b/packages/core/core/src/services/server/index.ts
@@ -21,7 +21,16 @@ const createServer = (strapi: Core.Strapi): Modules.Server.Server => {
     keys: strapi.config.get('server.app.keys'),
   });
 
-  app.use((ctx, next) => requestCtx.run(ctx, () => next()));
+  // Establish the request context and, nested within it, the DB read/write
+  // routing scope so reads in this request may be served by a read replica
+  // until the first write pins the rest of the request to the writer. The
+  // routing scope is only opened when a read replica is configured, so the
+  // default (single-connection) setup is unchanged.
+  app.use((ctx, next) =>
+    requestCtx.run(ctx, () =>
+      strapi.db.readConnection ? strapi.db.routing.run(() => next()) : next()
+    )
+  );
 
   const router = new Router();
 

--- a/packages/core/database/src/__tests__/connection.test.ts
+++ b/packages/core/database/src/__tests__/connection.test.ts
@@ -1,0 +1,133 @@
+import { buildReaderConfig, createReadReplicaConnection } from '../connection';
+import type { ConnectionConfig } from '../connection';
+
+const writerConfig: ConnectionConfig = {
+  client: 'postgres',
+  connection: {
+    host: 'writer.example.com',
+    port: 5432,
+    database: 'strapi',
+    user: 'strapi',
+    password: 'secret',
+    ssl: false,
+  },
+  pool: { min: 2, max: 10 },
+};
+
+describe('buildReaderConfig', () => {
+  it('returns undefined when no readReplica is configured', () => {
+    expect(buildReaderConfig(writerConfig)).toBeUndefined();
+  });
+
+  it('inherits client, credentials and pool from the writer', () => {
+    const reader = buildReaderConfig({
+      ...writerConfig,
+      readReplica: { connection: { host: 'reader.example.com' } },
+    });
+
+    expect(reader).toBeDefined();
+    expect(reader!.client).toBe('postgres');
+    expect(reader!.pool).toEqual({ min: 2, max: 10 });
+    expect(reader!.connection).toMatchObject({
+      host: 'reader.example.com', // overridden
+      port: 5432, // inherited
+      database: 'strapi', // inherited
+      user: 'strapi', // inherited
+      password: 'secret', // inherited
+      ssl: false, // inherited
+    });
+  });
+
+  it('does not mutate the original writer connection', () => {
+    const config: ConnectionConfig = {
+      ...writerConfig,
+      connection: { ...(writerConfig.connection as object) },
+      readReplica: { connection: { host: 'reader.example.com' } },
+    };
+    buildReaderConfig(config);
+    expect((config.connection as any).host).toBe('writer.example.com');
+  });
+
+  it('lets the replica override pool settings', () => {
+    const reader = buildReaderConfig({
+      ...writerConfig,
+      readReplica: {
+        connection: { host: 'reader.example.com' },
+        pool: { min: 5, max: 30 },
+      },
+    });
+    expect(reader!.pool).toEqual({ min: 5, max: 30 });
+  });
+
+  it('does not leak the readReplica key into the reader config', () => {
+    const reader = buildReaderConfig({
+      ...writerConfig,
+      readReplica: { connection: { host: 'reader.example.com' } },
+    });
+    expect(reader).not.toHaveProperty('readReplica');
+  });
+
+  it('throws when the writer uses a connection string but the replica override is a partial object', () => {
+    expect(() =>
+      buildReaderConfig({
+        client: 'postgres',
+        connection: 'postgres://u:p@writer.example.com:5432/strapi',
+        readReplica: { connection: { host: 'reader.example.com' } },
+      })
+    ).toThrow(/connection string/i);
+  });
+
+  it('allows a full connection-string replica when the writer uses a connection string', () => {
+    const reader = buildReaderConfig({
+      client: 'postgres',
+      connection: 'postgres://u:p@writer.example.com:5432/strapi',
+      readReplica: { connection: 'postgres://u:p@reader.example.com:5432/strapi' },
+    });
+    expect(reader!.connection).toBe('postgres://u:p@reader.example.com:5432/strapi');
+  });
+
+  it('lets the replica override credentials (separate reader user)', () => {
+    const reader = buildReaderConfig({
+      ...writerConfig,
+      readReplica: {
+        connection: { host: 'reader.example.com', user: 'readonly', password: 'ro-secret' },
+      },
+    });
+    expect(reader!.connection).toMatchObject({
+      host: 'reader.example.com',
+      user: 'readonly',
+      password: 'ro-secret',
+      database: 'strapi',
+    });
+  });
+});
+
+describe('createReadReplicaConnection', () => {
+  it('returns undefined when no readReplica is configured', () => {
+    expect(createReadReplicaConnection(writerConfig)).toBeUndefined();
+  });
+
+  it('throws for the sqlite client, which has no reader endpoint', () => {
+    expect(() =>
+      createReadReplicaConnection({
+        client: 'sqlite',
+        connection: { filename: 'writer.db' },
+        readReplica: { connection: { filename: 'reader.db' } },
+      })
+    ).toThrow(/sqlite/i);
+  });
+
+  it('creates a knex instance pointed at the reader host', () => {
+    const reader = createReadReplicaConnection({
+      ...writerConfig,
+      readReplica: { connection: { host: 'reader.example.com' } },
+    });
+
+    expect(reader).toBeDefined();
+    expect(reader!.client.connectionSettings.host).toBe('reader.example.com');
+    // sanity: the writer host is not used
+    expect(reader!.client.connectionSettings.host).not.toBe('writer.example.com');
+
+    return reader!.destroy();
+  });
+});

--- a/packages/core/database/src/__tests__/index.test.ts
+++ b/packages/core/database/src/__tests__/index.test.ts
@@ -37,6 +37,7 @@ jest.mock('../connection', () => ({
 
     return db;
   }),
+  createReadReplicaConnection: jest.fn(() => undefined),
 }));
 
 jest.mock('../dialects', () => ({

--- a/packages/core/database/src/__tests__/routing-context.test.ts
+++ b/packages/core/database/src/__tests__/routing-context.test.ts
@@ -1,0 +1,124 @@
+import { routingCtx } from '../routing-context';
+
+describe('routingCtx (request-scoped read/write routing)', () => {
+  describe('outside a scope', () => {
+    it('reports no scope', () => {
+      expect(routingCtx.hasScope()).toBe(false);
+    });
+
+    it('is not dirty', () => {
+      expect(routingCtx.isDirty()).toBe(false);
+    });
+
+    it('does not allow replica reads (safe default: writer)', () => {
+      expect(routingCtx.shouldUseReplica()).toBe(false);
+    });
+
+    it('markDirty outside a scope is a no-op and does not throw', () => {
+      expect(() => routingCtx.markDirty()).not.toThrow();
+      expect(routingCtx.isDirty()).toBe(false);
+    });
+  });
+
+  describe('inside a fresh scope', () => {
+    it('reports a scope', async () => {
+      await routingCtx.run(() => {
+        expect(routingCtx.hasScope()).toBe(true);
+      });
+    });
+
+    it('starts clean and allows replica reads', async () => {
+      await routingCtx.run(() => {
+        expect(routingCtx.isDirty()).toBe(false);
+        expect(routingCtx.shouldUseReplica()).toBe(true);
+      });
+    });
+
+    it('becomes dirty after markDirty and then routes reads to writer', async () => {
+      await routingCtx.run(() => {
+        expect(routingCtx.shouldUseReplica()).toBe(true);
+        routingCtx.markDirty();
+        expect(routingCtx.isDirty()).toBe(true);
+        expect(routingCtx.shouldUseReplica()).toBe(false);
+      });
+    });
+
+    it('returns the callback result', async () => {
+      const result = await routingCtx.run(() => 'value');
+      expect(result).toBe('value');
+    });
+  });
+
+  describe('withWriterOnly', () => {
+    it('forces reads to the writer within the callback', async () => {
+      await routingCtx.run(async () => {
+        expect(routingCtx.shouldUseReplica()).toBe(true);
+        await routingCtx.withWriterOnly(() => {
+          expect(routingCtx.isWriterOnly()).toBe(true);
+          expect(routingCtx.shouldUseReplica()).toBe(false);
+        });
+        // restored after the callback
+        expect(routingCtx.isWriterOnly()).toBe(false);
+        expect(routingCtx.shouldUseReplica()).toBe(true);
+      });
+    });
+
+    it('returns the callback result', async () => {
+      await routingCtx.run(async () => {
+        const result = await routingCtx.withWriterOnly(() => 'value');
+        expect(result).toBe('value');
+      });
+    });
+
+    it('is inert (still runs the callback) when there is no scope', async () => {
+      expect(routingCtx.isWriterOnly()).toBe(false);
+      const result = await routingCtx.withWriterOnly(() => 'ok');
+      expect(result).toBe('ok');
+      expect(routingCtx.isWriterOnly()).toBe(false);
+    });
+
+    it('restores the previous writer-only state even if the callback throws', async () => {
+      await routingCtx.run(async () => {
+        await expect(
+          routingCtx.withWriterOnly(() => {
+            throw new Error('boom');
+          })
+        ).rejects.toThrow('boom');
+        expect(routingCtx.isWriterOnly()).toBe(false);
+      });
+    });
+  });
+
+  describe('scope isolation', () => {
+    it('a fresh scope resets to clean even after a previous scope was dirtied', async () => {
+      await routingCtx.run(() => {
+        routingCtx.markDirty();
+        expect(routingCtx.isDirty()).toBe(true);
+      });
+
+      await routingCtx.run(() => {
+        expect(routingCtx.isDirty()).toBe(false);
+        expect(routingCtx.shouldUseReplica()).toBe(true);
+      });
+    });
+
+    it('dirtiness does not leak back outside the scope', async () => {
+      await routingCtx.run(() => {
+        routingCtx.markDirty();
+      });
+      expect(routingCtx.isDirty()).toBe(false);
+      expect(routingCtx.hasScope()).toBe(false);
+    });
+
+    it('nested run inherits the outer dirty state', async () => {
+      await routingCtx.run(async () => {
+        routingCtx.markDirty();
+        await routingCtx.run(() => {
+          // a nested scope must not "clean" an already-dirty ancestor,
+          // otherwise a read-after-write could escape to the replica
+          expect(routingCtx.isDirty()).toBe(true);
+        });
+      });
+    });
+  });
+});

--- a/packages/core/database/src/__tests__/routing.test.ts
+++ b/packages/core/database/src/__tests__/routing.test.ts
@@ -1,0 +1,197 @@
+import { Database, DatabaseConfig } from '../index';
+import { routingCtx } from '../routing-context';
+import { transactionCtx } from '../transaction-context';
+
+const makeFakeKnex = (tag: string) =>
+  ({
+    tag,
+    client: { connectionSettings: {} },
+    destroy: jest.fn(async () => undefined),
+    raw: jest.fn(async () => undefined),
+    transaction: jest.fn(async () => ({
+      commit: jest.fn(),
+      rollback: jest.fn(),
+      isCompleted: () => false,
+    })),
+  }) as any;
+
+const mockWriter = makeFakeKnex('writer');
+const mockReader = makeFakeKnex('reader');
+
+jest.mock('../connection', () => ({
+  createConnection: jest.fn(() => mockWriter),
+  createReadReplicaConnection: jest.fn((cfg: any) => (cfg?.readReplica ? mockReader : undefined)),
+}));
+
+jest.mock('../dialects', () => ({
+  getDialect: jest.fn(() => ({
+    configure: jest.fn(),
+    initialize: jest.fn(),
+    useReturning: () => false,
+  })),
+}));
+
+jest.mock('../migrations', () => ({
+  createMigrationsProvider: jest.fn(),
+}));
+
+const baseConnection = {
+  client: 'postgres' as const,
+  connection: {
+    host: 'writer.example.com',
+    port: 5432,
+    database: 'strapi',
+    user: 'strapi',
+    password: 'secret',
+  },
+};
+
+const withReplicaConfig: DatabaseConfig = {
+  connection: {
+    ...baseConnection,
+    readReplica: { connection: { host: 'reader.example.com' } },
+  },
+  settings: { migrations: { dir: 'migrations' } },
+};
+
+const noReplicaConfig: DatabaseConfig = {
+  connection: { ...baseConnection },
+  settings: { migrations: { dir: 'migrations' } },
+};
+
+describe('Database read/write routing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  describe('writer-model registry', () => {
+    it('registers models and reports them', () => {
+      const db = new Database(withReplicaConfig);
+      db.routing.registerWriterModels(['admin::user', 'admin::session']);
+      expect(db.isWriterModel('admin::user')).toBe(true);
+      expect(db.isWriterModel('admin::session')).toBe(true);
+      expect(db.isWriterModel('api::article.article')).toBe(false);
+    });
+  });
+
+  describe('readConnection wiring', () => {
+    it('creates a read connection when a replica is configured', () => {
+      const db = new Database(withReplicaConfig);
+      expect(db.readConnection).toBe(mockReader);
+    });
+
+    it('has no read connection when no replica is configured', () => {
+      const db = new Database(noReplicaConfig);
+      expect(db.readConnection).toBeUndefined();
+    });
+
+    it('destroys both connections on destroy', async () => {
+      const db = new Database(withReplicaConfig);
+      await db.destroy();
+      expect(mockWriter.destroy).toHaveBeenCalledTimes(1);
+      expect(mockReader.destroy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getConnection pool selection', () => {
+    let db: Database;
+
+    beforeEach(() => {
+      db = new Database(withReplicaConfig);
+    });
+
+    it('defaults to the writer (no intent given)', () => {
+      expect(db.getConnection()).toBe(mockWriter);
+    });
+
+    it('routes writes to the writer even inside a clean scope', async () => {
+      await routingCtx.run(() => {
+        expect(db.getConnection(undefined, { intent: 'write' })).toBe(mockWriter);
+      });
+    });
+
+    it('routes reads to the writer when there is no scope (safe default)', () => {
+      expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockWriter);
+    });
+
+    it('routes reads to the reader inside a clean scope', async () => {
+      await routingCtx.run(() => {
+        expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockReader);
+      });
+    });
+
+    it('routes reads to the writer once the scope is dirty', async () => {
+      await routingCtx.run(() => {
+        routingCtx.markDirty();
+        expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockWriter);
+      });
+    });
+
+    it('honours a forced writer even for a read in a clean scope', async () => {
+      await routingCtx.run(() => {
+        expect(db.getConnection(undefined, { intent: 'read', writer: true })).toBe(mockWriter);
+      });
+    });
+
+    it('honours a forced replica even for a read outside a scope', () => {
+      expect(db.getConnection(undefined, { intent: 'read', replica: true })).toBe(mockReader);
+    });
+
+    it('honours a forced replica even in a dirty scope', async () => {
+      await routingCtx.run(() => {
+        routingCtx.markDirty();
+        expect(db.getConnection(undefined, { intent: 'read', replica: true })).toBe(mockReader);
+      });
+    });
+
+    it('always uses the writer inside a transaction, even for a forced replica read', async () => {
+      await transactionCtx.run({} as any, async () => {
+        await routingCtx.run(() => {
+          expect(db.getConnection(undefined, { intent: 'read', replica: true })).toBe(mockWriter);
+        });
+      });
+    });
+
+    it('marks the routing scope dirty when a transaction runs (post-commit reads use the writer)', async () => {
+      await routingCtx.run(async () => {
+        // clean scope reads the replica
+        expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockReader);
+        await db.transaction(async () => 'done');
+        // a transaction implies a write -> scope is now dirty -> writer
+        expect(routingCtx.isDirty()).toBe(true);
+        expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockWriter);
+      });
+    });
+
+    it('exposes a routing scope (db.routing.run) that enables replica reads', async () => {
+      await db.routing.run(() => {
+        expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockReader);
+      });
+      // scope closed again -> back to writer
+      expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockWriter);
+    });
+
+    it('routes reads to the writer inside a withWriterOnly scope', async () => {
+      await db.routing.run(async () => {
+        expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockReader);
+        await db.routing.withWriterOnly(() => {
+          expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockWriter);
+          // writer-only wins even over a forced replica
+          expect(db.getConnection(undefined, { intent: 'read', replica: true })).toBe(mockWriter);
+        });
+        expect(db.getConnection(undefined, { intent: 'read' })).toBe(mockReader);
+      });
+    });
+
+    it('never routes to a reader when no replica is configured', async () => {
+      const dbNoReplica = new Database(noReplicaConfig);
+      await routingCtx.run(() => {
+        expect(dbNoReplica.getConnection(undefined, { intent: 'read', replica: true })).toBe(
+          mockWriter
+        );
+      });
+    });
+  });
+});

--- a/packages/core/database/src/connection.ts
+++ b/packages/core/database/src/connection.ts
@@ -1,5 +1,6 @@
 import knex from 'knex';
 import type { Knex } from 'knex';
+import { merge } from 'lodash/fp';
 
 const clientMap = {
   sqlite: 'better-sqlite3',
@@ -7,16 +8,78 @@ const clientMap = {
   postgres: 'pg',
 };
 
-function isClientValid(config: { client?: unknown }): config is { client: keyof typeof clientMap } {
+/**
+ * Optional read-replica (reader endpoint) configuration. Anything omitted here
+ * is inherited from the writer connection, so a typical Aurora setup only needs
+ * to override `connection.host`.
+ */
+export interface ReadReplicaConfig {
+  connection?: Knex.Config['connection'];
+  pool?: Knex.Config['pool'];
+}
+
+/**
+ * A Knex config extended with an optional `readReplica`. `readReplica` is a
+ * Strapi-owned field and must never be passed to Knex itself.
+ */
+export type ConnectionConfig = Knex.Config & { readReplica?: ReadReplicaConfig };
+
+function isClientValid<T extends { client?: unknown }>(
+  config: T
+): config is T & { client: keyof typeof clientMap } {
   return Object.keys(clientMap).includes(config.client as string);
 }
 
-export const createConnection = (userConfig: Knex.Config, strapiConfig?: Partial<Knex.Config>) => {
+/**
+ * Derive the reader Knex config from a user connection config by inheriting the
+ * writer config and applying the `readReplica` overrides. Returns `undefined`
+ * when no replica is configured. The `readReplica` key is stripped from the
+ * result so it never reaches Knex.
+ */
+export const buildReaderConfig = (userConfig: ConnectionConfig): Knex.Config | undefined => {
+  const { readReplica, ...writer } = userConfig;
+
+  if (!readReplica) {
+    return undefined;
+  }
+
+  // A partial object override cannot inherit the writer's embedded credentials
+  // when the writer connection is a connection string (or function), because
+  // there is nothing to deep-merge into. Require a complete reader connection
+  // instead of silently building one that has lost user/password/database.
+  if (
+    readReplica.connection &&
+    typeof readReplica.connection === 'object' &&
+    writer.connection &&
+    typeof writer.connection !== 'object'
+  ) {
+    throw new Error(
+      'database: `connection.readReplica.connection` must be a full connection string when the writer `connection` is a connection string or function; a partial object cannot inherit its credentials.'
+    );
+  }
+
+  // The reader inherits the writer config and applies the `readReplica`
+  // overrides (typically just `connection.host`). `merge` (immutable) deep-merges
+  // so credentials/pool/ssl are inherited while matching keys are overridden;
+  // `readReplica` is already stripped above so it never reaches Knex.
+  return merge(writer, readReplica) as Knex.Config;
+};
+
+export const createConnection = (
+  userConfig: ConnectionConfig,
+  strapiConfig?: Partial<Knex.Config>
+) => {
   if (!isClientValid(userConfig)) {
     throw new Error(`Unsupported database client ${userConfig.client}`);
   }
 
-  const knexConfig: Knex.Config = { ...userConfig, client: (clientMap as any)[userConfig.client] };
+  // `readReplica` is Strapi-owned and must not be forwarded to Knex.
+  const { readReplica, ...connectionConfig } = userConfig;
+
+  const knexConfig: Knex.Config = {
+    ...connectionConfig,
+    client: clientMap[userConfig.client as keyof typeof clientMap],
+  };
 
   // initialization code to run upon opening a new connection
   if (strapiConfig?.pool?.afterCreate) {
@@ -41,4 +104,30 @@ export const createConnection = (userConfig: Knex.Config, strapiConfig?: Partial
   }
 
   return knex(knexConfig);
+};
+
+/**
+ * Build the read-replica Knex connection, reusing the same `strapiConfig`
+ * (notably `pool.afterCreate`) as the writer so the reader pool runs the same
+ * per-connection dialect initialization (pg type parsers, `search_path`).
+ * Returns `undefined` when no replica is configured.
+ */
+export const createReadReplicaConnection = (
+  userConfig: ConnectionConfig,
+  strapiConfig?: Partial<Knex.Config>
+) => {
+  const readerConfig = buildReaderConfig(userConfig);
+
+  if (!readerConfig) {
+    return undefined;
+  }
+
+  // A reader endpoint only makes sense for client/server databases. sqlite is a
+  // local file with no replica, so a second pool would be meaningless.
+  if (userConfig.client === 'sqlite') {
+    throw new Error('database: `readReplica` is not supported for the sqlite client.');
+  }
+
+  // `readerConfig` already carries the writer's `client` (inherited via merge).
+  return createConnection(readerConfig, strapiConfig);
 };

--- a/packages/core/database/src/entity-manager/__tests__/em-routing.test.ts
+++ b/packages/core/database/src/entity-manager/__tests__/em-routing.test.ts
@@ -1,0 +1,91 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+
+import { Database, DatabaseConfig } from '../../index';
+import type { Model } from '../../types';
+
+const model: Model = {
+  uid: 'api::article.article',
+  singularName: 'article',
+  tableName: 'articles',
+  attributes: {
+    id: { type: 'integer' },
+    title: { type: 'string' },
+  },
+};
+
+// Execution tests need an on-disk SQLite file (a literal ':memory:' filename
+// leaves a stray file in cwd once real queries run). Keep it in the OS temp dir
+// and remove it after each test so nothing leaks into the repo.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strapi-em-routing-'));
+
+const configFor = (filename: string): DatabaseConfig => ({
+  connection: {
+    client: 'sqlite',
+    connection: { filename },
+    useNullAsDefault: true,
+  },
+  settings: { migrations: { dir: 'migrations' } },
+});
+
+describe('repository forwards routing overrides', () => {
+  let db: Database;
+  let dbFile: string;
+  let counter = 0;
+
+  beforeEach(async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    counter += 1;
+    dbFile = path.join(tmpDir, `${process.pid}-${counter}.sqlite`);
+    db = new Database(configFor(dbFile));
+    await db.init({ models: [model] });
+
+    const exists = await db.connection.schema.hasTable('articles');
+    if (!exists) {
+      await db.connection.schema.createTable('articles', (t) => {
+        t.increments('id');
+        t.string('title');
+      });
+    }
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+    fs.rmSync(dbFile, { force: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const optionsForArticles = () => {
+    const spy = jest.spyOn(db, 'getConnection');
+    return () => {
+      const call = spy.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('articles')
+      );
+      spy.mockRestore();
+      return (call?.[1] ?? {}) as { replica?: boolean; writer?: boolean };
+    };
+  };
+
+  it('findMany forwards replica:true', async () => {
+    const read = optionsForArticles();
+    await db.query(model.uid).findMany({ replica: true });
+    expect(read().replica).toBe(true);
+  });
+
+  it('count forwards replica:true', async () => {
+    const read = optionsForArticles();
+    await db.query(model.uid).count({ replica: true });
+    expect(read().replica).toBe(true);
+  });
+
+  it('findMany forwards writer:true', async () => {
+    const read = optionsForArticles();
+    await db.query(model.uid).findMany({ writer: true });
+    expect(read().writer).toBe(true);
+  });
+});

--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -317,7 +317,7 @@ export const createEntityManager = (db: Database): EntityManager => {
       const states = await db.lifecycles.run('beforeCount', uid, { params });
 
       const res = await this.createQueryBuilder(uid)
-        .init(pick(['_q', 'where', 'filters'], params))
+        .init(pick(['_q', 'where', 'filters', 'writer', 'replica'], params))
         .count()
         .first()
         .execute<{ count: number }>();

--- a/packages/core/database/src/entity-manager/types.ts
+++ b/packages/core/database/src/entity-manager/types.ts
@@ -17,9 +17,14 @@ export type Params = {
   limit?: number;
   offset?: number;
   count?: boolean;
+  writer?: boolean;
+  replica?: boolean;
 };
 
-export type FindOneParams = Pick<Params, 'where' | 'select' | 'populate' | '_q' | 'orderBy'>;
+export type FindOneParams = Pick<
+  Params,
+  'where' | 'select' | 'populate' | '_q' | 'orderBy' | 'writer' | 'replica'
+>;
 
 export interface Repository {
   findOne(params?: FindOneParams): Promise<any>;

--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -9,9 +9,10 @@ import { createEntityManager, EntityManager } from './entity-manager';
 import { createMigrationsProvider, MigrationProvider, type Migration } from './migrations';
 import { createLifecyclesProvider, LifecycleProvider } from './lifecycles';
 import type { Event } from './lifecycles';
-import { createConnection } from './connection';
+import { createConnection, createReadReplicaConnection, type ConnectionConfig } from './connection';
 import * as errors from './errors';
 import { Callback, transactionCtx, TransactionObject } from './transaction-context';
+import { routingCtx } from './routing-context';
 import { validateDatabase } from './validations';
 import type { Model, JoinTable } from './types';
 import type { Identifiers } from './utils/identifiers';
@@ -34,9 +35,26 @@ export type Logger = Record<
 >;
 
 export interface DatabaseConfig {
-  connection: Knex.Config;
+  connection: ConnectionConfig;
   settings: Settings;
   logger?: Logger;
+}
+
+/**
+ * Intent of a query, used to decide whether it may be served by a read replica.
+ * `read` queries (SELECT/count/…) are replica-eligible; `write` queries are not.
+ */
+export type QueryIntent = 'read' | 'write';
+
+/**
+ * Per-query routing controls. `writer`/`replica` are explicit escape hatches
+ * that override automatic routing (`replica` is still ignored inside a
+ * transaction, where the writer must always be used).
+ */
+export interface RoutingOptions {
+  intent?: QueryIntent;
+  writer?: boolean;
+  replica?: boolean;
 }
 
 const afterCreate =
@@ -53,6 +71,10 @@ const afterCreate =
 
 class Database {
   connection: Knex;
+
+  // Optional read-replica (reader endpoint) connection. Undefined unless a
+  // `readReplica` is configured. Reads may be routed here to offload the writer.
+  readConnection?: Knex;
 
   dialect: Dialect;
 
@@ -72,6 +94,21 @@ class Database {
 
   logger: Logger;
 
+  // Request-scoped read/write routing. Consumers wrap a unit of work in
+  // `db.routing.run(cb)` (safe replica reads), `db.routing.withWriterOnly(cb)`
+  // (pin a phase such as authentication to the writer), or declare
+  // auth-sensitive models once with `db.routing.registerWriterModels([...])`.
+  // The dirty-tracking primitives stay module-internal so external code can't
+  // silently defeat read-after-write safety.
+  routing: {
+    run: typeof routingCtx.run;
+    withWriterOnly: typeof routingCtx.withWriterOnly;
+    registerWriterModels: (uids: string[]) => void;
+  };
+
+  // UIDs whose reads must always use the writer (auth-sensitive models).
+  private writerModels = new Set<string>();
+
   constructor(config: DatabaseConfig) {
     this.config = {
       ...config,
@@ -83,6 +120,12 @@ class Database {
     };
 
     this.logger = config.logger ?? console;
+
+    this.routing = {
+      run: routingCtx.run,
+      withWriterOnly: routingCtx.withWriterOnly,
+      registerWriterModels: (uids: string[]) => this.registerWriterModels(uids),
+    };
 
     this.dialect = getDialect(this);
 
@@ -112,6 +155,12 @@ class Database {
     this.metadata = createMetadata([]);
 
     this.connection = createConnection(knexConfig, {
+      pool: { afterCreate: afterCreate(this) },
+    });
+
+    // Reuse the same afterCreate wiring so the reader pool runs the same
+    // per-connection dialect initialization (pg type parsers, search_path).
+    this.readConnection = createReadReplicaConnection(this.config.connection, {
       pool: { afterCreate: afterCreate(this) },
     });
 
@@ -147,6 +196,12 @@ class Database {
       }
     }
 
+    // Fail fast if a configured read replica is unreachable at startup.
+    if (this.readConnection) {
+      this.logger.debug('Verifying connection to the read replica');
+      await this.readConnection.raw('SELECT 1');
+    }
+
     this.metadata.loadModels(models);
     await validateDatabase(this);
     return this;
@@ -176,6 +231,11 @@ class Database {
   async transaction<TCallback extends Callback>(
     cb?: TCallback
   ): Promise<ReturnType<TCallback> | TransactionObject> {
+    // A transaction implies a write, so pin the rest of this routing scope to
+    // the writer even if the body only issues raw statements that bypass the
+    // query-builder's own markDirty. Reads after commit stay consistent.
+    routingCtx.markDirty();
+
     const notNestedTransaction = !transactionCtx.get();
     const trx = notNestedTransaction
       ? await this.connection.transaction()
@@ -220,11 +280,59 @@ class Database {
     return this.connection.client.connectionSettings.schema;
   }
 
+  /**
+   * Decide whether a query may be served by the read replica. The writer is
+   * always used unless every condition for safe replica reads holds: a replica
+   * is configured, we are not inside a transaction, the caller has not forced
+   * the writer, and either the caller forced the replica or this is a `read`
+   * in a clean routing scope (no write has happened yet in this scope).
+   */
+  private shouldRouteToReplica(options?: RoutingOptions): boolean {
+    if (!this.readConnection) {
+      return false;
+    }
+    // Transactions must always run against the writer (read-your-writes).
+    if (transactionCtx.get()) {
+      return false;
+    }
+    // A writer-only phase (e.g. authentication) wins over every other signal,
+    // including a forced replica read.
+    if (routingCtx.isWriterOnly()) {
+      return false;
+    }
+    if (options?.writer) {
+      return false;
+    }
+    if (options?.replica) {
+      return true;
+    }
+    if (options?.intent !== 'read') {
+      return false;
+    }
+    return routingCtx.shouldUseReplica();
+  }
+
+  /**
+   * Declare UIDs whose reads must always be served by the writer (auth-sensitive
+   * models such as users, tokens, sessions, permissions). Registered at
+   * bootstrap by core and plugins; inert when no read replica is configured.
+   */
+  registerWriterModels(uids: string[]) {
+    uids.forEach((uid) => this.writerModels.add(uid));
+  }
+
+  isWriterModel(uid: string): boolean {
+    return this.writerModels.has(uid);
+  }
+
   getConnection(): Knex;
-  getConnection(tableName?: string): Knex.QueryBuilder;
-  getConnection(tableName?: string): Knex | Knex.QueryBuilder {
+  getConnection(tableName?: string, options?: RoutingOptions): Knex.QueryBuilder;
+  getConnection(tableName?: string, options?: RoutingOptions): Knex | Knex.QueryBuilder {
+    const knexConnection = this.shouldRouteToReplica(options)
+      ? (this.readConnection as Knex)
+      : this.connection;
     const schema = this.getSchemaName();
-    const connection = tableName ? this.connection(tableName) : this.connection;
+    const connection = tableName ? knexConnection(tableName) : knexConnection;
     return schema ? connection.withSchema(schema) : connection;
   }
 
@@ -267,7 +375,14 @@ class Database {
 
   async destroy() {
     await this.lifecycles.clear();
-    await this.connection.destroy();
+    // Ensure the reader pool is torn down even if destroying the writer throws.
+    try {
+      await this.connection.destroy();
+    } finally {
+      if (this.readConnection) {
+        await this.readConnection.destroy();
+      }
+    }
   }
 }
 

--- a/packages/core/database/src/query/__tests__/query-routing.test.ts
+++ b/packages/core/database/src/query/__tests__/query-routing.test.ts
@@ -1,0 +1,143 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+
+import { Database, DatabaseConfig } from '../../index';
+import { routingCtx } from '../../routing-context';
+import createQueryBuilder from '../query-builder';
+import type { Model } from '../../types';
+
+const model: Model = {
+  uid: 'api::article.article',
+  singularName: 'article',
+  tableName: 'articles',
+  attributes: {
+    id: { type: 'integer' },
+    title: { type: 'string' },
+  },
+};
+
+// Execution tests need an on-disk SQLite file (a literal ':memory:' filename
+// leaves a stray file in cwd once real queries run). Keep it in the OS temp dir
+// and remove it after each test so nothing leaks into the repo.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strapi-db-routing-'));
+
+const configFor = (filename: string): DatabaseConfig => ({
+  connection: {
+    client: 'sqlite',
+    connection: { filename },
+    useNullAsDefault: true,
+  },
+  settings: { migrations: { dir: 'migrations' } },
+});
+
+describe('query-builder read/write routing', () => {
+  let db: Database;
+  let dbFile: string;
+  let counter = 0;
+
+  beforeEach(async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    counter += 1;
+    dbFile = path.join(tmpDir, `${process.pid}-${counter}.sqlite`);
+    db = new Database(configFor(dbFile));
+    await db.init({ models: [model] });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+    fs.rmSync(dbFile, { force: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const intentFor = (build: (qb: ReturnType<typeof createQueryBuilder>) => void) => {
+    const spy = jest.spyOn(db, 'getConnection');
+    const qb = createQueryBuilder(model.uid, db);
+    build(qb);
+    qb.getKnexQuery();
+    // the table-bound getConnection call carries the routing options
+    const call = spy.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('articles'));
+    spy.mockRestore();
+    return (call?.[1] ?? {}) as { intent?: string; writer?: boolean; replica?: boolean };
+  };
+
+  describe('intent derivation', () => {
+    it('marks a select as a read', () => {
+      expect(intentFor((qb) => qb.select('*')).intent).toBe('read');
+    });
+
+    it('marks a count as a read', () => {
+      expect(intentFor((qb) => qb.count()).intent).toBe('read');
+    });
+
+    it('marks an insert as a write', () => {
+      expect(intentFor((qb) => qb.insert({ title: 'x' })).intent).toBe('write');
+    });
+
+    it('marks an update as a write', () => {
+      expect(intentFor((qb) => qb.update({ title: 'x' })).intent).toBe('write');
+    });
+
+    it('marks a delete as a write', () => {
+      expect(intentFor((qb) => qb.delete()).intent).toBe('write');
+    });
+
+    it('marks a locking select (forUpdate) as a write', () => {
+      expect(intentFor((qb) => qb.select('*').forUpdate()).intent).toBe('write');
+    });
+  });
+
+  describe('writer-model registry', () => {
+    it('forces writer intent for a read on a registered writer-model', () => {
+      db.registerWriterModels([model.uid]);
+      const opts = intentFor((qb) => qb.select('*'));
+      expect(opts.intent).toBe('write');
+      expect(opts.writer).toBe(true);
+    });
+
+    it('leaves reads on unregistered models as reads', () => {
+      expect(intentFor((qb) => qb.select('*')).intent).toBe('read');
+    });
+  });
+
+  describe('per-query overrides', () => {
+    it('threads writer:true from init params', () => {
+      expect(intentFor((qb) => qb.init({ writer: true })).writer).toBe(true);
+    });
+
+    it('threads replica:true from init params', () => {
+      expect(intentFor((qb) => qb.init({ replica: true })).replica).toBe(true);
+    });
+  });
+
+  describe('write stickiness', () => {
+    beforeEach(async () => {
+      const exists = await db.connection.schema.hasTable('articles');
+      if (!exists) {
+        await db.connection.schema.createTable('articles', (t) => {
+          t.increments('id');
+          t.string('title');
+        });
+      }
+    });
+
+    it('marks the routing scope dirty after a write executes', async () => {
+      await routingCtx.run(async () => {
+        expect(routingCtx.isDirty()).toBe(false);
+        await createQueryBuilder(model.uid, db).insert({ title: 'hello' }).execute();
+        expect(routingCtx.isDirty()).toBe(true);
+      });
+    });
+
+    it('does not mark the scope dirty after a read executes', async () => {
+      await routingCtx.run(async () => {
+        await createQueryBuilder(model.uid, db).select('*').execute();
+        expect(routingCtx.isDirty()).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/core/database/src/query/__tests__/status-sort-distinct.test.ts
+++ b/packages/core/database/src/query/__tests__/status-sort-distinct.test.ts
@@ -51,6 +51,9 @@ const buildDb = ({ uid = UID, tableName = 'articles', i18n = false }: BuildDbOpt
     getConnection(tableNameArg?: string) {
       return tableNameArg ? connection(tableNameArg) : connection;
     },
+    isWriterModel() {
+      return false;
+    },
     metadata: {
       get(metaUid: string) {
         if (metaUid === uid) {

--- a/packages/core/database/src/query/helpers/order-by.ts
+++ b/packages/core/database/src/query/helpers/order-by.ts
@@ -188,7 +188,10 @@ export const wrapWithDeepSort = (originalQuery: knex.Knex.QueryBuilder, ctx: Ord
   const resultQueryAlias = qb.getAlias();
   const aliasedTableName = qb.mustUseAlias() ? alias(resultQueryAlias, tableName) : tableName;
 
-  const resultQuery = db.getConnection(aliasedTableName);
+  // Route the deep-sort wrapper with the same read/write intent as the query it
+  // wraps, so a replica-eligible read isn't forced onto the writer by this
+  // secondary connection.
+  const resultQuery = db.getConnection(aliasedTableName, qb.getRoutingOptions());
 
   // 1. Clone the original query to create the sub-query (referenced as baseQuery) and avoid any mutation on the initial object
   const baseQuery = originalQuery.clone();

--- a/packages/core/database/src/query/query-builder.ts
+++ b/packages/core/database/src/query/query-builder.ts
@@ -1,10 +1,11 @@
 import type { Knex } from 'knex';
 import _ from 'lodash/fp';
 
-import type { Database } from '..';
+import type { Database, RoutingOptions } from '..';
 
 import { DatabaseError } from '../errors';
 import { transactionCtx } from '../transaction-context';
+import { routingCtx } from '../routing-context';
 import { isKnexQuery } from '../utils/knex';
 import * as helpers from './helpers';
 import type { Join } from './helpers/join';
@@ -24,6 +25,8 @@ interface State {
   offset: number | null;
   transaction: any;
   forUpdate: boolean;
+  writer: boolean;
+  replica: boolean;
   onConflict: any;
   merge: any;
   ignore: boolean;
@@ -92,6 +95,8 @@ export interface QueryBuilder {
 
   forUpdate(): QueryBuilder;
 
+  getRoutingOptions(): RoutingOptions;
+
   init(params?: any): QueryBuilder;
 
   filters(filters: any): void;
@@ -118,7 +123,7 @@ export interface QueryBuilder {
 
   processSelect(): void;
 
-  getKnexQuery(): Knex.QueryBuilder;
+  getKnexQuery(routing?: RoutingOptions): Knex.QueryBuilder;
 
   execute<T>(options?: { mapResults?: boolean }): Promise<T>;
 
@@ -148,6 +153,8 @@ const createQueryBuilder = (
       offset: null,
       transaction: null,
       forUpdate: false,
+      writer: false,
+      replica: false,
       onConflict: null,
       merge: null,
       ignore: false,
@@ -313,6 +320,28 @@ const createQueryBuilder = (
       return this;
     },
 
+    /**
+     * Routing options derived from the query state. Reads (select/count/max)
+     * are replica-eligible; writes and locking reads (`forUpdate`) go to the
+     * writer. Explicit `writer`/`replica` flags are forwarded as escape hatches.
+     */
+    getRoutingOptions(): RoutingOptions {
+      // Auth-sensitive models are always served by the writer, regardless of
+      // query type or per-query overrides.
+      if (db.isWriterModel(uid)) {
+        return { intent: 'write', writer: true, replica: false };
+      }
+
+      const isRead =
+        (state.type === 'select' || state.type === 'count' || state.type === 'max') &&
+        !state.forUpdate;
+      return {
+        intent: isRead ? 'read' : 'write',
+        writer: state.writer,
+        replica: state.replica,
+      };
+    },
+
     init(params = {}) {
       const {
         _q: searchQuery,
@@ -324,7 +353,12 @@ const createQueryBuilder = (
         orderBy,
         groupBy,
         populate,
+        writer,
+        replica,
       } = params;
+
+      state.writer = !!writer;
+      state.replica = !!replica;
 
       if (!_.isNil(where)) {
         this.where(where);
@@ -571,14 +605,15 @@ const createQueryBuilder = (
       }
     },
 
-    getKnexQuery() {
+    getKnexQuery(routing?: RoutingOptions) {
       if (!state.type) {
         this.select('*');
       }
 
+      const routingOptions = routing ?? this.getRoutingOptions();
       const aliasedTableName = this.mustUseAlias() ? `${tableName} as ${this.alias}` : tableName;
 
-      const qb = db.getConnection(aliasedTableName);
+      const qb = db.getConnection(aliasedTableName, routingOptions);
 
       // The state should always be processed before calling shouldUseSubQuery as it
       // relies on the presence or absence of joins to determine the need of a subquery
@@ -722,10 +757,23 @@ const createQueryBuilder = (
 
     async execute({ mapResults = true } = {}) {
       try {
-        const qb = this.getKnexQuery();
+        const routing = this.getRoutingOptions();
+
+        // A write pins the rest of this routing scope to the writer so a
+        // subsequent read-after-write cannot be served stale by the replica.
+        if (routing.intent === 'write') {
+          routingCtx.markDirty();
+        }
+
+        const qb = this.getKnexQuery(routing);
 
         const transaction = transactionCtx.get();
         if (transaction) {
+          if (state.replica) {
+            db.logger.warn(
+              'A query requested the read replica inside a transaction; using the writer instead.'
+            );
+          }
           qb.transacting(transaction);
         }
 

--- a/packages/core/database/src/routing-context.ts
+++ b/packages/core/database/src/routing-context.ts
@@ -1,0 +1,96 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Request-scoped read/write routing state.
+ *
+ * When a read replica is configured, reads may be served by the replica to
+ * offload the writer. Replicas lag the writer, so a read issued after a write
+ * in the same logical unit of work (e.g. an HTTP request) could observe stale
+ * data. To preserve read-after-write consistency we track, per async scope,
+ * whether a write has occurred ("dirty"). Once dirty, subsequent reads in that
+ * scope are routed to the writer.
+ *
+ * Outside any scope (bootstrap, migrations, lifecycles, cron, CLI) there is no
+ * store, `shouldUseReplica()` returns false, and everything is routed to the
+ * writer — the safe default.
+ */
+interface RoutingStore {
+  dirty: boolean;
+  // When set, reads in this scope are forced to the writer regardless of
+  // dirty state or per-query overrides. Used to pin whole phases (e.g. the auth
+  // phase) to strong consistency.
+  writerOnly: boolean;
+}
+
+const storage = new AsyncLocalStorage<RoutingStore>();
+
+const routingCtx = {
+  /**
+   * Run `cb` inside a fresh routing scope. A nested run inherits the parent's
+   * dirty state *at creation time*, so a read-after-write already recorded on
+   * the parent cannot escape to the replica through a nested async context.
+   * (The snapshot does not propagate later parent/child changes across scopes;
+   * scopes are not nested in current usage — see server request middleware.)
+   */
+  run<T>(cb: () => T): T {
+    const parent = storage.getStore();
+    const store: RoutingStore = {
+      dirty: parent?.dirty ?? false,
+      writerOnly: parent?.writerOnly ?? false,
+    };
+    return storage.run(store, cb);
+  },
+
+  /** Mark the current scope as having performed a write. No-op outside a scope. */
+  markDirty() {
+    const store = storage.getStore();
+    if (store) {
+      store.dirty = true;
+    }
+  },
+
+  /**
+   * Run `cb` with reads forced to the writer for the current scope, restoring
+   * the previous state afterwards. Outside a scope it simply runs `cb` (reads
+   * already default to the writer without a scope).
+   */
+  async withWriterOnly<T>(cb: () => T | Promise<T>): Promise<T> {
+    const store = storage.getStore();
+    if (!store) {
+      return cb();
+    }
+    const previous = store.writerOnly;
+    store.writerOnly = true;
+    try {
+      return await cb();
+    } finally {
+      store.writerOnly = previous;
+    }
+  },
+
+  /** Whether the current scope is pinned to the writer. */
+  isWriterOnly() {
+    return storage.getStore()?.writerOnly ?? false;
+  },
+
+  /** Whether a write has occurred in the current scope. */
+  isDirty() {
+    return storage.getStore()?.dirty ?? false;
+  },
+
+  /** Whether we are currently inside a routing scope. */
+  hasScope() {
+    return storage.getStore() !== undefined;
+  },
+
+  /**
+   * Whether reads in the current scope may be served by the replica: only when
+   * a scope exists and no write has occurred in it yet.
+   */
+  shouldUseReplica() {
+    const store = storage.getStore();
+    return store !== undefined && !store.dirty && !store.writerOnly;
+  },
+};
+
+export { routingCtx };

--- a/packages/plugins/users-permissions/server/register.js
+++ b/packages/plugins/users-permissions/server/register.js
@@ -10,6 +10,15 @@ module.exports = ({ strapi }) => {
   strapi.get('auth').register('content-api', authStrategy);
   strapi.sanitizers.add('content-api.output', sanitizers.defaultSanitizeOutput);
 
+  // Auth-sensitive models: reads must always hit the writer so a blocked user or
+  // revoked permission isn't evaluated from a lagging read replica (incl. on
+  // `auth: false` routes like login that bypass the auth phase).
+  strapi.db.routing.registerWriterModels([
+    'plugin::users-permissions.user',
+    'plugin::users-permissions.role',
+    'plugin::users-permissions.permission',
+  ]);
+
   if (strapi.plugin('graphql')) {
     require('./graphql')({ strapi });
   }


### PR DESCRIPTION
### What does it do?

Adds optional **read/write splitting** to `@strapi/database` so deployments on a primary/replica topology (notably **Amazon Aurora** for PostgreSQL and MySQL) can offload reads to a reader endpoint while writes stay on the primary.

- **Config (backward compatible):** the existing `connection` block stays the writer. An optional `connection.readReplica` enables splitting and inherits the writer config, overriding only what differs (usually the host). No `readReplica` → identical behavior to today (single connection).
- **Automatic routing:** reads (`select`/`count`/`max`) go to the replica only inside a clean request scope; writes, transactions, `forUpdate` locking reads, and any read-after-write in the same request use the writer. Outside a request scope (bootstrap, migrations, lifecycles, cron, CLI) everything uses the writer — the safe default.
- **Request scope:** an `AsyncLocalStorage` routing context, opened by the HTTP server middleware only when a replica is configured.
- **Per-query escape hatches:** `strapi.db.query(uid).findMany({ writer: true })` / `{ replica: true }`.
- **Read-after-write safety:** the first write in a request (including any `db.transaction()`) pins the rest of the request to the writer, so a read can't observe stale data from a lagging replica.
- **Security:** auth/RBAC/token/session/user reads are pinned to the writer to avoid a stale-authorization window after a revoke (admin auth, API/transfer tokens, sessions, users-permissions).
- **Guards:** fail-fast if the replica is unreachable at startup; `readReplica` on `sqlite` is rejected; the deep-sort query wrapper honors routing.

### Why is it needed?

On Aurora (and similar primary/replica setups) the reader and writer are separate endpoints. Strapi currently opens a single connection and sends all traffic to one endpoint, so read traffic can't be offloaded to replicas.

### How to test it?

Unit tests cover the routing matrix, config merge, request-scoped write stickiness, and the auth-read pinning:

```bash
yarn test:unit packages/core/database
yarn test:unit packages/core/admin/server/src/services packages/core/core/src/services
```

Manual (Aurora / Postgres primary+replica): set `connection.readReplica.connection.host` to the reader endpoint, confirm SELECTs hit the reader and writes/transactions/read-after-write hit the writer.

> **Note:** local verification covered unit tests, typecheck, lint and prettier. A real Postgres/Aurora integration test (e.g. under `tests/api` behind a reader env var) and the e2e suite are **not** included yet — opened as a **draft** pending those and maintainer review, given the auth-critical surface touched.

### Related issue(s)/PR(s)

_N/A — please link if there is a tracking issue._
