### PR TITLE
fix(i18n): use fractional temp keys when filling locale

### DIFF
--- a/packages/plugins/i18n/server/src/services/__tests__/fill-from-locale.test.ts
+++ b/packages/plugins/i18n/server/src/services/__tests__/fill-from-locale.test.ts
@@ -299,10 +299,41 @@ describe('transformDocument — components', () => {
 
     const sections = result.sections as any[];
     expect(sections).toHaveLength(2);
-    expect(sections[0]).toMatchObject({ heading: 'First', __temp_key__: 1 });
-    expect(sections[1]).toMatchObject({ heading: 'Second', __temp_key__: 2 });
+    expect(sections[0]).toMatchObject({ heading: 'First', __temp_key__: 'a0' });
+    expect(sections[1]).toMatchObject({ heading: 'Second', __temp_key__: 'a1' });
     // id is in FIELDS_TO_REMOVE so it should be stripped
     expect(sections[0]).not.toHaveProperty('id');
+  });
+
+  test('continues repeatable component temp keys after the base-62 boundary', async () => {
+    const { service, mockStrapi } = makeService();
+    (mockStrapi.getModel as jest.Mock).mockImplementation((uid: string) => {
+      if (uid === MODEL) {
+        return {
+          uid: MODEL,
+          attributes: {
+            sections: { type: 'component', component: 'shared.section', repeatable: true },
+          },
+        };
+      }
+      return { uid, attributes: { heading: { type: 'string' } } };
+    });
+
+    const result = await service.transformDocument(
+      {
+        sections: Array.from({ length: 64 }, (_, index) => ({ heading: `Section ${index}` })),
+      },
+      MODEL as any,
+      TARGET_LOCALE,
+      makeUserAbility()
+    );
+
+    const sections = result.sections as any[];
+    expect(sections).toHaveLength(64);
+    expect(sections[0]).toMatchObject({ __temp_key__: 'a0' });
+    expect(sections[61]).toMatchObject({ __temp_key__: 'az' });
+    expect(sections[62]).toMatchObject({ __temp_key__: 'b00' });
+    expect(sections[63]).toMatchObject({ __temp_key__: 'b01' });
   });
 
   test('strips passwords inside components', async () => {
@@ -369,12 +400,12 @@ describe('transformDocument — dynamic zones', () => {
     expect(body[0]).toMatchObject({
       __component: 'blocks.text',
       content: 'Hello',
-      __temp_key__: 1,
+      __temp_key__: 'a0',
     });
     expect(body[1]).toMatchObject({
       __component: 'blocks.image',
       url: 'https://example.com/img.png',
-      __temp_key__: 2,
+      __temp_key__: 'a1',
     });
     // id is in FIELDS_TO_REMOVE
     expect(body[0]).not.toHaveProperty('id');

--- a/packages/plugins/i18n/server/src/services/fill-from-locale.ts
+++ b/packages/plugins/i18n/server/src/services/fill-from-locale.ts
@@ -3,6 +3,7 @@ import { contentTypes } from '@strapi/utils';
 import type { UID, Schema, Core } from '@strapi/types';
 
 const READ_ACTION = 'plugin::content-manager.explorer.read';
+const TEMP_KEY_DIGITS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
 /**
  * Returns the main display field for a model (e.g. title, name).
@@ -44,6 +45,57 @@ const FIELDS_TO_IGNORE = new Set([
 ]);
 
 const STATUS_FIELDS = new Set(['id', 'documentId', 'locale', 'updatedAt', 'publishedAt']);
+
+const incrementInitialTempKey = (key?: string): string => {
+  if (!key) {
+    return `a${TEMP_KEY_DIGITS[0]}`;
+  }
+
+  const [head, ...digits] = key;
+  let carry = true;
+
+  for (let index = digits.length - 1; carry && index >= 0; index -= 1) {
+    const nextDigitIndex = TEMP_KEY_DIGITS.indexOf(digits[index]) + 1;
+
+    if (nextDigitIndex === 0) {
+      throw new Error(`Invalid temporary key digit: ${digits[index]}`);
+    }
+
+    if (nextDigitIndex === TEMP_KEY_DIGITS.length) {
+      digits[index] = TEMP_KEY_DIGITS[0];
+    } else {
+      digits[index] = TEMP_KEY_DIGITS[nextDigitIndex];
+      carry = false;
+    }
+  }
+
+  if (!carry) {
+    return `${head}${digits.join('')}`;
+  }
+
+  if (head === 'z') {
+    throw new Error('Cannot increment temporary keys any further');
+  }
+
+  const nextHead = String.fromCharCode(head.charCodeAt(0) + 1);
+  if (nextHead > 'a') {
+    digits.push(TEMP_KEY_DIGITS[0]);
+  } else {
+    digits.pop();
+  }
+
+  return `${nextHead}${digits.join('')}`;
+};
+
+const generateInitialTempKeys = (length: number): string[] => {
+  let previousKey: string | undefined;
+
+  return Array.from({ length }, () => {
+    const nextKey = incrementInitialTempKey(previousKey);
+    previousKey = nextKey;
+    return nextKey;
+  });
+};
 
 /**
  * Normalizes a value to an array: arrays pass through, single values become [value], null/undefined become [].
@@ -421,10 +473,11 @@ const processDocumentData = async (
         attributes: {},
       }) as Schema.Component;
       if (attribute.repeatable && isArray(value)) {
+        const tempKeys = generateInitialTempKeys(value.length);
         result[key] = await Promise.all(
           value.map(async (item: Record<string, unknown>, index: number) => {
             const processed = await processDocumentData(item, compSchema, components, preResolved);
-            return { ...processed, __temp_key__: index + 1 };
+            return { ...processed, __temp_key__: tempKeys[index] };
           })
         );
       } else if (value) {
@@ -442,13 +495,14 @@ const processDocumentData = async (
     }
 
     if (attribute.type === 'dynamiczone' && isArray(value)) {
+      const tempKeys = generateInitialTempKeys(value.length);
       result[key] = await Promise.all(
         value.map(async (item: Record<string, unknown>, index: number) => {
           const compSchema = (components[item?.__component as string] || {
             attributes: {},
           }) as Schema.Component;
           const processed = await processDocumentData(item, compSchema, components, preResolved);
-          return { ...processed, __temp_key__: index + 1 };
+          return { ...processed, __temp_key__: tempKeys[index] };
         })
       );
       continue;


### PR DESCRIPTION
## Summary

- return fractional temp keys for repeatable components copied through fill from locale
- apply the same key shape to dynamic zone items returned by the service
- cover the generated key sequence, including the base-62 rollover boundary

## Why

Filled component and dynamic zone items were returned with numeric `__temp_key__` values. The content manager expects sortable string keys when adding or reordering items, so adding another repeatable component before saving could fail with `invalid order key head: undefined`.

## Validation

```sh
corepack yarn workspace @strapi/i18n test:unit server/src/services/__tests__/fill-from-locale.test.ts --runInBand
corepack yarn prettier --check packages/plugins/i18n/server/src/services/fill-from-locale.ts packages/plugins/i18n/server/src/services/__tests__/fill-from-locale.test.ts
git diff --check
cd packages/plugins/i18n && corepack yarn run -T eslint server/src/services/fill-from-locale.ts server/src/services/__tests__/fill-from-locale.test.ts
```

Fixes #26282
