### PR TITLE
fix(admin): derive canReadUsers correctly in audit logs list page

### DIFF
--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
@@ -23,12 +23,16 @@ const ListPage = () => {
   const permissions = useTypedSelector((state) => state.admin_app.permissions.settings);
 
   const {
-    allowedActions: { canRead: canReadAuditLogs, canReadUsers },
-    isLoading: isLoadingRBAC,
-  } = useRBAC({
-    ...permissions?.auditLogs,
-    readUsers: permissions?.users.read || [],
-  });
+    allowedActions: { canRead: canReadAuditLogs },
+    isLoading: isLoadingRBACAuditLogs,
+  } = useRBAC(permissions?.auditLogs?.read || []);
+
+  const {
+    allowedActions: { canRead: canReadUsers },
+    isLoading: isLoadingRBACUsers,
+  } = useRBAC(permissions?.users.read || []);
+
+  const isLoadingRBAC = isLoadingRBACAuditLogs || isLoadingRBACUsers;
 
   const [{ query }, setQuery] = useQueryParams<{ id?: AuditLog['id'] }>();
   const {

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/tests/ListPage.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/tests/ListPage.test.tsx
@@ -108,4 +108,26 @@ describe('ADMIN | Pages | AUDIT LOGS | ListPage', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add filter' })).toBeInTheDocument();
   });
+
+  it('should show the User filter option when the user can read admin users', async () => {
+    const { user } = render(<ListPage />);
+
+    await waitFor(() => expect(screen.queryByText('Loading content')).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+
+    await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
+
+    expect(await screen.findByRole('option', { name: 'Action' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Date' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'User' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', { name: 'User' }));
+    await user.click(
+      screen.getByRole('combobox', { name: 'Search and select an option to filter' })
+    );
+
+    expect(await screen.findByRole('option', { name: 'John Doe' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Kai Doe' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Fix the Audit Logs "User" filter never appearing in the Filters dropdown, for any user, regardless of permissions.
- `ListPage` used the deprecated object form of `useRBAC` and expected `canReadUsers` to be derived from the `readUsers` object key. The hook now flattens the object (discarding keys) and derives action names from the last segment of the permission action string, so `admin::audit-logs.read` and `admin::users.read` both collide on `canRead` — `canReadUsers` was never produced and the filter (and the admin-users fetch behind it) stayed permanently disabled.
- Split the check into two array-form `useRBAC` calls so each permission resolves independently (`canReadAuditLogs` from `auditLogs.read`, `canReadUsers` from `users.read`), and combine both loading states. This also removes the object-form deprecation warning from the page.
- Add regression coverage: opening the filters popover now asserts the "User" field option renders and lists the admin users (fails on `main`, passes with this change).

## Supporting evidence
- Server-side filtering has always worked: `GET /admin/audit-logs?filters[user][$eq]=<id>` filters correctly (verified against a live instance, counts matching the `strapi_audit_logs_user_lnk` table), so the defect was purely in the UI permission derivation.
- Permission data verified intact end to end: `admin::users.read` present in `GET /admin/users/me/permissions` and `POST /admin/permissions/check` returning `true` — yet `canReadUsers` remained `undefined`.

## Test plan
- `yarn test:front packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs`
- `cd packages/core/admin && yarn test:front` (full Core admin front suite: 115 suites / 748 tests green)
- `cd packages/core/admin && yarn test:ts:front` (no new errors vs `main` baseline)

---
Fixes EE-67
Related: EE-68 (follow-up: user filter dropdown pagination), #19539 (v4 issue on the same surface, different root cause)
