### PR TITLE
fix: guard RelativeTime against invalid dates

### DIFF
--- a/packages/core/content-manager/admin/src/components/RelativeTime.tsx
+++ b/packages/core/content-manager/admin/src/components/RelativeTime.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Duration, intervalToDuration, isPast } from 'date-fns';
+import { Duration, intervalToDuration, isPast, isValid } from 'date-fns';
 import { useIntl } from 'react-intl';
 
 const intervals: Array<keyof Duration> = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'];
@@ -33,6 +33,14 @@ interface RelativeTimeProps extends React.ComponentPropsWithoutRef<'time'> {
 const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
   ({ timestamp, customIntervals = [], ...restProps }, forwardedRef) => {
     const { formatRelativeTime, formatDate, formatTime } = useIntl();
+
+    if (!isValid(timestamp)) {
+      return (
+        <time ref={forwardedRef} role="time" {...restProps}>
+          -
+        </time>
+      );
+    }
 
     /**
      * TODO: make this auto-update, like a clock.

--- a/packages/core/content-manager/admin/src/components/tests/RelativeTime.test.tsx
+++ b/packages/core/content-manager/admin/src/components/tests/RelativeTime.test.tsx
@@ -48,4 +48,12 @@ describe('RelativeTime', () => {
 
     expect(screen.getByRole('time')).toHaveTextContent('now');
   });
+
+  it('renders a fallback instead of crashing when the timestamp is invalid', () => {
+    render(<RelativeTime timestamp={new Date({} as unknown as string)} />);
+
+    const timeElement = screen.getByRole('time');
+    expect(timeElement).toHaveTextContent('-');
+    expect(timeElement).not.toHaveAttribute('datetime');
+  });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Guards `RelativeTime` (content-manager) against invalid `Date` values. When the timestamp fails `isValid()`, the component now renders a `-` fallback instead of passing the invalid date to `intervalToDuration()` / `timestamp.toISOString()`, both of which throw.

Added a regression test covering the invalid-date case.

### Why is it needed?

The Homepage "Last edited entries" / "Last published entries" widgets crash the whole page with `RangeError: Start Date is invalid` when the `recent-documents` API returns a malformed date value (e.g. serialized as `{}`). The error originates in `RelativeTime`, which fed the value straight into `intervalToDuration` with no validity check, so a single bad timestamp took down the entire view.

This makes the widget resilient to any malformed date the API returns, rather than crashing.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #27013 
