### PR TITLE
chore(email-sendmail): migrate unit tests from jest to vitest

### DIFF
--- a/packages/providers/email-sendmail/__tests__/addressing.vitest.test.ts
+++ b/packages/providers/email-sendmail/__tests__/addressing.vitest.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import {
   collectRecipients,
   extractEmail,

--- a/packages/providers/email-sendmail/__tests__/direct-smtp.vitest.test.ts
+++ b/packages/providers/email-sendmail/__tests__/direct-smtp.vitest.test.ts
@@ -1,12 +1,13 @@
+import { describe, it, expect, beforeEach, vi, type MockedFunction } from 'vitest';
 import { resolveMx } from 'dns/promises';
 
 import { resolveMxHosts, sendDirectSmtp } from '../src/direct-smtp';
 
-jest.mock('dns/promises', () => ({
-  resolveMx: jest.fn(),
+vi.mock('dns/promises', () => ({
+  resolveMx: vi.fn(),
 }));
 
-const mockedResolveMx = resolveMx as jest.MockedFunction<typeof resolveMx>;
+const mockedResolveMx = resolveMx as MockedFunction<typeof resolveMx>;
 
 describe('resolveMxHosts', () => {
   beforeEach(() => {

--- a/packages/providers/email-sendmail/__tests__/index.vitest.test.ts
+++ b/packages/providers/email-sendmail/__tests__/index.vitest.test.ts
@@ -1,14 +1,15 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type MockedFunction } from 'vitest';
 import { generateKeyPairSync } from 'crypto';
 import { resolveMx } from 'dns/promises';
 
 import provider from '../src/index';
 import { MinimalSmtpServer } from './helpers/minimal-smtp-server';
 
-jest.mock('dns/promises', () => ({
-  resolveMx: jest.fn(),
+vi.mock('dns/promises', () => ({
+  resolveMx: vi.fn(),
 }));
 
-const mockedResolveMx = resolveMx as jest.MockedFunction<typeof resolveMx>;
+const mockedResolveMx = resolveMx as MockedFunction<typeof resolveMx>;
 
 describe('@strapi/provider-email-sendmail', () => {
   describe('init + send (integration against minimal SMTP)', () => {
@@ -53,7 +54,7 @@ describe('@strapi/provider-email-sendmail', () => {
     });
 
     it('merges silent: true by default and allows override', async () => {
-      const debug = jest.fn();
+      const debug = vi.fn();
       const instance = provider.init(
         {
           devPort: server.port,

--- a/packages/providers/email-sendmail/__tests__/logger.vitest.test.ts
+++ b/packages/providers/email-sendmail/__tests__/logger.vitest.test.ts
@@ -1,8 +1,9 @@
+import { describe, it, expect, vi } from 'vitest';
 import { createLogger } from '../src/logger';
 
 describe('createLogger', () => {
   it('uses custom logger even when silent is true (legacy guileen/node-sendmail)', () => {
-    const debug = jest.fn();
+    const debug = vi.fn();
     const logger = createLogger({
       silent: true,
       logger: { debug },
@@ -14,7 +15,7 @@ describe('createLogger', () => {
   it('noops missing methods on a partial custom logger', () => {
     const logger = createLogger({
       silent: false,
-      logger: { error: jest.fn() },
+      logger: { error: vi.fn() },
     });
     expect(() => logger.debug('x')).not.toThrow();
   });

--- a/packages/providers/email-sendmail/__tests__/mx-fallback.vitest.test.ts
+++ b/packages/providers/email-sendmail/__tests__/mx-fallback.vitest.test.ts
@@ -1,31 +1,32 @@
+import { describe, it, expect, beforeEach, vi, type MockedFunction } from 'vitest';
 import { resolveMx } from 'dns/promises';
 import { hostname as osHostname } from 'os';
 import nodemailer from 'nodemailer';
 
 import { sendDirectSmtp } from '../src/direct-smtp';
 
-jest.mock('dns/promises', () => ({
-  resolveMx: jest.fn(),
+vi.mock('dns/promises', () => ({
+  resolveMx: vi.fn(),
 }));
 
-jest.mock('os', () => ({
-  hostname: jest.fn(() => 'test-host.fallback'),
+vi.mock('os', () => ({
+  hostname: vi.fn(() => 'test-host.fallback'),
 }));
 
-jest.mock('nodemailer');
+vi.mock('nodemailer');
 
-const mockedResolveMx = resolveMx as jest.MockedFunction<typeof resolveMx>;
-const mockedOsHostname = osHostname as jest.MockedFunction<typeof osHostname>;
-const mockedCreateTransport = nodemailer.createTransport as jest.MockedFunction<
+const mockedResolveMx = resolveMx as MockedFunction<typeof resolveMx>;
+const mockedOsHostname = osHostname as MockedFunction<typeof osHostname>;
+const mockedCreateTransport = nodemailer.createTransport as MockedFunction<
   typeof nodemailer.createTransport
 >;
 
 describe('sendDirectSmtp MX fallback and transport options', () => {
-  const sendMail = jest.fn();
-  const close = jest.fn();
+  const sendMail = vi.fn();
+  const close = vi.fn();
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     mockedOsHostname.mockReturnValue('test-host.fallback');
     sendMail.mockResolvedValue({ messageId: '<id@test>' });
     close.mockImplementation(() => {});
@@ -134,7 +135,7 @@ describe('sendDirectSmtp MX fallback and transport options', () => {
         transport && typeof transport === 'object' && 'host' in transport
           ? String((transport as { host?: unknown }).host ?? '')
           : '';
-      const perHostSend = jest.fn();
+      const perHostSend = vi.fn();
       if (host === 'mx.bad.example') {
         perHostSend.mockRejectedValue(new Error('ECONNREFUSED'));
       } else {

--- a/packages/providers/email-sendmail/jest.config.js
+++ b/packages/providers/email-sendmail/jest.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  displayName: 'Sendmail email provider',
-  testPathIgnorePatterns: ['<rootDir>/__tests__/helpers/'],
-  watchman: false,
-};

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -42,19 +42,20 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc -p tsconfig.json",
-    "test:unit": "run -T jest --watchman=false",
+    "test:unit:vitest": "vitest run",
+    "test:unit:vitest:watch": "vitest --watch",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
     "nodemailer": "9.0.1"
   },
   "devDependencies": {
-    "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
     "@types/nodemailer": "7.0.11",
     "eslint-config-custom": "5.50.2",
-    "jest": "29.6.0",
-    "tsconfig": "5.50.2"
+    "tsconfig": "5.50.2",
+    "vitest": "catalog:",
+    "vitest-config": "5.50.2"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/email-sendmail/tsconfig.json
+++ b/packages/providers/email-sendmail/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src", "__tests__"],
+  "include": ["src", "__tests__", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   }
 }

--- a/packages/providers/email-sendmail/vitest.config.ts
+++ b/packages/providers/email-sendmail/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9963,13 +9963,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-sendmail@workspace:packages/providers/email-sendmail"
   dependencies:
-    "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     "@types/nodemailer": "npm:7.0.11"
     eslint-config-custom: "npm:5.50.2"
-    jest: "npm:29.6.0"
     nodemailer: "npm:9.0.1"
     tsconfig: "npm:5.50.2"
+    vitest: "catalog:"
+    vitest-config: "npm:5.50.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Fully migrates `@strapi/provider-email-sendmail` unit tests from Jest to Vitest (same pattern as email-amazon-ses / email-mailgun):

- Replace Jest scripts/deps with Vitest + shared `vitest-config`
- Add `vitest.config.ts` and rename suites to `*.vitest.test.ts`
- Convert `jest.*` APIs to `vi.*` / Vitest `MockedFunction`
- Remove `jest.config.js` and Jest type references from `tsconfig.json`

### Why is it needed?

Incremental Jest → Vitest migration for monorepo unit tests.

### How to test it?

```bash
yarn workspace @strapi/provider-email-sendmail test:unit:vitest
yarn workspace @strapi/provider-email-sendmail build
yarn workspace @strapi/provider-email-sendmail lint
yarn workspace @strapi/provider-email-sendmail test:ts
```

Verified locally: 5 files / 44 tests pass; build/lint/types clean.

### Related issue(s)/PR(s)

Part of the ongoing Jest → Vitest unit-test migration.