### PR TITLE
fix(content-manager): homepage recent-documents dates serialize as empty objects

### DIFF
--- a/packages/core/admin/.eslintrc.cjs
+++ b/packages/core/admin/.eslintrc.cjs
@@ -9,14 +9,13 @@ const config = {
     'rollup.config.mjs',
     'coverage/',
     'lint-staged.config.mjs',
-    'shared/**/*',
     // ee/server has no TS eslint project (#26699); back/CJS config can't parse these.
     'ee/server/**/*',
   ],
   overrides: [
     {
       files: ['**/*'],
-      excludedFiles: ['admin/**/*', 'ee/admin/**/*', 'server/**/*'],
+      excludedFiles: ['admin/**/*', 'ee/admin/**/*', 'server/**/*', 'shared/**/*'],
       extends: ['eslint-config-custom/back'],
     },
   ],

--- a/packages/core/admin/shared/.eslintrc.cjs
+++ b/packages/core/admin/shared/.eslintrc.cjs
@@ -1,0 +1,27 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  extends: ['eslint-config-custom/back/typescript'],
+  ignorePatterns: ['.eslintrc.cjs'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.eslint.json'],
+  },
+  overrides: [
+    {
+      // Contract files use declare namespace + empty object request shapes by convention.
+      files: ['contracts/**'],
+      rules: {
+        '@typescript-eslint/no-namespace': 'off',
+        '@typescript-eslint/ban-types': 'off',
+        '@typescript-eslint/no-empty-interface': 'off',
+        '@typescript-eslint/naming-convention': 'off',
+        'node/no-extraneous-import': 'off',
+      },
+    },
+  ],
+};
+
+module.exports = config;

--- a/packages/core/admin/shared/contracts/api-token.ts
+++ b/packages/core/admin/shared/contracts/api-token.ts
@@ -1,8 +1,8 @@
-export * from './content-api-token';
-export type { AdminApiToken, AdminTokenBody } from './admin-token';
-
 import type { ContentApiApiToken, ContentApiApiTokenBody } from './content-api-token';
 import type { AdminApiToken, AdminTokenBody } from './admin-token';
+
+export * from './content-api-token';
+export type { AdminApiToken, AdminTokenBody } from './admin-token';
 
 export type ApiToken = ContentApiApiToken | AdminApiToken;
 export type ApiTokenBody = ContentApiApiTokenBody | AdminTokenBody;

--- a/packages/core/admin/shared/contracts/authentication.ts
+++ b/packages/core/admin/shared/contracts/authentication.ts
@@ -1,5 +1,5 @@
-import type { AdminUser, SanitizedAdminUser } from './shared';
 import type { errors } from '@strapi/utils';
+import type { AdminUser, SanitizedAdminUser } from './shared';
 
 /**
  * /login - Log in as an admin user

--- a/packages/core/admin/shared/contracts/homepage.ts
+++ b/packages/core/admin/shared/contracts/homepage.ts
@@ -10,8 +10,8 @@ export interface RecentDocument {
   locale: string | null;
   status?: 'draft' | 'published' | 'modified';
   title: string;
-  updatedAt: Date;
-  publishedAt?: Date | null;
+  updatedAt: string;
+  publishedAt?: string | null;
 }
 
 export declare namespace GetRecentDocuments {

--- a/packages/core/admin/shared/contracts/user.ts
+++ b/packages/core/admin/shared/contracts/user.ts
@@ -1,12 +1,12 @@
 import { errors } from '@strapi/utils';
 
+import type { Data, Modules } from '@strapi/types';
 import type {
   AdminUserCreationPayload,
   AdminUserUpdatePayload,
   Pagination,
   SanitizedAdminUser,
 } from './shared';
-import type { Data, Modules } from '@strapi/types';
 
 /**
  * /create - Create an admin user

--- a/packages/core/admin/shared/tsconfig.eslint.json
+++ b/packages/core/admin/shared/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../server/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/core/content-manager/.eslintrc.cjs
+++ b/packages/core/content-manager/.eslintrc.cjs
@@ -9,12 +9,11 @@ const config = {
     'rollup.config.mjs',
     'coverage/',
     'lint-staged.config.mjs',
-    // Shared contracts are type-only; back/CJS config cannot parse them (same as @strapi/admin).
-    'shared/**/*',
   ],
   overrides: [
     {
       files: ['**/*'],
+      excludedFiles: ['admin/**/*', 'server/**/*', 'shared/**/*'],
       extends: ['eslint-config-custom/back'],
     },
   ],

--- a/packages/core/content-manager/.eslintrc.cjs
+++ b/packages/core/content-manager/.eslintrc.cjs
@@ -9,6 +9,8 @@ const config = {
     'rollup.config.mjs',
     'coverage/',
     'lint-staged.config.mjs',
+    // Shared contracts are type-only; back/CJS config cannot parse them (same as @strapi/admin).
+    'shared/**/*',
   ],
   overrides: [
     {

--- a/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
+++ b/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
@@ -341,6 +341,97 @@ describe('homepage service', () => {
       expect(wire[0].publishedAt).not.toEqual({});
     });
 
+    it('converts Date timestamps to ISO strings and keeps them after populate spread', async () => {
+      (strapiContentTypes.hasDraftAndPublish as jest.Mock).mockImplementation(() => true);
+
+      const updatedAt = new Date('2026-07-10T16:24:13.962Z');
+      const publishedAt = new Date('2026-07-10T16:24:14.099Z');
+
+      const contentTypes = {
+        'api::article.article': {
+          uid: 'api::article.article',
+          info: { displayName: 'Article' },
+          kind: 'collectionType',
+          options: { draftAndPublish: true },
+          attributes: {},
+        },
+      };
+
+      const findArticleDocuments = jest.fn(async () => [
+        {
+          documentId: 'article-1',
+          title: 'Article 1',
+          updatedAt,
+          publishedAt,
+        },
+      ]);
+      const findConfigurations = jest.fn(async () => [
+        {
+          value: JSON.stringify({
+            uid: 'api::article.article',
+            settings: { mainField: 'title' },
+          }),
+        },
+      ]);
+
+      const strapi = {
+        admin: {
+          services: {
+            permission: {
+              findMany: jest.fn(async () => [{ subject: 'api::article.article' }]),
+            },
+          },
+        },
+        contentTypes,
+        requestContext: {
+          get: jest.fn(() => ({
+            state: {
+              user: { id: 1 },
+              userAbility: {},
+            },
+          })),
+        },
+        db: {
+          query: jest.fn(() => ({
+            findMany: findConfigurations,
+          })),
+        },
+        plugin: jest.fn(() => ({
+          service: jest.fn(() => ({
+            create: jest.fn(() => ({
+              cannot: {
+                read: jest.fn(() => false),
+              },
+              sanitizedQuery: {
+                read: jest.fn(async (query: unknown) => query),
+              },
+            })),
+          })),
+        })),
+        contentType: jest.fn((uid: keyof typeof contentTypes) => contentTypes[uid]),
+        documents: jest.fn(() => ({
+          findMany: findArticleDocuments,
+        })),
+      };
+
+      const service = createHomepageService({ strapi } as any);
+
+      const result = await service.queryLastDocuments(
+        { sort: 'publishedAt:desc', populate: ['updatedAt', 'publishedAt'] },
+        true
+      );
+      const wire = JSON.parse(JSON.stringify(result));
+
+      expect(typeof result[0].updatedAt).toBe('string');
+      expect(typeof result[0].publishedAt).toBe('string');
+      expect(result[0].updatedAt).toBe(updatedAt.toISOString());
+      expect(result[0].publishedAt).toBe(publishedAt.toISOString());
+      expect(wire[0].updatedAt).toBe(updatedAt.toISOString());
+      expect(wire[0].publishedAt).toBe(publishedAt.toISOString());
+      expect(wire[0].updatedAt).not.toEqual({});
+      expect(wire[0].publishedAt).not.toEqual({});
+    });
+
     it('excludes non-displayed content types from recent documents', async () => {
       const contentTypes = {
         'api::article.article': {

--- a/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
+++ b/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
@@ -247,6 +247,100 @@ describe('homepage service', () => {
       ]);
     });
 
+    it('returns updatedAt and publishedAt as ISO strings (not Date objects)', async () => {
+      /**
+       * Regression for https://github.com/strapi/strapi/issues/27013:
+       * wrapping timestamps in `Date` made JSON responses emit `{}` after spread/clone,
+       * which crashes RelativeTime (RangeError: Start Date is invalid).
+       */
+      (strapiContentTypes.hasDraftAndPublish as jest.Mock).mockImplementation(() => true);
+
+      const updatedAt = '2026-07-10T16:24:13.962Z';
+      const publishedAt = '2026-07-10T16:24:14.099Z';
+
+      const contentTypes = {
+        'api::article.article': {
+          uid: 'api::article.article',
+          info: { displayName: 'Article' },
+          kind: 'collectionType',
+          options: { draftAndPublish: true },
+          attributes: {},
+        },
+      };
+
+      const findArticleDocuments = jest.fn(async () => [
+        {
+          documentId: 'article-1',
+          title: 'Article 1',
+          updatedAt,
+          publishedAt,
+        },
+      ]);
+      const findConfigurations = jest.fn(async () => [
+        {
+          value: JSON.stringify({
+            uid: 'api::article.article',
+            settings: { mainField: 'title' },
+          }),
+        },
+      ]);
+
+      const strapi = {
+        admin: {
+          services: {
+            permission: {
+              findMany: jest.fn(async () => [{ subject: 'api::article.article' }]),
+            },
+          },
+        },
+        contentTypes,
+        requestContext: {
+          get: jest.fn(() => ({
+            state: {
+              user: { id: 1 },
+              userAbility: {},
+            },
+          })),
+        },
+        db: {
+          query: jest.fn(() => ({
+            findMany: findConfigurations,
+          })),
+        },
+        plugin: jest.fn(() => ({
+          service: jest.fn(() => ({
+            create: jest.fn(() => ({
+              cannot: {
+                read: jest.fn(() => false),
+              },
+              sanitizedQuery: {
+                read: jest.fn(async (query: unknown) => query),
+              },
+            })),
+          })),
+        })),
+        contentType: jest.fn((uid: keyof typeof contentTypes) => contentTypes[uid]),
+        documents: jest.fn(() => ({
+          findMany: findArticleDocuments,
+        })),
+      };
+
+      const service = createHomepageService({ strapi } as any);
+
+      const result = await service.queryLastDocuments({ sort: 'publishedAt:desc' }, true);
+      const wire = JSON.parse(JSON.stringify(result));
+
+      expect(result).toHaveLength(1);
+      expect(typeof result[0].updatedAt).toBe('string');
+      expect(typeof result[0].publishedAt).toBe('string');
+      expect(result[0].updatedAt).toBe(updatedAt);
+      expect(result[0].publishedAt).toBe(publishedAt);
+      expect(wire[0].updatedAt).toBe(updatedAt);
+      expect(wire[0].publishedAt).toBe(publishedAt);
+      expect(wire[0].updatedAt).not.toEqual({});
+      expect(wire[0].publishedAt).not.toEqual({});
+    });
+
     it('excludes non-displayed content types from recent documents', async () => {
       const contentTypes = {
         'api::article.article': {

--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -175,7 +175,7 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
         kind: meta.contentType.kind,
         ...additionalFields,
         // Keep dates last so populate cannot overwrite with non-JSON-safe values
-        updatedAt: toIsoDateString(document.updatedAt) as string,
+        updatedAt: toIsoDateString(document.updatedAt) ?? String(document.updatedAt),
         publishedAt:
           meta.hasDraftAndPublish && document.publishedAt
             ? toIsoDateString(document.publishedAt)

--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -139,6 +139,19 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     }, []);
   };
 
+  /**
+   * Homepage widgets expect JSON-safe ISO strings. Returning `Date` objects can
+   * serialize as `{}` after spread/clone (see https://github.com/strapi/strapi/issues/27013).
+   */
+  const toIsoDateString = (value: unknown): string | null => {
+    if (value == null || value === '') {
+      return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(String(value));
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  };
+
   const formatDocuments = (
     documents: Modules.Documents.AnyDocument[],
     meta: ContentTypeMeta,
@@ -156,14 +169,17 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
       return {
         documentId: document.documentId,
         locale: document.locale ?? null,
-        updatedAt: new Date(document.updatedAt),
         title: document[meta.mainField ?? 'documentId'],
-        publishedAt:
-          meta.hasDraftAndPublish && document.publishedAt ? new Date(document.publishedAt) : null,
         contentTypeUid: meta.uid,
         contentTypeDisplayName: meta.contentType.info.displayName,
         kind: meta.contentType.kind,
         ...additionalFields,
+        // Keep dates last so populate cannot overwrite with non-JSON-safe values
+        updatedAt: toIsoDateString(document.updatedAt) as string,
+        publishedAt:
+          meta.hasDraftAndPublish && document.publishedAt
+            ? toIsoDateString(document.publishedAt)
+            : null,
       };
     });
   };
@@ -256,19 +272,20 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
       return recentDocuments
         .flat()
         .sort((a, b) => {
+          // ISO-8601 strings compare lexicographically in chronological order
           switch (additionalQueryParams?.sort) {
             case 'publishedAt:desc':
               if (!a.publishedAt || !b.publishedAt) return 0;
-              return b.publishedAt.valueOf() - a.publishedAt.valueOf();
+              return b.publishedAt.localeCompare(a.publishedAt);
             case 'publishedAt:asc':
               if (!a.publishedAt || !b.publishedAt) return 0;
-              return a.publishedAt.valueOf() - b.publishedAt.valueOf();
+              return a.publishedAt.localeCompare(b.publishedAt);
             case 'updatedAt:desc':
               if (!a.updatedAt || !b.updatedAt) return 0;
-              return b.updatedAt.valueOf() - a.updatedAt.valueOf();
+              return b.updatedAt.localeCompare(a.updatedAt);
             case 'updatedAt:asc':
               if (!a.updatedAt || !b.updatedAt) return 0;
-              return a.updatedAt.valueOf() - b.updatedAt.valueOf();
+              return a.updatedAt.localeCompare(b.updatedAt);
             default:
               return 0;
           }

--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -175,7 +175,7 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
         kind: meta.contentType.kind,
         ...additionalFields,
         // Keep dates last so populate cannot overwrite with non-JSON-safe values
-        updatedAt: toIsoDateString(document.updatedAt) ?? String(document.updatedAt),
+        updatedAt: toIsoDateString(document.updatedAt) ?? '',
         publishedAt:
           meta.hasDraftAndPublish && document.publishedAt
             ? toIsoDateString(document.publishedAt)
@@ -273,19 +273,25 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
         .flat()
         .sort((a, b) => {
           // ISO-8601 strings compare lexicographically in chronological order
+          const compareIso = (left: string, right: string, direction: 1 | -1) => {
+            if (left < right) return -1 * direction;
+            if (left > right) return 1 * direction;
+            return 0;
+          };
+
           switch (additionalQueryParams?.sort) {
             case 'publishedAt:desc':
               if (!a.publishedAt || !b.publishedAt) return 0;
-              return b.publishedAt.localeCompare(a.publishedAt);
+              return compareIso(a.publishedAt, b.publishedAt, -1);
             case 'publishedAt:asc':
               if (!a.publishedAt || !b.publishedAt) return 0;
-              return a.publishedAt.localeCompare(b.publishedAt);
+              return compareIso(a.publishedAt, b.publishedAt, 1);
             case 'updatedAt:desc':
               if (!a.updatedAt || !b.updatedAt) return 0;
-              return b.updatedAt.localeCompare(a.updatedAt);
+              return compareIso(a.updatedAt, b.updatedAt, -1);
             case 'updatedAt:asc':
               if (!a.updatedAt || !b.updatedAt) return 0;
-              return a.updatedAt.localeCompare(b.updatedAt);
+              return compareIso(a.updatedAt, b.updatedAt, 1);
             default:
               return 0;
           }

--- a/packages/core/content-manager/shared/.eslintrc.cjs
+++ b/packages/core/content-manager/shared/.eslintrc.cjs
@@ -1,0 +1,27 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  extends: ['eslint-config-custom/back/typescript'],
+  ignorePatterns: ['.eslintrc.cjs'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.eslint.json'],
+  },
+  overrides: [
+    {
+      // Contract files use declare namespace + empty object request shapes by convention.
+      files: ['contracts/**'],
+      rules: {
+        '@typescript-eslint/no-namespace': 'off',
+        '@typescript-eslint/ban-types': 'off',
+        '@typescript-eslint/no-empty-interface': 'off',
+        '@typescript-eslint/naming-convention': 'off',
+        'node/no-extraneous-import': 'off',
+      },
+    },
+  ],
+};
+
+module.exports = config;

--- a/packages/core/content-manager/shared/contracts/collection-types.ts
+++ b/packages/core/content-manager/shared/contracts/collection-types.ts
@@ -2,7 +2,6 @@ import { errors } from '@strapi/utils';
 import type { Modules, Struct, UID } from '@strapi/types';
 
 type PaginatedDocuments = Modules.Documents.PaginatedResult<UID.Schema>;
-type PaginationQuery = Modules.Documents.Params.Pagination.PageNotation;
 type SortQuery = Modules.Documents.Params.Sort.StringNotation<UID.Schema> & string;
 
 // Admin document response follows the same format as the document service

--- a/packages/core/content-manager/shared/contracts/components.ts
+++ b/packages/core/content-manager/shared/contracts/components.ts
@@ -1,6 +1,6 @@
 import type { Struct } from '@strapi/types';
-import type { Configuration, Settings, Metadatas, Layouts } from './content-types';
 import { errors } from '@strapi/utils';
+import type { Configuration, Settings, Metadatas, Layouts } from './content-types';
 
 export interface Component extends Struct.ComponentSchema {
   isDisplayed: boolean;

--- a/packages/core/content-manager/shared/contracts/homepage.ts
+++ b/packages/core/content-manager/shared/contracts/homepage.ts
@@ -10,8 +10,8 @@ export interface RecentDocument {
   locale: string | null;
   status?: 'draft' | 'published' | 'modified';
   title: string;
-  updatedAt: Date;
-  publishedAt?: Date | null;
+  updatedAt: string;
+  publishedAt?: string | null;
 }
 
 export declare namespace GetRecentDocuments {

--- a/packages/core/content-manager/shared/tsconfig.eslint.json
+++ b/packages/core/content-manager/shared/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../server/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/core/review-workflows/.eslintrc.cjs
+++ b/packages/core/review-workflows/.eslintrc.cjs
@@ -9,13 +9,11 @@ const config = {
     'rollup.config.mjs',
     'coverage/',
     'lint-staged.config.mjs',
-    // Shared contracts are type-only; back/CJS config cannot parse them (same as @strapi/admin).
-    'shared/**/*',
   ],
   overrides: [
     {
       files: ['**/*'],
-      excludedFiles: ['admin/**/*', 'server/**/*'],
+      excludedFiles: ['admin/**/*', 'server/**/*', 'shared/**/*'],
       extends: ['eslint-config-custom/back'],
     },
   ],

--- a/packages/core/review-workflows/.eslintrc.cjs
+++ b/packages/core/review-workflows/.eslintrc.cjs
@@ -9,6 +9,8 @@ const config = {
     'rollup.config.mjs',
     'coverage/',
     'lint-staged.config.mjs',
+    // Shared contracts are type-only; back/CJS config cannot parse them (same as @strapi/admin).
+    'shared/**/*',
   ],
   overrides: [
     {

--- a/packages/core/review-workflows/shared/.eslintrc.cjs
+++ b/packages/core/review-workflows/shared/.eslintrc.cjs
@@ -1,0 +1,27 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  extends: ['eslint-config-custom/back/typescript'],
+  ignorePatterns: ['.eslintrc.cjs'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.eslint.json'],
+  },
+  overrides: [
+    {
+      // Contract files use declare namespace + empty object request shapes by convention.
+      files: ['contracts/**'],
+      rules: {
+        '@typescript-eslint/no-namespace': 'off',
+        '@typescript-eslint/ban-types': 'off',
+        '@typescript-eslint/no-empty-interface': 'off',
+        '@typescript-eslint/naming-convention': 'off',
+        'node/no-extraneous-import': 'off',
+      },
+    },
+  ],
+};
+
+module.exports = config;

--- a/packages/core/review-workflows/shared/contracts/homepage.ts
+++ b/packages/core/review-workflows/shared/contracts/homepage.ts
@@ -10,8 +10,8 @@ export interface RecentDocument {
   locale: string | null;
   status?: 'draft' | 'published' | 'modified';
   title: string;
-  updatedAt: Date;
-  publishedAt?: Date | null;
+  updatedAt: string;
+  publishedAt?: string | null;
   strapi_stage?: {
     color?: string;
     name: string;

--- a/packages/core/review-workflows/shared/tsconfig.eslint.json
+++ b/packages/core/review-workflows/shared/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../server/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*"],
+  "exclude": ["node_modules"]
+}

--- a/tests/api/core/content-manager/homepage/admin-homepage.test.api.ts
+++ b/tests/api/core/content-manager/homepage/admin-homepage.test.api.ts
@@ -207,6 +207,12 @@ describe('Homepage API', () => {
       expect(response.body.data[1].status).toBe('modified');
       expect(response.body.data[2].status).toBe('draft');
       expect(response.body.data[3].status).toBe(undefined);
+      // Dates must be ISO strings on the wire (not Date→{} after serialization)
+      for (const doc of response.body.data) {
+        expect(typeof doc.updatedAt).toBe('string');
+        expect(doc.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(doc.updatedAt).not.toEqual({});
+      }
     });
 
     /**
@@ -267,6 +273,14 @@ describe('Homepage API', () => {
       // Assert the data is the published data, but the status should be modified
       expect(response.body.data[1].title).toBe('The Paperback Writer');
       expect(response.body.data[1].status).toBe('modified');
+      for (const doc of response.body.data) {
+        expect(typeof doc.updatedAt).toBe('string');
+        expect(typeof doc.publishedAt).toBe('string');
+        expect(doc.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(doc.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(doc.updatedAt).not.toEqual({});
+        expect(doc.publishedAt).not.toEqual({});
+      }
     });
 
     /**


### PR DESCRIPTION
### What does it do?

Makes `/content-manager/homepage/recent-documents` return `updatedAt` / `publishedAt` as ISO-8601 strings instead of `Date` objects. Updates the homepage contract types accordingly, sorts with string `localeCompare`, and keeps date fields after `...additionalFields` so populate cannot overwrite them with non-JSON-safe values.

Also ignores `shared/**/*` in the content-manager ESLint config (same pattern as `@strapi/admin`) so shared contracts can be committed without a false parse failure under the back/CJS config.

### Why is it needed?

Fixes #27013. The homepage “Last edited / Last published” widgets crash with `RangeError: Start Date is invalid` when the API serializes those timestamps as `{}`. Wrapping already-ISO DB values in `Date` is unnecessary for a JSON response and unsafe under spread/clone (`JSON.stringify({ ...new Date() })` → `{}`). `RelativeTime` then receives an invalid date and throws.

A frontend-only guard (see #27016) stops the crash but still shows `-` for entries with valid Postgres timestamps. This PR fixes the serialization root cause so the widgets show real relative times again.

### How to test it?

1. Unit: `yarn test:unit --testPathPattern='packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts'`
2. API (optional): homepage recent-documents cases in `tests/api/core/content-manager/homepage/admin-homepage.test.api.ts` now assert ISO string shape.
3. Manual: publish/update a few D&P entries, open `/admin`, confirm Last edited / Last published widgets render relative times (not `-` / not a crash).

### Related issue(s)/PR(s)

- Fixes #27013
- Supersedes approach in #27016 (frontend guard only — optional as defense-in-depth later, not required here)