### PR TITLE
chore(husky): run git hooks through yarn exec

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no-install -- commitlint --edit ${1}
+yarn exec commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx --no-install lint-staged
+yarn exec lint-staged --concurrent 8


### PR DESCRIPTION
### What does it do?

Routes the Husky hooks through `yarn exec` instead of `npx --no-install`:

```diff
 # .husky/pre-commit
-npx --no-install lint-staged
+yarn exec lint-staged --concurrent 8

 # .husky/commit-msg
-npx --no-install -- commitlint --edit ${1}
+yarn exec commitlint --edit "$1"
```

Two smaller fixes ride along:

- **Cap `lint-staged` concurrency at 8**, matching `nx.json#parallel`. It previously ran with the default unlimited concurrency, so a large staged changeset could fan out one eslint+prettier chain per matched workspace config at once.
- **Quote the commit-msg path** (`${1}` → `"$1"`) so a message file whose path contains spaces is passed as a single argument.

### Why is it needed?

This is a Yarn 4 workspace, but the hooks shell out to npm's binary resolver. `yarn exec` is the native way to run a workspace binary here, and it resolves through Yarn's own install state rather than through whatever `node_modules/.bin` happens to contain.

Concretely, `npx --no-install` only works because `node_modules/.bin` exists, which is an artifact of the `node-modules` linker. It is a working setup, not a broken one — but the hooks are coupled to that linker for no reason, and `yarn exec` decouples them at zero cost. Same pinned binaries, same behaviour, one less implicit assumption.

### Note on CI

A related observation while looking at this, offered as information rather than as something this PR asks anyone to act on.

CI also runs workspace binaries via npm, but with a bare `npx` and no `--no-install`:

- `.github/workflows/commitlint.yml` — `npx commitlint --from … --to …` (`@commitlint/cli` is a root devDependency, pinned to `19.2.0`)
- `.github/workflows/tests.yml` — `npx playwright install --with-deps` (`@playwright/test` is a root devDependency, pinned to `1.56.1`)

Both run immediately after `Monorepo install`, so they currently resolve from `node_modules/.bin` and get the pinned versions. The thing to know is the failure mode if that directory is ever absent: without `--no-install`, `npx` does not error — it silently **downloads the package from the registry**. commitlint would then run at floating-latest instead of the pinned `19.2.0`, and `playwright install` would fetch browsers for a version that need not match the installed `@playwright/test`.

Deliberately not touched here. It is a CI-policy call, and nothing is broken today.

### How to test it?

```
yarn install
git commit          # pre-commit + commit-msg hooks run via yarn exec
```

Both hooks run on this PR's own commit.

### Related issue(s)/PR(s)

The `node_modules/.bin` coupling surfaced while I was experimenting with `nodeLinker: pnpm` in #26986. That PR is an experiment of my own and may well be closed — this change does not depend on it, and is not an argument for it. It stands on its own as "use the workspace's own package manager to run the workspace's own binaries".

🤖 Generated with [Claude Code](https://claude.com/claude-code)