### PR TITLE
fix(content-manager): keep document status accurate on mixed-locale batches

### DIFF
--- a/packages/core/content-manager/server/src/services/__tests__/document-metadata.test.ts
+++ b/packages/core/content-manager/server/src/services/__tests__/document-metadata.test.ts
@@ -133,4 +133,61 @@ describe('document-metadata service', () => {
       expect(result?.map((entry) => entry.locale)).toEqual(['fr']);
     });
   });
+
+  describe('getManyAvailableStatus', () => {
+    const createServiceWithQuery = () => {
+      const findMany = jest.fn().mockResolvedValue([]);
+      const service = createService({ query: () => ({ findMany }) });
+
+      return { service, findMany };
+    };
+
+    const whereOf = (findMany: jest.Mock) => findMany.mock.calls[0][0].where;
+
+    it('filters on the locales when every version is localized', async () => {
+      const { service, findMany } = createServiceWithQuery();
+
+      await service.getManyAvailableStatus('api::article.article', [
+        { id: 1, documentId: 'doc-1', locale: 'en', publishedAt: null },
+        { id: 2, documentId: 'doc-2', locale: 'fr', publishedAt: null },
+      ]);
+
+      expect(whereOf(findMany)).toMatchObject({ locale: { $in: ['en', 'fr'] } });
+      expect(whereOf(findMany).$or).toBeUndefined();
+    });
+
+    it('does not filter on the locale when no version is localized', async () => {
+      const { service, findMany } = createServiceWithQuery();
+
+      await service.getManyAvailableStatus('api::article.article', [
+        { id: 1, documentId: 'doc-1', locale: null, publishedAt: null },
+        { id: 2, documentId: 'doc-2', locale: null, publishedAt: null },
+      ]);
+
+      expect(whereOf(findMany).locale).toBeUndefined();
+      expect(whereOf(findMany).$or).toBeUndefined();
+    });
+
+    /**
+     * A content type can hold versions with a locale next to versions without one —
+     * after i18n is disabled on it, or when a locale reaches a non-localized content
+     * type through the API. `locales` then only describes part of the batch, so
+     * filtering on it alone hid the counterparts of the non-localized versions, and
+     * the list view reported published documents as drafts.
+     */
+    it('also matches non-localized versions when the batch mixes both', async () => {
+      const { service, findMany } = createServiceWithQuery();
+
+      await service.getManyAvailableStatus('api::article.article', [
+        { id: 1, documentId: 'doc-1', locale: 'fr', publishedAt: null },
+        { id: 2, documentId: 'doc-2', locale: null, publishedAt: null },
+      ]);
+
+      expect(whereOf(findMany).locale).toBeUndefined();
+      expect(whereOf(findMany).$or).toEqual([
+        { locale: { $in: ['fr'] } },
+        { locale: { $null: true } },
+      ]);
+    });
+  });
 });

--- a/packages/core/content-manager/server/src/services/__tests__/document-metadata.test.ts
+++ b/packages/core/content-manager/server/src/services/__tests__/document-metadata.test.ts
@@ -160,8 +160,8 @@ describe('document-metadata service', () => {
       const { service, findMany } = createServiceWithQuery();
 
       await service.getManyAvailableStatus('api::article.article', [
-        { id: 1, documentId: 'doc-1', locale: null, publishedAt: null },
-        { id: 2, documentId: 'doc-2', locale: null, publishedAt: null },
+        { id: 1, documentId: 'doc-1', publishedAt: null },
+        { id: 2, documentId: 'doc-2', publishedAt: null },
       ]);
 
       expect(whereOf(findMany).locale).toBeUndefined();
@@ -180,7 +180,7 @@ describe('document-metadata service', () => {
 
       await service.getManyAvailableStatus('api::article.article', [
         { id: 1, documentId: 'doc-1', locale: 'fr', publishedAt: null },
-        { id: 2, documentId: 'doc-2', locale: null, publishedAt: null },
+        { id: 2, documentId: 'doc-2', publishedAt: null },
       ]);
 
       expect(whereOf(findMany).locale).toBeUndefined();

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -209,8 +209,20 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     };
 
     // If there is any locale to filter (if i18n is enabled)
-    if (locales.length) {
+    if (locales.length === documents.length) {
       where.locale = { $in: locales };
+    } else if (locales.length) {
+      /*
+       * The batch mixes localized and non-localized versions, which happens when a
+       * content type holds rows with a locale while others have none — for instance
+       * after i18n is disabled on it, or when a locale is sent to a non-localized
+       * content type through the API.
+       *
+       * `locales` only holds the locales that are actually set, so filtering on it
+       * alone would drop the counterparts of every version whose locale is null, and
+       * those versions would be reported as drafts even though they are published.
+       */
+      where.$or = [{ locale: { $in: locales } }, { locale: { $null: true } }];
     }
 
     return strapi.query(uid).findMany({


### PR DESCRIPTION
### What does it do?

Keeps the Content Manager list view from reporting published documents as drafts when a content type holds both localized and non-localized versions.

### Why is it needed?

`getManyAvailableStatus` builds its locale filter from whichever versions in the batch have a locale, then applies that filter to the whole batch:

```ts
const locales = documents.map((d) => d.locale).filter(Boolean);
// ...
// If there is any locale to filter (if i18n is enabled)
if (locales.length) {
  where.locale = { $in: locales };
}
```

The comment states the assumption: a batch is either fully localized (i18n enabled) or not localized at all. A content type can hold both. Rows keep their locale when i18n is disabled on them, and a locale sent to a non-localized content type through the API is stored as-is.

When the batch mixes both, the filter built from the localized rows excludes the counterparts of every row whose locale is `null`. `getStatus` then finds no published version for them and returns `draft`.

This only surfaces in the list view: opening a document shows the correct status, because the single-document path matches its counterpart on `documentId` **and** `locale`. That split is what makes the bug confusing to report — the list and the edit view disagree about the same document.

This is a plausible root cause for #22520 (all entries shown as draft after a v4 → v5 migration, correct status inside each entry) and #22570 (non-internationalized collections stuck in draft when mixed collections exist). Both are closed without an identified root cause.

Measured on a real 5.50.2 dataset — a non-localized content type with 36 documents, 35 of which have a published row, where 8 rows carry a stray `fr` locale:

| | counterparts found | statuses |
|---|---|---|
| before | 4 / 35 | 32 draft, 4 published |
| after | 35 / 35 | 35 published, 1 draft |

The one remaining draft is the document that genuinely has no published version. No data was modified.

### How to test it

`yarn jest packages/core/content-manager/server/src/services/__tests__/document-metadata.test.ts`

The added regression test fails on `develop` and passes with this change. Two accompanying tests pin the unchanged behaviour of the fully-localized and fully-non-localized batches — both already pass before the change.

To reproduce manually:

1. Create a content type with i18n disabled and Draft & Publish enabled.
2. Create a few entries and publish them.
3. Set a locale on one row only: `UPDATE <table> SET locale = 'en' WHERE id = <one id>;`
4. Open the list view — every entry whose locale is `null` now reads "Draft", while opening one shows "Published".

### Related issue(s)/PR(s)

Likely root cause of #22520 and #22570.


---
Fixes CPR-453