### PR TITLE
fix(admin): revalidate SPA shell to avoid stale chunk imports

### DIFF
--- a/packages/core/admin/server/src/routes/__tests__/serve-admin-panel.test.ts
+++ b/packages/core/admin/server/src/routes/__tests__/serve-admin-panel.test.ts
@@ -1,16 +1,96 @@
 import type { Context } from 'koa';
+import fse from 'fs-extra';
 
-import { serveStatic } from '../serve-admin-panel';
+import registerAdminPanelRoute, { serveStatic } from '../serve-admin-panel';
 
 jest.mock('koa-static', () => {
   return jest.fn(() => jest.fn());
 });
+
+jest.mock('fs-extra', () => ({
+  ...jest.requireActual('fs-extra'),
+  pathExistsSync: jest.fn(() => true),
+  createReadStream: jest.fn(() => 'index-html-stream'),
+}));
 
 const koaStatic = jest.requireMock('koa-static');
 
 describe('serveAdminPanel route', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('admin shell cache headers', () => {
+    const createStrapi = () => {
+      let registeredRoutes: any[] = [];
+      const strapi = {
+        dirs: { dist: { root: '/tmp/strapi-dist' } },
+        config: { admin: { path: '/admin' } },
+        server: {
+          routes: (routes: any[]) => {
+            registeredRoutes = routes;
+          },
+        },
+      };
+      return { strapi, getRoutes: () => registeredRoutes };
+    };
+
+    test('SPA fallback revalidates the HTML shell', async () => {
+      const { strapi, getRoutes } = createStrapi();
+      registerAdminPanelRoute({ strapi: strapi as any });
+
+      const [spaFallback] = getRoutes()[0].handler;
+      const headers: Record<string, string> = {};
+      const ctx = {
+        method: 'GET',
+        body: null,
+        status: 404,
+        type: undefined as string | undefined,
+        set: (key: string, value: string) => {
+          headers[key.toLowerCase()] = value;
+        },
+      };
+      const next = jest.fn(async () => undefined);
+
+      await spaFallback(ctx as unknown as Context, next);
+
+      expect(fse.createReadStream).toHaveBeenCalled();
+      expect(headers['cache-control']).toBe('no-cache');
+      expect(headers['surrogate-control']).toBe('no-store');
+    });
+
+    test('static HTML responses revalidate; hashed assets stay immutable', () => {
+      const { strapi, getRoutes } = createStrapi();
+      registerAdminPanelRoute({ strapi: strapi as any });
+
+      expect(koaStatic).toHaveBeenCalled();
+      const options = koaStatic.mock.calls[0][1];
+      expect(options.maxage).toBe(0);
+
+      const htmlHeaders: Record<string, string> = {};
+      options.setHeaders(
+        {
+          setHeader: (key: string, value: string) => {
+            htmlHeaders[key.toLowerCase()] = value;
+          },
+        },
+        '/tmp/build/index.html'
+      );
+      expect(htmlHeaders['cache-control']).toBe('no-cache');
+      expect(htmlHeaders['surrogate-control']).toBe('no-store');
+
+      const assetHeaders: Record<string, string> = {};
+      options.setHeaders(
+        {
+          setHeader: (key: string, value: string) => {
+            assetHeaders[key.toLowerCase()] = value;
+          },
+        },
+        '/tmp/build/layout-abc123.js'
+      );
+      expect(assetHeaders['cache-control']).toBe('public, max-age=31536000, immutable');
+      expect(assetHeaders['surrogate-control']).toBeUndefined();
+    });
   });
 
   describe('serveStatic', () => {

--- a/packages/core/admin/server/src/routes/__tests__/serve-admin-panel.test.ts
+++ b/packages/core/admin/server/src/routes/__tests__/serve-admin-panel.test.ts
@@ -1,7 +1,15 @@
-import type { Context } from 'koa';
+import type { Context, Next } from 'koa';
 import fse from 'fs-extra';
+import type { Core } from '@strapi/types';
 
 import registerAdminPanelRoute, { serveStatic } from '../serve-admin-panel';
+
+type AdminPanelRoute = {
+  method: string;
+  path: string;
+  handler: Array<(ctx: Context, next: Next) => Promise<void> | void>;
+  config: { auth: boolean };
+};
 
 jest.mock('koa-static', () => {
   return jest.fn(() => jest.fn());
@@ -22,12 +30,12 @@ describe('serveAdminPanel route', () => {
 
   describe('admin shell cache headers', () => {
     const createStrapi = () => {
-      let registeredRoutes: any[] = [];
+      let registeredRoutes: AdminPanelRoute[] = [];
       const strapi = {
         dirs: { dist: { root: '/tmp/strapi-dist' } },
         config: { admin: { path: '/admin' } },
         server: {
-          routes(routes: any[]) {
+          routes(routes: AdminPanelRoute[]) {
             registeredRoutes = routes;
           },
         },
@@ -37,7 +45,7 @@ describe('serveAdminPanel route', () => {
 
     test('SPA fallback revalidates the HTML shell', async () => {
       const { strapi, getRoutes } = createStrapi();
-      registerAdminPanelRoute({ strapi: strapi as any });
+      registerAdminPanelRoute({ strapi: strapi as unknown as Core.Strapi });
 
       const [spaFallback] = getRoutes()[0].handler;
       const headers: Record<string, string> = {};
@@ -61,7 +69,7 @@ describe('serveAdminPanel route', () => {
 
     test('static HTML responses revalidate; hashed assets stay immutable', () => {
       const { strapi } = createStrapi();
-      registerAdminPanelRoute({ strapi: strapi as any });
+      registerAdminPanelRoute({ strapi: strapi as unknown as Core.Strapi });
 
       expect(koaStatic).toHaveBeenCalled();
       const options = koaStatic.mock.calls[0][1];

--- a/packages/core/admin/server/src/routes/__tests__/serve-admin-panel.test.ts
+++ b/packages/core/admin/server/src/routes/__tests__/serve-admin-panel.test.ts
@@ -27,7 +27,7 @@ describe('serveAdminPanel route', () => {
         dirs: { dist: { root: '/tmp/strapi-dist' } },
         config: { admin: { path: '/admin' } },
         server: {
-          routes: (routes: any[]) => {
+          routes(routes: any[]) {
             registeredRoutes = routes;
           },
         },
@@ -46,7 +46,7 @@ describe('serveAdminPanel route', () => {
         body: null,
         status: 404,
         type: undefined as string | undefined,
-        set: (key: string, value: string) => {
+        set(key: string, value: string) {
           headers[key.toLowerCase()] = value;
         },
       };
@@ -60,7 +60,7 @@ describe('serveAdminPanel route', () => {
     });
 
     test('static HTML responses revalidate; hashed assets stay immutable', () => {
-      const { strapi, getRoutes } = createStrapi();
+      const { strapi } = createStrapi();
       registerAdminPanelRoute({ strapi: strapi as any });
 
       expect(koaStatic).toHaveBeenCalled();
@@ -70,7 +70,7 @@ describe('serveAdminPanel route', () => {
       const htmlHeaders: Record<string, string> = {};
       options.setHeaders(
         {
-          setHeader: (key: string, value: string) => {
+          setHeader(key: string, value: string) {
             htmlHeaders[key.toLowerCase()] = value;
           },
         },
@@ -82,7 +82,7 @@ describe('serveAdminPanel route', () => {
       const assetHeaders: Record<string, string> = {};
       options.setHeaders(
         {
-          setHeader: (key: string, value: string) => {
+          setHeader(key: string, value: string) {
             assetHeaders[key.toLowerCase()] = value;
           },
         },

--- a/packages/core/admin/server/src/routes/serve-admin-panel.ts
+++ b/packages/core/admin/server/src/routes/serve-admin-panel.ts
@@ -4,6 +4,15 @@ import fse from 'fs-extra';
 import koaStatic from 'koa-static';
 import type { Core } from '@strapi/types';
 
+const ADMIN_SHELL_CACHE_CONTROL = 'no-cache';
+const ADMIN_SHELL_SURROGATE_CONTROL = 'no-store';
+const HASHED_ASSET_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+const applyAdminShellCacheHeaders = (setHeader: (name: string, value: string) => void) => {
+  setHeader('Cache-Control', ADMIN_SHELL_CACHE_CONTROL);
+  setHeader('Surrogate-Control', ADMIN_SHELL_SURROGATE_CONTROL);
+};
+
 const registerAdminPanelRoute = ({ strapi }: { strapi: Core.Strapi }) => {
   let buildDir = resolve(strapi.dirs.dist.root, 'build');
 
@@ -22,6 +31,9 @@ const registerAdminPanelRoute = ({ strapi }: { strapi: Core.Strapi }) => {
       return;
     }
 
+    applyAdminShellCacheHeaders((name, value) => {
+      ctx.set(name, value);
+    });
     ctx.type = 'html';
     ctx.body = fse.createReadStream(join(buildDir, 'index.html'));
   };
@@ -33,15 +45,19 @@ const registerAdminPanelRoute = ({ strapi }: { strapi: Core.Strapi }) => {
       handler: [
         serveAdminMiddleware,
         serveStatic(buildDir, {
-          maxage: 31536000,
+          maxage: 0,
           defer: false,
           index: 'index.html',
           setHeaders(res: any, path: any) {
             const ext = extname(path);
-            // publicly cache static files to avoid unnecessary network & disk access
-            if (ext !== '.html') {
-              res.setHeader('cache-control', 'public, max-age=31536000, immutable');
+            if (ext === '.html') {
+              applyAdminShellCacheHeaders((name, value) => {
+                res.setHeader(name, value);
+              });
+              return;
             }
+
+            res.setHeader('Cache-Control', HASHED_ASSET_CACHE_CONTROL);
           },
         }),
       ],

--- a/packages/core/admin/server/src/routes/serve-admin-panel.ts
+++ b/packages/core/admin/server/src/routes/serve-admin-panel.ts
@@ -1,3 +1,4 @@
+import type { ServerResponse } from 'http';
 import type { Context, Next } from 'koa';
 import { resolve, join, extname, basename } from 'path';
 import fse from 'fs-extra';
@@ -48,7 +49,7 @@ const registerAdminPanelRoute = ({ strapi }: { strapi: Core.Strapi }) => {
           maxage: 0,
           defer: false,
           index: 'index.html',
-          setHeaders(res: any, path: any) {
+          setHeaders(res: ServerResponse, path: string) {
             const ext = extname(path);
             if (ext === '.html') {
               applyAdminShellCacheHeaders((name, value) => {


### PR DESCRIPTION
### What does it do?

* Serves the admin SPA shell (`index.html`) with `Cache-Control: no-cache` and `Surrogate-Control: no-store` on both the SPA fallback path and static `.html` responses.
* Keeps long-lived `immutable` caching for hashed non-HTML assets.
* Sets koa-static `maxage` to `0` so HTML cannot inherit a year-long default cache age.
* Adds unit coverage for shell vs hashed-asset header behaviour.

### Why is it needed?

After an admin rebuild, a cached `index.html` can still reference hashed chunk filenames that no longer exist. Browsers then fail with `TypeError: Failed to fetch dynamically imported module` (for example Content Manager `layout-*.js`). Revalidating the HTML shell keeps the chunk graph in sync with the current build.

### How to test it?

1. Build and run Strapi with the admin panel (for example `examples/getstarted` with a production-like `build` + `start`, or develop).
2. Confirm the admin loads.
3. Rebuild the admin so chunk hashes change, then reload without a hard refresh. Confirm there are no failed chunk / dynamic import errors.
4. Inspect response headers for `/admin` (or your admin path): HTML should include `cache-control: no-cache` and `surrogate-control: no-store`; hashed JS/CSS should remain `public, max-age=31536000, immutable`.
5. Unit: from `packages/core/admin`, `yarn test:unit --testPathPattern=serve-admin-panel.test`.

### Related issue(s)/PR(s)

* Fixes strapi/strapi#26217
* Fixes [CMS-1426](https://linear.app/strapi/issue/CMS-1426/fixadmin-revalidate-spa-shell-to-avoid-stale-chunk-imports)
* Related (abandoned community attempt): strapi/strapi#26234