### PR TITLE
chore(admin): singleton module handling for vite aliases

### DIFF
--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
@@ -5,9 +5,10 @@ import {
   ADMIN_PINNED_ALIAS_MODULES,
   ADMIN_VITE_ALIAS_MODULES,
   ADMIN_VITE_DEDUPE_MODULES,
+  ADMIN_VITE_SINGLETON_MODULES,
 } from '../admin-vite-alias-modules';
 import { buildAdminViteResolveAliases } from '../admin-vite-aliases';
-import { getModulePath } from '../resolve-module';
+import { getModulePath, getModulePathFrom } from '../resolve-module';
 
 const adminDeps = require('@strapi/admin/package.json').dependencies as Record<string, string>;
 
@@ -36,8 +37,22 @@ describe('buildAdminViteResolveAliases', () => {
     }
   });
 
-  it('uses the same module list for aliases and vite resolve.dedupe', () => {
-    expect(ADMIN_VITE_DEDUPE_MODULES).toBe(ADMIN_VITE_ALIAS_MODULES);
+  it('aliases CodeMirror singletons from @strapi/design-system', () => {
+    const alias = buildAdminViteResolveAliases();
+
+    for (const mod of ADMIN_VITE_SINGLETON_MODULES) {
+      expect(alias[mod]).toBe(getModulePathFrom('@strapi/design-system', mod));
+    }
+  });
+
+  it('includes alias and singleton modules in vite resolve.dedupe', () => {
+    for (const mod of ADMIN_VITE_ALIAS_MODULES) {
+      expect(ADMIN_VITE_DEDUPE_MODULES).toContain(mod);
+    }
+
+    for (const mod of ADMIN_VITE_SINGLETON_MODULES) {
+      expect(ADMIN_VITE_DEDUPE_MODULES).toContain(mod);
+    }
   });
 
   it.each(ADMIN_PINNED_ALIAS_MODULES)(

--- a/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
@@ -1,3 +1,5 @@
+import { ADMIN_VITE_SINGLETON_MODULES } from './admin-vite-singleton-modules';
+
 /**
  * Modules given explicit Vite resolve aliases (and included in resolve.dedupe) for the admin bundle.
  * Single source of truth for resolution contract tests.
@@ -20,8 +22,15 @@ export const ADMIN_VITE_ALIAS_MODULES = [
 
 export type AdminViteAliasModule = (typeof ADMIN_VITE_ALIAS_MODULES)[number];
 
-/** Same modules passed to Vite resolve.dedupe */
-export const ADMIN_VITE_DEDUPE_MODULES = ADMIN_VITE_ALIAS_MODULES;
+/**
+ * Modules passed to Vite resolve.dedupe (and aliased): admin-pinned aliases
+ */
+export const ADMIN_VITE_DEDUPE_MODULES = [
+  ...ADMIN_VITE_ALIAS_MODULES,
+  ...ADMIN_VITE_SINGLETON_MODULES,
+] as const;
+
+export { ADMIN_VITE_SINGLETON_MODULES };
 
 /**
  * Alias modules with exact versions declared in @strapi/admin dependencies (not peers).

--- a/packages/core/strapi/src/node/core/admin-vite-aliases.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-aliases.ts
@@ -1,10 +1,15 @@
-import { ADMIN_VITE_ALIAS_MODULES } from './admin-vite-alias-modules';
-import { getModulePath } from './resolve-module';
+import { ADMIN_VITE_ALIAS_MODULES, ADMIN_VITE_SINGLETON_MODULES } from './admin-vite-alias-modules';
+import { getModulePath, getModulePathFrom } from './resolve-module';
 
 /**
- * Vite resolve.alias entries for the admin bundle — every path comes from @strapi/admin's closure.
+ * Vite resolve.alias entries for the admin bundle.
  *
  * @internal
  */
 export const buildAdminViteResolveAliases = (): Record<string, string> =>
-  Object.fromEntries(ADMIN_VITE_ALIAS_MODULES.map((mod) => [mod, getModulePath(mod)]));
+  Object.fromEntries([
+    ...ADMIN_VITE_ALIAS_MODULES.map((mod) => [mod, getModulePath(mod)] as const),
+    ...ADMIN_VITE_SINGLETON_MODULES.map(
+      (mod) => [mod, getModulePathFrom('@strapi/design-system', mod)] as const
+    ),
+  ]);

--- a/packages/core/strapi/src/node/core/admin-vite-singleton-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-singleton-modules.ts
@@ -1,0 +1,19 @@
+/**
+ * Modules that must resolve to a single runtime instance in the admin Vite graph.
+ *
+ * CodeMirror extensions use instanceof checks internally, so JSONInput breaks if
+ * @codemirror/state is duplicated between @strapi/design-system and lang-json/uiw.
+ *
+ * @internal
+ */
+export const ADMIN_VITE_SINGLETON_MODULES = [
+  '@codemirror/state',
+  '@codemirror/view',
+  '@codemirror/language',
+  '@codemirror/lang-json',
+  '@codemirror/commands',
+  '@codemirror/lint',
+  '@uiw/react-codemirror',
+] as const;
+
+export type AdminViteSingletonModule = (typeof ADMIN_VITE_SINGLETON_MODULES)[number];

--- a/packages/core/strapi/src/node/core/resolve-module.ts
+++ b/packages/core/strapi/src/node/core/resolve-module.ts
@@ -2,29 +2,39 @@ import path from 'node:path';
 import readPkgUp from 'read-pkg-up';
 import resolveFrom from 'resolve-from';
 
-let adminPkgDir: string | undefined;
+const pkgDirCache = new Map<string, string>();
 
 /**
- * Package root of @strapi/admin — admin Vite aliases must resolve from here so pnpm
- * workspaces cannot pick up a hoisted incompatible major from another package
- * (e.g. @reduxjs/toolkit@2.x elsewhere while admin pins 1.9.x).
+ * Package root of a workspace / installed package (cached).
  */
-const getAdminPkgDir = (): string => {
-  if (!adminPkgDir) {
-    adminPkgDir = path.dirname(require.resolve('@strapi/admin/package.json'));
+const getPackageDir = (packageName: string): string => {
+  const cached = pkgDirCache.get(packageName);
+  if (cached) {
+    return cached;
   }
 
-  return adminPkgDir;
+  const dir = path.dirname(require.resolve(`${packageName}/package.json`));
+  pkgDirCache.set(packageName, dir);
+  return dir;
 };
 
 /**
- * Resolve module to package root for use in aliases.
+ * Resolve module to package root from a host package's dependency context.
  * Ensures pnpm's strict node_modules structure can resolve packages when bundling plugin chunks.
  *
  * @internal
  */
-export const getModulePath = (mod: string): string => {
-  const modulePath = resolveFrom(getAdminPkgDir(), mod);
+export const getModulePathFrom = (hostPackage: string, mod: string): string => {
+  const modulePath = resolveFrom(getPackageDir(hostPackage), mod);
   const pkg = readPkgUp.sync({ cwd: path.dirname(modulePath) });
   return pkg ? path.dirname(pkg.path) : modulePath;
 };
+
+/**
+ * Resolve module to package root from @strapi/admin's closure.
+ * Prefer this for admin-pinned aliases so pnpm workspaces cannot pick up a hoisted
+ * incompatible major (e.g. @reduxjs/toolkit@2.x elsewhere while admin pins 1.9.x).
+ *
+ * @internal
+ */
+export const getModulePath = (mod: string): string => getModulePathFrom('@strapi/admin', mod);

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -1,7 +1,10 @@
 import type { InlineConfig, UserConfig } from 'vite';
 
 import { getUserConfig } from '../core/config';
-import { ADMIN_VITE_DEDUPE_MODULES } from '../core/admin-vite-alias-modules';
+import {
+  ADMIN_VITE_DEDUPE_MODULES,
+  ADMIN_VITE_SINGLETON_MODULES,
+} from '../core/admin-vite-alias-modules';
 import { buildAdminViteResolveAliases } from '../core/admin-vite-aliases';
 import { collectAdminOptimizeDepsExclude } from '../core/admin-vite-optimize-exclude';
 import { isDesignSystemLinked } from '../core/linked-packages';
@@ -77,6 +80,7 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
         // Must pre-bundle for all apps (not only monorepo examples) or fresh create-strapi-app
         // projects blank-crash the admin (#25070, #26964).
         'prismjs/components/*.js',
+        ...ADMIN_VITE_SINGLETON_MODULES,
         /**
          * Pre-bundle other dependencies that would otherwise cause a page reload when imported.
          * See "performance" section: https://vite.dev/guide/dep-pre-bundling.html#the-why

--- a/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
+++ b/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
@@ -1,5 +1,6 @@
 import http from 'node:http';
 
+import { ADMIN_VITE_SINGLETON_MODULES } from '../core/admin-vite-alias-modules';
 import { resolveDevelopmentConfig } from './config';
 import type { BuildContext } from '../create-build-context';
 
@@ -56,6 +57,14 @@ describe('resolveDevelopmentConfig (Vite admin dev)', () => {
     expect(alias?.invariant).toEqual(expect.any(String));
     expect(alias?.prismjs).toEqual(expect.any(String));
     expect(alias?.lodash).toEqual(expect.any(String));
+
+    // CodeMirror must be a singleton for all admin builds (JSONInput instanceof checks).
+    expect(config.optimizeDeps?.include).toEqual(
+      expect.arrayContaining([...ADMIN_VITE_SINGLETON_MODULES])
+    );
+    for (const mod of ADMIN_VITE_SINGLETON_MODULES) {
+      expect(alias?.[mod]).toEqual(expect.any(String));
+    }
 
     await new Promise<void>((resolve) => {
       mockHttpServer.close(() => resolve());


### PR DESCRIPTION
### What does it do?
Forces CodeMirror-related packages to resolve as a single runtime instance in the admin Vite graph.
- Adds `ADMIN_VITE_SINGLETON_MODULES` (`@codemirror/*`, `@uiw/react-codemirror`) separate from admin-pinned alias modules

### Why is it needed?
CodeMirror extensions use `instanceof` checks. When the admin bundler loads more than one physical `@codemirror/state` (common in monorepo / yarn / yalc graphs where design-system and hoisted `@codemirror/lang-json` resolve different copies), JSONInput fails with:
```text
Unrecognized extension value in extension set ([object Object]).
This sometimes happens because multiple instances of @codemirror/state are loaded, breaking e2e test
```


### How to test it?
From repo root, run the unit tests covering the change:
yarn nx test @strapi/strapi --testPathPattern='admin-vite-aliases|resolve-development-config'

Merge into e.g https://github.com/strapi/strapi/pull/26713/ and see that the e2e tests pass
