### PR TITLE
docs(admin): document codemirror5 npm alias and supply-chain workaround

### DIFF
--- a/docs/docs/docs/01-core/admin/06-codemirror-dependency-alias.md
+++ b/docs/docs/docs/01-core/admin/06-codemirror-dependency-alias.md
@@ -1,0 +1,81 @@
+---
+title: CodeMirror dependency alias
+tags:
+  - admin
+  - content-manager
+  - dependencies
+---
+
+# The `codemirror5` dependency alias
+
+`@strapi/admin` and `@strapi/content-manager` both declare CodeMirror 5 through an
+[npm package alias](https://docs.npmjs.com/cli/v10/commands/npm-install#description) in their
+runtime `dependencies`:
+
+```json
+{
+  "dependencies": {
+    "codemirror5": "npm:codemirror@^5.65.11"
+  }
+}
+```
+
+This installs the real package `codemirror@5` but exposes it under the name `codemirror5`, so the
+code imports it explicitly:
+
+```ts
+import CodeMirror from 'codemirror5';
+import 'codemirror5/addon/display/placeholder';
+```
+
+## Why the alias exists
+
+Two **major versions of CodeMirror coexist** in the dependency tree, and the alias is what keeps
+them isolated:
+
+| Version          | Consumer                                                        | How it is pulled in                                       |
+| ---------------- | --------------------------------------------------------------- | --------------------------------------------------------- |
+| CodeMirror **5** | The legacy Markdown WYSIWYG editor in `@strapi/content-manager` | Direct dependency, via the `codemirror5` alias            |
+| CodeMirror **6** | `@strapi/design-system`'s code/JSON editor                      | Transitive, via `@uiw/react-codemirror` → `codemirror@^6` |
+
+Both are published under the same package name (`codemirror`) at incompatible majors. Declaring a
+plain `"codemirror": "^5"` dependency would compete with the hoisted transitive `codemirror@^6`, and
+the WYSIWYG could resolve to the CodeMirror 6 API at build time (a breaking change). The alias pins
+CodeMirror 5 deterministically for the admin bundle, independent of hoisting.
+
+## Known incompatibility: alias-unaware supply-chain scanners
+
+Some enterprise supply-chain tools do not understand npm aliases and treat `codemirror5` as if it
+were a real published package. For example, JFrog Curation (`jf ca`) requests a non-existent tarball
+and fails with a 404:
+
+```text
+[🚨Error] failed sending HEAD request to
+https://<artifactory>/artifactory/api/npm/<repo>/codemirror5/-/codemirror5-5.65.21.tgz
+for package 'codemirror5:5.65.21'. Status-code: 404
+```
+
+The alias itself is valid npm syntax and installs correctly (`npm ls codemirror5` resolves to
+`codemirror@5.65.x`). The failure is in the scanner's resolution of the alias name, not in the
+dependency graph. See [#26865](https://github.com/strapi/strapi/issues/26865).
+
+### Workarounds
+
+`npm`/`yarn` `overrides`/`resolutions` do **not** help — the scanner reads the alias _name_
+(`codemirror5`) before resolution, so pinning the underlying version changes nothing.
+
+Configure the scanner to skip the aliased name instead. The underlying package remains fully
+auditable under its real name, `codemirror@5.65.x`.
+
+- **JFrog Curation** — add a policy exclusion (waiver) for the component named `codemirror5` in the
+  Curation policy that governs the repository. Match by component name rather than version, because
+  no `codemirror5` tarball is ever resolved.
+- **Other alias-unaware scanners** — exclude or ignore the `codemirror5` component by name, or point
+  the audit at the resolved package `codemirror@5.65.x`.
+
+## Removing the alias
+
+The alias can only be dropped once the legacy Markdown WYSIWYG editor no longer depends on
+CodeMirror 5 — for example by migrating it to the CodeMirror 6 stack already present in the tree
+(`@uiw/react-codemirror`). Until then the alias is load-bearing and must remain in
+`dependencies`.


### PR DESCRIPTION
### What does it do?

Adds a contributor-docs page documenting the `codemirror5` npm alias and its supply-chain-scanner incompatibility.

- **New file:** `docs/docs/docs/01-core/admin/06-codemirror-dependency-alias.md`
- **Explains the alias:** `@strapi/admin` and `@strapi/content-manager` declare `"codemirror5": "npm:codemirror@^5.65.11"` in their published runtime `dependencies`, and import it as `import CodeMirror from 'codemirror5'`.
- **Explains why it exists:** CodeMirror **5** powers the legacy Markdown WYSIWYG in `@strapi/content-manager`, while CodeMirror **6** is pulled in transitively via `@strapi/design-system` → `@uiw/react-codemirror`. The alias isolates the two incompatible majors so the WYSIWYG resolves to CM5 deterministically regardless of hoisting.
- **Documents the incompatibility:** alias-unaware scanners (e.g. JFrog Curation `jf ca`) read the alias *name* and request a non-existent `codemirror5-5.65.x.tgz`, failing with a `404`.
- **Provides workarounds:** exclude/waive the `codemirror5` component **by name** in the scanner policy (the real package stays auditable as `codemirror@5.65.x`); notes that `overrides`/`resolutions` do **not** help because the scanner reads the alias name before resolution.
- **No code, dependency, or config changes** — the alias is intentionally left in place because it is required for correct resolution.

### Why is it needed?

- The alias is valid npm syntax and installs correctly, but breaks enterprise supply-chain audits, failing CI pipelines before deployment.
- Security waivers can't be obtained because the aliased name doesn't exist on the registry.
- The behaviour is non-obvious, so documenting the cause and the scanner-side fix unblocks affected organizations without destabilizing the CM5/CM6 setup.

### How to test it?

- Run `yarn prettier --check docs/docs/docs/01-core/admin/06-codemirror-dependency-alias.md` → passes.
- Build/serve the contributor docs and confirm the **CodeMirror dependency alias** page renders under **Core → Admin** with correct frontmatter and formatting.

### Related issue(s)/PR(s)

- Fix #26865