### PR TITLE
fix(upgrade): send configured npm credentials to authenticated registries

### DIFF
--- a/packages/utils/upgrade/src/modules/npm/__tests__/package.auth.test.ts
+++ b/packages/utils/upgrade/src/modules/npm/__tests__/package.auth.test.ts
@@ -1,0 +1,99 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { Package } from '../package';
+import { Logger } from '../../logger';
+
+// Reproduction for https://github.com/strapi/strapi/issues/26962
+// The upgrade tool must send the npm-configured credentials when the registry
+// requires authentication. `Package.refresh()` currently issues a bare
+// `fetch()` with no Authorization header, so an authenticated registry returns
+// 403 and the upgrade fails with "Request failed for <url>".
+
+const TOKEN = 's3cr3t-repro-token';
+
+const mockNpmPackage = {
+  _id: '@test/test',
+  name: '@test/test',
+  versions: {
+    '1.0.0': { name: '@test/test', version: '1.0.0' },
+  },
+};
+
+const mockLogger = {
+  debug: jest.fn(),
+  warn: jest.fn(),
+  isSilent: false,
+  isDebug: false,
+  setSilent: jest.fn(),
+  setDebug: jest.fn(),
+  warnings: 0,
+  errors: 0,
+  stdout: undefined,
+  stderr: undefined,
+  info: jest.fn(),
+  error: jest.fn(),
+  raw: jest.fn(),
+} as unknown as Logger;
+
+describe('Package.refresh() against an authenticated registry (#26962)', () => {
+  let server: http.Server;
+  let registryUrl: string;
+  let cwd: string;
+  const originalEnv = { ...process.env };
+
+  beforeAll((done) => {
+    // A registry that mirrors Verdaccio's `access: $authenticated`: reads require auth.
+    server = http.createServer((req, res) => {
+      if (req.headers.authorization === `Bearer ${TOKEN}`) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(mockNpmPackage));
+      } else {
+        res.writeHead(403);
+        res.end('Forbidden');
+      }
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      registryUrl = `http://127.0.0.1:${port}`;
+
+      // A project whose .npmrc holds a valid token for that registry, exactly
+      // like a user who has authenticated with `npm login`.
+      cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'upgrade-auth-'));
+      fs.writeFileSync(
+        path.join(cwd, '.npmrc'),
+        `//127.0.0.1:${port}/:_authToken=${TOKEN}\nregistry=${registryUrl}\n`
+      );
+
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    process.env = originalEnv;
+    if (cwd) fs.rmSync(cwd, { recursive: true, force: true });
+    server.close(done);
+  });
+
+  it('resolves the package version using the configured npm credentials', async () => {
+    process.env.NPM_REGISTRY_URL = registryUrl;
+
+    const pkg = new Package('@test/test', cwd, mockLogger);
+
+    // Sanity check: the token itself is valid — an authenticated request works.
+    const authed = await fetch(`${registryUrl}/@test/test`, {
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    expect(authed.status).toBe(200);
+
+    // The upgrade tool should succeed too, because credentials are configured.
+    // BUG: refresh() sends no Authorization header, so this rejects with
+    // "Request failed for <url>" (the registry answers 403).
+    await expect(pkg.refresh()).resolves.toBeDefined();
+    expect(pkg.isLoaded).toBe(true);
+  });
+});

--- a/packages/utils/upgrade/src/modules/npm/__tests__/registry-token.test.ts
+++ b/packages/utils/upgrade/src/modules/npm/__tests__/registry-token.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { getRegistryAuthHeader } from '../registry-token';
+
+describe('getRegistryAuthHeader', () => {
+  let cwd: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'registry-token-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    process.env = { ...originalEnv };
+  });
+
+  const writeNpmrc = (contents: string) => {
+    fs.writeFileSync(path.join(cwd, '.npmrc'), contents);
+  };
+
+  it('returns undefined when no .npmrc credentials exist', () => {
+    // Point HOME at an empty dir so the machine's real ~/.npmrc is ignored.
+    process.env.HOME = cwd;
+    jest.spyOn(os, 'homedir').mockReturnValue(cwd);
+
+    expect(getRegistryAuthHeader('https://registry.example.com', cwd)).toBeUndefined();
+  });
+
+  it('resolves a Bearer token from the matching nerf dart', () => {
+    jest.spyOn(os, 'homedir').mockReturnValue(cwd);
+    writeNpmrc('//registry.example.com/:_authToken=abc123\n');
+
+    expect(getRegistryAuthHeader('https://registry.example.com', cwd)).toBe('Bearer abc123');
+  });
+
+  it('matches a registry served under a sub-path (longest match first)', () => {
+    jest.spyOn(os, 'homedir').mockReturnValue(cwd);
+    writeNpmrc(
+      [
+        '//registry.example.com/:_authToken=root-token',
+        '//registry.example.com/artifactory/api/npm/repo/:_authToken=scoped-token',
+      ].join('\n')
+    );
+
+    expect(
+      getRegistryAuthHeader('https://registry.example.com/artifactory/api/npm/repo/', cwd)
+    ).toBe('Bearer scoped-token');
+  });
+
+  it('expands env var references like npm does', () => {
+    jest.spyOn(os, 'homedir').mockReturnValue(cwd);
+    process.env.MY_NPM_TOKEN = 'from-env';
+    // eslint-disable-next-line no-template-curly-in-string -- literal .npmrc content
+    writeNpmrc('//registry.example.com/:_authToken=${MY_NPM_TOKEN}\n');
+
+    expect(getRegistryAuthHeader('https://registry.example.com', cwd)).toBe('Bearer from-env');
+  });
+
+  it('supports legacy Basic _auth credentials', () => {
+    jest.spyOn(os, 'homedir').mockReturnValue(cwd);
+    writeNpmrc('//registry.example.com/:_auth=dXNlcjpwYXNz\n');
+
+    expect(getRegistryAuthHeader('https://registry.example.com', cwd)).toBe('Basic dXNlcjpwYXNz');
+  });
+});

--- a/packages/utils/upgrade/src/modules/npm/package.ts
+++ b/packages/utils/upgrade/src/modules/npm/package.ts
@@ -5,6 +5,7 @@ import { packageManager } from '@strapi/utils';
 
 import { ProxyAgent } from 'undici';
 import * as constants from './constants';
+import { getRegistryAuthHeader } from './registry-token';
 import { isLiteralSemVer } from '../version';
 
 import type { Package as PackageInterface, NPMPackage, NPMPackageVersion } from './types';
@@ -138,9 +139,19 @@ export class Package implements PackageInterface {
   }
 
   async refresh() {
-    const packageURL = `${await this.determineRegistryUrl()}/${this.name}`;
+    const registryUrl = await this.determineRegistryUrl();
+    const packageURL = `${registryUrl}/${this.name}`;
+
+    // Reuse the credentials the user already configured for their registry
+    // (e.g. private registries that require authentication for reads).
+    const authHeader = getRegistryAuthHeader(registryUrl, this.cwd);
+    if (authHeader) {
+      this.logger.debug(`Using configured registry credentials for ${registryUrl}`);
+    }
 
     const response = await fetch(packageURL, {
+      ...(authHeader ? { headers: { authorization: authHeader } } : {}),
+      // @ts-expect-error Node.js fetch supports dispatcher (undici extension)
       dispatcher: agent,
     });
 

--- a/packages/utils/upgrade/src/modules/npm/registry-token.ts
+++ b/packages/utils/upgrade/src/modules/npm/registry-token.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Resolves the `Authorization` header to use when talking to an npm registry,
+ * reading the credentials the user has already configured in their `.npmrc`
+ * (the same files npm/pnpm read: the project one, then the user one).
+ *
+ * npm stores per-registry credentials keyed by "nerf dart" — the registry URL
+ * stripped of its protocol, e.g. `//registry.example.com/:_authToken=...`. This
+ * mirrors that lookup (longest path match first, for registries served under a
+ * sub-path) and expands `${ENV_VAR}` references like npm does.
+ *
+ * Returns `undefined` when no credentials are configured, so requests to public
+ * registries stay unauthenticated exactly as before.
+ */
+
+const expandEnv = (value: string): string =>
+  value.replace(/\$\{([^}]+)\}/g, (_match, name) => process.env[name] ?? '');
+
+const parseNpmrc = (filePath: string): Record<string, string> => {
+  const config: Record<string, string> = {};
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return config;
+  }
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const isComment = line.startsWith('#') || line.startsWith(';');
+    const separatorIndex = line.indexOf('=');
+
+    if (line && !isComment && separatorIndex !== -1) {
+      const key = line.slice(0, separatorIndex).trim();
+      const value = line.slice(separatorIndex + 1).trim();
+      config[key] = value;
+    }
+  }
+
+  return config;
+};
+
+// Build the candidate "nerf dart" keys for a registry URL, from the most
+// specific (full path) to the least specific (host only).
+const nerfDartCandidates = (registryUrl: string): string[] => {
+  const { host, pathname } = new URL(registryUrl);
+  const segments = pathname.split('/').filter(Boolean);
+
+  const candidates: string[] = [];
+  for (let i = segments.length; i >= 0; i -= 1) {
+    const subPath = segments.slice(0, i).join('/');
+    candidates.push(`//${host}/${subPath ? `${subPath}/` : ''}`);
+  }
+
+  return candidates;
+};
+
+export const getRegistryAuthHeader = (registryUrl: string, cwd: string): string | undefined => {
+  // Project config overrides user config, so parse the user file first and let
+  // the project file take precedence when merging.
+  const npmrcFiles = [path.join(os.homedir(), '.npmrc'), path.join(cwd, '.npmrc')];
+
+  const config: Record<string, string> = {};
+  for (const file of npmrcFiles) {
+    Object.assign(config, parseNpmrc(file));
+  }
+
+  for (const base of nerfDartCandidates(registryUrl)) {
+    const authToken = config[`${base}:_authToken`];
+    if (authToken) {
+      return `Bearer ${expandEnv(authToken)}`;
+    }
+
+    const auth = config[`${base}:_auth`];
+    if (auth) {
+      return `Basic ${expandEnv(auth)}`;
+    }
+  }
+
+  // Legacy, non-scoped credentials.
+  if (config._authToken) {
+    return `Bearer ${expandEnv(config._authToken)}`;
+  }
+
+  if (config._auth) {
+    return `Basic ${expandEnv(config._auth)}`;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
### What does it do?

`@strapi/upgrade` resolves the latest matching version by fetching the package
manifest from the npm registry in `Package.refresh()`. That request was a bare
`fetch(packageURL, { dispatcher: agent })` with **no `Authorization` header** —
`determineRegistryUrl()` resolved the registry URL but nothing read the npm auth
token. Registries that require authentication for reads therefore answered
`403 Forbidden` and the upgrade aborted with `Request failed for <url>`.

This PR:
- Adds `registry-token.ts`, a small dependency-free resolver that reads the auth
  token from the user's `.npmrc` (project then user config), matching npm's
  "nerf dart" lookup (`//host/path/:_authToken`, longest path first), with
  `${ENV_VAR}` expansion and legacy `_auth` (Basic) support.
- Attaches the `Authorization` header in `Package.refresh()` when credentials are
  configured. Requests to public/unauthenticated registries are unchanged (no
  header is sent when no token is found).

### Why is it needed?

The upgrade tool makes its own HTTP request instead of going through the package
manager, so a valid npm token configured for a private/authenticated registry was
never used and `npx @strapi/upgrade latest` failed. See #26962.

### How to test it?

Automated:
- `cd packages/utils/upgrade && yarn test:unit modules/npm`
- `package.auth.test.ts` spins up a local registry that requires auth and asserts
  `refresh()` succeeds using a token from `.npmrc` (fails on `develop`, passes here).

Manual (mirrors the report):
1. Run an authenticated registry (e.g. Verdaccio with `access: $authenticated`)
   proxying `@strapi/*`, and `npm login` against it.
2. Point a Strapi project at that registry (`.npmrc` `registry=` + `_authToken`).
3. `npx @strapi/upgrade latest --debug` → resolves versions instead of
   `Request failed for <url>`.

### Related issue(s)/PR(s)

Fix #26962