### PR TITLE
chore(email-nodemailer): migrate unit tests from jest to vitest

### DIFF
--- a/packages/providers/email-nodemailer/jest.config.js
+++ b/packages/providers/email-nodemailer/jest.config.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  displayName: 'Nodemailer email provider',
-};

--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -69,19 +69,20 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc -p tsconfig.json",
-    "test:unit": "run -T jest",
+    "test:unit:vitest": "vitest run",
+    "test:unit:vitest:watch": "vitest --watch",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
     "nodemailer": "9.0.1"
   },
   "devDependencies": {
-    "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
     "@types/nodemailer": "7.0.11",
     "eslint-config-custom": "5.50.2",
-    "jest": "29.6.0",
-    "tsconfig": "5.50.2"
+    "tsconfig": "5.50.2",
+    "vitest": "catalog:",
+    "vitest-config": "5.50.2"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/email-nodemailer/src/__tests__/email-address.vitest.test.ts
+++ b/packages/providers/email-nodemailer/src/__tests__/email-address.vitest.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import {
   parseEmailAddress,
   parseMultipleEmailAddresses,

--- a/packages/providers/email-nodemailer/src/__tests__/index.vitest.test.ts
+++ b/packages/providers/email-nodemailer/src/__tests__/index.vitest.test.ts
@@ -1,15 +1,16 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import nodemailer from 'nodemailer';
 
 import provider from '../index';
 
-jest.mock('nodemailer');
+vi.mock('nodemailer');
 
-const mockSendMail = jest.fn();
-const mockVerify = jest.fn();
-const mockIsIdle = jest.fn();
-const mockClose = jest.fn();
+const mockSendMail = vi.fn();
+const mockVerify = vi.fn();
+const mockIsIdle = vi.fn();
+const mockClose = vi.fn();
 
-(nodemailer.createTransport as jest.Mock).mockReturnValue({
+(nodemailer.createTransport as Mock).mockReturnValue({
   sendMail: mockSendMail,
   verify: mockVerify,
   isIdle: mockIsIdle,
@@ -18,7 +19,7 @@ const mockClose = jest.fn();
 
 describe('@strapi/provider-email-nodemailer', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('init', () => {
@@ -500,7 +501,7 @@ describe('@strapi/provider-email-nodemailer', () => {
     });
 
     it('returns true when transporter does not support isIdle', () => {
-      (nodemailer.createTransport as jest.Mock).mockReturnValueOnce({
+      (nodemailer.createTransport as Mock).mockReturnValueOnce({
         sendMail: mockSendMail,
         verify: mockVerify,
         close: mockClose,

--- a/packages/providers/email-nodemailer/tsconfig.json
+++ b/packages/providers/email-nodemailer/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts"],
   "exclude": ["**/__tests__/**"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   }
 }

--- a/packages/providers/email-nodemailer/vitest.config.ts
+++ b/packages/providers/email-nodemailer/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9937,13 +9937,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-nodemailer@workspace:packages/providers/email-nodemailer"
   dependencies:
-    "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     "@types/nodemailer": "npm:7.0.11"
     eslint-config-custom: "npm:5.50.2"
-    jest: "npm:29.6.0"
     nodemailer: "npm:9.0.1"
     tsconfig: "npm:5.50.2"
+    vitest: "catalog:"
+    vitest-config: "npm:5.50.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Fully migrates `@strapi/provider-email-nodemailer` unit tests from Jest to Vitest (same pattern as email-amazon-ses / email-mailgun):

- Replace Jest scripts/deps with Vitest + shared `vitest-config`
- Add `vitest.config.ts` and rename suites to `*.vitest.test.ts`
- Convert `jest.*` APIs to `vi.*` / Vitest `Mock`
- Remove `jest.config.js` and Jest type references from `tsconfig.json`

### Why is it needed?

Incremental Jest → Vitest migration for monorepo unit tests.

### How to test it?

```bash
yarn workspace @strapi/provider-email-nodemailer test:unit:vitest
yarn workspace @strapi/provider-email-nodemailer build
yarn workspace @strapi/provider-email-nodemailer lint
yarn workspace @strapi/provider-email-nodemailer test:ts
```

Verified locally: 2 files / 98 tests pass; build/lint/types clean.

### Related issue(s)/PR(s)

Part of the ongoing Jest → Vitest unit-test migration.