### PR TITLE
fix(admin): allow opt-in for non-public webhook URLs

### DIFF
--- a/packages/core/admin/server/src/controllers/__tests__/webhooks.test.ts
+++ b/packages/core/admin/server/src/controllers/__tests__/webhooks.test.ts
@@ -1,0 +1,73 @@
+import { webhookValidator } from '../webhooks';
+
+// Repro + fix coverage for https://github.com/strapi/strapi/issues/26876
+// In production the webhook URL validator rejects non-public (internal/cluster)
+// URLs as an SSRF guard. That must stay the secure default, but users running
+// behind private networks (e.g. Kubernetes) need an opt-in to allow them.
+
+const INTERNAL_URL = 'http://10.0.0.5/strapi/cache/invalidate';
+const PUBLIC_URL = 'https://example.com/hook';
+
+const baseWebhook = {
+  name: 'test',
+  headers: {},
+  events: ['entry.create'],
+};
+
+const setConfig = (webhooks: Record<string, unknown>) => {
+  (global as any).strapi = {
+    config: {
+      get(key: string, defaultValue?: unknown) {
+        if (key === 'server.webhooks.allowNonPublicUrls') {
+          return webhooks.allowNonPublicUrls ?? defaultValue;
+        }
+        return defaultValue;
+      },
+    },
+  };
+};
+
+describe('webhookValidator - non-public URL handling (#26876)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    delete (global as any).strapi;
+  });
+
+  it('rejects internal URLs in production by default (SSRF guard stays on)', async () => {
+    process.env.NODE_ENV = 'production';
+    setConfig({});
+
+    await expect(webhookValidator.validate({ ...baseWebhook, url: INTERNAL_URL })).rejects.toThrow(
+      /public internet/
+    );
+  });
+
+  it('allows internal URLs in production when server.webhooks.allowNonPublicUrls is true', async () => {
+    process.env.NODE_ENV = 'production';
+    setConfig({ allowNonPublicUrls: true });
+
+    await expect(
+      webhookValidator.validate({ ...baseWebhook, url: INTERNAL_URL })
+    ).resolves.toMatchObject({ url: INTERNAL_URL });
+  });
+
+  it('always allows public URLs in production', async () => {
+    process.env.NODE_ENV = 'production';
+    setConfig({});
+
+    await expect(
+      webhookValidator.validate({ ...baseWebhook, url: PUBLIC_URL })
+    ).resolves.toMatchObject({ url: PUBLIC_URL });
+  });
+
+  it('does not enforce the guard outside production', async () => {
+    process.env.NODE_ENV = 'development';
+    setConfig({});
+
+    await expect(
+      webhookValidator.validate({ ...baseWebhook, url: INTERNAL_URL })
+    ).resolves.toMatchObject({ url: INTERNAL_URL });
+  });
+});

--- a/packages/core/admin/server/src/controllers/webhooks.ts
+++ b/packages/core/admin/server/src/controllers/webhooks.ts
@@ -34,6 +34,15 @@ const webhookValidator = yup
             return true;
           }
 
+          // Opt-in escape hatch for deployments whose webhook targets are only
+          // reachable on a private network (e.g. Kubernetes cluster URLs like
+          // `*.svc.cluster.local`). The SSRF guard stays on by default; users
+          // must explicitly set `server.webhooks.allowNonPublicUrls` to allow
+          // non-public URLs. (GH#26876)
+          if (strapi.config.get('server.webhooks.allowNonPublicUrls', false)) {
+            return true;
+          }
+
           try {
             const parsedUrl = new URL(url!);
             const isLocalUrl = await isLocalhostIp(parsedUrl.hostname);
@@ -64,6 +73,8 @@ const webhookValidator = yup
 const updateWebhookValidator = webhookValidator.shape({
   isEnabled: yup.boolean(),
 });
+
+export { webhookValidator, updateWebhookValidator };
 
 export default {
   async listWebhooks(ctx: Context) {


### PR DESCRIPTION
### What does it do?

Adds an opt-in configuration flag that allows webhook URLs pointing to non-public (internal/private) addresses.

- The webhook URL validator has a production-only **SSRF guard** (`is-public-url`) that rejects any URL whose host resolves to a private/loopback address via `is-localhost-ip` (`packages/core/admin/server/src/controllers/webhooks.ts`).
- This also blocks **legitimate internal targets** — e.g. Kubernetes service URLs like `http://myapp.namespace.svc.cluster.local/...`, which resolve to private ClusterIPs.
- The guard now short-circuits to "allowed" when **`server.webhooks.allowNonPublicUrls`** is set to `true`. It stays **on by default**, so the secure behavior is unchanged unless a user explicitly opts in.
- Exported `webhookValidator` / `updateWebhookValidator` and added unit-test coverage.

### Why is it needed?

- Self-hosted / Kubernetes users cannot register webhooks to internal services in production; saving fails with `Url is not supported because it isn't reachable over the public internet`.
- Removing the guard outright would reintroduce SSRF risk, so an explicit opt-in preserves secure defaults while unblocking these deployments.

### How to test it?

- Automated: `yarn jest --config jest.config.js controllers/__tests__/webhooks` → 4 passing cases:
  - internal URL rejected in production by default (guard on),
  - internal URL allowed in production when `server.webhooks.allowNonPublicUrls: true`,
  - public URL always allowed,
  - guard not enforced outside production.
- Manual: set `NODE_ENV=production`, add `webhooks: { allowNonPublicUrls: true }` under `config/server`, then create a webhook with an internal URL (e.g. `http://10.0.0.5/hook`) — it saves successfully. Without the flag, it is rejected.

### Related issue(s)/PR(s)

- Fix #26876
- Docs: a follow-up note for `server.webhooks.allowNonPublicUrls` should be added to https://github.com/strapi/documentation