### PR TITLE
fix(content-manager): single-row delete 404 for non-i18n types with l…

### DIFF
--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -17,6 +17,7 @@ import { getDocumentLocaleAndStatus } from './validation/dimensions';
 import { formatDocumentWithMetadata } from './utils/metadata';
 import { indexByDocumentId } from './utils/document-status';
 import { getPopulateForLocalizations, buildDeepPopulate } from '../services/utils/populate';
+import { isContentTypeLocalized } from '../mcp/permissions';
 
 /**
  * Returns documentIds for (documentId, locale) that have both draft and published,
@@ -615,8 +616,16 @@ export default {
 
     const { locale } = await getDocumentLocaleAndStatus(ctx.query, model);
 
+    // Non-localized content types store entries with `locale: null`, so filtering by a
+    // specific locale matches nothing and would incorrectly return 404. Only apply the
+    // locale filter when the content type is actually localized. (GH#26238)
+    const resolvedLocale = isContentTypeLocalized(strapi, model) ? locale : undefined;
+
     // Find locales to delete
-    const documentLocales = await documentManager.findLocales(id, model, { populate, locale });
+    const documentLocales = await documentManager.findLocales(id, model, {
+      populate,
+      locale: resolvedLocale,
+    });
 
     if (documentLocales.length === 0) {
       return ctx.notFound();
@@ -628,7 +637,7 @@ export default {
       }
     }
 
-    const result = await documentManager.delete(id, model, { locale });
+    const result = await documentManager.delete(id, model, { locale: resolvedLocale });
 
     ctx.body = await permissionChecker.sanitizeOutput(result);
   },

--- a/tests/api/core/content-manager/content-manager/delete-non-i18n-locale.test.api.js
+++ b/tests/api/core/content-manager/content-manager/delete-non-i18n-locale.test.api.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// Repro for https://github.com/strapi/strapi/issues/26238
+// Single-row delete via the Content Manager returns 404 for a non-i18n
+// collection type when a locale query param is present, because findLocales
+// filters `where.locale = <locale>` while non-i18n rows have `locale = null`.
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+
+const model = {
+  draftAndPublish: true,
+  pluginOptions: {}, // non-i18n (not localized)
+  singularName: 'errorcode',
+  pluralName: 'errorcodes',
+  displayName: 'Errorcode',
+  attributes: {
+    code: { type: 'string' },
+  },
+};
+
+const uid = 'api::errorcode.errorcode';
+
+describe('CM single-row delete for non-i18n type with locale param (#26238)', () => {
+  beforeAll(async () => {
+    await builder.addContentType(model).build();
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  const createEntry = async () => {
+    const { body } = await rq({
+      url: `/content-manager/collection-types/${uid}`,
+      method: 'POST',
+      body: { code: 'E-001' },
+    });
+    return body.data;
+  };
+
+  test('deletes without a locale param (baseline)', async () => {
+    const entry = await createEntry();
+    const res = await rq({
+      url: `/content-manager/collection-types/${uid}/${entry.documentId}`,
+      method: 'DELETE',
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  test('deletes even when a locale query param is passed', async () => {
+    const entry = await createEntry();
+    const res = await rq({
+      url: `/content-manager/collection-types/${uid}/${entry.documentId}`,
+      method: 'DELETE',
+      qs: { locale: 'en' },
+    });
+
+    // Bug: returned 404 because findLocales matched nothing for a null-locale row.
+    expect(res.statusCode).toBe(200);
+
+    // The entry is actually gone.
+    const getRes = await rq({
+      url: `/content-manager/collection-types/${uid}/${entry.documentId}`,
+      method: 'GET',
+    });
+    expect(getRes.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
### What does it do?

Fixes single-row delete in the Content Manager returning **404** for non-i18n collection types when a `locale` query param is present.

- The `delete` controller passed the request `locale` to `documentManager.findLocales` unconditionally (`packages/core/content-manager/server/src/controllers/collection-types.ts`).
- For a **non-localized** content type, entries are stored with `locale: null`, so `findLocales` builds `where.locale = "<locale>"`, matches nothing, and the handler returns `ctx.notFound()`.
- The fix only applies the locale filter when the content type is localized (via the existing `isContentTypeLocalized` helper); non-i18n deletes now ignore the locale param. The same resolved locale is used for the actual `delete` call.
- Localized content types are unaffected.

### Why is it needed?

- Deleting a single non-i18n entry from the Content Manager fails with 404, even though the entry exists, bulk delete works, and programmatic deletion works (reported and confirmed in #26238).

### How to test it?

- Automated (added): `tests/api/core/content-manager/content-manager/delete-non-i18n-locale.test.api.js`
  - non-i18n delete without a locale param → 200 (baseline),
  - non-i18n delete **with** `?locale=en` → 200 and the entry is actually gone (was 404).
- Regression: i18n Content Manager CRUD suite still passes (localized delete unchanged).
- Manual: create a non-i18n collection type with Draft & Publish, add an entry, delete it from the Content Manager list/edit view — it deletes instead of erroring.

### Related issue(s)/PR(s)

- Fix #26238
- Supersedes the closed, unmerged #26308 (same root cause, server-side fix).