### PR TITLE
fix(content-manager): validate items passed to plugin action APIs

### DIFF
--- a/packages/core/content-manager/admin/src/content-manager.ts
+++ b/packages/core/content-manager/admin/src/content-manager.ts
@@ -163,9 +163,12 @@ class ContentManagerPlugin {
   addEditViewSidePanel(panels: PanelComponent[]): void;
   addEditViewSidePanel(panels: DescriptionReducer<PanelComponent> | PanelComponent[]) {
     if (Array.isArray(panels)) {
+      validateDescriptionItems(panels, 'addEditViewSidePanel', 'panels');
       this.editViewSidePanels = [...this.editViewSidePanels, ...panels];
     } else if (typeof panels === 'function') {
-      this.editViewSidePanels = panels(this.editViewSidePanels);
+      const result = panels(this.editViewSidePanels);
+      validateDescriptionItems(result, 'addEditViewSidePanel', 'panels');
+      this.editViewSidePanels = result;
     } else {
       throw new Error(
         `Expected the \`panels\` passed to \`addEditViewSidePanel\` to be an array or a function, but received ${getPrintableType(
@@ -181,9 +184,12 @@ class ContentManagerPlugin {
     actions: DescriptionReducer<DocumentActionComponent> | DocumentActionComponent[]
   ) {
     if (Array.isArray(actions)) {
+      validateDescriptionItems(actions, 'addDocumentAction', 'actions');
       this.documentActions = [...this.documentActions, ...actions];
     } else if (typeof actions === 'function') {
-      this.documentActions = actions(this.documentActions);
+      const result = actions(this.documentActions);
+      validateDescriptionItems(result, 'addDocumentAction', 'actions');
+      this.documentActions = result;
     } else {
       throw new Error(
         `Expected the \`actions\` passed to \`addDocumentAction\` to be an array or a function, but received ${getPrintableType(
@@ -199,9 +205,12 @@ class ContentManagerPlugin {
     actions: DescriptionReducer<HeaderActionComponent> | HeaderActionComponent[]
   ) {
     if (Array.isArray(actions)) {
+      validateDescriptionItems(actions, 'addDocumentHeaderAction', 'actions');
       this.headerActions = [...this.headerActions, ...actions];
     } else if (typeof actions === 'function') {
-      this.headerActions = actions(this.headerActions);
+      const result = actions(this.headerActions);
+      validateDescriptionItems(result, 'addDocumentHeaderAction', 'actions');
+      this.headerActions = result;
     } else {
       throw new Error(
         `Expected the \`actions\` passed to \`addDocumentHeaderAction\` to be an array or a function, but received ${getPrintableType(
@@ -215,9 +224,12 @@ class ContentManagerPlugin {
   addBulkAction(actions: BulkActionComponent[]): void;
   addBulkAction(actions: DescriptionReducer<BulkActionComponent> | BulkActionComponent[]) {
     if (Array.isArray(actions)) {
+      validateDescriptionItems(actions, 'addBulkAction', 'actions');
       this.bulkActions = [...this.bulkActions, ...actions];
     } else if (typeof actions === 'function') {
-      this.bulkActions = actions(this.bulkActions);
+      const result = actions(this.bulkActions);
+      validateDescriptionItems(result, 'addBulkAction', 'actions');
+      this.bulkActions = result;
     } else {
       throw new Error(
         `Expected the \`actions\` passed to \`addBulkAction\` to be an array or a function, but received ${getPrintableType(
@@ -284,6 +296,29 @@ const getPrintableType = (value: unknown): string => {
   }
 
   return nativeType;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * validateDescriptionItems
+ * -----------------------------------------------------------------------------------------------*/
+
+/**
+ * @internal
+ * @description Descriptions must be functions (they're rendered as components so hooks can be used
+ * inside them), not plain objects. Passing a plain object crashes deep inside
+ * `DescriptionComponentRenderer` with an unhelpful `description is not a function` error, so we
+ * validate eagerly here to fail fast with a clear message pointing at the offending API call.
+ */
+const validateDescriptionItems = (items: unknown[], apiName: string, argName: string): void => {
+  items.forEach((item, index) => {
+    if (typeof item !== 'function') {
+      throw new Error(
+        `Expected every item in the \`${argName}\` array passed to \`${apiName}\` to be a function that returns a description object, but received ${getPrintableType(
+          item
+        )} at index ${index}. Did you forget to wrap it in a function, e.g. \`() => ({ ...yourAction })\`?`
+      );
+    }
+  });
 };
 
 export { ContentManagerPlugin };

--- a/packages/core/content-manager/admin/src/tests/content-manager.test.ts
+++ b/packages/core/content-manager/admin/src/tests/content-manager.test.ts
@@ -143,6 +143,17 @@ describe('content-manager', () => {
         'Expected the `panels` passed to `addEditViewSidePanel` to be an array or a function, but received string'
       );
     });
+
+    it("should throw a clear error if an item in the array isn't a function", () => {
+      const plugin = new ContentManagerPlugin();
+
+      expect(() =>
+        // @ts-expect-error – testing it fails.
+        plugin.addEditViewSidePanel([{ title: 'test', content: null }])
+      ).toThrowError(
+        'Expected every item in the `panels` array passed to `addEditViewSidePanel` to be a function that returns a description object, but received object at index 0'
+      );
+    });
   });
 
   describe('addDocumentAction', () => {
@@ -202,6 +213,17 @@ describe('content-manager', () => {
         'Expected the `actions` passed to `addDocumentAction` to be an array or a function, but received string'
       );
     });
+
+    it("should throw a clear error if an item in the array isn't a function", () => {
+      const plugin = new ContentManagerPlugin();
+
+      expect(() =>
+        // @ts-expect-error – testing it fails.
+        plugin.addDocumentAction([{ label: 'Publish & Notify Twitter', onClick: () => {} }])
+      ).toThrowError(
+        'Expected every item in the `actions` array passed to `addDocumentAction` to be a function that returns a description object, but received object at index 0'
+      );
+    });
   });
 
   describe('addDocumentHeaderAction', () => {
@@ -229,6 +251,56 @@ describe('content-manager', () => {
         plugin.addDocumentHeaderAction('I will break')
       ).toThrowError(
         'Expected the `actions` passed to `addDocumentHeaderAction` to be an array or a function, but received string'
+      );
+    });
+
+    it("should throw a clear error if an item in the array isn't a function", () => {
+      const plugin = new ContentManagerPlugin();
+
+      expect(() =>
+        // @ts-expect-error – testing it fails.
+        plugin.addDocumentHeaderAction([{ label: 'Notify Twitter', onClick: () => {} }])
+      ).toThrowError(
+        'Expected every item in the `actions` array passed to `addDocumentHeaderAction` to be a function that returns a description object, but received object at index 0'
+      );
+    });
+  });
+
+  describe('addBulkAction', () => {
+    it('should let users add a bulk action as an array', () => {
+      const plugin = new ContentManagerPlugin();
+
+      expect(plugin.bulkActions).toHaveLength(0);
+
+      plugin.addBulkAction([
+        () => ({
+          label: 'Dummy Bulk Action',
+          onClick: () => {},
+        }),
+      ]);
+
+      expect(plugin.bulkActions).toHaveLength(1);
+    });
+
+    it("should throw an error if you've not passed a function or an array", () => {
+      const plugin = new ContentManagerPlugin();
+
+      expect(() =>
+        // @ts-expect-error – testing it fails.
+        plugin.addBulkAction('I will break')
+      ).toThrowError(
+        'Expected the `actions` passed to `addBulkAction` to be an array or a function, but received string'
+      );
+    });
+
+    it("should throw a clear error if an item in the array isn't a function", () => {
+      const plugin = new ContentManagerPlugin();
+
+      expect(() =>
+        // @ts-expect-error – testing it fails.
+        plugin.addBulkAction([{ label: 'Dummy Bulk Action', onClick: () => {} }])
+      ).toThrowError(
+        'Expected every item in the `actions` array passed to `addBulkAction` to be a function that returns a description object, but received object at index 0'
       );
     });
   });


### PR DESCRIPTION
### What does it do?

`addBulkAction`, `addDocumentAction`, `addDocumentHeaderAction`, and `addEditViewSidePanel` (`packages/core/content-manager/admin/src/content-manager.ts`) already validated that the top-level argument is an array or a reducer function, but never validated that each *item* inside that array is itself a function. Each item is later called as `description(props)` inside `DescriptionComponentRenderer` (`packages/core/admin/admin/src/components/DescriptionComponentRenderer.tsx:143`), so passing a plain object for an item crashes deep inside a renderer with a bare `description is not a function` — no indication of which plugin API call, or which item, caused it.

This adds eager, per-item validation to all four APIs (for both the array form and the reducer form) with an error message that names the API, the argument, the offending index, and how to fix it.

### Why is it needed?

From the reporter's example:

```ts
app.getPlugin('content-manager').apis.addBulkAction([
  {
    label: 'Dummy Bulk Action',
    onClick: (event) => { alert('Bulk action triggered!'); },
    icon: null,
    type: 'default',
    variant: 'secondary',
    disabled: false,
  },
]);
```

This is a very natural thing to write if you don't already know each item must be wrapped in a function (`() => ({...})`), and the resulting crash gives no hint about the actual cause — a plugin author has to go digging through a stack trace that bottoms out inside an internal renderer component to figure out the fix.

### How to test it?

Unit tests added in `packages/core/content-manager/admin/src/tests/content-manager.test.ts` for all four APIs, reproducing the exact plain-object shape from the issue and asserting the new, descriptive error message. `addBulkAction` previously had no dedicated test coverage at all — added the missing baseline coverage for it too.

### Related issue(s)/PR(s)

Fix #24025