### PR TITLE
fix(strapi): fix develop blank admin from optimizeDeps auto-exclude

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -113,7 +113,7 @@
     "highlight.js": "^10.4.1",
     "immer": "9.0.21",
     "inquirer": "9.3.8",
-    "invariant": "^2.2.4",
+    "invariant": "2.2.4",
     "is-localhost-ip": "2.0.0",
     "json-logic-js": "2.0.5",
     "jsonwebtoken": "9.0.3",

--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
@@ -11,6 +11,22 @@ import { getModulePath } from '../resolve-module';
 
 const adminDeps = require('@strapi/admin/package.json').dependencies as Record<string, string>;
 
+/** CJS/UMD deps on optimizeDeps.include must stay aliased for pnpm (#27014). */
+const PNPM_OPTIMIZE_ALIAS_MODULES = ['invariant', 'prismjs', 'lodash'] as const;
+
+describe('ADMIN_VITE_ALIAS_MODULES contract', () => {
+  it.each(PNPM_OPTIMIZE_ALIAS_MODULES)(
+    'includes %s for pnpm optimizeDeps.include resolution (#27014)',
+    (mod) => {
+      expect(ADMIN_VITE_ALIAS_MODULES).toContain(mod);
+    }
+  );
+
+  it('pins invariant alongside other @strapi/admin dependency versions', () => {
+    expect(ADMIN_PINNED_ALIAS_MODULES).toContain('invariant');
+  });
+});
+
 describe('buildAdminViteResolveAliases', () => {
   it('sets an alias for every admin vite alias module via getModulePath', () => {
     const alias = buildAdminViteResolveAliases();

--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
@@ -14,6 +14,13 @@ jest.mock('../dependencies', () => ({
   getModule: jest.fn(),
 }));
 
+jest.mock('read-pkg-up', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const readPkgUp = jest.requireMock('read-pkg-up').default as jest.Mock;
+
 const PINNED_OPTIMIZE_MODULES = [...ADMIN_VITE_ALIAS_MODULES, '@strapi/strapi'] as const;
 
 const preBuiltReactPeerPackage = (name: string) => ({
@@ -123,6 +130,7 @@ describe('collectAdminOptimizeDepsExclude', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    readPkgUp.mockResolvedValue(undefined);
   });
 
   it('excludes pre-built React peer libraries from plugin dependencies', async () => {
@@ -156,11 +164,60 @@ describe('collectAdminOptimizeDepsExclude', () => {
     ]);
   });
 
-  it('does not scan app root dependencies for auto-exclude', async () => {
-    getModuleMock.mockResolvedValue(strapiDesignExtendedLike);
+  it('never excludes @strapi/strapi from app root but still excludes matching UI kits', async () => {
+    readPkgUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          '@strapi/strapi': '5.50.2',
+          'strapi-design-extended': '^0.0.13',
+        },
+      },
+    });
 
-    await expect(collectAdminOptimizeDepsExclude('/app', [])).resolves.toEqual([]);
-    expect(getModuleMock).not.toHaveBeenCalled();
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === '@strapi/strapi') {
+        return preBuiltReactPeerPackage('@strapi/strapi');
+      }
+
+      if (name === 'strapi-design-extended') {
+        return strapiDesignExtendedLike;
+      }
+
+      return null;
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', [])).resolves.toEqual([
+      'strapi-design-extended',
+    ]);
+  });
+
+  it('never auto-excludes official @strapi packages that match the heuristic', async () => {
+    const plugins: PluginMeta[] = [
+      {
+        name: 'my-plugin',
+        importName: 'myPlugin',
+        type: 'module',
+        modulePath: '@org/my-plugin/strapi-admin',
+      },
+    ];
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === '@org/my-plugin') {
+        return {
+          dependencies: {
+            '@strapi/icons': '2.2.0',
+          },
+        };
+      }
+
+      if (name === '@strapi/icons') {
+        return preBuiltReactPeerPackage('@strapi/icons');
+      }
+
+      return null;
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', plugins)).resolves.toEqual([]);
   });
 
   it('never excludes pinned admin singleton modules from plugin dependencies', async () => {

--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
@@ -182,4 +182,33 @@ describe('collectAdminOptimizeDepsExclude', () => {
 
     await expect(collectAdminOptimizeDepsExclude('/app', [])).resolves.toEqual([]);
   });
+
+  it('never excludes @strapi/strapi from optimizeDeps when it is an app dependency', async () => {
+    readPkgUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          '@strapi/strapi': '5.50.2',
+        },
+      },
+    });
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === '@strapi/strapi') {
+        return {
+          name: '@strapi/strapi',
+          type: 'module',
+          module: './dist/index.js',
+          files: ['dist'],
+          peerDependencies: {
+            react: '^18.0.0',
+            'react-dom': '^18.0.0',
+          },
+        };
+      }
+
+      return null;
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', [])).resolves.toEqual([]);
+  });
 });

--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
@@ -14,12 +14,18 @@ jest.mock('../dependencies', () => ({
   getModule: jest.fn(),
 }));
 
-jest.mock('read-pkg-up', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
+const PINNED_OPTIMIZE_MODULES = [...ADMIN_VITE_ALIAS_MODULES, '@strapi/strapi'] as const;
 
-const readPkgUp = jest.requireMock('read-pkg-up').default as jest.Mock;
+const preBuiltReactPeerPackage = (name: string) => ({
+  name,
+  type: 'module',
+  module: './dist/index.js',
+  files: ['dist'],
+  peerDependencies: {
+    react: '^18.0.0',
+    'react-dom': '^18.0.0',
+  },
+});
 
 const strapiDesignExtendedLike = {
   name: 'strapi-design-extended',
@@ -117,13 +123,6 @@ describe('collectAdminOptimizeDepsExclude', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    readPkgUp.mockResolvedValue({
-      packageJson: {
-        dependencies: {
-          react: '^18.0.0',
-        },
-      },
-    });
   });
 
   it('excludes pre-built React peer libraries from plugin dependencies', async () => {
@@ -157,58 +156,80 @@ describe('collectAdminOptimizeDepsExclude', () => {
     ]);
   });
 
-  it('never excludes pinned admin singleton modules', async () => {
-    readPkgUp.mockResolvedValue({
-      packageJson: {
-        dependencies: Object.fromEntries(ADMIN_VITE_ALIAS_MODULES.map((name) => [name, '1.0.0'])),
-      },
-    });
-
-    getModuleMock.mockImplementation(async (name: string) => {
-      if (ADMIN_VITE_ALIAS_MODULES.includes(name as (typeof ADMIN_VITE_ALIAS_MODULES)[number])) {
-        return {
-          name,
-          type: 'module',
-          module: './dist/index.js',
-          files: ['dist'],
-          peerDependencies: {
-            react: '^18.0.0',
-          },
-        };
-      }
-
-      return null;
-    });
+  it('does not scan app root dependencies for auto-exclude', async () => {
+    getModuleMock.mockResolvedValue(strapiDesignExtendedLike);
 
     await expect(collectAdminOptimizeDepsExclude('/app', [])).resolves.toEqual([]);
+    expect(getModuleMock).not.toHaveBeenCalled();
   });
 
-  it('never excludes @strapi/strapi from optimizeDeps when it is an app dependency', async () => {
-    readPkgUp.mockResolvedValue({
-      packageJson: {
-        dependencies: {
-          '@strapi/strapi': '5.50.2',
-        },
+  it('never excludes pinned admin singleton modules from plugin dependencies', async () => {
+    const plugins: PluginMeta[] = [
+      {
+        name: 'my-plugin',
+        importName: 'myPlugin',
+        type: 'module',
+        modulePath: '@org/my-plugin/strapi-admin',
       },
-    });
+    ];
 
     getModuleMock.mockImplementation(async (name: string) => {
-      if (name === '@strapi/strapi') {
+      if (name === '@org/my-plugin') {
         return {
-          name: '@strapi/strapi',
-          type: 'module',
-          module: './dist/index.js',
-          files: ['dist'],
-          peerDependencies: {
-            react: '^18.0.0',
-            'react-dom': '^18.0.0',
-          },
+          dependencies: Object.fromEntries(
+            PINNED_OPTIMIZE_MODULES.map((moduleName) => [moduleName, '1.0.0'])
+          ),
         };
+      }
+
+      if (PINNED_OPTIMIZE_MODULES.includes(name as (typeof PINNED_OPTIMIZE_MODULES)[number])) {
+        return preBuiltReactPeerPackage(name);
       }
 
       return null;
     });
 
-    await expect(collectAdminOptimizeDepsExclude('/app', [])).resolves.toEqual([]);
+    await expect(collectAdminOptimizeDepsExclude('/app', plugins)).resolves.toEqual([]);
+  });
+
+  it('does not exclude @strapi/strapi or alias modules for a typical consumer app', async () => {
+    const plugins: PluginMeta[] = [
+      {
+        name: 'users-permissions',
+        importName: 'usersPermissions',
+        type: 'module',
+        modulePath: '@strapi/plugin-users-permissions/strapi-admin',
+      },
+    ];
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === '@strapi/plugin-users-permissions') {
+        return {
+          dependencies: {
+            '@strapi/design-system': '^2.2.0',
+            '@strapi/strapi': '5.50.2',
+            react: '^18.0.0',
+            'strapi-design-extended': '^0.0.13',
+          },
+        };
+      }
+
+      if (
+        name === '@strapi/strapi' ||
+        ADMIN_VITE_ALIAS_MODULES.includes(name as (typeof ADMIN_VITE_ALIAS_MODULES)[number])
+      ) {
+        return preBuiltReactPeerPackage(name);
+      }
+
+      if (name === 'strapi-design-extended') {
+        return strapiDesignExtendedLike;
+      }
+
+      return null;
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', plugins)).resolves.toEqual([
+      'strapi-design-extended',
+    ]);
   });
 });

--- a/packages/core/strapi/src/node/core/__tests__/resolve-module.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/resolve-module.test.ts
@@ -19,6 +19,9 @@ const loadGetModulePath = (
   return { getModulePath, resolveFromMock };
 };
 
+/** Bare specifiers on optimizeDeps.include that broke pnpm dev without aliases (#27014). */
+const PNPM_OPTIMIZE_RESOLVE_MODULES = ['invariant', 'prismjs'] as const;
+
 describe('getModulePath', () => {
   afterEach(() => {
     jest.resetModules();
@@ -33,6 +36,17 @@ describe('getModulePath', () => {
 
     expect(resolveFromMock).toHaveBeenCalledWith(adminPkgDir, mod);
   });
+
+  it.each(PNPM_OPTIMIZE_RESOLVE_MODULES)(
+    'resolves %s from @strapi/admin closure without bare-specifier failure (#27014)',
+    (mod) => {
+      const { getModulePath, resolveFromMock } = loadGetModulePath();
+
+      expect(() => getModulePath(mod)).not.toThrow();
+      expect(getModulePath(mod)).toMatch(/node_modules/);
+      expect(resolveFromMock).toHaveBeenCalledWith(adminPkgDir, mod);
+    }
+  );
 
   it.each(ADMIN_PINNED_ALIAS_MODULES)(
     'resolves %s to the version pinned by @strapi/admin',

--- a/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
@@ -14,6 +14,8 @@ export const ADMIN_VITE_ALIAS_MODULES = [
   '@strapi/design-system',
   '@radix-ui/react-tooltip',
   'lodash',
+  'invariant',
+  'prismjs',
 ] as const;
 
 export type AdminViteAliasModule = (typeof ADMIN_VITE_ALIAS_MODULES)[number];
@@ -29,4 +31,5 @@ export const ADMIN_PINNED_ALIAS_MODULES = [
   'react-redux',
   '@strapi/design-system',
   'lodash',
+  'invariant',
 ] as const satisfies readonly AdminViteAliasModule[];

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import readPkgUp from 'read-pkg-up';
 
 import { ADMIN_VITE_ALIAS_MODULES } from './admin-vite-alias-modules';
 import { getModule, type PackageJson } from './dependencies';
@@ -16,6 +17,8 @@ const REACT_PEER_DEPENDENCIES = new Set(['react', 'react-dom']);
  * (see vite/config.ts — #26964, #26944, #27014).
  */
 const PINNED_OPTIMIZE_MODULES = new Set<string>([...ADMIN_VITE_ALIAS_MODULES, '@strapi/strapi']);
+
+const isOfficialStrapiPackage = (name: string): boolean => name.startsWith('@strapi/');
 
 type PackageExportEntry =
   | string
@@ -141,14 +144,20 @@ const getPluginPackageJson = async (
   return getModule(getPluginPackageName(plugin.modulePath), cwd);
 };
 
+const loadAppPackageJson = async (cwd: string): Promise<PackageJson | null> => {
+  const result = await readPkgUp({ cwd });
+
+  return result?.packageJson ?? null;
+};
+
 /**
  * Pre-built ESM libraries with React peers (shared plugin UI kits) are incompatible with
  * Strapi's React/design-system pre-bundling. Skip dep optimization so they resolve through
  * the admin resolve aliases instead of being re-bundled by Vite.
  *
- * Only plugin package.json dependencies are scanned — not the app root. Every consumer app
- * lists @strapi/strapi in dependencies, which matched the ESM+dist+React heuristic and was
- * wrongly auto-excluded (#26944, #27014). Plugin dependency graphs are the intended scope.
+ * Scans app and plugin dependency trees (#26944). Official @strapi/* packages and pinned
+ * singletons are never auto-excluded — @strapi/strapi matches the heuristic but must stay on
+ * the optimizeDeps.include path (#26944, #27014).
  *
  * @internal
  */
@@ -157,6 +166,13 @@ export const collectAdminOptimizeDepsExclude = async (
   plugins: PluginMeta[]
 ): Promise<string[]> => {
   const candidateNames = new Set<string>();
+  const appPkg = await loadAppPackageJson(cwd);
+
+  if (appPkg) {
+    for (const name of collectDependencyNames(appPkg)) {
+      candidateNames.add(name);
+    }
+  }
 
   for (const plugin of plugins) {
     const pluginPkg = await getPluginPackageJson(plugin, cwd);
@@ -171,7 +187,7 @@ export const collectAdminOptimizeDepsExclude = async (
   const exclude: string[] = [];
 
   for (const name of candidateNames) {
-    if (PINNED_OPTIMIZE_MODULES.has(name)) {
+    if (PINNED_OPTIMIZE_MODULES.has(name) || isOfficialStrapiPackage(name)) {
       continue;
     }
 

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import readPkgUp from 'read-pkg-up';
 
 import { ADMIN_VITE_ALIAS_MODULES } from './admin-vite-alias-modules';
 import { getModule, type PackageJson } from './dependencies';
@@ -10,13 +9,13 @@ const REACT_PEER_DEPENDENCIES = new Set(['react', 'react-dom']);
 
 /**
  * Packages explicitly pre-bundled or aliased for the admin singleton contract.
- * Never auto-exclude these — they must stay on the include/dedupe path.
+ * Never auto-exclude these — they must stay on the optimizeDeps.include / dedupe path.
+ *
+ * The admin entry host (@strapi/strapi) must never land in optimizeDeps.exclude (#26944, #27014).
+ * CJS-only deps imported by @strapi/admin (e.g. invariant, lodash) belong in optimizeDeps.include
+ * (see vite/config.ts — #26964, #26944, #27014).
  */
-const PINNED_OPTIMIZE_MODULES = new Set<string>([
-  ...ADMIN_VITE_ALIAS_MODULES,
-  // Admin entry host must stay on optimizeDeps include path (@strapi/strapi/admin imports invariant).
-  '@strapi/strapi',
-]);
+const PINNED_OPTIMIZE_MODULES = new Set<string>([...ADMIN_VITE_ALIAS_MODULES, '@strapi/strapi']);
 
 type PackageExportEntry =
   | string
@@ -142,16 +141,14 @@ const getPluginPackageJson = async (
   return getModule(getPluginPackageName(plugin.modulePath), cwd);
 };
 
-const loadAppPackageJson = async (cwd: string): Promise<PackageJson | null> => {
-  const result = await readPkgUp({ cwd });
-
-  return result?.packageJson ?? null;
-};
-
 /**
  * Pre-built ESM libraries with React peers (shared plugin UI kits) are incompatible with
  * Strapi's React/design-system pre-bundling. Skip dep optimization so they resolve through
  * the admin resolve aliases instead of being re-bundled by Vite.
+ *
+ * Only plugin package.json dependencies are scanned — not the app root. Every consumer app
+ * lists @strapi/strapi in dependencies, which matched the ESM+dist+React heuristic and was
+ * wrongly auto-excluded (#26944, #27014). Plugin dependency graphs are the intended scope.
  *
  * @internal
  */
@@ -160,13 +157,6 @@ export const collectAdminOptimizeDepsExclude = async (
   plugins: PluginMeta[]
 ): Promise<string[]> => {
   const candidateNames = new Set<string>();
-  const appPkg = await loadAppPackageJson(cwd);
-
-  if (appPkg) {
-    for (const name of collectDependencyNames(appPkg)) {
-      candidateNames.add(name);
-    }
-  }
 
   for (const plugin of plugins) {
     const pluginPkg = await getPluginPackageJson(plugin, cwd);

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -12,7 +12,11 @@ const REACT_PEER_DEPENDENCIES = new Set(['react', 'react-dom']);
  * Packages explicitly pre-bundled or aliased for the admin singleton contract.
  * Never auto-exclude these — they must stay on the include/dedupe path.
  */
-const PINNED_OPTIMIZE_MODULES = new Set<string>(ADMIN_VITE_ALIAS_MODULES);
+const PINNED_OPTIMIZE_MODULES = new Set<string>([
+  ...ADMIN_VITE_ALIAS_MODULES,
+  // Admin entry host must stay on optimizeDeps include path (@strapi/strapi/admin imports invariant).
+  '@strapi/strapi',
+]);
 
 type PackageExportEntry =
   | string

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -68,6 +68,8 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
         // Pre-bundle lodash: design-system uses named imports (e.g. assignWith) but lodash
         // is CommonJS-only; pre-bundling converts it to ESM for the browser
         'lodash',
+        // Pre-bundle invariant: @strapi/strapi/admin imports it; CJS-only without pre-bundling.
+        'invariant',
         // Pre-bundle prismjs so plugin chunks get a valid ESM namespace (prismjs is UMD and can
         // otherwise expose an empty object when bundled, causing "Prism is not defined" in admin).
         'prismjs',

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -42,6 +42,9 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
     },
     envPrefix: 'STRAPI_ADMIN_',
     optimizeDeps: {
+      // Contract (#26964, #26944, #27014):
+      // - CJS packages imported by @strapi/admin MUST be in optimizeDeps.include (invariant, lodash, …).
+      // - The admin entry host (@strapi/strapi) MUST NOT be in optimizeDeps.exclude.
       // When design-system is linked (portal:, file:, yarn link), exclude from pre-bundling
       // so changes are reflected without clearing node_modules/.strapi/vite cache.
       // Also skip pre-built ESM plugin UI libraries with React peers (see collectAdminOptimizeDepsExclude).
@@ -65,13 +68,10 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
         // Omit when linked so local changes are picked up (see exclude above)
         ...(!designSystemLinked ? ['@strapi/design-system'] : []),
         '@radix-ui/react-tooltip',
-        // Pre-bundle lodash: design-system uses named imports (e.g. assignWith) but lodash
-        // is CommonJS-only; pre-bundling converts it to ESM for the browser
+        // CJS-only; required for @strapi/admin in dev (#26944, #26964, #27014).
         'lodash',
-        // Pre-bundle invariant: @strapi/strapi/admin imports it; CJS-only without pre-bundling.
         'invariant',
-        // Pre-bundle prismjs so plugin chunks get a valid ESM namespace (prismjs is UMD and can
-        // otherwise expose an empty object when bundled, causing "Prism is not defined" in admin).
+        // UMD; without pre-bundling plugin chunks get empty namespace → "Prism is not defined" (#26964).
         'prismjs',
         /**
          * Pre-bundle other dependencies that would otherwise cause a page reload when imported.

--- a/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
+++ b/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
@@ -51,6 +51,12 @@ describe('resolveDevelopmentConfig (Vite admin dev)', () => {
       expect.arrayContaining(['invariant', 'lodash', 'prismjs'])
     );
 
+    // Same modules need explicit aliases so pnpm can resolve optimizeDeps.include (#27014).
+    const alias = config.resolve?.alias as Record<string, string> | undefined;
+    expect(alias?.invariant).toEqual(expect.any(String));
+    expect(alias?.prismjs).toEqual(expect.any(String));
+    expect(alias?.lodash).toEqual(expect.any(String));
+
     await new Promise<void>((resolve) => {
       mockHttpServer.close(() => resolve());
     });

--- a/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
+++ b/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
@@ -46,6 +46,11 @@ describe('resolveDevelopmentConfig (Vite admin dev)', () => {
     });
     expect((config.server?.hmr as { clientPort?: number }).clientPort).toBeUndefined();
 
+    // CJS-only deps imported by @strapi/admin must stay pre-bundled in dev (#26944, #26964, #27014).
+    expect(config.optimizeDeps?.include).toEqual(
+      expect.arrayContaining(['invariant', 'lodash', 'prismjs'])
+    );
+
     await new Promise<void>((resolve) => {
       mockHttpServer.close(() => resolve());
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9021,7 +9021,7 @@ __metadata:
     highlight.js: "npm:^10.4.1"
     immer: "npm:9.0.21"
     inquirer: "npm:9.3.8"
-    invariant: "npm:^2.2.4"
+    invariant: "npm:2.2.4"
     is-localhost-ip: "npm:2.0.0"
     jest: "npm:29.6.0"
     json-logic-js: "npm:2.0.5"
@@ -20820,7 +20820,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.4":
+"invariant@npm:2.2.4, invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:


### PR DESCRIPTION
## Summary

Fixes a develop-mode blank admin regression introduced by strapi/strapi#26944.

PR strapi/strapi#26944 added `admin-vite-optimize-exclude.ts`, which auto-excludes pre-built ESM libraries with React peers from Vite `optimizeDeps`. `@strapi/strapi` matches that heuristic (ESM + dist + React peers), so it was excluded from pre-bundling. The admin entry imports from `@strapi/strapi/admin`, which pulls in the CJS-only `invariant` package — without pre-bundling, the browser fails to load it and the admin panel renders blank in develop mode.

This PR:

* Pins `@strapi/strapi` in the never-exclude set so the admin entry host stays on the `optimizeDeps.include` path
* Skips **all** `@strapi/*` **packages** from auto-exclude (official packages are never third-party UI kit candidates)
* Adds `invariant` to `optimizeDeps.include` as a belt-and-suspenders safeguard (same pattern as `lodash`)
* **Preserves** strapi/strapi#26944 **scope:** auto-exclude still scans **app + plugin** dependency trees (UI kits listed only in app `package.json` still work)
* Documents the Vite admin dev contract in code comments (strapi/strapi#26964, strapi/strapi#26944, strapi/strapi#27014)

Related: strapi/strapi#26944, strapi/strapi#26964

## Regression prevention / contract tests

Jest contract tests guard the develop-mode admin Vite config:

<!-- linear:table-colwidths:400,400 -->
| Test file | Contract |
| -- | -- |
| `resolve-development-config.test.ts` | `optimizeDeps.include` always contains `invariant`, `lodash`, `prismjs` |
| `admin-vite-optimize-exclude.test.ts` | App root `@strapi/strapi` is never excluded; matching UI kits in app root still are |
|  | Official `@strapi/*` packages matching the heuristic are never auto-excluded |
|  | Every `PINNED_OPTIMIZE_MODULES` / `ADMIN_VITE_ALIAS_MODULES` entry is never excluded when present in plugin deps |
|  | Typical consumer plugin graph (`@strapi/plugin-users-permissions`) does not exclude `@strapi/strapi` or alias modules |

Run:

```bash
yarn jest --testPathPattern='admin-vite-optimize-exclude|resolve-development-config'
```

(14 tests)

**Release QA:** `strapi-release-testing` skill updated (cms-brain `23c3656`) — add `npm run develop` admin screenshot smoke for Vite `optimizeDeps` changes.

## Test plan

- [X] `yarn jest --testPathPattern='admin-vite-optimize-exclude|resolve-development-config'` (14 tests pass)
- [ ] `yarn develop` on a Strapi 5.50 app — admin panel loads (no blank screen / invariant ESM error)
- [ ] Confirm `collectAdminOptimizeDepsExclude` no longer returns `@strapi/strapi` for a typical app