### PR TITLE
fix(admin): make plugin/setting "Select all" work in admin token permissions

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/Permissions.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/Permissions.tsx
@@ -647,15 +647,25 @@ const reducer = (state: State, action: Action) =>
         let nextModifiedDataState = cloneDeep(state.modifiedData);
         const oldValues = get(nextModifiedDataState, pathToValue, {});
 
+        const root = pathToValue[0];
+        // Plugin & setting permissions are stored with `subject: null` and their real
+        // action id is the full `plugin::`/`admin::` leaf segment (not the UI subcategory).
+        // For those, let the checker derive the action from each leaf path (subject stays null).
+        const isPluginOrSetting = root === 'plugins' || root === 'settings';
+
         let actionId: string | undefined;
-        let subject: string | undefined;
+        let subject: string | null | undefined;
 
-        if (pathToValue.length >= 2) {
-          subject = pathToValue[1];
-        }
+        if (isPluginOrSetting) {
+          subject = null;
+        } else {
+          if (pathToValue.length >= 2) {
+            subject = pathToValue[1];
+          }
 
-        if (pathToValue.length >= 3) {
-          actionId = pathToValue[2];
+          if (pathToValue.length >= 3) {
+            actionId = pathToValue[2];
+          }
         }
 
         const permissionChecker = createDynamicActionPermissionChecker(
@@ -668,7 +678,6 @@ const reducer = (state: State, action: Action) =>
 
         // In App Token context, when enabling, inherit conditions from the user's permissions.
         if (value === true && userPermissions !== undefined) {
-          const root = pathToValue[0];
           const subjectForLookup =
             root === 'collectionTypes' || root === 'singleTypes' ? (subject ?? null) : null;
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/tests/Permissions.test.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/tests/Permissions.test.tsx
@@ -7,6 +7,8 @@ import { Permissions, type PermissionsAPI } from '../Permissions';
 
 import layout from './test-data.json';
 
+import type { Permission as AuthPermission } from '../../../../../../features/Auth';
+
 const COLUMN_HEADERS = ['Create', 'Read', 'Update', 'Delete', 'Publish'];
 
 const COLLECTION_TYPES = layout.sections.collectionTypes.subjects.map(
@@ -242,5 +244,64 @@ describe('hasLocaleValidationErrors() — ref API', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Select fr Read permission' }));
 
     expect(ref.current!.hasLocaleValidationErrors()).toBe(true);
+  });
+});
+
+/**
+ * Regression test for CMS-627.
+ *
+ * On the Create/Edit Admin Token screen the permission matrix is rendered with
+ * `userPermissions` so selections are restricted to what the token owner is
+ * allowed to grant. In that mode the per-subcategory "Select all" checkbox for
+ * plugins/settings did nothing: plugin/setting permissions are stored with
+ * `subject: null` and their real action id is the full `plugin::` leaf segment,
+ * but the parent-checkbox reducer treated the category as the subject and the UI
+ * subcategory as the action, so the owner-permission lookup never matched and
+ * every leaf was filtered out.
+ *
+ * "Select all" must now select the subcategory actions the owner holds, while
+ * still leaving out any action the owner does not have.
+ */
+describe('Permissions — "Select all" in Admin Token mode (userPermissions provided)', () => {
+  const settingPermission = (action: string): AuthPermission => ({
+    action,
+    subject: null,
+    properties: {},
+    conditions: [],
+  });
+
+  it('selects the owner-granted actions of a settings subcategory and skips the rest', async () => {
+    // Owner holds Create/Read/Update for i18n locales, but NOT Delete.
+    const userPermissions: AuthPermission[] = [
+      settingPermission('plugin::i18n.locale.create'),
+      settingPermission('plugin::i18n.locale.read'),
+      settingPermission('plugin::i18n.locale.update'),
+    ];
+
+    const { user } = render(
+      <Permissions layout={layout} userPermissions={userPermissions} isFormDisabled={false} />
+    );
+
+    // Go to the Settings tab and open the Internationalization category.
+    await user.click(screen.getByRole('tab', { name: 'Settings' }));
+    await user.click(screen.getByRole('button', { name: /Internationalization/ }));
+
+    const create = screen.getByLabelText('Create');
+    const read = screen.getByLabelText('Read');
+    const update = screen.getByLabelText('Update');
+    const del = screen.getByLabelText('Delete');
+
+    // The granted actions are enabled; the ungranted one is disabled.
+    expect(create).not.toBeChecked();
+    expect(del).toBeDisabled();
+
+    // Click the subcategory "Select all".
+    await user.click(screen.getByLabelText('Select all'));
+
+    // Owner-granted actions get selected; the ungranted "Delete" stays unchecked.
+    expect(create).toBeChecked();
+    expect(read).toBeChecked();
+    expect(update).toBeChecked();
+    expect(del).not.toBeChecked();
   });
 });


### PR DESCRIPTION
### What does it do?

Fixes the per-subcategory **"Select all"** checkbox on the **Create/Edit Admin Token** screen (Plugins and Settings tabs), which previously did nothing.

The admin-token permission matrix reuses the Roles `Permissions` component but passes `userPermissions` (the token owner's permissions) so selections can be restricted to what the owner may grant. In that mode, the parent-checkbox reducer (`ON_CHANGE_TOGGLE_PARENT_CHECKBOX`) derived `subject` from the category segment (e.g. `content-manager`) and `actionId` from the UI subcategory (e.g. `collection-types`). But plugin/setting permissions are stored with `subject: null` and their real action id is the full `plugin::`/`admin::` leaf segment, so the owner-permission lookup never matched and `updateValuesWithPermissions` filtered out every leaf.

For the `plugins`/`settings` roots, the reducer now passes `subject: null` and lets the checker derive the action from each leaf path. Role editing (no `userPermissions`) is unaffected — the checker is `undefined` there and behaviour falls back to the unrestricted path.

### Why is it needed?

On the admin token create/edit screen, clicking "Select all" for a plugin or setting subcategory did nothing (neither checked nor unchecked), forcing users to tick every permission individually.

### How to test it?

1. Enable the Admin Tokens feature and go to **Settings → Admin Tokens → Create new admin token**.
2. Open the **Plugins** tab, expand **Content manager**, and click **"Select all"** on a subcategory (e.g. Collection Types) → the actions get selected (and clicking again clears them).
3. Open the **Settings** tab, expand **Internationalization**, click **"Select all"** → all Locale actions (Create/Read/Update/Delete) get selected.

Automated: `yarn nx run @strapi/admin:test:front -- --testPathPattern=Roles` — includes a new regression test in `Permissions.test.tsx` covering "Select all" in admin-token mode (it fails without this fix).

### Related issue(s)/PR(s)

Fixes CMS-627
