### PR TITLE
fix(utils): skip null populate values instead of crashing

### DIFF
--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -249,6 +249,21 @@ describe('convert-query-params', () => {
       );
     });
 
+    // e.g. `?populate[relation]` with no value parses to `{ relation: null }`
+    // when `strictNullHandling` is on; this used to crash with a 500.
+    test.each<[label: string, key: string]>([
+      ['a relation', 'one_to_one'],
+      ['a dynamic zone', 'dz'],
+      ['a morph relation', 'morph_to_one'],
+    ])('skips a null populate value for %s instead of crashing', (_label, key) => {
+      const result = transformer.private_convertPopulateQueryParams(
+        { [key]: null } as never,
+        models['api::dog.dog']
+      );
+
+      expect(result).toStrictEqual({});
+    });
+
     describe('Fields selection', () => {
       test('should not select documentId when selecting fields for components', () => {
         const populate = {

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -442,6 +442,14 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
         return subPopulate === true ? { ...acc, [key]: true } : acc;
       }
 
+      // A nil value (e.g. `?populate[relation]` with no value, parsed as `null`
+      // when `strictNullHandling` is on) is not a valid populate directive.
+      // Skip it instead of dereferencing null further down (which threw
+      // "Cannot use 'in' operator" / "Cannot convert undefined or null to object").
+      if (isNil(subPopulate)) {
+        return acc;
+      }
+
       const attribute = attributes[key];
 
       if (!attribute) {


### PR DESCRIPTION
### What does it do?

`convertPopulateObject` (in `@strapi/utils` `convert-query-params.ts`) only guarded **string** and **boolean** populate values. A `null` value for a real schema attribute fell through both guards and then crashed:

- **plain relation / component / media** → `hasPopulateFragmentDefined(subPopulate)` did `'on' in null` → `TypeError: Cannot use 'in' operator to search for 'on' in null` (`typeof null === 'object'` passes the first check).
- **dynamic zone / morphTo** → `Object.keys(null)` → `TypeError: Cannot convert undefined or null to object`.

This adds an `isNil` guard so a nil populate value is skipped (treated as a no-op directive) instead of being dereferenced.

### Why is it needed?

It's reachable from a normal REST request. The core query middleware parses query strings with `strictNullHandling`, so `GET /api/dogs?populate[one_to_one]` (a `populate` key with no value) becomes `{ populate: { one_to_one: null } }`. That currently returns a **500** instead of being handled. The same happens for a dynamic-zone/morph key (`?populate[dz]`).

### How to test it?

Unit test (added to `convert-query-params.test.ts`):

```
yarn jest --config jest.config.js packages/core/utils/src/__tests__/convert-query-params.test.ts
```

The new cases — `skips a null populate value for a relation / a dynamic zone / a morph relation instead of crashing` — **fail on `develop`** with the two `TypeError`s above and pass with this change (they now return `{}`). The full suite (95 tests) stays green; `eslint` and `prettier --check` pass.

### Related issue(s)/PR(s)

Found while auditing `@strapi/utils`; same class as the previously-fixed `traverse-entity` nil-guard (#26842).
