### PR TITLE
fix(content-manager): don't restore component relation when reset and re-added

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
@@ -424,14 +424,25 @@ const filterDataByRemovedPaths = (
           );
         });
       } else {
-        result[attrName] = filterDataByRemovedPaths(
+        // A non-repeatable component value with no `id` is a freshly (re-)created
+        // instance — e.g. the component was reset (set to null) and re-added. It must
+        // not inherit the previous component's data (id, relations, …) from
+        // `initialValues`; otherwise the server updates the old component row in place
+        // and, given an empty relation diff, restores the previously connected
+        // relations on save (see https://github.com/strapi/strapi/issues/25030).
+        // Mirror the safeguard already applied to dynamic-zone items below.
+        const isNewComponent = value?.id === undefined || value?.id === null;
+
+        const cleaned = filterDataByRemovedPaths(
           value,
-          initialValue ?? {},
+          isNewComponent ? {} : (initialValue ?? {}),
           compSchema,
           components,
           removedPaths,
           [...currentPath, attrName]
         );
+
+        result[attrName] = isNewComponent ? { ...cleaned, id: undefined } : cleaned;
       }
 
       continue;

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/tests/data.test.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/tests/data.test.ts
@@ -529,6 +529,86 @@ describe('data', () => {
       expect(result.data).not.toHaveProperty('internationalCode');
       expect(result.removedAttributes).toEqual(['internationalCode']);
     });
+
+    // https://github.com/strapi/strapi/issues/25030
+    it('should not restore a non-repeatable component relation when the component is reset and re-added', () => {
+      const componentSchema = {
+        uid: 'basic.relation' as const,
+        category: 'basic',
+        modelType: 'component' as const,
+        modelName: 'relation',
+        globalId: 'ComponentBasicRelation',
+        info: { displayName: 'Relation' },
+        options: {},
+        pluginOptions: {},
+        attributes: {
+          id: { type: 'integer' as const },
+          documentId: { type: 'string' as const },
+          categories: {
+            type: 'relation' as const,
+            relation: 'oneToMany' as const,
+            target: 'api::category.category' as const,
+          },
+        },
+      };
+
+      const result = handleInvisibleAttributes(
+        {
+          documentId: 'ow3vxhwkt7ca7yw8dvda4ek4',
+          title: 'My entry',
+          // The user reset the component (→ null) and re-added it via the
+          // initializer, so `getValues()` holds a freshly created, empty
+          // component with no id.
+          single_relation: {},
+        },
+        {
+          schema: {
+            uid: 'api::bugtest.bugtest',
+            kind: 'collectionType',
+            modelType: 'contentType',
+            modelName: 'bugtest',
+            globalId: 'BugTest',
+            info: {
+              displayName: 'BugTest',
+              singularName: 'bugtest',
+              pluralName: 'bugtests',
+              description: '',
+            },
+            options: { draftAndPublish: true },
+            pluginOptions: {},
+            attributes: {
+              documentId: { type: 'string' },
+              title: { type: 'string' },
+              single_relation: {
+                type: 'component',
+                component: 'basic.relation',
+                repeatable: false,
+              },
+            },
+          },
+          // The previously-saved component (id + connected relation) as it is
+          // loaded into the form.
+          initialValues: {
+            documentId: 'ow3vxhwkt7ca7yw8dvda4ek4',
+            title: 'My entry',
+            single_relation: {
+              id: 5,
+              categories: { connect: [], disconnect: [] },
+            },
+          },
+          components: {
+            'basic.relation': componentSchema,
+          },
+        }
+      );
+
+      // The re-added component must not inherit the previous component's id nor
+      // its relation from initialValues; otherwise the server updates the old
+      // component row in place and restores the relation on save.
+      expect(result.data.single_relation).toBeDefined();
+      expect(result.data.single_relation.id).toBeUndefined();
+      expect(result.data.single_relation).not.toHaveProperty('categories');
+    });
   });
 
   describe('prepareTempKeys', () => {


### PR DESCRIPTION
### What does it do?

Stops a component relation from being silently restored after the component is reset and re-added.

- In `filterDataByRemovedPaths` (`EditView/utils/data.ts`), a **non-repeatable** component whose current value has no `id` is now treated as a freshly created instance: it no longer inherits fields (`id`, relations, …) from `initialValues`, and its `id` is forced to `undefined` — mirroring the safeguard already used for dynamic-zone items.
- Adds a regression test in `EditView/utils/tests/data.test.ts`.

### Why is it needed?

When a component containing a relation was reset (set to `null`) and re-added, `getValues()` correctly held an empty component, but `handleInvisibleAttributes` re-injected the old component `id` and relation from `initialValues`. The client then submitted `{ id, categories: { connect: [], disconnect: [] } }`; the server updated the existing component row in place and, given the empty diff, kept the previously connected relation — so the relation reappeared on save even though the UI showed it removed (#25030).

### How to test it?

- Automated: `yarn test:front packages/core/content-manager/admin/src/pages/EditView/utils/tests/data.test.ts` — see the test *"should not restore a non-repeatable component relation when the component is reset and re-added"* (fails on `develop`, passes with this change).
- Manual:
  1. Create an entry with a non-repeatable component that has a relation field.
  2. Connect a relation inside the component, then Save/Publish.
  3. Without saving, reset the component and re-add it (empty).
  4. Save. The relation must **not** come back.

### Related issue(s)/PR(s)

- Fix #25030