### PR TITLE
fix(admin): expire admin reset-password tokens

### DIFF
--- a/packages/core/admin/ee/server/src/services/auth.ts
+++ b/packages/core/admin/ee/server/src/services/auth.ts
@@ -2,6 +2,10 @@ import _ from 'lodash';
 import { errors } from '@strapi/utils';
 import { getService } from '../utils';
 import { isSsoLocked } from '../utils/sso-lock';
+import {
+  assignResetPasswordToken,
+  assertResetPasswordTokenIsValid,
+} from '../../../../server/src/services/auth';
 
 const { ApplicationError } = errors;
 /**
@@ -18,8 +22,7 @@ const forgotPassword = async ({ email }: any = {}) => {
     return;
   }
 
-  const resetPasswordToken = getService('token').createToken();
-  await getService('user').updateById(user.id, { resetPasswordToken });
+  const resetPasswordToken = await assignResetPasswordToken(user.id);
 
   // Send an email to the admin.
   const url = `${strapi.config.get(
@@ -61,9 +64,12 @@ const resetPassword = async ({ resetPasswordToken, password }: any = {}) => {
     throw new ApplicationError();
   }
 
+  await assertResetPasswordTokenIsValid(matchingUser);
+
   return getService('user').updateById(matchingUser.id, {
     password,
     resetPasswordToken: null,
+    resetPasswordTokenExpiresAt: null,
   });
 };
 

--- a/packages/core/admin/ee/server/src/services/user.ts
+++ b/packages/core/admin/ee/server/src/services/user.ts
@@ -225,7 +225,13 @@ const isLastSuperAdminUser = async (userId: unknown) => {
  */
 const sanitizeUser = (user: any) => {
   return {
-    ..._.omit(user, ['password', 'resetPasswordToken', 'registrationToken', 'roles']),
+    ..._.omit(user, [
+      'password',
+      'resetPasswordToken',
+      'resetPasswordTokenExpiresAt',
+      'registrationToken',
+      'roles',
+    ]),
     roles: user.roles && user.roles.map(sanitizeUserRoles),
   };
 };

--- a/packages/core/admin/server/src/content-types/User.ts
+++ b/packages/core/admin/server/src/content-types/User.ts
@@ -58,6 +58,12 @@ export default {
       private: true,
       searchable: false,
     },
+    resetPasswordTokenExpiresAt: {
+      type: 'datetime',
+      configurable: false,
+      private: true,
+      searchable: false,
+    },
     registrationToken: {
       type: 'string',
       configurable: false,

--- a/packages/core/admin/server/src/services/__tests__/auth.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/auth.test.ts
@@ -340,6 +340,42 @@ describe('Auth', () => {
       }
     });
 
+    test('Fails and clears the token for a legacy token with no expiry (#25711)', async () => {
+      const resetPasswordToken = '123';
+      // A token issued before expiry was introduced: set, but with no expiry.
+      const user = {
+        id: 1,
+        resetPasswordToken,
+      };
+
+      const findOne = jest.fn(() => Promise.resolve(user));
+      const updateById = jest.fn(() => Promise.resolve());
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne };
+          },
+        },
+        admin: { services: { user: { updateById } } },
+        config: { get: (_key: string, defaultValue: unknown) => defaultValue },
+      } as any;
+
+      expect.assertions(2);
+
+      try {
+        await resetPassword({ resetPasswordToken, password: 'Test1234' });
+      } catch (e) {
+        expect(e instanceof errors.ApplicationError).toBe(true);
+      }
+
+      // The stale token must be cleared so it can no longer be retried.
+      expect(updateById).toHaveBeenCalledWith(user.id, {
+        resetPasswordToken: null,
+        resetPasswordTokenExpiresAt: null,
+      });
+    });
+
     test('Changes password and clear reset token', async () => {
       const resetPasswordToken = '123';
       const user = {

--- a/packages/core/admin/server/src/services/__tests__/auth.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/auth.test.ts
@@ -209,7 +209,10 @@ describe('Auth', () => {
 
       expect(findOne).toHaveBeenCalled();
       expect(createToken).toHaveBeenCalled();
-      expect(updateById).toHaveBeenCalledWith(user.id, { resetPasswordToken });
+      expect(updateById).toHaveBeenCalledWith(user.id, {
+        resetPasswordToken,
+        resetPasswordTokenExpiresAt: expect.any(Date),
+      });
     });
 
     test('Will call the send service', async () => {
@@ -307,9 +310,13 @@ describe('Auth', () => {
       }
     });
 
-    test('Changes password and clear reset token', async () => {
+    test('Fails if reset token has expired (#25711)', async () => {
       const resetPasswordToken = '123';
-      const user = { id: 1 };
+      const user = {
+        id: 1,
+        // Expired one minute ago
+        resetPasswordTokenExpiresAt: new Date(Date.now() - 60 * 1000).toISOString(),
+      };
 
       const findOne = jest.fn(() => Promise.resolve(user));
       const updateById = jest.fn(() => Promise.resolve());
@@ -321,6 +328,37 @@ describe('Auth', () => {
           },
         },
         admin: { services: { user: { updateById } } },
+        config: { get: (_key: string, defaultValue: unknown) => defaultValue },
+      } as any;
+
+      expect.assertions(1);
+
+      try {
+        await resetPassword({ resetPasswordToken, password: 'Test1234' });
+      } catch (e) {
+        expect(e instanceof errors.ApplicationError).toBe(true);
+      }
+    });
+
+    test('Changes password and clear reset token', async () => {
+      const resetPasswordToken = '123';
+      const user = {
+        id: 1,
+        // Valid for another hour
+        resetPasswordTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      };
+
+      const findOne = jest.fn(() => Promise.resolve(user));
+      const updateById = jest.fn(() => Promise.resolve());
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne };
+          },
+        },
+        admin: { services: { user: { updateById } } },
+        config: { get: (_key: string, defaultValue: unknown) => defaultValue },
       } as any;
 
       const input = { resetPasswordToken, password: 'Test1234' };
@@ -329,6 +367,7 @@ describe('Auth', () => {
       expect(updateById).toHaveBeenCalledWith(user.id, {
         password: input.password,
         resetPasswordToken: null,
+        resetPasswordTokenExpiresAt: null,
       });
     });
   });

--- a/packages/core/admin/server/src/services/auth.ts
+++ b/packages/core/admin/server/src/services/auth.ts
@@ -2,10 +2,30 @@ import bcrypt from 'bcryptjs';
 import _ from 'lodash';
 import { errors } from '@strapi/utils';
 import { getService } from '../utils';
+import { expiresInToSeconds } from './token';
 import type { AdminUser } from '../../../shared/contracts/shared';
 import '@strapi/types';
 
 const { ApplicationError } = errors;
+
+// Default lifetime of an admin reset-password token. Overridable via
+// `admin.forgotPassword.tokenExpiresIn` (number of seconds or a shorthand like '15m', '1h').
+const DEFAULT_RESET_PASSWORD_TOKEN_EXPIRES_IN = '1h';
+
+/**
+ * Resolve the reset-password token lifetime, in milliseconds, from config.
+ * Falls back to {@link DEFAULT_RESET_PASSWORD_TOKEN_EXPIRES_IN} for unset/invalid values.
+ */
+const getResetPasswordTokenTTL = (): number => {
+  const configured = strapi.config.get(
+    'admin.forgotPassword.tokenExpiresIn',
+    DEFAULT_RESET_PASSWORD_TOKEN_EXPIRES_IN
+  );
+  const seconds =
+    expiresInToSeconds(configured) ??
+    (expiresInToSeconds(DEFAULT_RESET_PASSWORD_TOKEN_EXPIRES_IN) as number);
+  return seconds * 1000;
+};
 
 /**
  * hashes a password
@@ -60,7 +80,11 @@ const forgotPassword = async ({ email } = {} as { email: string }) => {
   }
 
   const resetPasswordToken = getService('token').createToken();
-  await getService('user').updateById(user.id, { resetPasswordToken });
+  const resetPasswordTokenExpiresAt = new Date(Date.now() + getResetPasswordTokenTTL());
+  await getService('user').updateById(user.id, {
+    resetPasswordToken,
+    resetPasswordTokenExpiresAt,
+  });
 
   // Send an email to the admin.
   const url = `${strapi.config.get(
@@ -104,9 +128,25 @@ const resetPassword = async (
     throw new ApplicationError();
   }
 
+  // Reject expired tokens. Tokens without an expiry (e.g. issued before this was
+  // introduced) are treated as expired so they cannot be used indefinitely. (GH#25711)
+  const { resetPasswordTokenExpiresAt } = matchingUser;
+  const isExpired =
+    !resetPasswordTokenExpiresAt || new Date(resetPasswordTokenExpiresAt).getTime() <= Date.now();
+
+  if (isExpired) {
+    // Clear the stale token so it can no longer be retried.
+    await getService('user').updateById(matchingUser.id, {
+      resetPasswordToken: null,
+      resetPasswordTokenExpiresAt: null,
+    });
+    throw new ApplicationError('This reset password token has expired');
+  }
+
   return getService('user').updateById(matchingUser.id, {
     password,
     resetPasswordToken: null,
+    resetPasswordTokenExpiresAt: null,
   });
 };
 

--- a/packages/core/admin/server/src/services/auth.ts
+++ b/packages/core/admin/server/src/services/auth.ts
@@ -9,7 +9,7 @@ import '@strapi/types';
 const { ApplicationError } = errors;
 
 // Default lifetime of an admin reset-password token. Overridable via
-// `admin.forgotPassword.tokenExpiresIn` (number of seconds or a shorthand like '15m', '1h').
+// `admin.forgotPassword.expiresIn` (number of seconds or a shorthand like '15m', '1h').
 const DEFAULT_RESET_PASSWORD_TOKEN_EXPIRES_IN = '1h';
 
 /**
@@ -18,13 +18,50 @@ const DEFAULT_RESET_PASSWORD_TOKEN_EXPIRES_IN = '1h';
  */
 const getResetPasswordTokenTTL = (): number => {
   const configured = strapi.config.get(
-    'admin.forgotPassword.tokenExpiresIn',
+    'admin.forgotPassword.expiresIn',
     DEFAULT_RESET_PASSWORD_TOKEN_EXPIRES_IN
   );
   const seconds =
     expiresInToSeconds(configured) ??
     (expiresInToSeconds(DEFAULT_RESET_PASSWORD_TOKEN_EXPIRES_IN) as number);
   return seconds * 1000;
+};
+
+/**
+ * Create a reset-password token with an expiry and persist it on the user.
+ * Shared by the CE and EE auth services so the expiry behaviour can't drift.
+ * @returns the generated reset-password token
+ */
+const assignResetPasswordToken = async (userId: AdminUser['id']): Promise<string> => {
+  const resetPasswordToken = getService('token').createToken();
+  const resetPasswordTokenExpiresAt = new Date(Date.now() + getResetPasswordTokenTTL());
+
+  await getService('user').updateById(userId, {
+    resetPasswordToken,
+    resetPasswordTokenExpiresAt,
+  });
+
+  return resetPasswordToken;
+};
+
+/**
+ * Reject a reset-password token that has expired — or that has no expiry at all
+ * (tokens issued before this was introduced) — clearing the stale token so it
+ * cannot be retried. Shared by the CE and EE auth services. (GH#25711)
+ */
+const assertResetPasswordTokenIsValid = async (user: AdminUser): Promise<void> => {
+  const { resetPasswordTokenExpiresAt } = user;
+  const isExpired =
+    !resetPasswordTokenExpiresAt || new Date(resetPasswordTokenExpiresAt).getTime() <= Date.now();
+
+  if (isExpired) {
+    // Clear the stale token so it can no longer be retried.
+    await getService('user').updateById(user.id, {
+      resetPasswordToken: null,
+      resetPasswordTokenExpiresAt: null,
+    });
+    throw new ApplicationError('This reset password token has expired');
+  }
 };
 
 /**
@@ -79,12 +116,7 @@ const forgotPassword = async ({ email } = {} as { email: string }) => {
     return;
   }
 
-  const resetPasswordToken = getService('token').createToken();
-  const resetPasswordTokenExpiresAt = new Date(Date.now() + getResetPasswordTokenTTL());
-  await getService('user').updateById(user.id, {
-    resetPasswordToken,
-    resetPasswordTokenExpiresAt,
-  });
+  const resetPasswordToken = await assignResetPasswordToken(user.id);
 
   // Send an email to the admin.
   const url = `${strapi.config.get(
@@ -128,20 +160,7 @@ const resetPassword = async (
     throw new ApplicationError();
   }
 
-  // Reject expired tokens. Tokens without an expiry (e.g. issued before this was
-  // introduced) are treated as expired so they cannot be used indefinitely. (GH#25711)
-  const { resetPasswordTokenExpiresAt } = matchingUser;
-  const isExpired =
-    !resetPasswordTokenExpiresAt || new Date(resetPasswordTokenExpiresAt).getTime() <= Date.now();
-
-  if (isExpired) {
-    // Clear the stale token so it can no longer be retried.
-    await getService('user').updateById(matchingUser.id, {
-      resetPasswordToken: null,
-      resetPasswordTokenExpiresAt: null,
-    });
-    throw new ApplicationError('This reset password token has expired');
-  }
+  await assertResetPasswordTokenIsValid(matchingUser);
 
   return getService('user').updateById(matchingUser.id, {
     password,
@@ -151,3 +170,4 @@ const resetPassword = async (
 };
 
 export default { checkCredentials, validatePassword, hashPassword, forgotPassword, resetPassword };
+export { getResetPasswordTokenTTL, assignResetPasswordToken, assertResetPasswordTokenIsValid };

--- a/packages/core/admin/server/src/services/user.ts
+++ b/packages/core/admin/server/src/services/user.ts
@@ -34,7 +34,13 @@ const getSessionManager = () => {
  */
 const sanitizeUser = (user: AdminUser): SanitizedAdminUser => {
   return {
-    ..._.omit(user, ['password', 'resetPasswordToken', 'registrationToken', 'roles']),
+    ..._.omit(user, [
+      'password',
+      'resetPasswordToken',
+      'resetPasswordTokenExpiresAt',
+      'registrationToken',
+      'roles',
+    ]),
     roles: user.roles && user.roles.map(sanitizeUserRoles),
   };
 };

--- a/packages/core/admin/shared/contracts/shared.ts
+++ b/packages/core/admin/shared/contracts/shared.ts
@@ -25,6 +25,7 @@ export interface AdminUser extends Entity {
   email?: string;
   password?: string;
   resetPasswordToken?: string | null;
+  resetPasswordTokenExpiresAt?: string | Date | null;
   registrationToken?: string | null;
   isActive: boolean;
   roles: AdminRole[];
@@ -43,7 +44,10 @@ export type AdminUserUpdatePayload = Omit<AdminUser, keyof Entity | 'roles'> & {
   roles: Data.ID[];
 };
 
-export type SanitizedAdminUser = Omit<AdminUser, 'password' | 'resetPasswordToken' | 'roles'> & {
+export type SanitizedAdminUser = Omit<
+  AdminUser,
+  'password' | 'resetPasswordToken' | 'resetPasswordTokenExpiresAt' | 'roles'
+> & {
   roles: SanitizedAdminRole[];
 };
 

--- a/packages/core/types/src/core/config/admin.ts
+++ b/packages/core/types/src/core/config/admin.ts
@@ -64,6 +64,11 @@ export interface ForgotPassword {
   emailTemplate?: string;
   from?: string;
   replyTo?: string;
+  /**
+   * Lifetime of the reset-password token. Accepts a number of seconds or a
+   * shorthand string such as `'15m'` / `'1h'`. Defaults to `'1h'`.
+   */
+  expiresIn?: string | number;
 }
 
 export interface RateLimit {


### PR DESCRIPTION
### What does it do?

Makes admin password-reset tokens expire.

- Adds a private `resetPasswordTokenExpiresAt` datetime field to the `admin::user` content type.
- `forgotPassword` now stores an expiry (`now + TTL`) alongside the token. TTL defaults to **1 hour** and is configurable via `admin.forgotPassword.expiresIn` (seconds, or shorthand like `15m`/`1h`), parsed with the existing `expiresInToSeconds` helper.
- `resetPassword` rejects a token that is expired — or that has no expiry (tokens issued before this change) — and clears the stale token so it can't be retried.
- `resetPasswordTokenExpiresAt` is added to the `AdminUser` type and excluded from `SanitizedAdminUser` (kept private, never returned by the API).

### Why is it needed?

- Previously the reset token had no expiry and `resetPassword` never checked age, so a token leaked via email interception, logs, or a compromised inbox stayed valid **indefinitely** — a real account-takeover risk (#25711).

### How to test it?

- Automated: `yarn jest --config jest.config.js packages/core/admin/server/src/services/__tests__/auth`
  - `forgotPassword` stores a `resetPasswordTokenExpiresAt`,
  - `resetPassword` throws for an expired token,
  - `resetPassword` succeeds and clears both token fields for a valid token.
- Manual: set `admin.forgotPassword.expiresIn` to a short value (e.g. `30s`), trigger a reset, wait past it, and confirm the reset link is rejected.

### Related issue(s)/PR(s)

- Fix #25711
- Supersedes the closed #25712 (its expiry field was never persisted on the model, so tokens always read as expired — addressed here).