### PR TITLE
fix(create-strapi-app): npm ci fails on fresh npm scaffold

### DIFF
--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -172,7 +172,8 @@ async function run(args: string[]): Promise<void> {
       // third party
       react: '^18.0.0',
       'react-dom': '^18.0.0',
-      'react-router-dom': '^6.0.0',
+      // Match @strapi/* peer ranges (^6.30.3) so npm peer resolution stays clean
+      'react-router-dom': '^6.30.3',
       'styled-components': '^6.0.0',
     },
     shouldCreateGrowthSsoTrial,

--- a/packages/cli/create-strapi-app/src/utils/__tests__/get-package-manager-args.test.ts
+++ b/packages/cli/create-strapi-app/src/utils/__tests__/get-package-manager-args.test.ts
@@ -4,7 +4,7 @@ import { getInstallArgs } from '../get-package-manager-args';
 
 jest.mock('execa');
 
-const mockedExeca = execa as jest.MockedFunction<typeof execa>;
+const mockedExeca = execa as unknown as jest.Mock;
 
 describe('getInstallArgs', () => {
   beforeEach(() => {
@@ -12,7 +12,7 @@ describe('getInstallArgs', () => {
   });
 
   it('does not pass --legacy-peer-deps for npm', async () => {
-    mockedExeca.mockResolvedValue({ stdout: '10.9.2' } as execa.ExecaReturnValue);
+    mockedExeca.mockResolvedValue({ stdout: '10.9.2' });
 
     const { cmdArgs } = await getInstallArgs('npm');
 
@@ -21,7 +21,7 @@ describe('getInstallArgs', () => {
   });
 
   it('keeps yarn classic network timeout', async () => {
-    mockedExeca.mockResolvedValue({ stdout: '1.22.22' } as execa.ExecaReturnValue);
+    mockedExeca.mockResolvedValue({ stdout: '1.22.22' });
 
     const { cmdArgs } = await getInstallArgs('yarn');
 
@@ -29,7 +29,7 @@ describe('getInstallArgs', () => {
   });
 
   it('does not add extra args for yarn 4+', async () => {
-    mockedExeca.mockResolvedValue({ stdout: '4.12.0' } as execa.ExecaReturnValue);
+    mockedExeca.mockResolvedValue({ stdout: '4.12.0' });
 
     const { cmdArgs, envArgs } = await getInstallArgs('yarn');
 
@@ -38,7 +38,7 @@ describe('getInstallArgs', () => {
   });
 
   it('does not add extra args for pnpm', async () => {
-    mockedExeca.mockResolvedValue({ stdout: '10.25.0' } as execa.ExecaReturnValue);
+    mockedExeca.mockResolvedValue({ stdout: '10.25.0' });
 
     const { cmdArgs } = await getInstallArgs('pnpm');
 

--- a/packages/cli/create-strapi-app/src/utils/__tests__/get-package-manager-args.test.ts
+++ b/packages/cli/create-strapi-app/src/utils/__tests__/get-package-manager-args.test.ts
@@ -1,0 +1,47 @@
+import execa from 'execa';
+
+import { getInstallArgs } from '../get-package-manager-args';
+
+jest.mock('execa');
+
+const mockedExeca = execa as jest.MockedFunction<typeof execa>;
+
+describe('getInstallArgs', () => {
+  beforeEach(() => {
+    mockedExeca.mockReset();
+  });
+
+  it('does not pass --legacy-peer-deps for npm', async () => {
+    mockedExeca.mockResolvedValue({ stdout: '10.9.2' } as execa.ExecaReturnValue);
+
+    const { cmdArgs } = await getInstallArgs('npm');
+
+    expect(cmdArgs).toEqual(['install']);
+    expect(cmdArgs).not.toContain('--legacy-peer-deps');
+  });
+
+  it('keeps yarn classic network timeout', async () => {
+    mockedExeca.mockResolvedValue({ stdout: '1.22.22' } as execa.ExecaReturnValue);
+
+    const { cmdArgs } = await getInstallArgs('yarn');
+
+    expect(cmdArgs).toEqual(['install', '--network-timeout', '1000000']);
+  });
+
+  it('does not add extra args for yarn 4+', async () => {
+    mockedExeca.mockResolvedValue({ stdout: '4.12.0' } as execa.ExecaReturnValue);
+
+    const { cmdArgs, envArgs } = await getInstallArgs('yarn');
+
+    expect(cmdArgs).toEqual(['install']);
+    expect(envArgs).toEqual({ YARN_HTTP_TIMEOUT: '1000000' });
+  });
+
+  it('does not add extra args for pnpm', async () => {
+    mockedExeca.mockResolvedValue({ stdout: '10.25.0' } as execa.ExecaReturnValue);
+
+    const { cmdArgs } = await getInstallArgs('pnpm');
+
+    expect(cmdArgs).toEqual(['install']);
+  });
+});

--- a/packages/cli/create-strapi-app/src/utils/get-package-manager-args.ts
+++ b/packages/cli/create-strapi-app/src/utils/get-package-manager-args.ts
@@ -15,8 +15,11 @@ type VersionedEnvMap = {
 const installArgumentsMap: {
   [key: string]: VersionedArgumentsMap;
 } = {
+  // Do not pass --legacy-peer-deps: a lockfile written under that mode fails
+  // strict `npm ci` unless the same flag is set (see #27019). Fresh Strapi apps
+  // install cleanly with npm's default peer-dep resolution.
   npm: {
-    '*': ['--legacy-peer-deps'],
+    '*': [],
   },
   yarn: {
     '<4': ['--network-timeout', '1000000'],

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -145,7 +145,7 @@
     "typescript": "5.9.3",
     "use-context-selector": "1.4.1",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@strapi/admin-test-utils": "5.50.2",

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -108,7 +108,7 @@
     "slate-history": "0.93.0",
     "slate-react": "0.98.4",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@strapi/admin": "5.50.2",

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -91,7 +91,7 @@
     "react-markdown": "9.1.0",
     "react-redux": "8.1.3",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@strapi/admin": "5.50.2",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -114,7 +114,7 @@
     "typescript": "5.9.3",
     "undici": "6.27.0",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@swc/core": "1.13.5",

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -71,7 +71,7 @@
     "react-intl": "6.6.2",
     "react-query": "3.39.3",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@strapi/admin": "5.50.2",

--- a/packages/core/openapi/__tests__/zod-to-openapi.test.ts
+++ b/packages/core/openapi/__tests__/zod-to-openapi.test.ts
@@ -1,0 +1,17 @@
+import * as z from 'zod/v4';
+
+import { zodToOpenAPI } from '../src/utils/zod';
+
+describe('zodToOpenAPI', () => {
+  it('does not embed $id from zod toJSONSchema (stable OpenAPI output)', () => {
+    const schema = zodToOpenAPI(z.object({ name: z.string() }));
+
+    expect(schema).not.toHaveProperty('$id');
+    expect(schema).toMatchObject({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    });
+  });
+});

--- a/packages/core/openapi/__tests__/zod-to-openapi.test.ts
+++ b/packages/core/openapi/__tests__/zod-to-openapi.test.ts
@@ -1,5 +1,8 @@
+import type { Core } from '@strapi/types';
 import * as z from 'zod/v4';
 
+import { DocumentContextFactory } from '../src/context';
+import { ComponentsWriter } from '../src/post-processor/component-writer';
 import { zodToOpenAPI } from '../src/utils/zod';
 
 describe('zodToOpenAPI', () => {
@@ -13,5 +16,35 @@ describe('zodToOpenAPI', () => {
         name: { type: 'string' },
       },
     });
+  });
+});
+
+describe('ComponentsWriter', () => {
+  it('strips $id from component schemas written from the global registry', () => {
+    const registered = z.object({ title: z.string() });
+    z.globalRegistry.add(registered, { id: 'CoverageProbeDocument' });
+
+    try {
+      const context = new DocumentContextFactory().create({
+        strapi: {
+          config: { get: () => undefined },
+        } as unknown as Core.Strapi,
+        routes: [],
+      });
+
+      new ComponentsWriter().postProcess(context);
+
+      const schema = context.output.data.components?.schemas?.CoverageProbeDocument;
+      expect(schema).toBeDefined();
+      expect(schema).not.toHaveProperty('$id');
+      expect(schema).toMatchObject({
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+        },
+      });
+    } finally {
+      z.globalRegistry.remove(registered);
+    }
   });
 });

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "debug": "4.3.4",
     "openapi-types": "12.1.3",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@strapi/types": "5.50.2",

--- a/packages/core/openapi/src/post-processor/component-writer.ts
+++ b/packages/core/openapi/src/post-processor/component-writer.ts
@@ -1,7 +1,7 @@
 import { OpenAPIV3_1 } from 'openapi-types';
 import * as z from 'zod/v4';
 import type { DocumentContext } from '../types';
-import { toComponentsPath } from '../utils/zod';
+import { stripJsonSchemaId, toComponentsPath } from '../utils/zod';
 import type { PostProcessor } from './types';
 
 export class ComponentsWriter implements PostProcessor {
@@ -11,6 +11,12 @@ export class ComponentsWriter implements PostProcessor {
     const { schemas } = z.toJSONSchema(z.globalRegistry, {
       uri: toComponentsPath,
     }) as OpenAPIV3_1.ComponentsObject;
+
+    for (const schema of Object.values(schemas ?? {})) {
+      if (schema && typeof schema === 'object') {
+        stripJsonSchemaId(schema);
+      }
+    }
 
     const existingComponents = output.data.components ?? {};
 

--- a/packages/core/openapi/src/utils/zod.ts
+++ b/packages/core/openapi/src/utils/zod.ts
@@ -4,6 +4,18 @@ import * as z from 'zod/v4';
 import type { OpenAPIV3_1 } from 'openapi-types';
 
 /**
+ * Zod ≥3.25.76 embeds `$id` in `toJSONSchema` output (set after `override`).
+ * Strip it so OpenAPI documents stay stable — inline schemas use random UUIDs
+ * as registry ids — and match the pre-3.25.76 shape.
+ */
+export const stripJsonSchemaId = <T extends object>(schema: T): T => {
+  if ('$id' in schema) {
+    delete (schema as { $id?: string }).$id;
+  }
+  return schema;
+};
+
+/**
  * Converts a Zod schema to an OpenAPI Schema Object.
  *
  * @description
@@ -31,7 +43,6 @@ import type { OpenAPIV3_1 } from 'openapi-types';
  * const openAPISchema = zodToOpenAPI(userSchema);
  * ```
  */
-
 export const zodToOpenAPI = (
   zodSchema: z.ZodType
 ): OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject => {
@@ -52,7 +63,7 @@ export const zodToOpenAPI = (
     const { schemas } = z.toJSONSchema(registry, { uri: toComponentsPath });
 
     // TODO: make sure it's compliant
-    return schemas[id] as OpenAPIV3_1.SchemaObject;
+    return stripJsonSchemaId(schemas[id] as OpenAPIV3_1.SchemaObject);
   } catch (e) {
     throw new Error("Couldn't transform the zod schema into an OpenAPI schema");
   }

--- a/packages/core/strapi/src/node/core/__tests__/dependencies.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/dependencies.test.ts
@@ -150,11 +150,11 @@ describe('admin peer dependency checks', () => {
       );
     });
 
-    it('uses npm with legacy peer deps when npm is the package manager', () => {
+    it('uses npm without legacy peer deps when npm is the package manager', () => {
       getPackageManagerMock.mockReturnValue('npm');
 
       expect(getInstallCommandHint([{ name: 'react', wantedVersion: '^18.0.0' }])).toBe(
-        'npm install --legacy-peer-deps --save react@^18.0.0'
+        'npm install --save react@^18.0.0'
       );
     });
   });
@@ -168,22 +168,23 @@ describe('admin peer dependency checks', () => {
       expect(logger.error).toHaveBeenCalledWith(
         'Please install them manually before re-running this command:',
         expect.any(String),
-        '  npm install --legacy-peer-deps --save react@^18.0.0'
+        '  npm install --save react@^18.0.0'
       );
     });
   });
 
   describe('installAdminPeerDeps', () => {
-    it('runs npm install with legacy peer deps', async () => {
+    it('runs npm install without legacy peer deps', async () => {
       const logger = createLogger();
 
       await installAdminPeerDeps([{ name: 'react', wantedVersion: '^18.0.0' }], { cwd, logger });
 
       expect(execaMock).toHaveBeenCalledWith(
         'npm',
-        ['install', '--legacy-peer-deps', '--save', 'react@^18.0.0'],
+        ['install', '--save', 'react@^18.0.0'],
         expect.objectContaining({ cwd })
       );
+      expect(execaMock.mock.calls[0][1]).not.toContain('--legacy-peer-deps');
     });
   });
 
@@ -250,9 +251,10 @@ describe('admin peer dependency checks', () => {
         );
         expect(execaMock).toHaveBeenCalledWith(
           'npm',
-          expect.arrayContaining(['install', '--legacy-peer-deps', '--save', 'react@^18.0.0']),
+          expect.arrayContaining(['install', '--save', 'react@^18.0.0']),
           expect.objectContaining({ cwd })
         );
+        expect(execaMock.mock.calls[0][1]).not.toContain('--legacy-peer-deps');
         expect(execaMock).toHaveBeenCalledWith(
           'node',
           ['/path/to/strapi', 'build'],

--- a/packages/core/strapi/src/node/core/dependencies.ts
+++ b/packages/core/strapi/src/node/core/dependencies.ts
@@ -129,7 +129,9 @@ const getInstallCommandHint = (missing: AdminPeerDep[]) => {
     return `pnpm add --save-prod ${packages}`;
   }
 
-  return `npm install --legacy-peer-deps --save ${packages}`;
+  // Do not use --legacy-peer-deps: it rewrites package-lock in a mode that
+  // breaks plain `npm ci` (#27019). Fresh apps install cleanly without it.
+  return `npm install --save ${packages}`;
 };
 
 const reportMissingAdminPeerDeps = (logger: Logger, missing: AdminPeerDep[]) => {
@@ -227,7 +229,7 @@ const installAdminPeerDeps = async (
   let result: ExecaReturnValue<string> | undefined;
 
   if (packageManager === 'npm') {
-    const npmArgs = ['install', '--legacy-peer-deps', '--save', ...packages];
+    const npmArgs = ['install', '--save', ...packages];
     logger.info(`Running 'npm ${npmArgs.join(' ')}'`);
     result = await execa('npm', npmArgs, execOptions);
   } else if (packageManager === 'yarn') {

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -72,7 +72,7 @@
     "typedoc": "0.28.19",
     "typedoc-github-wiki-theme": "2.1.0",
     "typedoc-plugin-markdown": "4.11.0",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@types/jest": "29.5.2",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -99,7 +99,7 @@
     "react-select": "5.8.0",
     "sharp": "0.34.5",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@strapi/admin": "5.50.2",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -58,7 +58,7 @@
     "p-map": "4.0.0",
     "preferred-pm": "3.1.3",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@types/http-errors": "2.0.4",

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -69,7 +69,7 @@
     "react-intl": "6.6.2",
     "react-redux": "8.1.3",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@strapi/admin": "5.50.2",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -72,7 +72,7 @@
     "react-redux": "8.1.3",
     "url-join": "4.0.1",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@strapi/strapi": "5.50.2",

--- a/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
+++ b/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
@@ -134,6 +134,13 @@ describe('create-strapi-app', () => {
       // npm install must use default peer resolution so the lockfile works with
       // plain `npm ci` (#27019) — do not force legacy-peer-deps via .npmrc
       expect(fs.existsSync(path.join(projectDir, '.npmrc'))).toBe(false);
+
+      const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), 'utf8'));
+      // Align with @strapi/* peer ranges so strict npm peer resolution succeeds
+      expect(pkg.dependencies['react-router-dom']).toBe('^6.30.3');
+      expect(pkg.dependencies.react).toBe('^18.0.0');
+      expect(pkg.dependencies['react-dom']).toBe('^18.0.0');
+      expect(pkg.dependencies['styled-components']).toBe('^6.0.0');
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });
     }

--- a/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
+++ b/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
@@ -123,7 +123,7 @@ describe('create-strapi-app', () => {
     }
   });
 
-  it('does not write a Yarn config for npm projects', async () => {
+  it('does not write a Yarn config or .npmrc for npm projects', async () => {
     const projectDir = mkProjectDir();
     try {
       await spawnCsa([projectDir, ...baseScaffoldArgs, '--use-npm'])
@@ -131,6 +131,9 @@ describe('create-strapi-app', () => {
         .end();
 
       expect(fs.existsSync(path.join(projectDir, '.yarnrc.yml'))).toBe(false);
+      // npm install must use default peer resolution so the lockfile works with
+      // plain `npm ci` (#27019) — do not force legacy-peer-deps via .npmrc
+      expect(fs.existsSync(path.join(projectDir, '.npmrc'))).toBe(false);
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9062,7 +9062,7 @@ __metadata:
     vite: "npm:5.4.21"
     vite-plugin-dts: "npm:^4.3.0"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/data-transfer": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -9181,7 +9181,7 @@ __metadata:
     slate-react: "npm:0.98.4"
     styled-components: "npm:6.4.1"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -9289,7 +9289,7 @@ __metadata:
     vitest: "catalog:"
     vitest-config: "npm:5.50.2"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -9383,7 +9383,7 @@ __metadata:
     vitest: "catalog:"
     vitest-config: "npm:5.50.2"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   languageName: unknown
   linkType: soft
 
@@ -9526,7 +9526,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     koa: ^2.15.2
@@ -9626,7 +9626,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
@@ -9671,7 +9671,7 @@ __metadata:
     debug: "npm:4.3.4"
     jest: "npm:29.6.0"
     openapi-types: "npm:12.1.3"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   languageName: unknown
   linkType: soft
 
@@ -9911,7 +9911,7 @@ __metadata:
     styled-components: "npm:6.4.1"
     url-join: "npm:4.0.1"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -10202,7 +10202,7 @@ __metadata:
     typedoc-plugin-markdown: "npm:4.11.0"
     typescript: "npm:5.9.3"
     undici: "npm:6.27.0"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   languageName: unknown
   linkType: soft
 
@@ -10346,7 +10346,7 @@ __metadata:
     sharp: "npm:0.34.5"
     styled-components: "npm:6.4.1"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -10380,7 +10380,7 @@ __metadata:
     vitest: "catalog:"
     vitest-config: "npm:5.50.2"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "npm:3.25.76"
   languageName: unknown
   linkType: soft
 
@@ -32842,14 +32842,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:3.25.67":
-  version: 3.25.67
-  resolution: "zod@npm:3.25.67"
-  checksum: 10c0/80a0cab3033272c4ab9312198081f0c4ea88e9673c059aa36dc32024906363729db54bdb78f3dc9d5529bd1601f74974d5a56c0a23e40c6f04a9270c9ff22336
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.19.1, zod@npm:^3.24.1":
+"zod@npm:3.25.76, zod@npm:^3.19.1, zod@npm:^3.24.1":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c


### PR DESCRIPTION
### What does it do?

1. Stops `create-strapi-app` from running `npm install --legacy-peer-deps` during scaffolding, so the generated lockfile works with plain `npm ci` (Docker / CI).
2. Stops `@strapi/strapi` admin-peer auto-install / install hints from using `--legacy-peer-deps` (same lockfile hazard after `develop --install-deps`).
3. Pins scaffolded `react-router-dom` to `^6.30.3` to match published `@strapi/*` peer ranges.
4. Bumps monorepo `zod` from `3.25.67` → `3.25.76` so `ai` / `@ai-sdk/*` peers (`^3.25.76 || ^4.1.8`) are satisfied without nesting `zod@4`.

Does **not** write a project `.npmrc` with `legacy-peer-deps=true` — that would permanently force legacy peer resolution for every future install in the app.

### Why is it needed?

Fixes strapi/strapi#27019: a freshly scaffolded npm project fails `npm ci` out of the box. Scaffolding installed with `--legacy-peer-deps`, which writes a lockfile that npm’s strict `npm ci` rejects unless the same flag is set again.

**Alternative to** strapi/strapi#27033\*\*:\*\* writing `.npmrc` with `legacy-peer-deps=true` makes `npm ci` work, but opts every npm app into legacy peer resolution forever (including `--no-install` flows). Removing the flag fixes the desync without limiting future installs.

### Why was `--legacy-peer-deps` added originally?

Best reconstruction from git history and issues (there is **no documented rationale** in the introducing PR):

* The flag was added in [#20268](<https://github.com/strapi/strapi/pull/20268>) (May 2024, CLI UX rework) when the npm/yarn/pnpm install-args map was introduced. Before that, generators used plain `npm install` (no legacy flag). The PR body and review threads never explain why npm needed it.
* Around the same era, several create/install failures were real **Strapi peer-declaration bugs** (e.g. [#18706](<https://github.com/strapi/strapi/issues/18706>) users-permissions advertising `peer @strapi/strapi@"4.0.0"`, [#18652](<https://github.com/strapi/strapi/issues/18652>) styled-components mismatch on plugin-cloud). Maintainers fixed those at the source and only suggested `--legacy-peer-deps` as a temporary workaround.
* Likely intent of baking the flag into create: defensive scaffolding against npm 7+ peer strictness / that class of peer mistakes — then it was copied forward through the templates rewrite and [#21329](<https://github.com/strapi/strapi/pull/21329>) without being revisited.

### Why we don’t need it anymore

* Current published `@strapi/*` peer ranges for a default app are coherent (`@strapi/strapi` `^5.0.0`, react 17|18, etc.). The old “broken peer pin” class of bugs is not reproducing on 5.50.x.
* Strict `npm install` (no `--legacy-peer-deps`) succeeds today for vanilla, example, and website-shaped dependency sets; the resulting lockfile passes plain `npm ci`.
* Keeping the flag actively hurts: it is what desyncs the lock for `npm ci`, and it can hide future peer regressions instead of failing closed so we fix them.
* Related: auto-install with `--legacy-peer-deps` during build previously caused real damage ([#26344](<https://github.com/strapi/strapi/issues/26344>)); this PR keeps create and admin-peer install on the same strict path.

### How to test it?

```bash
yarn workspace create-strapi-app test:unit -- src/utils/__tests__/get-package-manager-args.test.ts
yarn workspace @strapi/strapi test:unit -- src/node/core/__tests__/dependencies.test.ts

# Consumer-style (built create-strapi-app or canary of this branch)
npx create-strapi-app my-app --typescript --use-npm --install --quickstart --no-run --skip-cloud
cd my-app
test ! -f .npmrc
npm ci
```

### Related issue(s)/PR(s)

* Fixes strapi/strapi#27019
* Alternative to strapi/strapi#27033 (do not merge both)
* Flag introduced in [#20268](<https://github.com/strapi/strapi/issues/20268>); historical peer bugs e.g. [#18706](<https://github.com/strapi/strapi/issues/18706>), [#18652](<https://github.com/strapi/strapi/issues/18652>)
* Related prior damage from legacy install during build: strapi/strapi#26344 / strapi/strapi#26483