### PR TITLE
fix(content-manager): prevent clone from synthesizing empty components for restricted fields

### DIFF
--- a/packages/core/content-manager/server/src/controllers/utils/__tests__/clone-exclude.test.ts
+++ b/packages/core/content-manager/server/src/controllers/utils/__tests__/clone-exclude.test.ts
@@ -1,0 +1,72 @@
+import { excludeNotCreatableFields } from '../clone';
+
+// Repro for https://github.com/strapi/strapi/issues/26998
+// When a user cannot create nested component fields and the clone body does not
+// contain the component, excludeNotCreatableFields must NOT synthesize an empty
+// component object (which would overwrite the source with null values).
+describe('excludeNotCreatableFields', () => {
+  const fakeModels = {
+    simple: {
+      modelName: 'Fake simple model',
+      info: { displayName: 'Simple' },
+      attributes: {
+        text: { type: 'string' },
+      },
+    },
+    withComponent: {
+      modelName: 'Fake model with component',
+      info: { displayName: 'With component' },
+      attributes: {
+        title: { type: 'string' },
+        metadata: {
+          type: 'component',
+          repeatable: false,
+          component: 'simple',
+        },
+      },
+    },
+  } as any;
+
+  beforeEach(() => {
+    global.strapi = {
+      getModel: jest.fn((uid) => fakeModels[uid]),
+    } as any;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('does not synthesize a component when it is absent from the clone body', () => {
+    // User can create top-level fields, but NOT the nested component field.
+    const permissionChecker = {
+      can: {
+        create: jest.fn((_data: any, path: string) => path !== 'metadata.text'),
+      },
+    };
+
+    // Body has no `metadata` — source entry did not populate the component.
+    const body = { title: 'Hello' };
+
+    const result = excludeNotCreatableFields('withComponent', permissionChecker)(body);
+
+    // Expected: metadata stays absent so clone copies it from the source (empty stays empty).
+    expect(result).not.toHaveProperty('metadata');
+    expect(result).toEqual({ title: 'Hello' });
+  });
+
+  test('still nulls a restricted nested field when the component IS present', () => {
+    const permissionChecker = {
+      can: {
+        create: jest.fn((_data: any, path: string) => path !== 'metadata.text'),
+      },
+    };
+
+    const body = { title: 'Hello', metadata: { text: 'secret' } };
+
+    const result = excludeNotCreatableFields('withComponent', permissionChecker)(body);
+
+    // When the component exists in the body, the restricted nested field is nulled.
+    expect(result).toEqual({ title: 'Hello', metadata: { text: null } });
+  });
+});

--- a/packages/core/content-manager/server/src/controllers/utils/clone.ts
+++ b/packages/core/content-manager/server/src/controllers/utils/clone.ts
@@ -1,4 +1,4 @@
-import { set } from 'lodash/fp';
+import { get, set } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
 import { ProhibitedCloningField } from '../../../../shared/contracts/collection-types';
 
@@ -104,10 +104,20 @@ const excludeNotCreatableFields =
         }
         // Go deeper into the component
         case 'component': {
-          return excludeNotCreatableFields(attribute.component, permissionChecker)(body, [
-            ...path,
-            attributeName,
-          ] as any);
+          const componentPath = [...path, attributeName];
+
+          // Only descend when the component is actually present in the payload.
+          // Otherwise `set` below would synthesize an empty component object
+          // (e.g. `{ metadata: { label: null } }`) and overwrite the source
+          // entry with null values on clone (GH#26998).
+          if (get(componentPath, body) == null) {
+            return body;
+          }
+
+          return excludeNotCreatableFields(attribute.component, permissionChecker)(
+            body,
+            componentPath as any
+          );
         }
         // Attribute should be null if the user can't create it
         default: {


### PR DESCRIPTION
### What does it do?

Fixes clone sanitization synthesizing empty component objects when a user lacks permission on nested component fields.

- **Root cause:** in `excludeNotCreatableFields` (`packages/core/content-manager/server/src/controllers/utils/clone.ts`), the `component` case recursed unconditionally and called `set('<component>.<field>', null, body)` for each restricted nested field. Because `lodash/fp`'s `set` creates intermediate objects, a component **absent** from the clone payload was materialized as `{ metadata: { label: null, score: null, notes: null } }`.
- **Fix:** only descend into a component when it is actually present in the payload (`get(componentPath, body) != null`); otherwise leave the body untouched so `clone` copies the field from the source.
- **Behavior preserved:** when the component **is** present, restricted nested fields are still nulled as before.
- Adds unit-test coverage for both cases.

### Why is it needed?

- When a restricted admin duplicates an entry whose non-repeatable component is empty, an empty component row was written to the database, overwriting the expected (empty/source) value.
- Omitted fields should be copied from the source on clone — not synthesized with `null` values.

### How to test it?

- Automated: `yarn jest --config jest.config.js utils/__tests__/clone` → all pass, including the new `excludeNotCreatableFields` cases.
- Manual (matches the issue):
  - Create a collection type (e.g. `Article`) with a non-repeatable component (`metadata`).
  - Configure a role that allows the parent collection but denies all nested component fields.
  - Create an entry with the component left empty.
  - As the restricted user, duplicate the entry and inspect the DB — no empty component row is created.

### Related issue(s)/PR(s)

- Fix #26998