### PR TITLE
fix(create-strapi-app): write .npmrc with legacy-peer-deps=true to fi…

### DIFF
--- a/packages/cli/create-strapi-app/src/create-strapi.ts
+++ b/packages/cli/create-strapi-app/src/create-strapi.ts
@@ -22,6 +22,17 @@ import { getInstallArgs, getPackageManagerVersion } from './utils/get-package-ma
 
 const yarnNodeModulesConfig = 'nodeLinker: node-modules\n';
 
+/**
+ * When npm is the package manager, scaffolding installs with --legacy-peer-deps
+ * (see get-package-manager-args.ts). The lockfile that npm writes under legacy
+ * peer-dep resolution is incompatible with `npm ci`'s strict validation unless
+ * the same flag is set in the project config. Per the npm docs:
+ *   "if you used --legacy-peer-deps you must provide the same flags to npm ci"
+ * Writing .npmrc with legacy-peer-deps=true ensures `npm ci` (used by
+ * CI/CD pipelines and Docker) succeeds on a fresh scaffold.
+ */
+const npmRcConfig = 'legacy-peer-deps=true\n';
+
 const getUserAgentPackageManagerVersion = (packageManager: Scope['packageManager']) => {
   const userAgent = process.env.npm_config_user_agent ?? '';
   const [agent] = userAgent.split(' ');
@@ -162,6 +173,13 @@ async function createApp(scope: Scope) {
       !(await fse.pathExists(join(rootPath, '.yarnrc.yml')))
     ) {
       await fse.writeFile(join(rootPath, '.yarnrc.yml'), yarnNodeModulesConfig);
+    }
+
+    // Write .npmrc so that `npm ci` uses the same --legacy-peer-deps resolution
+    // strategy that was used during scaffolding install, preventing lockfile
+    // mismatch errors (e.g. zod@3 vs zod@4) in CI/CD pipelines and Docker.
+    if (packageManager === 'npm' && !(await fse.pathExists(join(rootPath, '.npmrc')))) {
+      await fse.writeFile(join(rootPath, '.npmrc'), npmRcConfig);
     }
 
     await writePnpmWorkspaceConfig(scopeWithPnpmVersion, pnpmVersion);


### PR DESCRIPTION
## What's happening

When you create a fresh Strapi project and try to run `npm ci`, it just fails. No code changes, nothing. Right out of the box:

```
npm ERR! Invalid: lock file's zod@3.25.67 does not satisfy zod@4.4.3
npm ERR! Missing: picomatch@2.3.2 from lock file
```

This breaks Docker and any CI/CD that uses `npm ci` as the install step.

## What I found

The scaffold runs `npm install --legacy-peer-deps` during setup. That's why the lockfile ends up with older version pins — that's just how legacy peer dep resolution works.

The issue is that `npm ci` doesn't know about that flag. So when it checks the lockfile strictly, it sees a mismatch and crashes.

The npm docs even say this directly — if you installed with `--legacy-peer-deps`, you have to use that same flag when running `npm ci` too. But there's nothing in the generated project telling it to do that.

## The fix

Just write a `.npmrc` file into the project with `legacy-peer-deps=true`. npm reads that automatically, so `npm ci` will use the same mode that was used during install.

One small file, no behavior change for anyone not using `npm ci`.

## I tested it

First confirmed the bug:

```bash
npx create-strapi-app@5.50.2 my-app --typescript --use-npm --install --quickstart
cd my-app
npm ci
# ❌ crashes with zod version mismatch
```

Then applied the fix manually and ran again:

```bash
echo "legacy-peer-deps=true" >> .npmrc
npm ci
# ✅ added 1367 packages in 13s
```

Works perfectly.

Fixes #27019
<img width="1920" height="1080" alt="Screenshot From 2026-07-16 08-27-53" src="https://github.com/user-attachments/assets/d53e6c69-249c-40da-a77d-e54f91cb223a" />
<img width="1920" height="1080" alt="Screenshot From 2026-07-16 08-28-27" src="https://github.com/user-attachments/assets/115083ca-d55b-4ee4-b360-11bb5c129ec2" />
