### PR TITLE
fix(core): prevent crash validating a unique field in a nested component with null data (#23690)

### DIFF
--- a/packages/core/core/src/services/entity-validator/__tests__/unique-nested-component.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/unique-nested-component.test.ts
@@ -1,0 +1,51 @@
+import entityValidator from '..';
+
+describe('Entity validator - unique field in a nested component', () => {
+  const metaModel = {
+    modelType: 'component',
+    uid: 'default.meta',
+    globalId: 'ComponentDefaultMeta',
+    attributes: { slug: { type: 'string', unique: true } },
+  };
+
+  const entryModel = {
+    modelType: 'component',
+    uid: 'default.entry',
+    globalId: 'ComponentDefaultEntry',
+    attributes: { meta: { type: 'component', component: 'default.meta', repeatable: false } },
+  };
+
+  const model: any = {
+    modelType: 'contentType',
+    uid: 'api::test.test',
+    kind: 'collectionType',
+    modelName: 'test',
+    globalId: 'test',
+    info: { displayName: 'Test', singularName: 'test', pluralName: 'tests' },
+    options: {},
+    attributes: { entries: { type: 'component', component: 'default.entry', repeatable: true } },
+  };
+
+  const models: Record<string, any> = {
+    'api::test.test': model,
+    'default.entry': entryModel,
+    'default.meta': metaModel,
+  };
+
+  beforeEach(() => {
+    global.strapi = {
+      getModel: (uid: string) => models[uid],
+      db: { query: () => ({ findOne: async () => null }) },
+    } as any;
+  });
+
+  it('does not crash when a repeatable item has a null nested component', async () => {
+    // The second entry has a `null` nested `meta` component, so the path
+    // `meta.slug` used by the unique validator hits `null.slug`. (#23690)
+    const input = { entries: [{ meta: { slug: 'a' } }, { meta: null }] };
+
+    await expect(
+      entityValidator.validateEntityCreation(model, input as any)
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/core/core/src/services/entity-validator/validators.ts
+++ b/packages/core/core/src/services/entity-validator/validators.ts
@@ -259,9 +259,12 @@ const addUniqueValidator = <T extends yup.AnySchema>(
       // Construct the full path to the unique field within the component.
       const pathToCheck = [...componentContext.pathToComponent.slice(1), updatedName].join('.');
 
-      // Extract the values from the repeatable data using the constructed path
+      // Extract the values from the repeatable data using the constructed path.
+      // Use optional chaining so that a missing/empty nested component along the
+      // path resolves to `undefined` instead of throwing
+      // "Cannot read properties of undefined".
       const values = componentContext.repeatableData.map((item) => {
-        return pathToCheck.split('.').reduce((acc, key) => acc[key], item as any);
+        return pathToCheck.split('.').reduce((acc, key) => acc?.[key], item as any);
       });
 
       // Check if the value is repeated in the current entity


### PR DESCRIPTION
### What does it do?

The unique validator for a field inside a repeatable component extracts the value from each item by reducing over the path segments:

```ts
// packages/core/core/src/services/entity-validator/validators.ts
const values = componentContext.repeatableData.map((item) => {
  return pathToCheck.split('.').reduce((acc, key) => acc[key], item as any);
});
```

When a nested component along that path is `null`/missing in one of the repeatable items, an intermediate `acc` is `null`, so the next `acc[key]` dereferences null (e.g. `null['slug']`) and throws:

```
TypeError: Cannot read properties of undefined (reading 'slug')
```

This crashes the whole save/publish request (a 500).

This change uses optional chaining (`acc?.[key]`) so a missing nested component resolves to `undefined` — which simply doesn't match the uniqueness check — instead of throwing. Behavior is unchanged when the path is fully populated.

### Why is it needed?

As reported in #23690, setting the `unique` constraint on a text field inside a component that is nested within a repeatable component crashes on publish when one of the repeatable entries doesn't have that nested component filled in. The uniqueness check should tolerate incomplete/optional nested data rather than crash.

### How to test it?

Unit test (added):

```
yarn jest --config jest.config.js packages/core/core/src/services/entity-validator/__tests__/unique-nested-component.test.ts
```

`Entity validator - unique field in a nested component › does not crash when a repeatable item has a null nested component` validates an entity whose repeatable component has an item with a `null` nested component. It **fails on `develop`** with `TypeError: Cannot read properties of null (reading 'slug')` and passes with this change.

The full `entity-validator` suite stays green (176 tests); `eslint` and `prettier --check` pass on the changed files.

### Related issue(s)/PR(s)

Fixes #23690
