### PR TITLE
chore(email-mailgun): migrate unit tests from jest to vitest

### DIFF
--- a/packages/providers/email-mailgun/jest.config.js
+++ b/packages/providers/email-mailgun/jest.config.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  displayName: 'Mailgun email provider',
-};

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -43,8 +43,8 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc -p tsconfig.json",
-    "test:unit": "run -T jest",
-    "test:unit:watch": "run -T jest --watch",
+    "test:unit:vitest": "vitest run",
+    "test:unit:vitest:watch": "vitest --watch",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
@@ -53,11 +53,11 @@
     "mailgun.js": "10.2.1"
   },
   "devDependencies": {
-    "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.50.2",
-    "jest": "29.6.0",
-    "tsconfig": "5.50.2"
+    "tsconfig": "5.50.2",
+    "vitest": "catalog:",
+    "vitest-config": "5.50.2"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/email-mailgun/src/__tests__/convert-provider-options.vitest.test.ts
+++ b/packages/providers/email-mailgun/src/__tests__/convert-provider-options.vitest.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import formData from 'form-data';
 import Mailgun from 'mailgun.js';
 

--- a/packages/providers/email-mailgun/tsconfig.json
+++ b/packages/providers/email-mailgun/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   }
 }

--- a/packages/providers/email-mailgun/vitest.config.ts
+++ b/packages/providers/email-mailgun/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9941,13 +9941,13 @@ __metadata:
   resolution: "@strapi/provider-email-mailgun@workspace:packages/providers/email-mailgun"
   dependencies:
     "@strapi/utils": "npm:5.50.2"
-    "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.50.2"
     form-data: "npm:4.0.6"
-    jest: "npm:29.6.0"
     mailgun.js: "npm:10.2.1"
     tsconfig: "npm:5.50.2"
+    vitest: "catalog:"
+    vitest-config: "npm:5.50.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Fully migrates `@strapi/provider-email-mailgun` unit tests from Jest to Vitest, matching the existing `@strapi/provider-email-amazon-ses` cutover:

- Replace Jest scripts/deps with Vitest + shared `vitest-config`
- Add `vitest.config.ts` and rename the suite to `*.vitest.test.ts`
- Remove `jest.config.js` and Jest type references from `tsconfig.json`

### Why is it needed?

Incremental Jest → Vitest migration for monorepo unit tests. Mailgun is a small leaf provider (1 suite, no mocks), so it is a low-risk package to finish before larger ones.

### How to test it?

```bash
yarn workspace @strapi/provider-email-mailgun test:unit:vitest
yarn workspace @strapi/provider-email-mailgun build
yarn workspace @strapi/provider-email-mailgun lint
yarn workspace @strapi/provider-email-mailgun test:ts
yarn test:unit:vitest
```

Verified locally: package Vitest 2/2 pass, build/lint/types clean, root `test:unit:vitest` 26 files / 200 tests pass.

### Related issue(s)/PR(s)

Part of the ongoing Jest → Vitest unit-test migration (same pattern as email-amazon-ses).