### PR TITLE
fix(admin): scope audit logs user filter to log authors

### DIFF
--- a/packages/core/admin/admin/tests/server.ts
+++ b/packages/core/admin/admin/tests/server.ts
@@ -608,6 +608,20 @@ export const server: SetupServer = setupServer(
     /**
      * Audit Logs
      */
+    http.get('/admin/audit-logs/users', () => {
+      return HttpResponse.json({
+        results: [
+          { id: 1, email: 'john@testing.com', displayName: 'John Doe' },
+          { id: 2, email: 'kai@testing.com', displayName: 'Kai Doe' },
+        ],
+        pagination: {
+          page: 1,
+          pageSize: 10,
+          pageCount: 1,
+          total: 2,
+        },
+      });
+    }),
     http.get('/admin/audit-logs', () => {
       return HttpResponse.json({
         results: [

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { Flex, IconButton, Typography } from '@strapi/design-system';
 import { Eye } from '@strapi/icons';
 import { useIntl } from 'react-intl';
@@ -18,32 +20,51 @@ import { useFormatTimeStamp } from './hooks/useFormatTimeStamp';
 import { getDefaultMessage } from './utils/getActionTypesDefaultMessages';
 import { getDisplayedFilters } from './utils/getDisplayedFilters';
 
+const USERS_PAGE_SIZE = 10;
+
 const ListPage = () => {
   const { formatMessage } = useIntl();
   const permissions = useTypedSelector((state) => state.admin_app.permissions.settings);
 
   const {
-    allowedActions: { canRead: canReadAuditLogs, canReadUsers },
+    allowedActions: { canRead: canReadAuditLogs },
     isLoading: isLoadingRBAC,
-  } = useRBAC({
-    ...permissions?.auditLogs,
-    readUsers: permissions?.users.read || [],
-  });
+  } = useRBAC(permissions?.auditLogs?.read || []);
 
   const [{ query }, setQuery] = useQueryParams<{ id?: AuditLog['id'] }>();
+  const [usersPageSize, setUsersPageSize] = React.useState(USERS_PAGE_SIZE);
   const {
     auditLogs,
     users,
+    usersPagination,
+    isLoadingUsers,
     isLoading: isLoadingData,
     hasError,
   } = useAuditLogsData({
     canReadAuditLogs,
-    canReadUsers,
+    usersPageSize,
   });
+
+  const { page = 1, pageCount = 1 } = usersPagination ?? {};
+  const hasMoreUsers = page < pageCount;
+
+  const handleLoadMoreUsers = () => {
+    if (hasMoreUsers) {
+      setUsersPageSize((prevPageSize) => prevPageSize + USERS_PAGE_SIZE);
+    }
+  };
 
   const formatTimeStamp = useFormatTimeStamp();
 
-  const displayedFilters = getDisplayedFilters({ formatMessage, users, canReadUsers });
+  const displayedFilters = getDisplayedFilters({
+    formatMessage,
+    users,
+    usersFilter: {
+      loading: isLoadingUsers,
+      hasMoreItems: hasMoreUsers,
+      onLoadMore: handleLoadMoreUsers,
+    },
+  });
 
   const headers: Table.Header<AuditLog, object>[] = [
     {

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/components/ComboboxFilter.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/components/ComboboxFilter.tsx
@@ -4,7 +4,18 @@ import { useIntl } from 'react-intl';
 import { Filters } from '../../../../../../../../admin/src/components/Filters';
 import { useField } from '../../../../../../../../admin/src/components/Form';
 
-export const ComboboxFilter = (props: Filters.ValueInputProps) => {
+export interface ComboboxFilterProps extends Filters.ValueInputProps {
+  loading?: boolean;
+  hasMoreItems?: boolean;
+  onLoadMore?: () => void;
+}
+
+export const ComboboxFilter = ({
+  loading,
+  hasMoreItems,
+  onLoadMore,
+  ...props
+}: ComboboxFilterProps) => {
   const { formatMessage } = useIntl();
   const field = useField<string>(props.name);
   const ariaLabel = formatMessage({
@@ -17,7 +28,14 @@ export const ComboboxFilter = (props: Filters.ValueInputProps) => {
   };
 
   return (
-    <Combobox aria-label={ariaLabel} value={field.value} onChange={handleChange}>
+    <Combobox
+      aria-label={ariaLabel}
+      value={field.value}
+      onChange={handleChange}
+      loading={loading}
+      hasMoreItems={hasMoreItems}
+      onLoadMore={onLoadMore}
+    >
       {props.options?.map((opt) => {
         const value = typeof opt === 'string' ? opt : opt.value;
         const label = typeof opt === 'string' ? opt : opt.label;

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/hooks/tests/useAuditLogsData.test.ts
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/hooks/tests/useAuditLogsData.test.ts
@@ -1,0 +1,53 @@
+import { renderHook, server, waitFor } from '@tests/utils';
+import { http, HttpResponse } from 'msw';
+
+import { useAuditLogsData } from '../useAuditLogsData';
+
+const AUTHORS = Array.from({ length: 12 }, (_, index) => ({
+  id: index + 1,
+  email: `user${index + 1}@test.io`,
+  displayName: `User ${index + 1}`,
+}));
+
+describe('useAuditLogsData', () => {
+  beforeEach(() => {
+    server.use(
+      http.get('/admin/audit-logs/users', ({ request }) => {
+        const url = new URL(request.url);
+        const pageSize = Number(url.searchParams.get('pageSize') ?? 10);
+
+        return HttpResponse.json({
+          results: AUTHORS.slice(0, pageSize),
+          pagination: {
+            page: 1,
+            pageSize,
+            pageCount: Math.ceil(AUTHORS.length / pageSize),
+            total: AUTHORS.length,
+          },
+        });
+      })
+    );
+  });
+
+  it('should fetch audit log authors with the given page size and expose the pagination', async () => {
+    const { result } = renderHook(() =>
+      useAuditLogsData({ canReadAuditLogs: true, usersPageSize: 12 })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.users).toHaveLength(12);
+    expect(result.current.usersPagination).toMatchObject({ page: 1, pageCount: 1, total: 12 });
+  });
+
+  it('should only expose the first page of audit log authors by default', async () => {
+    const { result } = renderHook(() =>
+      useAuditLogsData({ canReadAuditLogs: true, usersPageSize: 10 })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.users).toHaveLength(10);
+    expect(result.current.usersPagination).toMatchObject({ page: 1, pageCount: 2, total: 12 });
+  });
+});

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/hooks/useAuditLogsData.ts
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/hooks/useAuditLogsData.ts
@@ -3,15 +3,14 @@ import * as React from 'react';
 import { useNotification } from '../../../../../../../../admin/src/features/Notifications';
 import { useAPIErrorHandler } from '../../../../../../../../admin/src/hooks/useAPIErrorHandler';
 import { useQueryParams } from '../../../../../../../../admin/src/hooks/useQueryParams';
-import { useAdminUsers } from '../../../../../../../../admin/src/services/users';
-import { useGetAuditLogsQuery } from '../../../../../services/auditLogs';
+import { useGetAuditLogsQuery, useGetAuditLogUsersQuery } from '../../../../../services/auditLogs';
 
 export const useAuditLogsData = ({
   canReadAuditLogs,
-  canReadUsers,
+  usersPageSize,
 }: {
   canReadAuditLogs: boolean;
-  canReadUsers: boolean;
+  usersPageSize: number;
 }) => {
   const { toggleNotification } = useNotification();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
@@ -22,13 +21,21 @@ export const useAuditLogsData = ({
     error,
     isError: isUsersError,
     isLoading: isLoadingUsers,
-  } = useAdminUsers(
-    {},
+  } = useGetAuditLogUsersQuery(
+    { pageSize: usersPageSize },
     {
-      skip: !canReadUsers,
+      skip: !canReadAuditLogs,
       refetchOnMountOrArgChange: true,
     }
   );
+
+  const [usersData, setUsersData] = React.useState<typeof data>();
+
+  React.useEffect(() => {
+    if (data) {
+      setUsersData(data);
+    }
+  }, [data]);
 
   React.useEffect(() => {
     if (error) {
@@ -54,8 +61,10 @@ export const useAuditLogsData = ({
 
   return {
     auditLogs,
-    users: data?.users ?? [],
-    isLoading: isLoadingUsers || isLoadingAuditLogs,
+    users: usersData?.results ?? [],
+    usersPagination: usersData?.pagination ?? undefined,
+    isLoadingUsers,
+    isLoading: (isLoadingUsers && !usersData) || isLoadingAuditLogs,
     hasError: isAuditLogsError || isUsersError,
   };
 };

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/tests/ListPage.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/tests/ListPage.test.tsx
@@ -108,4 +108,43 @@ describe('ADMIN | Pages | AUDIT LOGS | ListPage', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add filter' })).toBeInTheDocument();
   });
+
+  it('should show the User filter option even when the user cannot read admin users', async () => {
+    const { user } = render(<ListPage />, {
+      providerOptions: {
+        permissions: (defaultPermissions) =>
+          defaultPermissions.filter((permission) => permission.action !== 'admin::users.read'),
+      },
+    });
+
+    await waitFor(() => expect(screen.queryByText('Loading content')).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+
+    await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
+
+    expect(await screen.findByRole('option', { name: 'User' })).toBeInTheDocument();
+  });
+
+  it('should show the User filter option when the user can read admin users', async () => {
+    const { user } = render(<ListPage />);
+
+    await waitFor(() => expect(screen.queryByText('Loading content')).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+
+    await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
+
+    expect(await screen.findByRole('option', { name: 'Action' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Date' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'User' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', { name: 'User' }));
+    await user.click(
+      screen.getByRole('combobox', { name: 'Search and select an option to filter' })
+    );
+
+    expect(await screen.findByRole('option', { name: 'John Doe' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Kai Doe' })).toBeInTheDocument();
+  });
 });

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/utils/getDisplayedFilters.ts
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/utils/getDisplayedFilters.ts
@@ -1,20 +1,23 @@
 import { IntlShape } from 'react-intl';
 
 import { Filters } from '../../../../../../../../admin/src/components/Filters';
-import { getDisplayName } from '../../../../../../../../admin/src/utils/users';
-import { SanitizedAdminUser } from '../../../../../../../../shared/contracts/shared';
-import { ComboboxFilter } from '../components/ComboboxFilter';
+import { GetUsers } from '../../../../../../../../shared/contracts/audit-logs';
+import { ComboboxFilter, ComboboxFilterProps } from '../components/ComboboxFilter';
 
 import { actionTypes, getDefaultMessage } from './getActionTypesDefaultMessages';
+
+type UsersFilterProps = Pick<ComboboxFilterProps, 'loading' | 'hasMoreItems' | 'onLoadMore'>;
+
+type AuditLogUser = NonNullable<GetUsers.Response['results']>[number];
 
 export const getDisplayedFilters = ({
   formatMessage,
   users,
-  canReadUsers,
+  usersFilter,
 }: {
   formatMessage: IntlShape['formatMessage'];
-  users: SanitizedAdminUser[];
-  canReadUsers: boolean;
+  users: AuditLogUser[];
+  usersFilter?: UsersFilterProps;
 }): Filters.Filter[] => {
   const operators = [
     {
@@ -64,26 +67,23 @@ export const getDisplayedFilters = ({
     },
   ] satisfies Filters.Filter[];
 
-  if (canReadUsers && users) {
-    return [
-      ...filters,
-      {
-        input: ComboboxFilter,
-        label: formatMessage({
-          id: 'Settings.permissions.auditLogs.user',
-          defaultMessage: 'User',
-        }),
-        mainField: { name: 'id', type: 'integer' },
-        name: 'user',
-        operators,
-        options: users.map((user) => ({
-          label: getDisplayName(user),
-          value: user.id.toString(),
-        })),
-        type: 'relation',
-      } satisfies Filters.Filter,
-    ];
-  }
-
-  return filters;
+  return [
+    ...filters,
+    {
+      input: ComboboxFilter,
+      label: formatMessage({
+        id: 'Settings.permissions.auditLogs.user',
+        defaultMessage: 'User',
+      }),
+      mainField: { name: 'id', type: 'integer' },
+      name: 'user',
+      operators,
+      options: users.map((user) => ({
+        label: user.displayName,
+        value: user.id.toString(),
+      })),
+      type: 'relation',
+      ...usersFilter,
+    } satisfies Filters.Filter & UsersFilterProps,
+  ];
 };

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/utils/tests/getDisplayedFilters.test.ts
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/utils/tests/getDisplayedFilters.test.ts
@@ -3,48 +3,51 @@ import { getDisplayedFilters } from '../getDisplayedFilters';
 const mockUsers = [
   {
     id: 1,
-    firstname: 'test',
-    lastname: 'tester',
     email: 'test@test.com',
-    isActive: true,
-    blocked: false,
-    createdAt: '',
-    updatedAt: '',
-    roles: [],
+    displayName: 'test tester',
   },
   {
     id: 2,
-    firstname: 'test2',
-    lastname: 'tester2',
     email: 'test2@test.com',
-    isActive: true,
-    blocked: false,
-    createdAt: '',
-    updatedAt: '',
-    roles: [],
+    displayName: 'test2 tester2',
   },
 ];
 
 describe('Audit Logs getDisplayedFilters', () => {
-  it('should return all filters when canReadUsers is true', () => {
+  it('should return the action, date and user filters', () => {
     const filters = getDisplayedFilters({
       users: mockUsers,
       // @ts-expect-error - mock
       formatMessage: jest.fn(({ defaultMessage }) => defaultMessage),
-      canReadUsers: true,
     });
     const filterNames = filters.map((filter) => filter.name);
     expect(filterNames).toEqual(['action', 'date', 'user']);
   });
 
-  it('should not return user filter when canReadUsers is false', () => {
+  it('should map the users to combobox options using their display name', () => {
     const filters = getDisplayedFilters({
       users: mockUsers,
       // @ts-expect-error - mock
       formatMessage: jest.fn(({ defaultMessage }) => defaultMessage),
-      canReadUsers: false,
     });
-    const filterNames = filters.map((filter) => filter.name);
-    expect(filterNames).toEqual(['action', 'date']);
+
+    const userFilter = filters.find((filter) => filter.name === 'user');
+    expect(userFilter?.options).toEqual([
+      { label: 'test tester', value: '1' },
+      { label: 'test2 tester2', value: '2' },
+    ]);
+  });
+
+  it('should forward the pagination props to the user filter', () => {
+    const onLoadMore = jest.fn();
+    const filters = getDisplayedFilters({
+      users: mockUsers,
+      // @ts-expect-error - mock
+      formatMessage: jest.fn(({ defaultMessage }) => defaultMessage),
+      usersFilter: { loading: true, hasMoreItems: true, onLoadMore },
+    });
+
+    const userFilter = filters.find((filter) => filter.name === 'user');
+    expect(userFilter).toMatchObject({ loading: true, hasMoreItems: true, onLoadMore });
   });
 });

--- a/packages/core/admin/ee/admin/src/services/auditLogs.ts
+++ b/packages/core/admin/ee/admin/src/services/auditLogs.ts
@@ -14,10 +14,21 @@ const auditLogsService = adminApi.injectEndpoints({
     getAuditLog: builder.query<AuditLogs.Get.Response, AuditLogs.Get.Params['id']>({
       query: (id) => `/admin/audit-logs/${id}`,
     }),
+    getAuditLogUsers: builder.query<
+      AuditLogs.GetUsers.Response,
+      AuditLogs.GetUsers.Request['query']
+    >({
+      query: (params) => ({
+        url: `/admin/audit-logs/users`,
+        config: {
+          params,
+        },
+      }),
+    }),
   }),
   overrideExisting: false,
 });
 
-const { useGetAuditLogsQuery, useGetAuditLogQuery } = auditLogsService;
+const { useGetAuditLogsQuery, useGetAuditLogQuery, useGetAuditLogUsersQuery } = auditLogsService;
 
-export { useGetAuditLogsQuery, useGetAuditLogQuery };
+export { useGetAuditLogsQuery, useGetAuditLogQuery, useGetAuditLogUsersQuery };

--- a/packages/core/admin/ee/server/src/audit-logs/controllers/__tests__/audit-logs.test.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/controllers/__tests__/audit-logs.test.ts
@@ -1,0 +1,38 @@
+import auditLogsController from '../audit-logs';
+
+describe('Audit logs controller', () => {
+  const findManyUsers = jest.fn().mockResolvedValue({
+    results: [{ id: 1, email: 'ana@test.io', displayName: 'Ana Doe' }],
+    pagination: { page: 1, pageSize: 10, pageCount: 1, total: 1 },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    global.strapi = {
+      get: jest.fn(() => ({ findManyUsers })),
+    } as any;
+  });
+
+  describe('findManyUsers', () => {
+    it('should return the users provided by the audit logs service', async () => {
+      const ctx = { request: { query: { page: 1, pageSize: 10, filters: { id: 1 } } } } as any;
+
+      await auditLogsController.findManyUsers(ctx);
+
+      expect(strapi.get).toHaveBeenCalledWith('audit-logs');
+      expect(findManyUsers).toHaveBeenCalledWith({ page: 1, pageSize: 10 });
+      expect(ctx.body).toEqual({
+        results: [{ id: 1, email: 'ana@test.io', displayName: 'Ana Doe' }],
+        pagination: { page: 1, pageSize: 10, pageCount: 1, total: 1 },
+      });
+    });
+
+    it('should reject an invalid query', async () => {
+      const ctx = { request: { query: { pageSize: 1000 } } } as any;
+
+      await expect(auditLogsController.findManyUsers(ctx)).rejects.toThrow();
+      expect(findManyUsers).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/admin/ee/server/src/audit-logs/controllers/audit-logs.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/controllers/audit-logs.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'koa';
 
-import { validateFindMany } from '../validation/audit-logs';
+import { validateFindMany, validateFindManyUsers } from '../validation/audit-logs';
 
 export default {
   async findMany(ctx: Context) {
@@ -9,6 +9,16 @@ export default {
 
     const auditLogs = strapi.get('audit-logs');
     const body = await auditLogs.findMany(query);
+
+    ctx.body = body;
+  },
+
+  async findManyUsers(ctx: Context) {
+    const { query } = ctx.request;
+    const { page, pageSize } = await validateFindManyUsers(query);
+
+    const auditLogs = strapi.get('audit-logs');
+    const body = await auditLogs.findManyUsers({ page, pageSize });
 
     ctx.body = body;
   },

--- a/packages/core/admin/ee/server/src/audit-logs/routes/__tests__/audit-logs.test.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/routes/__tests__/audit-logs.test.ts
@@ -1,0 +1,27 @@
+import auditLogsRoutes from '../audit-logs';
+
+describe('Audit logs routes', () => {
+  it('should declare /audit-logs/users before /audit-logs/:id so it is not matched as an id', () => {
+    const paths = auditLogsRoutes.routes.map((route) => route.path);
+
+    const usersIndex = paths.indexOf('/audit-logs/users');
+    const byIdIndex = paths.indexOf('/audit-logs/:id');
+
+    expect(usersIndex).toBeGreaterThan(-1);
+    expect(byIdIndex).toBeGreaterThan(-1);
+    expect(usersIndex).toBeLessThan(byIdIndex);
+  });
+
+  it('should protect every route with the audit-logs read permission and feature middleware', () => {
+    for (const route of auditLogsRoutes.routes) {
+      expect(route.config.middlewares).toHaveLength(1);
+      expect(route.config.policies).toEqual([
+        'admin::isAuthenticatedAdmin',
+        {
+          name: 'admin::hasPermissions',
+          config: { actions: ['admin::audit-logs.read'] },
+        },
+      ]);
+    }
+  });
+});

--- a/packages/core/admin/ee/server/src/audit-logs/routes/audit-logs.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/routes/audit-logs.ts
@@ -1,5 +1,18 @@
 import { enableFeatureMiddleware } from '../../routes/utils';
 
+const getRouteConfig = () => ({
+  middlewares: [enableFeatureMiddleware('audit-logs')],
+  policies: [
+    'admin::isAuthenticatedAdmin',
+    {
+      name: 'admin::hasPermissions',
+      config: {
+        actions: ['admin::audit-logs.read'],
+      },
+    },
+  ],
+});
+
 export default {
   type: 'admin',
   routes: [
@@ -7,35 +20,19 @@ export default {
       method: 'GET',
       path: '/audit-logs',
       handler: 'audit-logs.findMany',
-      config: {
-        middlewares: [enableFeatureMiddleware('audit-logs')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::audit-logs.read'],
-            },
-          },
-        ],
-      },
+      config: getRouteConfig(),
+    },
+    {
+      method: 'GET',
+      path: '/audit-logs/users',
+      handler: 'audit-logs.findManyUsers',
+      config: getRouteConfig(),
     },
     {
       method: 'GET',
       path: '/audit-logs/:id',
       handler: 'audit-logs.findOne',
-      config: {
-        middlewares: [enableFeatureMiddleware('audit-logs')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::audit-logs.read'],
-            },
-          },
-        ],
-      },
+      config: getRouteConfig(),
     },
   ],
 };

--- a/packages/core/admin/ee/server/src/audit-logs/services/__tests__/find-many-users.test.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/__tests__/find-many-users.test.ts
@@ -1,0 +1,79 @@
+import { createAuditLogsService } from '../audit-logs';
+
+describe('Audit logs service | findManyUsers', () => {
+  const authors = [
+    { id: 1, email: 'ana@test.io', username: null, firstname: 'Ana', lastname: 'Doe' },
+    { id: 2, email: 'bob@test.io', username: 'bob', firstname: null, lastname: null },
+  ];
+
+  const mockPluck = jest.fn().mockResolvedValue([1, 2]);
+  const mockDistinct = jest.fn(() => ({ pluck: mockPluck }));
+  const mockFindPage = jest.fn().mockResolvedValue({
+    results: authors,
+    pagination: { page: 1, pageSize: 10, pageCount: 1, total: 2 },
+  });
+
+  const strapi = {
+    db: {
+      connection: jest.fn(() => ({ distinct: mockDistinct })),
+      metadata: {
+        get: jest.fn(() => ({
+          attributes: {
+            user: {
+              type: 'relation',
+              joinTable: {
+                name: 'strapi_audit_logs_user_lnk',
+                inverseJoinColumn: { name: 'user_id' },
+              },
+            },
+          },
+        })),
+      },
+      query: jest.fn(() => ({ findPage: mockFindPage })),
+    },
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return only the users that authored audit logs, sanitized to the audit log user shape', async () => {
+    const service = createAuditLogsService(strapi);
+
+    const result = await service.findManyUsers({ page: 1, pageSize: 10 });
+
+    expect(strapi.db.connection).toHaveBeenCalledWith('strapi_audit_logs_user_lnk');
+    expect(mockPluck).toHaveBeenCalledWith('user_id');
+    expect(strapi.db.query).toHaveBeenCalledWith('admin::user');
+    expect(mockFindPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { $in: [1, 2] } },
+        page: 1,
+        pageSize: 10,
+      })
+    );
+    expect(result.results).toEqual([
+      { id: 1, email: 'ana@test.io', displayName: 'Ana Doe' },
+      { id: 2, email: 'bob@test.io', displayName: 'bob' },
+    ]);
+    expect(result.pagination).toMatchObject({ page: 1, pageCount: 1, total: 2 });
+  });
+
+  it('should only forward pagination params to the users query', async () => {
+    const service = createAuditLogsService(strapi);
+
+    await service.findManyUsers({
+      page: 2,
+      pageSize: 20,
+      filters: { password: { $startsWith: 'x' } },
+      populate: ['roles'],
+    } as any);
+
+    const findPageArgs = mockFindPage.mock.calls[0][0];
+    expect(findPageArgs.page).toBe(2);
+    expect(findPageArgs.pageSize).toBe(20);
+    expect(findPageArgs.where).toEqual({ id: { $in: [1, 2] } });
+    expect(findPageArgs.filters).toBeUndefined();
+    expect(findPageArgs.populate).toBeUndefined();
+  });
+});

--- a/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts
@@ -45,7 +45,7 @@ const createAuditLogsService = (strapi: Core.Strapi) => {
     },
 
     async findMany(query: unknown) {
-      const { results, pagination } = await strapi.db?.query('admin::audit-log').findPage({
+      const { results, pagination } = await strapi.db.query('admin::audit-log').findPage({
         populate: ['user'],
         select: ['action', 'date', 'payload'],
         ...strapi.get('query-params').transform('admin::audit-log', query),
@@ -61,6 +61,41 @@ const createAuditLogsService = (strapi: Core.Strapi) => {
 
       return {
         results: sanitizedResults,
+        pagination,
+      };
+    },
+
+    async findManyUsers(query: { page?: number | string; pageSize?: number | string }) {
+      const { page = 1, pageSize = 10 } = query;
+
+      const userAttribute = strapi.db.metadata.get('admin::audit-log').attributes.user;
+
+      if (
+        userAttribute?.type !== 'relation' ||
+        !('joinTable' in userAttribute) ||
+        !userAttribute.joinTable ||
+        !('inverseJoinColumn' in userAttribute.joinTable)
+      ) {
+        throw new Error('The audit log user relation is expected to use a join table');
+      }
+
+      const { joinTable } = userAttribute;
+
+      const authorIds = await strapi.db
+        .connection(joinTable.name)
+        .distinct(joinTable.inverseJoinColumn.name)
+        .pluck(joinTable.inverseJoinColumn.name);
+
+      const { results, pagination } = await strapi.db.query('admin::user').findPage({
+        select: ['id', 'email', 'username', 'firstname', 'lastname'],
+        where: { id: { $in: authorIds } },
+        orderBy: { id: 'asc' },
+        page: Number(page),
+        pageSize: Number(pageSize),
+      });
+
+      return {
+        results: results.map(getSanitizedUser),
         pagination,
       };
     },

--- a/packages/core/admin/ee/server/src/audit-logs/validation/__tests__/audit-logs.test.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/validation/__tests__/audit-logs.test.ts
@@ -1,0 +1,29 @@
+import { validateFindMany, validateFindManyUsers } from '../audit-logs';
+
+describe('Audit logs validation', () => {
+  describe('validateFindMany', () => {
+    it('should accept pagination and an allowed sort', async () => {
+      await expect(
+        validateFindMany({ page: 1, pageSize: 10, sort: 'date:DESC' })
+      ).resolves.toBeDefined();
+    });
+
+    it('should reject a disallowed sort', async () => {
+      await expect(validateFindMany({ sort: 'payload:ASC' })).rejects.toThrow();
+    });
+  });
+
+  describe('validateFindManyUsers', () => {
+    it('should accept pagination params', async () => {
+      await expect(validateFindManyUsers({ page: 2, pageSize: 20 })).resolves.toBeDefined();
+    });
+
+    it('should reject a page size above the limit', async () => {
+      await expect(validateFindManyUsers({ pageSize: 1000 })).rejects.toThrow();
+    });
+
+    it('should reject a non-positive page', async () => {
+      await expect(validateFindManyUsers({ page: 0 })).rejects.toThrow();
+    });
+  });
+});

--- a/packages/core/admin/ee/server/src/audit-logs/validation/audit-logs.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/validation/audit-logs.ts
@@ -11,8 +11,20 @@ const validateFindManySchema = yup
   })
   .required();
 
+const validateFindManyUsersSchema = yup
+  .object()
+  .shape({
+    page: yup.number().integer().min(1),
+    pageSize: yup.number().integer().min(1).max(100),
+  })
+  .required();
+
 export const validateFindMany = validateYupSchema(validateFindManySchema, { strict: false });
+export const validateFindManyUsers = validateYupSchema(validateFindManyUsersSchema, {
+  strict: false,
+});
 
 export default {
   validateFindMany,
+  validateFindManyUsers,
 };

--- a/packages/core/admin/shared/contracts/audit-logs.ts
+++ b/packages/core/admin/shared/contracts/audit-logs.ts
@@ -53,4 +53,26 @@ namespace Get {
       };
 }
 
-export { AuditLog, GetAll, Get };
+namespace GetUsers {
+  export interface Request {
+    body: {};
+    query: {
+      page?: number;
+      pageSize?: number;
+    };
+  }
+
+  export type Response =
+    | {
+        pagination: Pagination;
+        results: Pick<SanitizedAdminUserForAuditLogs, 'id' | 'email' | 'displayName'>[];
+        error?: never;
+      }
+    | {
+        pagination?: never;
+        results?: never;
+        error?: errors.ApplicationError;
+      };
+}
+
+export { AuditLog, GetAll, Get, GetUsers };


### PR DESCRIPTION
## What does it do?

Fixes three related defects in the Audit Logs "User" filter and reworks its data source:

1. **The filter option was never displayed (EE-67).** `ListPage` relied on the deprecated object form of `useRBAC`, expecting the `canReadUsers` action to be derived from the `readUsers` object key. The current implementation flattens the object and derives action names from the last segment of the permission action string, so `admin::audit-logs.read` and `admin::users.read` both resolve to `canRead`. As a result, `canReadUsers` was always `undefined`, the filter was never rendered and the admin users request was always skipped. Fixed by migrating to the array form of `useRBAC`.
2. **The filter options were limited to the first page of admin users (EE-68).** The users request was issued without pagination parameters, so only the first 10 admin users could be selected. The combobox now paginates with incremental loading, following the pattern established for the Review Workflows assignee filter (#25967).
3. **The filter visibility check was inconsistent with the rest of the feature (EE-69).** The filter was hidden from roles lacking `admin::users.read`, while the audit log list and detail responses already expose actor identities (`id`, `email`, `displayName`) to any role with `admin::audit-logs.read`, and the API applies user filters without requiring `admin::users.read`. The check was client-side only. Following the agreed direction on EE-69 — actor visibility is inherent to audit logs access — the filter is now available to any role that can access the feature.

To support (3) without widening access to `GET /admin/users`, this PR introduces `GET /admin/audit-logs/users`: it returns the distinct users that authored audit log entries, sanitized to the same shape the entries already expose (`id`, `email`, `displayName`), paginated, and protected by the same `admin::audit-logs.read` policy and feature middleware as the other audit-logs routes. The query is restricted to `page`/`pageSize`. Scoping the response to authors guarantees the filter exposes no information beyond what the audit log entries already contain, and that every option yields results. `GET /admin/users`, its policies and the RBAC layer are not modified.

## Why is it needed?

The User filter is one of the three documented filters of the Audit Logs feature and was unusable. The underlying permission inconsistency is documented and discussed in EE-69, where the direction implemented here was agreed upon.

Alternatives considered: deriving the filter options from the loaded audit log entries (rejected: only authors present on the current page would be filterable) and extending access to `GET /admin/users` (rejected: broader impact on the permission layer than required).

## How to test it?

1. Run an application with an EE license including Audit Logs.
2. Settings → Audit Logs → Filters: the "User" field is available, lists the users that appear in the logs, loads more on scroll, and filtering by a user returns their entries.
3. With a role that has `admin::audit-logs.read` but not `admin::users.read`: the filter is available and functional, while `GET /admin/users` remains forbidden.

Automated coverage:
- Server unit tests for the new service method, controller and validation (distinct authors, sanitized shape, pagination-only query forwarding, query validation).
- Front tests covering: the filter renders without `admin::users.read`; the data hook requests `/admin/audit-logs/users` with the given page size and exposes pagination; the load-more props are forwarded to the filter input; regression test for the `useRBAC` action-name collision.
- Full Core admin front suite, server unit suite and both type-check targets verified against the `main` baseline (no new failures or errors).

## Related issue(s)/PR(s)

- Fixes EE-67, EE-68, EE-69 (internal)
- Supersedes #27004 (initially split; consolidated once the EE-69 direction made the intermediate state obsolete)
- #25967: pagination pattern precedent (Review Workflows assignee filter)
