### PR TITLE
fix(upgrade): skip cross-major packages when pinning dependencies

### DIFF
--- a/packages/utils/upgrade/src/modules/project/__tests__/strapi-dependencies.test.ts
+++ b/packages/utils/upgrade/src/modules/project/__tests__/strapi-dependencies.test.ts
@@ -91,6 +91,37 @@ describe('strapi-dependencies', () => {
         '@strapi/types': '4.26.1',
       });
     });
+
+    it('skips packages with a different major version than the pin target', () => {
+      const packageJSON = {
+        name: 'test-app',
+        version: '0.1.0',
+        dependencies: {
+          '@strapi/strapi': '^5.33.0',
+          '@strapi/design-system': '^2.2.0',
+          '@strapi/icons': '^2.2.0',
+        },
+        devDependencies: {
+          '@strapi/types': '^5.33.0',
+        },
+      };
+
+      const unpinned = findUnpinnedStrapiDependencies(
+        packageJSON.dependencies,
+        packageJSON.devDependencies
+      );
+
+      const updated = pinStrapiDependencies(packageJSON, '5.50.1', unpinned);
+
+      expect(updated.dependencies).toEqual({
+        '@strapi/strapi': '5.50.1',
+        '@strapi/design-system': '^2.2.0',
+        '@strapi/icons': '^2.2.0',
+      });
+      expect(updated.devDependencies).toEqual({
+        '@strapi/types': '5.50.1',
+      });
+    });
   });
 
   describe('getStrapiPinTargetVersion', () => {

--- a/packages/utils/upgrade/src/modules/project/strapi-dependencies.ts
+++ b/packages/utils/upgrade/src/modules/project/strapi-dependencies.ts
@@ -96,7 +96,16 @@ export const pinStrapiDependencies = (
     ...asDependencyRecord(packageJSON.devDependencies),
   };
 
-  for (const { name, section } of unpinned) {
+  const pinMajor = semver.major(pinVersion);
+
+  for (const { name, section, declaredVersion } of unpinned) {
+    // Skip packages whose major version differs from the pin target.
+    // E.g. @strapi/design-system (^2.x) should not be pinned to v5.x.
+    const rangeMin = semver.minVersion(declaredVersion);
+    if (rangeMin && semver.major(rangeMin.version) !== pinMajor) {
+      continue;
+    }
+
     if (section === 'dependencies') {
       dependencies[name] = pinVersion;
     } else {


### PR DESCRIPTION
## What type of PR is this?
fix

## What does this PR do?
Skips packages whose major version differs from the pin target when pinning Strapi dependencies.

## Why is this needed?
The upgrade tool (`yarn upgrade`) applies the same pin version to all `@strapi/*` packages. Packages like `@strapi/design-system` (v2.x) and `@strapi/icons` (v2.x) have their own versioning scheme, so pinning them to `5.50.1` breaks the installation with `No candidates found`.

## What changed
- `packages/utils/upgrade/src/modules/project/strapi-dependencies.ts`: Added major version comparison in `pinStrapiDependencies` to skip packages where `semver.major(rangeMin) !== semver.major(pinVersion)`
- Added test case: `skips packages with a different major version than the pin target`

## Reproduction
1. Create a Strapi 5 project with `@strapi/design-system: ^2.2.0`
2. Run `yarn upgrade`
3. The tool suggests pinning `@strapi/design-system` to `5.50.1` which doesn't exist

## Related
Fixes #27051

---
Fixes CPR-456