### PR TITLE
fix(content-releases): normalise release id so rescheduling cancels the stale job

### DIFF
--- a/packages/core/content-releases/server/src/services/__tests__/scheduling.test.ts
+++ b/packages/core/content-releases/server/src/services/__tests__/scheduling.test.ts
@@ -62,6 +62,35 @@ describe('Scheduling service', () => {
       expect(strapiMock.cron.add).toHaveBeenCalledTimes(2);
     });
 
+    it('should cancel the previous job when the release is created with a numeric id and updated with a string id', async () => {
+      const strapiMock = {
+        ...baseStrapiMock,
+        db: {
+          query: jest.fn(() => ({
+            findOne: jest.fn().mockReturnValue({ id: 1 }),
+          })),
+        },
+      };
+
+      const oldJobDate = new Date();
+      const newJobDate = new Date(oldJobDate.getTime() + 1000);
+
+      // @ts-expect-error Ignore missing properties
+      const schedulingService = createSchedulingService({ strapi: strapiMock });
+
+      // create() and syncFromDatabase() pass the numeric database row id
+      const scheduledJobs = await schedulingService.set(1, oldJobDate);
+      expect(scheduledJobs.size).toBe(1);
+      expect(strapiMock.cron.add).toHaveBeenCalledTimes(1);
+
+      // the update controller passes ctx.params.id, which is always a string
+      await schedulingService.set('1', newJobDate);
+
+      expect(strapiMock.cron.remove).toHaveBeenCalledWith('publishRelease_1');
+      expect(strapiMock.cron.add).toHaveBeenCalledTimes(2);
+      expect(scheduledJobs.size).toBe(1);
+    });
+
     it('should create a new job', async () => {
       const strapiMock = {
         ...baseStrapiMock,

--- a/packages/core/content-releases/server/src/services/scheduling.ts
+++ b/packages/core/content-releases/server/src/services/scheduling.ts
@@ -10,6 +10,8 @@ const createSchedulingService = ({ strapi }: { strapi: Core.Strapi }) => {
 
   return {
     async set(releaseId: Release['id'], scheduleDate: Date) {
+      const id = String(releaseId); // callers pass both numeric (db row) and string (ctx.params) ids
+
       const release = await strapi.db
         .query(RELEASE_MODEL_UID)
         .findOne({ where: { id: releaseId, releasedAt: null } });
@@ -18,7 +20,7 @@ const createSchedulingService = ({ strapi }: { strapi: Core.Strapi }) => {
         throw new errors.NotFoundError(`No release found for id ${releaseId}`);
       }
 
-      const taskName = `publishRelease_${releaseId}`;
+      const taskName = `publishRelease_${id}`;
 
       strapi.cron.add({
         [taskName]: {
@@ -29,19 +31,21 @@ const createSchedulingService = ({ strapi }: { strapi: Core.Strapi }) => {
         },
       });
 
-      if (scheduledJobs.has(releaseId)) {
-        this.cancel(releaseId);
+      if (scheduledJobs.has(id)) {
+        this.cancel(id);
       }
 
-      scheduledJobs.set(releaseId, taskName);
+      scheduledJobs.set(id, taskName);
 
       return scheduledJobs;
     },
 
     cancel(releaseId: Release['id']) {
-      if (scheduledJobs.has(releaseId)) {
-        strapi.cron.remove(scheduledJobs.get(releaseId)!);
-        scheduledJobs.delete(releaseId);
+      const id = String(releaseId); // normalise to match key from set()
+
+      if (scheduledJobs.has(id)) {
+        strapi.cron.remove(scheduledJobs.get(id)!);
+        scheduledJobs.delete(id);
       }
 
       return scheduledJobs;


### PR DESCRIPTION
### What does it do?

It normalises the release id to a string inside the content-releases scheduling service, in `set()` and `cancel()`, so the in-memory job map is always keyed consistently no matter if the caller passed a numeric or a string id. It also adds a unit test covering the create/update sequence that triggered the bug (see support ticket no. 9798).

### Why is it needed?

The scheduling service tracks active jobs in a `Map` keyed by release id, and it cancels the previous job on reschedule by checking `scheduledJobs.has(releaseId)`. The problem is that callers pass different id types. `create()` and `syncFromDatabase()` pass the numeric database row id, while the update and delete controllers pass `ctx.params.id`, which Koa provides as a string.

`Map` lookups use SameValueZero, so `has('51')` returns false when the stored key is the number `51`. Because of that, editing a scheduled release silently skipped the cancel step: the old `node-schedule` job stayed armed at the old time, and a second job was added for the new time.

That is exactly what we saw in the reported ticket (9798), where a release scheduled for 20:30 published roughly 12 hours early at 08:30, an earlier AM/PM value that had since been updated. The key mismatch affects `delete()` as well, since it calls `cancel()` with a numeric id and can therefore fail to tear down a job that was created during an earlier.

Normalising the id inside the service, rather than at each call site, is the safer choice. It makes every entry point converge on a single map key and keeps current and future callers consistent without having to remember to coerce the id themselves.

### How to test it?

Run the unit tests for the scheduling service:

```
yarn test:unit packages/core/content-releases/server/src/services/__tests__/scheduling.test.ts
```

The new test schedules a release with a numeric id (the create path), reschedules it with a string id (the update path), and asserts that the previous job is cancelled and only one job remains. It fails on the current code and passes with the fix.

### Related issue(s)/PR(s)

Potentially relates to #24727 which was closed as pending reproduction.
