### PR TITLE
fix(content-manager): store relative image URLs in blocks editor

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Image.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Image.tsx
@@ -80,7 +80,12 @@ const Image = ({ attributes, children, element }: RenderElementProps) => {
         $isFocused={editorIsFocused && imageIsSelected}
         hasRadius
       >
-        <img src={url} alt={alternativeText} width={width} height={height} />
+        <img
+          src={prefixFileUrlWithBackendUrl(url)}
+          alt={alternativeText}
+          width={width}
+          height={height}
+        />
       </ImageWrapper>
     </Box>
   );
@@ -147,7 +152,7 @@ const ImageDialog = () => {
       const nodeImage: Block<'image'>['image'] = {
         ...expectedImage,
         alternativeText: expectedImage.alternativeText || expectedImage.name,
-        url: prefixFileUrlWithBackendUrl(image.url),
+        url: image.url,
       };
 
       return nodeImage;

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/Image.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/Image.test.tsx
@@ -28,7 +28,7 @@ jest.mock('@strapi/admin/strapi-admin', () => ({
         'media-library': ({ onSelectAssets }: MediaLibraryProps) => (
           <div>
             <p>{mockMediaLibraryTitle}</p>
-            <button type="button" onClick={() => onSelectAssets([mockImage])}>
+            <button type="button" onClick={() => onSelectAssets(mockSelectedImages)}>
               {mockMediaLibrarySubmitButton}
             </button>
           </div>
@@ -41,6 +41,9 @@ jest.mock('@strapi/admin/strapi-admin', () => ({
 const mockMediaLibraryTitle = 'dialog component';
 const mockMediaLibrarySubmitButton = 'upload images';
 
+// The images the mocked media library returns when its submit button is clicked
+let mockSelectedImages: (typeof mockImage)[] = [mockImage];
+
 const render = (ui: ReactElement, { baseEditor }: { baseEditor?: Editor } = {}) =>
   renderRTL(ui, {
     renderOptions: {
@@ -49,6 +52,10 @@ const render = (ui: ReactElement, { baseEditor }: { baseEditor?: Editor } = {}) 
   });
 
 describe('Image', () => {
+  beforeEach(() => {
+    mockSelectedImages = [mockImage];
+  });
+
   it('renders an image block properly', () => {
     render(
       imageBlocks.image.renderElement({
@@ -68,6 +75,26 @@ describe('Image', () => {
     const image = screen.getByRole('img', { name: 'Some image' });
     expect(image).toBeInTheDocument();
     expect(image).toHaveAttribute('src', 'https://example.com/image.png');
+  });
+
+  it('prefixes a relative image URL with the backend URL when rendering', () => {
+    render(
+      imageBlocks.image.renderElement({
+        children: 'A line of text in a paragraph.',
+        element: {
+          type: 'image',
+          image: { url: '/uploads/image.png', alternativeText: 'Some image' },
+          children: [{ type: 'text', text: '' }],
+        },
+        attributes: {
+          'data-slate-node': 'element',
+          ref: null,
+        },
+      })
+    );
+
+    const image = screen.getByRole('img', { name: 'Some image' });
+    expect(image).toHaveAttribute('src', 'http://localhost:1337/uploads/image.png');
   });
 
   it('handles enter key on an image', () => {
@@ -133,6 +160,40 @@ describe('Image', () => {
       {
         type: 'image',
         image: mockImage,
+        children: [{ type: 'text', text: '' }],
+      },
+    ]);
+  });
+
+  it('stores a relative image URL without the backend URL prefix', async () => {
+    const relativeImage = { ...mockImage, url: '/uploads/relative_image.png' };
+    mockSelectedImages = [relativeImage];
+
+    const baseEditor = createEditor();
+    baseEditor.children = [{ type: 'paragraph', children: [{ type: 'text', text: '' }] }];
+
+    await waitFor(() =>
+      Transforms.select(baseEditor, {
+        anchor: { path: [0, 0], offset: 0 },
+        focus: { path: [0, 0], offset: 0 },
+      })
+    );
+
+    // Display the media library modal via handleConvert
+    const modalComponent = imageBlocks.image.handleConvert!(baseEditor);
+    const modalUi = modalComponent!();
+    const { user } = render(modalUi, {
+      baseEditor,
+    });
+
+    // Fake selecting an image that has a relative URL
+    await user.click(screen.getByText(mockMediaLibrarySubmitButton));
+
+    // The URL is kept relative so the content stays portable across environments
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'image',
+        image: relativeImage,
         children: [{ type: 'text', text: '' }],
       },
     ]);


### PR DESCRIPTION
### What does it do?

Embedding an image in a Blocks (rich text) field now stores the media library URL as-is, and the backend URL is applied only when the image is rendered in the editor (`Image.tsx`).

### Why is it needed?

`handleSelectAssets` ran the selected image URL through `prefixFileUrlWithBackendUrl` before saving, so the stored content ended up with an absolute URL like `http://localhost:1337/uploads/image.png`. That origin is baked into the content, so embedded images break as soon as it changes: editing on localhost leaves images missing after deployment, and moving from staging to production breaks all of them.

Keeping the URL relative makes the content portable across environments, matching how the rest of Strapi stores media. The editor preview still works because the URL is prefixed at render time, and already-absolute URLs (e.g. from an upload provider) are left untouched.

### How to test it?

Add a content type with a Blocks field, embed an image from the media library, and save — the stored `url` is now relative (`/uploads/...`) and the image still displays in the editor.

Unit tests in `packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/Image.test.tsx` cover both sides: a relative URL is stored without the backend prefix, and it is prefixed with the backend URL when rendered.

### Related issue(s)/PR(s)

Fix #25758


---
Fixes CPR-454