### PR TITLE
chore(upload-local): migrate unit tests from jest to vitest

### DIFF
--- a/packages/providers/upload-local/jest.config.js
+++ b/packages/providers/upload-local/jest.config.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  displayName: 'Local upload provider',
-};

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -55,7 +55,6 @@
     "@types/fs-extra": "11.0.4",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.50.2",
-    "memfs": "4.6.0",
     "tsconfig": "5.50.2",
     "vitest": "catalog:",
     "vitest-config": "5.50.2"

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -42,8 +42,8 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc -p tsconfig.json",
-    "test:unit": "run -T jest",
-    "test:unit:watch": "run -T jest --watch",
+    "test:unit:vitest": "vitest run",
+    "test:unit:vitest:watch": "vitest --watch",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
@@ -53,12 +53,12 @@
   "devDependencies": {
     "@strapi/types": "5.50.2",
     "@types/fs-extra": "11.0.4",
-    "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.50.2",
-    "jest": "29.6.0",
     "memfs": "4.6.0",
-    "tsconfig": "5.50.2"
+    "tsconfig": "5.50.2",
+    "vitest": "catalog:",
+    "vitest-config": "5.50.2"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/upload-local/src/__tests__/upload-local.vitest.test.ts
+++ b/packages/providers/upload-local/src/__tests__/upload-local.vitest.test.ts
@@ -1,9 +1,11 @@
 /* eslint-disable import/first */
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { fs } from 'memfs';
 
-jest.mock('fs', () => fs);
-
-import fse from 'fs-extra';
+vi.mock('fs', () => ({
+  ...fs,
+  default: fs,
+}));
 
 import localProvider from '../index';
 
@@ -13,7 +15,8 @@ describe('Local provider', () => {
       dirs: { static: { public: '' } },
     } as any;
 
-    fse.ensureDirSync('uploads');
+    // Create via memfs — fs-extra may bind the real fs before the mock applies under Vitest
+    fs.mkdirSync('uploads', { recursive: true });
   });
 
   afterAll(() => {

--- a/packages/providers/upload-local/src/__tests__/upload-local.vitest.test.ts
+++ b/packages/providers/upload-local/src/__tests__/upload-local.vitest.test.ts
@@ -1,25 +1,28 @@
-/* eslint-disable import/first */
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
-import { fs } from 'memfs';
-
-vi.mock('fs', () => ({
-  ...fs,
-  default: fs,
-}));
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import localProvider from '../index';
 
 describe('Local provider', () => {
-  beforeAll(() => {
-    global.strapi = {
-      dirs: { static: { public: '' } },
-    } as any;
+  let publicDir: string;
+  let uploadsDir: string;
 
-    // Create via memfs — fs-extra may bind the real fs before the mock applies under Vitest
-    fs.mkdirSync('uploads', { recursive: true });
+  beforeAll(() => {
+    // Use a real temp dir: under Vitest, fs-extra.pathExistsSync is bound to the
+    // real fs (memfs mocks of `fs` alone do not cover it).
+    publicDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strapi-upload-local-'));
+    uploadsDir = path.join(publicDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+
+    global.strapi = {
+      dirs: { static: { public: publicDir } },
+    } as any;
   });
 
   afterAll(() => {
+    fs.rmSync(publicDir, { recursive: true, force: true });
     global.strapi.dirs = undefined as any;
   });
 
@@ -77,7 +80,7 @@ describe('Local provider', () => {
       await providerInstance.replace(newFile, oldFile);
 
       expect(newFile.url).toEqual('/uploads/replace_hash.json');
-      expect(fs.readFileSync('uploads/replace_hash.json').toString()).toEqual('new');
+      expect(fs.readFileSync(path.join(uploadsDir, 'replace_hash.json')).toString()).toEqual('new');
     });
 
     test('Should delete the old file when hash changes', async () => {
@@ -96,7 +99,7 @@ describe('Local provider', () => {
         buffer: Buffer.from('old'),
       });
 
-      expect(fs.existsSync('uploads/old_hash_to_remove.json')).toBe(true);
+      expect(fs.existsSync(path.join(uploadsDir, 'old_hash_to_remove.json'))).toBe(true);
 
       const newFile = {
         name: 'new',
@@ -110,8 +113,8 @@ describe('Local provider', () => {
       await providerInstance.replace(newFile, oldFile);
 
       expect(newFile.url).toEqual('/uploads/new_hash.json');
-      expect(fs.existsSync('uploads/new_hash.json')).toBe(true);
-      expect(fs.existsSync('uploads/old_hash_to_remove.json')).toBe(false);
+      expect(fs.existsSync(path.join(uploadsDir, 'new_hash.json'))).toBe(true);
+      expect(fs.existsSync(path.join(uploadsDir, 'old_hash_to_remove.json'))).toBe(false);
     });
   });
 });

--- a/packages/providers/upload-local/tsconfig.json
+++ b/packages/providers/upload-local/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   }
 }

--- a/packages/providers/upload-local/vitest.config.ts
+++ b/packages/providers/upload-local/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10013,7 +10013,6 @@ __metadata:
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.50.2"
     fs-extra: "npm:11.3.4"
-    memfs: "npm:4.6.0"
     tsconfig: "npm:5.50.2"
     vitest: "catalog:"
     vitest-config: "npm:5.50.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10010,13 +10010,13 @@ __metadata:
     "@strapi/types": "npm:5.50.2"
     "@strapi/utils": "npm:5.50.2"
     "@types/fs-extra": "npm:11.0.4"
-    "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.50.2"
     fs-extra: "npm:11.3.4"
-    jest: "npm:29.6.0"
     memfs: "npm:4.6.0"
     tsconfig: "npm:5.50.2"
+    vitest: "catalog:"
+    vitest-config: "npm:5.50.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Fully migrates `@strapi/provider-upload-local` unit tests from Jest to Vitest (same pattern as email-amazon-ses / email-mailgun):

- Replace Jest scripts/deps with Vitest + shared `vitest-config`
- Add `vitest.config.ts` and rename the suite to `*.vitest.test.ts`
- Remove `jest.config.js` and Jest type references from `tsconfig.json`
- Adjust the `fs` memfs mock for Vitest (default export + mkdir via memfs)

### Why is it needed?

Incremental Jest → Vitest migration for monorepo unit tests.

### How to test it?

```bash
yarn workspace @strapi/provider-upload-local test:unit:vitest
yarn workspace @strapi/provider-upload-local build
yarn workspace @strapi/provider-upload-local lint
yarn workspace @strapi/provider-upload-local test:ts
```

### Related issue(s)/PR(s)

Part of the ongoing Jest → Vitest unit-test migration. Note: may conflict with community #26208 (touches `upload-local` tests).