### PR TITLE
fix: reject GraphQL reserved enum values

### DIFF
--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/types.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/types.test.ts
@@ -369,6 +369,93 @@ describe('Type validators', () => {
     });
   });
 
+  describe('enumeration type', () => {
+    test.each(['true', 'false', 'null'])(
+      'does not allow GraphQL reserved enum value %s',
+      (value) => {
+        const attributes = {
+          status: {
+            type: 'enumeration',
+            enum: [value],
+          },
+        } satisfies Struct.SchemaAttributes;
+
+        const validator = getTypeValidator(attributes.status, {
+          types: ['enumeration'],
+          attributes,
+        });
+
+        expect(validator.isValidSync(attributes.status)).toBe(false);
+      }
+    );
+
+    test('returns a clear validation error for GraphQL reserved enum values', () => {
+      const attributes = {
+        status: {
+          type: 'enumeration',
+          enum: ['true'],
+        },
+      } satisfies Struct.SchemaAttributes;
+
+      const validator = getTypeValidator(attributes.status, {
+        types: ['enumeration'],
+        attributes,
+      });
+
+      expect(() => validator.validateSync(attributes.status)).toThrow(
+        'must not be one of the GraphQL reserved values: true, false, null'
+      );
+    });
+
+    test('allows enum values that are not GraphQL reserved literals', () => {
+      const attributes = {
+        status: {
+          type: 'enumeration',
+          enum: ['draft', 'published'],
+        },
+      } satisfies Struct.SchemaAttributes;
+
+      const validator = getTypeValidator(attributes.status, {
+        types: ['enumeration'],
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.status)).toBe(true);
+    });
+
+    test('allows case variants of GraphQL reserved enum values', () => {
+      const attributes = {
+        status: {
+          type: 'enumeration',
+          enum: ['True', 'FALSE', 'Null'],
+        },
+      } satisfies Struct.SchemaAttributes;
+
+      const validator = getTypeValidator(attributes.status, {
+        types: ['enumeration'],
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.status)).toBe(true);
+    });
+
+    test('does not allow enum arrays containing a GraphQL reserved value', () => {
+      const attributes = {
+        status: {
+          type: 'enumeration',
+          enum: ['draft', 'true'],
+        },
+      } satisfies Struct.SchemaAttributes;
+
+      const validator = getTypeValidator(attributes.status, {
+        types: ['enumeration'],
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.status)).toBe(false);
+    });
+  });
+
   describe('media type', () => {
     test('Validates allowedTypes', () => {
       // @ts-expect-error - Silence the cast as Struct.SchemaAttributes since allowedTypes expects one of 'audios',

--- a/packages/core/content-type-builder/server/src/controllers/validation/common.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/common.ts
@@ -16,6 +16,7 @@ export const CATEGORY_NAME_REGEX = /^[A-Za-z][-_0-9A-Za-z]*$/;
 export const ICON_REGEX = /^[A-Za-z0-9][-A-Za-z0-9]*$/;
 export const UID_REGEX = /^[A-Za-z0-9-_.~]*$/;
 export const KEBAB_BASE_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const GRAPHQL_RESERVED_ENUM_VALUES = new Set(['true', 'false', 'null']);
 
 export type CommonTestConfig = TestConfig<unknown | undefined, Record<string, unknown>>;
 
@@ -59,6 +60,12 @@ export const isValidEnum: CommonTestConfig = {
   name: 'isValidEnum',
   message: '${path} should not start with number',
   test: (val) => val === '' || !strings.startsWithANumber(val as string),
+};
+
+export const isValidGraphQLEnumValue: CommonTestConfig = {
+  name: 'isValidGraphQLEnumValue',
+  message: '${path} must not be one of the GraphQL reserved values: true, false, null',
+  test: (val) => val === '' || !GRAPHQL_RESERVED_ENUM_VALUES.has(val as string),
 };
 
 export const areEnumValuesUnique: CommonTestConfig = {

--- a/packages/core/content-type-builder/server/src/controllers/validation/types.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/types.ts
@@ -11,6 +11,7 @@ import {
   isValidDefaultJSON,
   isValidName,
   isValidEnum,
+  isValidGraphQLEnumValue,
   isValidRegExpPattern,
   UID_REGEX,
 } from './common';
@@ -156,7 +157,7 @@ const getTypeShape = (attribute: Schema.Attribute.AnyAttribute, { attributes }: 
       return {
         enum: yup
           .array()
-          .of(yup.string().test(isValidEnum).required())
+          .of(yup.string().test(isValidEnum).test(isValidGraphQLEnumValue).required())
           .min(1)
           .test(areEnumValuesUnique)
           .required(),


### PR DESCRIPTION
## Summary

- Reject GraphQL reserved enum literal values (`true`, `false`, `null`) in content-type builder enumeration attributes.
- Keep non-reserved enum values and case variants valid.
- Add regression coverage for the reserved values, mixed enum arrays, valid values, and validation messaging.

Fixes #23720.

## Validation

```sh
corepack yarn workspace @strapi/content-type-builder test:unit server/src/controllers/validation/__tests__/types.test.ts --runInBand
corepack yarn workspace @strapi/utils build
corepack yarn workspace @strapi/content-type-builder test:ts:back
corepack yarn prettier --check packages/core/content-type-builder/server/src/controllers/validation/common.ts packages/core/content-type-builder/server/src/controllers/validation/types.ts packages/core/content-type-builder/server/src/controllers/validation/__tests__/types.test.ts
git diff --check origin/develop...HEAD
```
