### PR TITLE
fix(upload): report real upload progress in the media library

### DIFF
--- a/packages/core/upload/admin/src/future/services/tests/uploadFileViaXHR.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadFileViaXHR.test.ts
@@ -1,4 +1,13 @@
+import { attemptTokenRefresh } from '@strapi/admin/strapi-admin';
+
 import { uploadFileViaXHR, UploadAbortedError, UploadFileError } from '../uploadFileViaXHR';
+
+jest.mock('@strapi/admin/strapi-admin', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin'),
+  attemptTokenRefresh: jest.fn(),
+}));
+
+const attemptTokenRefreshMock = jest.mocked(attemptTokenRefresh);
 
 interface ProgressLike {
   loaded: number;
@@ -67,6 +76,7 @@ describe('uploadFileViaXHR', () => {
 
   beforeEach(() => {
     MockXHR.instances = [];
+    attemptTokenRefreshMock.mockReset();
     OriginalXHR = global.XMLHttpRequest;
     // Stub the global so the function under test uses our controllable fake.
     global.XMLHttpRequest = MockXHR as unknown as typeof XMLHttpRequest;
@@ -100,6 +110,43 @@ describe('uploadFileViaXHR', () => {
       status: 400,
     });
     await expect(promise).rejects.toBeInstanceOf(UploadFileError);
+  });
+
+  it('refreshes the access token and retries once on a 401 response', async () => {
+    const controller = new AbortController();
+    const formData = new FormData();
+    attemptTokenRefreshMock.mockResolvedValue('refreshed-token');
+
+    const promise = uploadFileViaXHR(ENDPOINT, 'expired-token', formData, controller.signal);
+    lastXHR().respond(401, JSON.stringify({ error: { message: 'Unauthorized' } }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(attemptTokenRefreshMock).toHaveBeenCalledTimes(1);
+    expect(MockXHR.instances).toHaveLength(2);
+    expect(lastXHR().headers.Authorization).toBe('Bearer refreshed-token');
+    expect(lastXHR().sent).toBe(formData);
+
+    const file = { id: 1, name: 'photo.png', hash: 'abc' };
+    lastXHR().respond(201, JSON.stringify(file));
+
+    await expect(promise).resolves.toEqual(file);
+  });
+
+  it('returns the original 401 error when refreshing the access token fails', async () => {
+    const controller = new AbortController();
+    attemptTokenRefreshMock.mockRejectedValue(new Error('Refresh failed'));
+
+    const promise = uploadFileViaXHR(ENDPOINT, 'expired-token', new FormData(), controller.signal);
+    lastXHR().respond(401, JSON.stringify({ error: { message: 'Unauthorized' } }));
+
+    await expect(promise).rejects.toMatchObject({
+      name: 'UploadFileError',
+      message: 'Unauthorized',
+      status: 401,
+    });
+    expect(MockXHR.instances).toHaveLength(1);
   });
 
   it('rejects with an UploadAbortedError when the signal aborts mid-flight', async () => {

--- a/packages/core/upload/admin/src/future/services/uploadFileViaXHR.ts
+++ b/packages/core/upload/admin/src/future/services/uploadFileViaXHR.ts
@@ -1,3 +1,5 @@
+import { attemptTokenRefresh } from '@strapi/admin/strapi-admin';
+
 import type { File } from '../../../../shared/contracts/files';
 
 /**
@@ -44,7 +46,7 @@ export type UploadProgressCallback = (bytes: number, total: number) => void;
  * @throws {UploadAbortedError} When the signal aborts.
  * @throws {UploadFileError} On a non-2xx response or network error.
  */
-export const uploadFileViaXHR = <T = File>(
+const sendUploadViaXHR = <T>(
   url: string,
   token: string | null | undefined,
   formData: FormData,
@@ -111,4 +113,32 @@ export const uploadFileViaXHR = <T = File>(
 
     xhr.send(formData);
   });
+};
+
+export const uploadFileViaXHR = async <T = File>(
+  url: string,
+  token: string | null | undefined,
+  formData: FormData,
+  signal: AbortSignal,
+  onProgress?: UploadProgressCallback
+): Promise<T> => {
+  try {
+    return await sendUploadViaXHR<T>(url, token, formData, signal, onProgress);
+  } catch (error) {
+    if (!(error instanceof UploadFileError) || error.status !== 401) {
+      throw error;
+    }
+
+    try {
+      const refreshedToken = await attemptTokenRefresh();
+
+      return await sendUploadViaXHR<T>(url, refreshedToken, formData, signal, onProgress);
+    } catch (refreshError) {
+      if (refreshError instanceof UploadFileError) {
+        throw refreshError;
+      }
+
+      throw error;
+    }
+  }
 };

--- a/packages/core/upload/admin/src/future/services/uploadFileViaXHR.ts
+++ b/packages/core/upload/admin/src/future/services/uploadFileViaXHR.ts
@@ -39,18 +39,19 @@ export type UploadProgressCallback = (bytes: number, total: number) => void;
  * @param formData - Prebuilt multipart body containing the single file and its `fileInfo`.
  * @param signal - Aborts the in-flight request when triggered.
  * @param onProgress - Called with `(loaded, total)` bytes as the upload progresses.
- * @returns The parsed, signed `File` on a 2xx response.
+ * @returns The parsed response body on a 2xx response — a signed `File` by default,
+ * or `T` when the endpoint returns a different shape (e.g. an array of files).
  * @throws {UploadAbortedError} When the signal aborts.
  * @throws {UploadFileError} On a non-2xx response or network error.
  */
-export const uploadFileViaXHR = (
+export const uploadFileViaXHR = <T = File>(
   url: string,
   token: string | null | undefined,
   formData: FormData,
   signal: AbortSignal,
   onProgress?: UploadProgressCallback
-): Promise<File> => {
-  return new Promise<File>((resolve, reject) => {
+): Promise<T> => {
+  return new Promise<T>((resolve, reject) => {
     if (signal.aborted) {
       reject(new UploadAbortedError());
       return;
@@ -81,7 +82,7 @@ export const uploadFileViaXHR = (
 
       if (xhr.status >= 200 && xhr.status < 300) {
         try {
-          resolve(JSON.parse(xhr.responseText) as File);
+          resolve(JSON.parse(xhr.responseText) as T);
         } catch {
           reject(new UploadFileError('Failed to parse upload response'));
         }

--- a/packages/core/upload/admin/src/hooks/tests/useUpload.test.ts
+++ b/packages/core/upload/admin/src/hooks/tests/useUpload.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook, waitFor } from '@tests/utils';
+
+import { useUpload } from '../useUpload';
+
+import type { UploadProgressCallback } from '../../future/services/uploadFileViaXHR';
+
+const uploadFileViaXHRMock = jest.fn();
+
+jest.mock('../../future/services/uploadFileViaXHR', () => ({
+  ...jest.requireActual('../../future/services/uploadFileViaXHR'),
+  uploadFileViaXHR: (...args: unknown[]) => uploadFileViaXHRMock(...args),
+}));
+
+type UploadArgs = Parameters<ReturnType<typeof useUpload>['upload']>;
+
+const FIXTURE_ASSET = {
+  name: 'asset.pdf',
+  rawFile: new File(['file content'], 'asset.pdf', { type: 'application/pdf' }),
+} as unknown as UploadArgs[0];
+
+describe('useUpload', () => {
+  test('reports byte-level upload progress as a 0-100 percentage', async () => {
+    let capturedOnProgress: UploadProgressCallback | undefined;
+    let resolveUpload!: (value: unknown) => void;
+
+    uploadFileViaXHRMock.mockImplementation(
+      (_url, _token, _formData, _signal, onProgress: UploadProgressCallback) => {
+        capturedOnProgress = onProgress;
+        return new Promise((resolve) => {
+          resolveUpload = resolve;
+        });
+      }
+    );
+
+    const { result } = renderHook(() => useUpload());
+
+    let uploadPromise: Promise<unknown>;
+    act(() => {
+      uploadPromise = result.current.upload(FIXTURE_ASSET, null);
+    });
+
+    await waitFor(() => expect(uploadFileViaXHRMock).toHaveBeenCalledTimes(1));
+
+    // Halfway: 100 MiB of 200 MiB sent
+    act(() => {
+      capturedOnProgress?.(104857600, 209715200);
+    });
+    expect(result.current.progress).toBe(50);
+
+    act(() => {
+      capturedOnProgress?.(209715200, 209715200);
+      resolveUpload([{ id: 1 }]);
+    });
+    await act(async () => {
+      await uploadPromise;
+    });
+
+    expect(result.current.progress).toBe(100);
+
+    const [url] = uploadFileViaXHRMock.mock.calls[0];
+    expect(url).toBe(`${window.strapi.backendURL}/upload`);
+  });
+});

--- a/packages/core/upload/admin/src/hooks/useUpload.ts
+++ b/packages/core/upload/admin/src/hooks/useUpload.ts
@@ -1,10 +1,11 @@
 import * as React from 'react';
 
-import { useFetchClient, FetchClient, adminApi } from '@strapi/admin/strapi-admin';
+import { adminApi } from '@strapi/admin/strapi-admin';
 import { useMutation, useQueryClient } from 'react-query';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useStore } from 'react-redux';
 
 import { File, RawFile, CreateFile } from '../../../shared/contracts/files';
+import { uploadFileViaXHR } from '../future/services/uploadFileViaXHR';
 import { pluginId } from '../pluginId';
 
 const endpoint = `/${pluginId}`;
@@ -15,12 +16,18 @@ interface Asset extends Omit<File, 'id' | 'hash'> {
   hash?: File['hash'];
 }
 
+interface StoreState {
+  admin_app: {
+    token?: string | null;
+  };
+}
+
 const uploadAssets = (
   assets: Asset | Asset[],
   folderId: number | null,
   signal: AbortSignal,
   onProgress: (progress: number) => void,
-  post: FetchClient['post']
+  token: string | null | undefined
 ): Promise<CreateFile.Response['data']> => {
   const assetsArray = Array.isArray(assets) ? assets : [assets];
   const formData = new FormData();
@@ -46,13 +53,20 @@ const uploadAssets = (
   });
 
   /**
-   * onProgress is not possible using native fetch
-   * need to look into an alternative to make it work
-   * perhaps using xhr like Axios does
+   * Native fetch cannot report upload progress, so upload via the shared XHR
+   * service and surface its byte-level progress as a 0-100 percentage.
    */
-  return post<CreateFile.Response['data'], CreateFile.Request['body']>(endpoint, formData, {
+  return uploadFileViaXHR<CreateFile.Response['data']>(
+    `${window.strapi.backendURL}${endpoint}`,
+    token,
+    formData,
     signal,
-  }).then((res) => res.data);
+    (loaded, total) => {
+      if (total > 0) {
+        onProgress(Math.round((loaded / total) * 100));
+      }
+    }
+  );
 };
 
 export const useUpload = () => {
@@ -61,7 +75,7 @@ export const useUpload = () => {
   const queryClient = useQueryClient();
   const abortController = new AbortController();
   const signal = abortController.signal;
-  const { post } = useFetchClient();
+  const store = useStore<StoreState>();
 
   const mutation = useMutation<
     CreateFile.Response['data'],
@@ -69,7 +83,7 @@ export const useUpload = () => {
     { assets: Asset | Asset[]; folderId: number | null }
   >(
     ({ assets, folderId }) => {
-      return uploadAssets(assets, folderId, signal, setProgress, post);
+      return uploadAssets(assets, folderId, signal, setProgress, store.getState().admin_app?.token);
     },
     {
       onSuccess() {

--- a/packages/core/upload/admin/src/hooks/useUpload.ts
+++ b/packages/core/upload/admin/src/hooks/useUpload.ts
@@ -86,6 +86,7 @@ export const useUpload = () => {
       return uploadAssets(assets, folderId, signal, setProgress, store.getState().admin_app?.token);
     },
     {
+      mutationKey: [pluginId, 'upload'],
       onSuccess() {
         queryClient.refetchQueries([pluginId, 'assets'], { active: true });
         queryClient.refetchQueries([pluginId, 'asset-count'], { active: true });


### PR DESCRIPTION
### What does it do?

Adds real upload progress reporting to the Media Library upload flow.

- Uses `XMLHttpRequest` to receive byte-level upload progress events.
- Converts uploaded bytes into a percentage displayed by the existing progress UI.
- Supports the array response returned by the `/upload` endpoint.
- Refreshes an expired admin access token and retries the upload once after a `401`.
- Adds a stable mutation key to the upload mutation.
- Adds tests covering progress reporting, authentication headers, token refresh and retry, cancellation, and upload errors.

https://github.com/user-attachments/assets/79381f06-293e-490a-b760-7ee17f18b6b6


### Why is it needed?

The Media Library displayed an upload progress indicator, but uploads used the Fetch API, which does not expose upload progress events. As a result, the indicator remained at `0%` while a file was uploading.

Using XHR allows the UI to report the actual upload progress. The token-refresh handling preserves the authentication behavior previously provided by Strapi’s shared fetch client.

### How to test it?

Run the focused frontend tests:

```bash
yarn workspace @strapi/upload test:front \
  --runInBand \
  --watchman=false \
  useUpload.test.ts \
  uploadFileViaXHR.test.ts
```

### Related issue(s)/PR(s)

N/A
