### PR TITLE
fix(content-manager): skip blocks editor remount on equal value echoes

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -269,7 +269,7 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
       }
       clearTimeout(debounceTimeout.current);
       debounceTimeout.current = null;
-      incrementSlateUpdatesCount();
+      // Counter was already bumped when the AST changed; only push form state here.
       // Ensure Strapi Form state updates before the next event (e.g. Save click) reads values.
       flushSync(() => {
         onChange(
@@ -277,7 +277,7 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
           normalizeBlocksState(editor, editor.children) as Schema.Attribute.BlocksValue
         );
       });
-    }, [editor, incrementSlateUpdatesCount, name, onChange]);
+    }, [editor, name, onChange]);
 
     const handleSlateChange = React.useCallback(
       (state: Descendant[]) => {
@@ -289,15 +289,20 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
            * state in sync with it in order to make sure that things like the "modified" state
            * isn't broken. Updating the whole state on every change is very expensive however,
            * so we debounce calls to onChange to mitigate input lag.
+           *
+           * Bump the reset-key counter immediately (not inside the debounce). Otherwise any
+           * value-prop identity change during the 300ms window — e.g. clicking the blocks
+           * toolbar — looks like an external update with stale empty form state and remounts
+           * the editor, wiping the pending input (blocks e2e flake).
            */
+          incrementSlateUpdatesCount();
+
           if (debounceTimeout.current) {
             clearTimeout(debounceTimeout.current);
           }
 
           // Set a new debounce timeout
           debounceTimeout.current = setTimeout(() => {
-            incrementSlateUpdatesCount();
-
             // Normalize the state (empty editor becomes null)
             onChange(name, normalizeBlocksState(editor, state) as Schema.Attribute.BlocksValue);
             debounceTimeout.current = null;

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -159,16 +159,29 @@ function useResetKey(
 
     // If the 2 refs are not equal, it means the value was updated from outside
     if (valueUpdatesCount.current !== slateUpdatesCount.current) {
+      // Bring the 2 refs back in sync
+      slateUpdatesCount.current = valueUpdatesCount.current;
+
+      // The update may just be an echo of the editor's own content coming back through the form
+      // (e.g. the debounced sync, or a re-render while document queries settle). Remounting in
+      // that case is pointless and destructive: it wipes pending input and the DOM under the
+      // user's caret. Only force a remount when the content is actually different.
+      const externalState = value?.length ? normalizeBlocksState(editor, value) : null;
+      const editorState = normalizeBlocksState(editor, editor.children);
+      if (JSON.stringify(externalState) === JSON.stringify(editorState)) {
+        return;
+      }
+
+      // The remount reuses the same editor instance, so a selection pointing into the old
+      // content would survive it and crash slate-react's toDOMPoint when the new content is
+      // shorter. Drop the selection before swapping the children.
       if (editor.selection) {
         Transforms.deselect(editor);
       }
 
-      // So we change the key to force a rerender of the Slate editor,
+      // Change the key to force a rerender of the Slate editor,
       // which will pick up the new value through its initialValue prop
       setKey((previousKey) => previousKey + 1);
-
-      // Then bring the 2 refs back in sync
-      slateUpdatesCount.current = valueUpdatesCount.current;
     }
   }, [editor, value]);
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
@@ -202,19 +202,11 @@ const BlocksDropdown = () => {
       editor.children.length === 1 && Editor.isEmpty(editor, editor.children[0]);
 
     if (!editor.selection && !editorIsEmpty) {
-      // When there is no selection, create an empty block at the end of the editor
-      // so that it can be converted to the selected block
-      Transforms.insertNodes(
-        editor,
-        {
-          type: 'quote',
-          children: [{ type: 'text', text: '' }],
-        },
-        {
-          select: true,
-          // Since there's no selection, Slate will automatically insert the node at the end
-        }
-      );
+      // Toolbar buttons steal focus in Playwright (and sometimes in real browsers), clearing
+      // selection. Convert the last existing block — do not insert a new empty block, which
+      // would leave the user's content behind and convert a blank node instead.
+      const [, lastPath] = Editor.last(editor, []);
+      Transforms.select(editor, Editor.range(editor, lastPath));
     } else if (!editor.selection && editorIsEmpty) {
       // When there is no selection and the editor is empty,
       // select the empty paragraph from Slate's initialValue so it gets converted

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/tests/BlocksEditorResetKey.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/tests/BlocksEditorResetKey.test.tsx
@@ -1,0 +1,142 @@
+/* eslint-disable testing-library/no-node-access */
+/* eslint-disable check-file/filename-naming-convention */
+
+import * as React from 'react';
+
+import { act, render, screen } from '@tests/utils';
+import { type Editor, Transforms } from 'slate';
+import { ReactEditor } from 'slate-react';
+
+import { BlocksEditor } from '../BlocksEditor';
+import { defaultBlocksStore } from '../DefaultBlocksStore';
+
+import type { Schema } from '@strapi/types';
+
+// Capture the editor instances created by BlocksEditor so tests can inspect and drive them
+const createdEditors: Editor[] = [];
+
+jest.mock('slate', () => {
+  const actual = jest.requireActual('slate');
+  return {
+    ...actual,
+    createEditor: () => {
+      const editor = actual.createEditor();
+      createdEditors.push(editor);
+      return editor;
+    },
+  };
+});
+
+jest.mock('@strapi/admin/strapi-admin', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin'),
+  useElementOnScreen: jest.fn(() => ({ current: null })),
+  useIsMobile: jest.fn().mockReturnValue(false),
+  useStrapiApp: jest
+    .fn()
+    .mockImplementation((_name: string, selector: (state: unknown) => unknown) =>
+      selector({
+        plugins: {
+          'content-manager': {
+            apis: { getRichTextBlocks: () => ({ ...defaultBlocksStore }) },
+          },
+        },
+      })
+    ),
+}));
+
+const paragraph = (text: string): Schema.Attribute.BlocksValue => [
+  {
+    type: 'paragraph',
+    children: [{ type: 'text', text }],
+  },
+];
+
+const setup = (value: Schema.Attribute.BlocksValue) => {
+  const onChange = jest.fn();
+
+  const result = render(
+    <BlocksEditor
+      name="blocks-editor"
+      value={value}
+      onChange={onChange}
+      error={undefined}
+      ariaLabelId="blocks-editor-label"
+    />
+  );
+
+  return { ...result, onChange, editor: createdEditors[createdEditors.length - 1] };
+};
+
+describe('BlocksEditor value reset', () => {
+  beforeAll(() => {
+    // jsdom's Range lacks getBoundingClientRect, which the editor's scroll-into-view code needs
+    Range.prototype.getBoundingClientRect = jest.fn(() => ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      toJSON: jest.fn(),
+    }));
+  });
+
+  beforeEach(() => {
+    createdEditors.length = 0;
+  });
+
+  it('does not remount the editor when the value prop is a new reference with equal content', async () => {
+    const { rerender, onChange } = setup(paragraph('Some content'));
+
+    const editable = await screen.findByRole('textbox');
+
+    // Same content, new identity — like the form echoing the editor's own state back
+    rerender(
+      <BlocksEditor
+        name="blocks-editor"
+        value={paragraph('Some content')}
+        onChange={onChange}
+        error={undefined}
+        ariaLabelId="blocks-editor-label"
+      />
+    );
+
+    // The Slate subtree must not have been remounted, otherwise pending input and
+    // the DOM under the user's caret would be wiped
+    expect(screen.getByRole('textbox')).toBe(editable);
+    expect(screen.getByText('Some content')).toBeInTheDocument();
+  });
+
+  it('drops a stale selection when an external value change forces a remount', async () => {
+    const initialText = 'A line of text long enough';
+    const { rerender, onChange, editor } = setup(paragraph(initialText));
+
+    await screen.findByRole('textbox');
+
+    // Focus and place the selection at the end of the current content, like a user typing.
+    // Focus matters: the "sync after discard" effect already deselects a blurred editor, so
+    // the crash only reproduces while the editor is focused.
+    act(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, { path: [0, 0], offset: initialText.length });
+    });
+
+    // External update with shorter content (e.g. discard, fill from another locale).
+    // Without deselecting first, the surviving selection points past the new content
+    // and slate-react crashes with "Cannot resolve a DOM point from Slate point".
+    rerender(
+      <BlocksEditor
+        name="blocks-editor"
+        value={paragraph('Hi')}
+        onChange={onChange}
+        error={undefined}
+        ariaLabelId="blocks-editor-label"
+      />
+    );
+
+    expect(editor.selection).toBeNull();
+    expect(screen.getByText('Hi')).toBeInTheDocument();
+  });
+});

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/tests/BlocksToolbar.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/tests/BlocksToolbar.test.tsx
@@ -642,7 +642,7 @@ describe('BlocksToolbar', () => {
     ]);
   });
 
-  it('creates a new node when selecting a block if there is no selection', async () => {
+  it('converts the last block when selecting a block type if there is no selection', async () => {
     const { user } = setup([
       {
         type: 'paragraph',
@@ -650,27 +650,18 @@ describe('BlocksToolbar', () => {
       },
     ]);
 
-    // Convert selection to a code block
+    // Toolbar steals focus (clears selection); convert the existing content, don't insert empty
     const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
     await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Quote' }));
 
     expect(baseEditor.children).toEqual([
       {
-        type: 'paragraph',
-        children: [
-          {
-            type: 'text',
-            text: 'Some paragraph',
-          },
-        ],
-      },
-      {
         type: 'quote',
         children: [
           {
             type: 'text',
-            text: '',
+            text: 'Some paragraph',
           },
         ],
       },


### PR DESCRIPTION
### What does it do?

Fixes two product bugs that make `blocks.spec.ts` (`adds a code block and specifies the language`) flake:

1. **`useResetKey`** — skip remount when the incoming `value` is deep-equal to editor content (form echoes / empty↔empty), and bump the slate update counter **immediately** on AST change (not inside the 300ms debounce). Otherwise any value-prop identity change during that window remounts over pending input.
2. **`BlocksToolbar`** — when the toolbar steals focus and clears selection, convert the **last existing** block instead of inserting a new empty block to convert (which left user content behind and produced an empty code block).

Adds/updates unit coverage: `BlocksEditorResetKey.test.tsx`, toolbar no-selection conversion test.

### Why is it needed?

Seen on https://github.com/strapi/strapi/actions/runs/29499058361/job/87625560701 (PR #26300 — unrelated). Playwright `fill()` then toolbar → code block left empty; `getByText(code)` timed out. Trace showed empty `<code>` with only a zero-width placeholder after conversion.

Not a test timeout / structural test change — product races.

Related broader draft #26968 overlaps the content-equal remount skip; this PR also covers the debounce-window remount and the toolbar empty-insert path.

### How to test it?

1. Unit: `BlocksEditorResetKey.test.tsx`, updated `BlocksToolbar` no-selection test.
2. E2E: `tests/e2e/tests/content-manager/blocks.spec.ts` (chromium EE/CE shard 1/4).

### Related issue(s)/PR(s)

- Flake job: https://github.com/strapi/strapi/actions/runs/29499058361/job/87625560701?pr=26300
- Related: #26968