### PR TITLE
feat(document-service): durable componentKey for nested components

### DIFF
--- a/docs/docs/rfcs/03-component-key.md
+++ b/docs/docs/rfcs/03-component-key.md
@@ -1,0 +1,98 @@
+---
+title: Durable componentKey for nested components
+description: Add a stable componentKey identity for component instances across draft/publish clones so Content API clients can round-trip nested updates without relying on status-local numeric ids
+tags:
+  - content-api
+  - document-service
+  - components
+  - draft-and-publish
+---
+
+# Durable `componentKey` for nested components
+
+**Status:** Draft  
+**Related docs:** [Updating repeatable components](https://docs.strapi.io/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api)
+
+## Summary
+
+Documents have a stable `documentId` across draft/publish. Nested components only have status-local numeric `id`s. Publishing creates new component rows, so the draft and published versions of the “same” block have different `id`s.
+
+That breaks the natural Content API round-trip:
+
+1. REST `GET` returns **published** component `id`s
+2. `PUT` / Document Service `update` writes the **draft**
+3. Reusing published `id`s fails (`Some of the provided components … are not related to the entity`)
+
+Today’s supported workaround is to omit ids and replace the whole component array (recreate). That remains valid and non-breaking. This RFC adds an additive durable identity so clients can also do v4-style targeted updates safely.
+
+## Goals
+
+- Non-breaking: omit-id full-array replace keeps working; draft-`id` updates keep working (Content Manager).
+- Honest identity: do **not** silently remap published numeric `id` → draft row.
+- Align with the `documentId` mental model: stable handle for the logical nested block; `id` remains the row PK.
+- Fail closed: unknown / foreign keys reject like invalid ids.
+
+## Non-goals
+
+- Silent published→draft numeric `id` remapping as the permanent contract.
+- Treating components as full documents (no independent D&P lifecycle).
+- Relation-style `set` / `update` / `remove` grammar (possible follow-up once keys exist).
+
+## Proposal
+
+Add a system attribute **`componentKey`** (string, cuid2) on every component model:
+
+| Field          | Meaning                                                               |
+| -------------- | --------------------------------------------------------------------- |
+| `id`           | Database row for this status/locale parent (ephemeral across publish) |
+| `componentKey` | Logical instance identity (copied on publish/clone/discard)           |
+
+Draft and published remain **separate rows** with separate field values. They may share a `componentKey` when they represent the same logical block after publish/clone.
+
+### Behavior
+
+1. **Create** — mint `componentKey` if absent; preserve if present (publish/clone path).
+2. **Publish / discard / clone** — funnel through `createComponents` → `createComponent`; keys copy with other scalars.
+3. **Update** — before delete/update, resolve payload `componentKey` → row `id` on the **parent being updated** (usually draft). Unknown keys → ApplicationError.
+4. **Omit-id full replace** — unchanged.
+5. **Update by draft `id`** — unchanged.
+
+### Security
+
+- Resolve only against components linked to the parent entity under update (and `__component` for dynamic zones).
+- Do not allow reassigning `componentKey` on update.
+- Never resolve by bare published numeric `id` across statuses.
+
+### Migration
+
+1. Schema sync adds `component_key` (system attribute on component models).
+2. Internal migration backfills a unique key per existing row.
+3. Twins share keys after the **next publish** (key copied draft → published). Optional follow-up: twin existing pairs by parent + field + order without re-publish.
+
+## Implementation sketch
+
+Primary touchpoints:
+
+- `transform-content-types-to-models.ts` — add `componentKey` for `modelType === 'component'`
+- `document-service/components.ts` — assign/preserve on create; resolve key→id in `updateComponents`
+- `@strapi/utils` `ID_FIELDS` + reserved `component_key`
+- Internal migration `5.0.0-07-component-key`
+- API tests under `tests/api/core/strapi/document-service/component-key.test.api.ts`
+
+## Follow-ups
+
+- [ ] GraphQL / OpenAPI surfacing
+- [ ] data-transfer `createComponent` parity
+- [ ] Unskip Content API component-id tests; add REST `componentKey` cases
+- [ ] Best-effort twinning migration for existing draft/published pairs
+- [ ] Public docs: document round-trip; retire “not recommended” once shipped
+- [ ] Consider whether REST should de-emphasize numeric component `id` in examples
+
+## Acceptance criteria
+
+- [ ] Create component → response includes `componentKey`
+- [ ] Publish → draft and published rows share the same `componentKey`, different `id`
+- [ ] Load published → update with `{ componentKey, …fields }` updates the draft instance
+- [ ] Omit-id array replace still works
+- [ ] Invalid / foreign `componentKey` → 400
+- [ ] Nested components + dynamic zones covered

--- a/docs/docs/rfcs/03-component-key.md
+++ b/docs/docs/rfcs/03-component-key.md
@@ -92,7 +92,7 @@ Primary touchpoints:
 
 - [ ] Create component → response includes `componentKey`
 - [ ] Publish → draft and published rows share the same `componentKey`, different `id`
-- [ ] Load published → update with `{ componentKey, …fields }` updates the draft instance
+- [ ] Load published → update with `\{ componentKey, …fields \}` updates the draft instance
 - [ ] Omit-id array replace still works
 - [ ] Invalid / foreign `componentKey` → 400
 - [ ] Nested components + dynamic zones covered

--- a/docs/docs/rfcs/03-component-key.md
+++ b/docs/docs/rfcs/03-component-key.md
@@ -42,20 +42,21 @@ Today’s supported workaround is to omit ids and replace the whole component ar
 
 Add a system attribute **`componentKey`** (string, cuid2) on every component model:
 
-| Field          | Meaning                                                               |
-| -------------- | --------------------------------------------------------------------- |
-| `id`           | Database row for this status/locale parent (ephemeral across publish) |
-| `componentKey` | Logical instance identity (copied on publish/clone/discard)           |
+| Field          | Meaning                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| `id`           | Database row for this status/locale parent (ephemeral across publish)    |
+| `componentKey` | Logical instance identity (copied on publish/discard; reminted on clone) |
 
-Draft and published remain **separate rows** with separate field values. They may share a `componentKey` when they represent the same logical block after publish/clone.
+Draft and published remain **separate rows** with separate field values. They may share a `componentKey` when they represent the same logical block after publish.
 
 ### Behavior
 
-1. **Create** — mint `componentKey` if absent; preserve if present (publish/clone path).
-2. **Publish / discard / clone** — funnel through `createComponents` → `createComponent`; keys copy with other scalars.
-3. **Update** — before delete/update, resolve payload `componentKey` → row `id` on the **parent being updated** (usually draft). Unknown keys → ApplicationError.
-4. **Omit-id full replace** — unchanged.
-5. **Update by draft `id`** — unchanged.
+1. **Create** — mint `componentKey` if absent; preserve if present (publish/discard path).
+2. **Publish / discard** — funnel through `createComponents` → `createComponent`; keys copy with other scalars.
+3. **Document clone** — strip source `componentKey`s so `createComponent` mints **new** keys (clone is a new document, same as a new `documentId`).
+4. **Update** — before delete/update, resolve payload `componentKey` → row `id` on the **parent being updated** (usually draft). Unknown keys → ApplicationError.
+5. **Omit-id full replace** — unchanged.
+6. **Update by draft `id`** — unchanged.
 
 ### Security
 
@@ -82,17 +83,18 @@ Primary touchpoints:
 ## Follow-ups
 
 - [ ] GraphQL / OpenAPI surfacing
-- [ ] data-transfer `createComponent` parity
-- [ ] Unskip Content API component-id tests; add REST `componentKey` cases
+- [x] data-transfer `createComponent` parity
+- [x] Unskip Content API component-id tests; add REST `componentKey` cases
 - [ ] Best-effort twinning migration for existing draft/published pairs
 - [ ] Public docs: document round-trip; retire “not recommended” once shipped
 - [ ] Consider whether REST should de-emphasize numeric component `id` in examples
 
 ## Acceptance criteria
 
-- [ ] Create component → response includes `componentKey`
-- [ ] Publish → draft and published rows share the same `componentKey`, different `id`
-- [ ] Load published → update with `\{ componentKey, …fields \}` updates the draft instance
-- [ ] Omit-id array replace still works
-- [ ] Invalid / foreign `componentKey` → 400
-- [ ] Nested components + dynamic zones covered
+- [x] Create component → response includes `componentKey`
+- [x] Publish → draft and published rows share the same `componentKey`, different `id`
+- [x] Load published → update with `\{ componentKey, …fields \}` updates the draft instance
+- [x] Omit-id array replace still works
+- [x] Invalid / foreign `componentKey` → 400
+- [x] Nested components + dynamic zones covered
+- [x] Document clone mints new `componentKey`s

--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/content-type.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/content-type.test.ts
@@ -57,13 +57,13 @@ describe('Content type validator', () => {
         expect(err).toMatchObject({
           name: 'ValidationError',
           message:
-            'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
+            'Attribute keys cannot be one of id, document_id, component_key, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
           details: {
             errors: [
               {
                 path: ['contentType', 'attributes', 'entryId'],
                 message:
-                  'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
+                  'Attribute keys cannot be one of id, document_id, component_key, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
                 name: 'ValidationError',
               },
             ],
@@ -93,13 +93,13 @@ describe('Content type validator', () => {
         expect(err).toMatchObject({
           name: 'ValidationError',
           message:
-            'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
+            'Attribute keys cannot be one of id, document_id, component_key, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
           details: {
             errors: [
               {
                 path: ['contentType', 'attributes', 'ENTRY_ID'],
                 message:
-                  'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
+                  'Attribute keys cannot be one of id, document_id, component_key, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
                 name: 'ValidationError',
               },
             ],

--- a/packages/core/core/src/services/document-service/components.ts
+++ b/packages/core/core/src/services/document-service/components.ts
@@ -475,14 +475,16 @@ const createComponent = async <TUID extends UID.Component>(
     // Make sure we don't save the component with a pre-defined ID
     omit('id'),
     // Preserve componentKey on publish/clone; mint one on first create
-    (value: Input<TUID>) => ({
-      ...value,
-      componentKey:
-        typeof (value as { componentKey?: string }).componentKey === 'string' &&
-        (value as { componentKey?: string }).componentKey
-          ? (value as { componentKey: string }).componentKey
-          : createDocumentId(),
-    }),
+    (value: Input<TUID>) => {
+      const existingKey = (value as unknown as { componentKey?: string }).componentKey;
+      return {
+        ...value,
+        componentKey:
+          typeof existingKey === 'string' && existingKey.length > 0
+            ? existingKey
+            : createDocumentId(),
+      };
+    },
     assignComponentData(schema, componentData)
   );
 

--- a/packages/core/core/src/services/document-service/components.ts
+++ b/packages/core/core/src/services/document-service/components.ts
@@ -7,6 +7,7 @@ import {
   getComponentJoinColumnEntityName,
   getComponentJoinColumnInverseName,
   getComponentTypeColumn,
+  createDocumentId,
 } from '../../utils/transform-content-types-to-models';
 
 // type aliases for readability
@@ -173,8 +174,22 @@ const updateComponents = async <TUID extends UID.Schema, TData extends Partial<I
     if (attribute.type === 'component') {
       const { component: componentUID, repeatable = false } = attribute;
 
-      const componentValue = data[attributeName as keyof TData] as ComponentValue;
-      await deleteOldComponents(uid, componentUID, entityToUpdate, attributeName, componentValue);
+      const rawComponentValue = data[attributeName as keyof TData] as ComponentValue;
+      const previousValue = (await strapi.db
+        .query(uid)
+        .load(entityToUpdate, attributeName)) as ComponentValue;
+
+      // Resolve durable componentKey → row id on this parent (draft or published) before
+      // delete/update so Content API clients can round-trip keys from either status.
+      const componentValue = resolveComponentIdentities(
+        attributeName,
+        previousValue,
+        rawComponentValue
+      );
+
+      await deleteOldComponents(uid, componentUID, entityToUpdate, attributeName, componentValue, {
+        previousValue,
+      });
 
       if (repeatable === true) {
         if (!Array.isArray(componentValue)) {
@@ -206,9 +221,20 @@ const updateComponents = async <TUID extends UID.Schema, TData extends Partial<I
         };
       }
     } else if (attribute.type === 'dynamiczone') {
-      const dynamiczoneValues = data[attributeName as keyof TData] as DynamicZoneValue;
+      const rawDynamiczoneValues = data[attributeName as keyof TData] as DynamicZoneValue;
+      const previousValue = (await strapi.db
+        .query(uid)
+        .load(entityToUpdate, attributeName)) as DynamicZoneValue;
 
-      await deleteOldDZComponents(uid, entityToUpdate, attributeName, dynamiczoneValues);
+      const dynamiczoneValues = resolveComponentIdentities(
+        attributeName,
+        previousValue,
+        rawDynamiczoneValues
+      ) as DynamicZoneValue;
+
+      await deleteOldDZComponents(uid, entityToUpdate, attributeName, dynamiczoneValues, {
+        previousValue,
+      });
 
       if (!Array.isArray(dynamiczoneValues)) {
         throw new Error('Expected an array to create repeatable component');
@@ -232,6 +258,68 @@ const updateComponents = async <TUID extends UID.Schema, TData extends Partial<I
   return componentBody;
 };
 
+/**
+ * Map payload entries that carry `componentKey` (without a usable row `id`) onto the
+ * matching component row already linked to this parent entity.
+ *
+ * Fail closed: unknown keys throw the same relation error as invalid ids.
+ * Entries without id/key are creates. Existing `id` wins and is left unchanged.
+ */
+const resolveComponentIdentities = <T extends ComponentValue | DynamicZoneValue>(
+  attributeName: string,
+  previousValue: T | null | undefined,
+  componentValue: T
+): T => {
+  if (componentValue == null) {
+    return componentValue;
+  }
+
+  const previous = _.castArray(previousValue || []).filter(Boolean) as Array<{
+    id?: Modules.EntityService.Params.Attribute.ID;
+    componentKey?: string;
+    __component?: string;
+  }>;
+
+  const resolveOne = (value: any) => {
+    if (value == null || typeof value !== 'object') {
+      return value;
+    }
+
+    if (typeof value.id !== 'undefined') {
+      return value;
+    }
+
+    if (typeof value.componentKey === 'undefined' || value.componentKey === null) {
+      return value;
+    }
+
+    const match = previous.find((entry) => {
+      if (entry.componentKey !== value.componentKey) {
+        return false;
+      }
+      // Dynamic zones: keys are only unique within the same __component uid
+      if (value.__component && entry.__component && value.__component !== entry.__component) {
+        return false;
+      }
+      return true;
+    });
+
+    if (!match?.id) {
+      throw new errors.ApplicationError(
+        `Some of the provided components in ${attributeName} are not related to the entity`
+      );
+    }
+
+    return { ...value, id: match.id };
+  };
+
+  if (Array.isArray(componentValue)) {
+    return componentValue.map(resolveOne) as T;
+  }
+
+  return resolveOne(componentValue) as T;
+};
+
 const pickStringifiedId = ({
   id,
 }: {
@@ -249,11 +337,12 @@ const deleteOldComponents = async <TUID extends UID.Schema>(
   componentUID: UID.Component,
   entityToUpdate: { id: Modules.EntityService.Params.Attribute.ID },
   attributeName: string,
-  componentValue: ComponentValue
+  componentValue: ComponentValue,
+  options?: { previousValue?: ComponentValue }
 ) => {
-  const previousValue = (await strapi.db
-    .query(uid)
-    .load(entityToUpdate, attributeName)) as ComponentValue;
+  const previousValue =
+    options?.previousValue ??
+    ((await strapi.db.query(uid).load(entityToUpdate, attributeName)) as ComponentValue);
   const idsToKeep = _.castArray(componentValue).filter(has('id')).map(pickStringifiedId);
   const allIds = _.castArray(previousValue).filter(has('id')).map(pickStringifiedId);
 
@@ -278,11 +367,12 @@ const deleteOldDZComponents = async <TUID extends UID.Schema>(
   uid: TUID,
   entityToUpdate: { id: Modules.EntityService.Params.Attribute.ID },
   attributeName: string,
-  dynamiczoneValues: DynamicZoneValue
+  dynamiczoneValues: DynamicZoneValue,
+  options?: { previousValue?: DynamicZoneValue }
 ) => {
-  const previousValue = (await strapi.db
-    .query(uid)
-    .load(entityToUpdate, attributeName)) as DynamicZoneValue;
+  const previousValue =
+    options?.previousValue ??
+    ((await strapi.db.query(uid).load(entityToUpdate, attributeName)) as DynamicZoneValue);
 
   const idsToKeep = _.castArray(dynamiczoneValues)
     .filter(has('id'))
@@ -384,6 +474,15 @@ const createComponent = async <TUID extends UID.Component>(
   const transform = pipe(
     // Make sure we don't save the component with a pre-defined ID
     omit('id'),
+    // Preserve componentKey on publish/clone; mint one on first create
+    (value: Input<TUID>) => ({
+      ...value,
+      componentKey:
+        typeof (value as { componentKey?: string }).componentKey === 'string' &&
+        (value as { componentKey?: string }).componentKey
+          ? (value as { componentKey: string }).componentKey
+          : createDocumentId(),
+    }),
     assignComponentData(schema, componentData)
   );
 
@@ -400,11 +499,12 @@ const updateComponent = async <TUID extends UID.Component>(
 
   const componentData = await updateComponents(uid, componentToUpdate, data);
 
+  // componentKey is durable identity — do not allow clients to reassign it on update
   return strapi.db.query(uid).update({
     where: {
       id: componentToUpdate.id,
     },
-    data: assignComponentData(schema, componentData, data),
+    data: assignComponentData(schema, componentData, omit('componentKey', data)),
   });
 };
 

--- a/packages/core/core/src/services/document-service/components.ts
+++ b/packages/core/core/src/services/document-service/components.ts
@@ -474,7 +474,8 @@ const createComponent = async <TUID extends UID.Component>(
   const transform = pipe(
     // Make sure we don't save the component with a pre-defined ID
     omit('id'),
-    // Preserve componentKey on publish/clone; mint one on first create
+    // Preserve componentKey on publish/discard; mint one on first create.
+    // Document clone strips keys first so this mints fresh identities.
     (value: Input<TUID>) => {
       const existingKey = (value as unknown as { componentKey?: string }).componentKey;
       return {
@@ -710,6 +711,59 @@ const createComponentRelationFilter = () => {
   };
 };
 
+/**
+ * Remove `componentKey` from nested component / dynamic-zone payloads (in place).
+ * Used by document clone so createComponent mints new keys for the duplicate document.
+ * Publish/discard must NOT call this — they intentionally preserve keys across status rows.
+ */
+const stripComponentKeys = <T extends Record<string, unknown>>(
+  schema: Schema.Schema,
+  data: T
+): T => {
+  if (data == null || typeof data !== 'object') {
+    return data;
+  }
+
+  const { attributes = {} } = schema;
+
+  for (const attributeName of Object.keys(attributes)) {
+    const attribute = attributes[attributeName];
+    const value = data[attributeName as keyof T];
+
+    if (value == null) {
+      continue;
+    }
+
+    if (attribute.type === 'component') {
+      const componentSchema = strapi.getModel(attribute.component);
+
+      const stripOne = (entry: any) => {
+        if (entry == null || typeof entry !== 'object') {
+          return;
+        }
+        delete entry.componentKey;
+        stripComponentKeys(componentSchema, entry);
+      };
+
+      if (attribute.repeatable && Array.isArray(value)) {
+        value.forEach(stripOne);
+      } else {
+        stripOne(value);
+      }
+    } else if (attribute.type === 'dynamiczone' && Array.isArray(value)) {
+      value.forEach((entry: any) => {
+        if (entry == null || typeof entry !== 'object' || !entry.__component) {
+          return;
+        }
+        delete entry.componentKey;
+        stripComponentKeys(strapi.getModel(entry.__component), entry);
+      });
+    }
+  }
+
+  return data;
+};
+
 export {
   omitComponentData,
   assignComponentData,
@@ -718,6 +772,7 @@ export {
   updateComponents,
   deleteComponents,
   deleteComponent,
+  stripComponentKeys,
   createComponentRelationFilter,
   findComponentParent,
   getParentSchemasForComponent,

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -464,6 +464,8 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
           contentType,
           (modelUid) => strapi.getModel(modelUid as UID.Schema)
         );
+        // Clone is a new document — mint fresh componentKeys (do not copy source keys)
+        components.stripComponentKeys(contentType, data);
         const dataWithDocumentId = assoc('documentId', newDocumentId, data);
         const doc = await entries.create({
           ...queryParams,

--- a/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
+++ b/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
@@ -262,7 +262,10 @@ const expectedModels = [
     uid: 'api::empty.empty',
     singularName: 'empty',
     tableName: 'empty',
-    attributes: { id: { type: 'increments' } },
+    attributes: {
+      id: { type: 'increments' },
+      componentKey: { type: 'string' },
+    },
     lifecycles: {},
   },
 ];

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -283,15 +283,18 @@ export const transformContentTypesToModels = (
 
     // Add document id to content types
     // as it is not documented
+    // NOTE: this helper also receives component schemas at runtime (see Strapi bootstrap),
+    // even though LoadedContentTypeModel is typed as ContentTypeSchema only.
+    const modelType = (contentType as { modelType: string }).modelType;
     const documentIdAttribute: Record<string, Schema.Attribute.AnyAttribute> =
-      contentType.modelType === 'contentType'
+      modelType === 'contentType'
         ? { documentId: { type: 'string', default: createDocumentId } }
         : {};
 
     // Durable identity for component instances across draft/publish clones.
     // Copied on publish/clone (same value on both status rows); numeric `id` stays row-local.
     const componentKeyAttribute: Record<string, Schema.Attribute.AnyAttribute> =
-      contentType.modelType === 'component'
+      modelType === 'component'
         ? { componentKey: { type: 'string', default: createDocumentId } }
         : {};
 
@@ -334,7 +337,7 @@ export const transformContentTypesToModels = (
     // Keep the exact same name/columns schema sync already produced so existing databases
     // see no index diff on upgrade (a rename would orphan the old index, since the schema
     // builder's dropIndex is a silent no-op unless forceMigration is enabled).
-    if (contentType.modelType === 'contentType') {
+    if (modelType === 'contentType') {
       model.indexes = [
         ...(model.indexes || []),
         {

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -288,9 +288,16 @@ export const transformContentTypesToModels = (
         ? { documentId: { type: 'string', default: createDocumentId } }
         : {};
 
+    // Durable identity for component instances across draft/publish clones.
+    // Copied on publish/clone (same value on both status rows); numeric `id` stays row-local.
+    const componentKeyAttribute: Record<string, Schema.Attribute.AnyAttribute> =
+      contentType.modelType === 'component'
+        ? { componentKey: { type: 'string', default: createDocumentId } }
+        : {};
+
     // TODO: this needs to be combined with getReservedNames, we should not be maintaining two lists
-    // Prevent user from creating a documentId attribute
-    const reservedAttributeNames = ['document_id', identifiers.ID_COLUMN];
+    // Prevent user from creating a documentId / componentKey attribute
+    const reservedAttributeNames = ['document_id', 'component_key', identifiers.ID_COLUMN];
     Object.keys(contentType.attributes || {}).forEach((attributeName) => {
       const snakeCasedAttributeName = _.snakeCase(attributeName);
       if (reservedAttributeNames.includes(snakeCasedAttributeName)) {
@@ -314,6 +321,7 @@ export const transformContentTypesToModels = (
           type: 'increments',
         },
         ...documentIdAttribute,
+        ...componentKeyAttribute,
         ...transformAttributes(contentType, identifiers),
       },
       indexes: contentType.indexes as Model['indexes'],

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -54,6 +54,7 @@
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
+    "@paralleldrive/cuid2": "2.2.2",
     "@strapi/logger": "5.51.1",
     "@strapi/types": "5.51.1",
     "@strapi/utils": "5.51.1",

--- a/packages/core/data-transfer/src/utils/components.ts
+++ b/packages/core/data-transfer/src/utils/components.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { get, has, omit, pipe, assign } from 'lodash/fp';
+import { createId } from '@paralleldrive/cuid2';
 
 import { contentTypes as contentTypesUtils, async, errors } from '@strapi/utils';
 import type { Modules, UID, Data, Utils, Schema, Core } from '@strapi/types';
@@ -424,6 +425,15 @@ const createComponent = async <TUID extends UID.Component = UID.Component>(
   const transform = pipe(
     // Make sure we don't save the component with a pre-defined ID
     omit('id'),
+    // Preserve componentKey when restoring/transferring; mint one when absent
+    (value: Modules.EntityService.Params.Data.Input<TUID>) => {
+      const existingKey = (value as unknown as { componentKey?: string }).componentKey;
+      return {
+        ...value,
+        componentKey:
+          typeof existingKey === 'string' && existingKey.length > 0 ? existingKey : createId(),
+      };
+    },
     // Remove the component data from the original data object ...
     (payload) => omitComponentData(model, payload),
     // ... and assign the newly created component instead
@@ -443,11 +453,12 @@ const updateComponent = async <TUID extends UID.Component>(
 
   const componentData = await updateComponents(uid, componentToUpdate, data);
 
+  // componentKey is durable identity — do not allow reassignment on update
   return strapi.db.query(uid).update({
     where: {
       id: componentToUpdate.id,
     },
-    data: Object.assign(omitComponentData(model, data), componentData),
+    data: Object.assign(omitComponentData(model, omit('componentKey', data)), componentData),
   });
 };
 

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-07-component-key.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-07-component-key.ts
@@ -1,0 +1,70 @@
+/**
+ * Add + backfill `component_key` on existing component tables.
+ *
+ * Internal migrations run *before* schema sync, so this migration must create the
+ * column when missing. Schema sync then tracks it via the system `componentKey`
+ * attribute on component models (transformContentTypesToModels).
+ *
+ * Existing draft/published pairs get unique keys per row; they share a key after
+ * the next publish (createComponent preserves keys when cloning draft → published).
+ *
+ * @see docs/docs/rfcs/03-component-key.md
+ */
+import { createId } from '@paralleldrive/cuid2';
+import type { Knex } from 'knex';
+
+import type { Migration } from '../common';
+import type { Database } from '../..';
+
+const COMPONENT_KEY_COLUMN = 'component_key';
+
+const ensureAndBackfillComponentKeys = async (knex: Knex, db: Database) => {
+  for (const meta of db.metadata.values()) {
+    // Only component models receive the system `componentKey` attribute
+    if (!meta.attributes?.componentKey) {
+      continue;
+    }
+
+    const tableName = meta.tableName;
+    const hasTable = await knex.schema.hasTable(tableName);
+    if (!hasTable) {
+      continue;
+    }
+
+    const hasColumn = await knex.schema.hasColumn(tableName, COMPONENT_KEY_COLUMN);
+    if (!hasColumn) {
+      await knex.schema.alterTable(tableName, (table) => {
+        table.string(COMPONENT_KEY_COLUMN);
+      });
+    }
+
+    // Process in batches to avoid loading entire tables
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const rows: Array<{ id: number | string }> = await knex(tableName)
+        .select('id')
+        .whereNull(COMPONENT_KEY_COLUMN)
+        .limit(500);
+
+      if (rows.length === 0) {
+        break;
+      }
+
+      for (const row of rows) {
+        await knex(tableName)
+          .where({ id: row.id })
+          .update({ [COMPONENT_KEY_COLUMN]: createId() });
+      }
+    }
+  }
+};
+
+export const createdComponentKey: Migration = {
+  name: '5.0.0-07-component-key',
+  async up(knex, db) {
+    await ensureAndBackfillComponentKeys(knex, db);
+  },
+  async down() {
+    // Keys are additive; column drop is handled by schema sync if the attribute is removed
+  },
+};

--- a/packages/core/database/src/migrations/internal-migrations/index.ts
+++ b/packages/core/database/src/migrations/internal-migrations/index.ts
@@ -5,6 +5,7 @@ import { createdLocale } from './5.0.0-03-locale';
 import { createdPublishedAt } from './5.0.0-04-published-at';
 import { dropSlugFieldsIndex } from './5.0.0-05-drop-slug-unique-index';
 import { addDocumentIdIndexes } from './5.0.0-06-add-document-id-indexes';
+import { createdComponentKey } from './5.0.0-07-component-key';
 
 /**
  * List of all the internal migrations. The array order will be the order in which they are executed.
@@ -22,4 +23,5 @@ export const internalMigrations: Migration[] = [
   createdPublishedAt,
   dropSlugFieldsIndex,
   addDocumentIdIndexes,
+  createdComponentKey,
 ];

--- a/packages/core/types/src/data/component.ts
+++ b/packages/core/types/src/data/component.ts
@@ -13,7 +13,19 @@ import type * as UID from '../uid';
 export type Component<
   TComponentUID extends UID.Component = UID.Component,
   TComponentKeys extends AttributeNames<TComponentUID> = AttributeNames<TComponentUID>,
-> = Intersect<[{ id: ID }, Pick<AttributeValues<TComponentUID>, TComponentKeys>]>;
+> = Intersect<
+  [
+    {
+      id: ID;
+      /**
+       * Durable identity for this component instance across draft/publish clones.
+       * Prefer this over `id` for Content API round-trips when Draft & Publish is enabled.
+       */
+      componentKey?: string;
+    },
+    Pick<AttributeValues<TComponentUID>, TComponentKeys>,
+  ]
+>;
 
 /**
  * @internal

--- a/packages/core/utils/src/__tests__/content-types.test.ts
+++ b/packages/core/utils/src/__tests__/content-types.test.ts
@@ -71,6 +71,7 @@ describe('Content types utils', () => {
       expect(getNonWritableAttributes(model)).toEqual([
         'id',
         'documentId',
+        'componentKey',
         'createdAt',
         'updatedAt',
         'non_writable_field',

--- a/packages/core/utils/src/content-types.ts
+++ b/packages/core/utils/src/content-types.ts
@@ -15,6 +15,7 @@ const COLLECTION_TYPE = 'collectionType';
 
 const ID_ATTRIBUTE = 'id';
 const DOC_ID_ATTRIBUTE = 'documentId';
+const COMPONENT_KEY_ATTRIBUTE = 'componentKey';
 
 const PUBLISHED_AT_ATTRIBUTE = 'publishedAt';
 const FIRST_PUBLISHED_AT_ATTRIBUTE = 'firstPublishedAt';
@@ -27,6 +28,7 @@ const UPDATED_AT_ATTRIBUTE = 'updatedAt';
 const constants = {
   ID_ATTRIBUTE,
   DOC_ID_ATTRIBUTE,
+  COMPONENT_KEY_ATTRIBUTE,
   PUBLISHED_AT_ATTRIBUTE,
   FIRST_PUBLISHED_AT_ATTRIBUTE,
   CREATED_BY_ATTRIBUTE,
@@ -38,7 +40,7 @@ const constants = {
 };
 
 /** ID-like fields accepted at root level and on relations/media/components (validate/sanitize traversal). */
-const ID_FIELDS: string[] = [ID_ATTRIBUTE, DOC_ID_ATTRIBUTE];
+const ID_FIELDS: string[] = [ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, COMPONENT_KEY_ATTRIBUTE];
 /** Keys accepted on morphTo relation payloads (e.g. __type). */
 const MORPH_TO_KEYS: string[] = ['__type'];
 /** Keys accepted on dynamic zone component payloads (e.g. __component). */
@@ -55,6 +57,7 @@ const RESERVED_ATTRIBUTE_NAMES: string[] = [
   // ID fields
   'id',
   'document_id',
+  'component_key',
 
   // Creator fields
   'created_at',
@@ -209,6 +212,7 @@ const getNonWritableAttributes = (model: Model) => {
   return _.uniq([
     ID_ATTRIBUTE,
     DOC_ID_ATTRIBUTE,
+    COMPONENT_KEY_ATTRIBUTE,
     ...getTimestamps(model),
     ...nonWritableAttributes,
   ]);

--- a/packages/plugins/i18n/server/src/services/__tests__/content-types.test.ts
+++ b/packages/plugins/i18n/server/src/services/__tests__/content-types.test.ts
@@ -342,6 +342,45 @@ describe('content-types service', () => {
         },
       });
     });
+
+    test('Removes componentKey from components and dynamic zones', () => {
+      const compoModel = {
+        attributes: {
+          name: { type: 'string' },
+        },
+      };
+
+      global.strapi = {
+        components: {
+          compo: compoModel,
+        },
+      } as any;
+
+      const model = {
+        attributes: {
+          component: {
+            type: 'component',
+            repeatable: true,
+            component: 'compo',
+          },
+          dz: {
+            type: 'dynamiczone',
+            components: ['compo'],
+          },
+        },
+      };
+
+      const input = {
+        component: [{ id: 2, componentKey: 'key-a', name: 'Hello' }],
+        dz: [{ id: 3, componentKey: 'key-b', __component: 'compo', name: 'World' }],
+      };
+
+      const result = copyNonLocalizedAttributes(model, input);
+      expect(result).toEqual({
+        component: [{ name: 'Hello' }],
+        dz: [{ __component: 'compo', name: 'World' }],
+      });
+    });
   });
 
   describe('fillNonLocalizedAttributes', () => {

--- a/packages/plugins/i18n/server/src/services/content-types.ts
+++ b/packages/plugins/i18n/server/src/services/content-types.ts
@@ -10,6 +10,7 @@ const {
   getScalarAttributes,
   getRelationalAttributes,
 } = contentTypeUtils;
+const { COMPONENT_KEY_ATTRIBUTE } = contentTypeUtils.constants;
 const { ApplicationError } = errors;
 
 const hasLocalizedOption = (modelOrAttribute: any) => {
@@ -64,9 +65,16 @@ const getNonLocalizedAttributes = (model: any) => {
   );
 };
 
-const removeId = (value: any) => {
+const removeIdentifiers = (value: any) => {
   if (typeof value === 'object' && has('id', value)) {
     delete value.id;
+  }
+
+  // componentKey identifies a single component row on a single entry. Copies made for
+  // another locale must get their own key, otherwise the document service resolves the
+  // copied key against the target entry's components and fails to find a match.
+  if (typeof value === 'object' && has(COMPONENT_KEY_ATTRIBUTE, value)) {
+    delete value[COMPONENT_KEY_ATTRIBUTE];
   }
 };
 
@@ -77,7 +85,7 @@ const removeIdsMut = (model: any, entry: any): Record<string, any> => {
     return entry as unknown as Record<string, any>;
   }
 
-  removeId(entry);
+  removeIdentifiers(entry);
 
   _.forEach(model.attributes, (attr, attrName) => {
     const value = entry[attrName];

--- a/tests/api/core/content-type-builder/collection-type.test.api.js
+++ b/tests/api/core/content-type-builder/collection-type.test.api.js
@@ -233,7 +233,7 @@ describe('Content Type Builder - Content types', () => {
               errors: [
                 {
                   message:
-                    'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
+                    'Attribute keys cannot be one of id, document_id, component_key, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
                   name: 'ValidationError',
                   path: ['contentType', 'attributes', prefix],
                   value: {

--- a/tests/api/core/strapi/document-service/component-key.test.api.ts
+++ b/tests/api/core/strapi/document-service/component-key.test.api.ts
@@ -1,0 +1,160 @@
+'use strict';
+
+/**
+ * Draft coverage for durable componentKey across Draft & Publish.
+ * @see docs/docs/rfcs/03-component-key.md
+ */
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+
+let strapi;
+
+const component = {
+  displayName: 'key-compo',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+};
+
+const ct = {
+  displayName: 'with-key-compo',
+  singularName: 'with-key-compo',
+  pluralName: 'with-key-compos',
+  draftAndPublish: true,
+  attributes: {
+    title: {
+      type: 'string',
+    },
+    blocks: {
+      type: 'component',
+      component: 'default.key-compo',
+      repeatable: true,
+    },
+  },
+};
+
+describe('Document Service — componentKey', () => {
+  beforeAll(async () => {
+    await builder.addComponent(component).addContentType(ct).build();
+
+    strapi = await createStrapiInstance();
+    // Auth request kept for follow-up REST / Content Manager cases
+    await createAuthRequest({ strapi });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('assigns componentKey on create and preserves it across publish', async () => {
+    const created = await strapi.documents('api::with-key-compo.with-key-compo').create({
+      data: {
+        title: 'hello',
+        blocks: [{ name: 'a' }, { name: 'b' }],
+      },
+      populate: ['blocks'],
+    });
+
+    expect(created.blocks).toHaveLength(2);
+    expect(created.blocks[0].componentKey).toEqual(expect.any(String));
+    expect(created.blocks[1].componentKey).toEqual(expect.any(String));
+    expect(created.blocks[0].componentKey).not.toBe(created.blocks[1].componentKey);
+
+    const draftKeys = created.blocks.map((b) => b.componentKey);
+
+    await strapi.documents('api::with-key-compo.with-key-compo').publish({
+      documentId: created.documentId,
+    });
+
+    const published = await strapi.documents('api::with-key-compo.with-key-compo').findOne({
+      documentId: created.documentId,
+      status: 'published',
+      populate: ['blocks'],
+    });
+
+    expect(published.blocks.map((b) => b.componentKey).sort()).toEqual([...draftKeys].sort());
+    // Row ids differ across status even when keys match
+    const publishedByKey = Object.fromEntries(published.blocks.map((b) => [b.componentKey, b.id]));
+    const draftByKey = Object.fromEntries(created.blocks.map((b) => [b.componentKey, b.id]));
+    for (const key of draftKeys) {
+      expect(publishedByKey[key]).toBeDefined();
+      expect(publishedByKey[key]).not.toBe(draftByKey[key]);
+    }
+  });
+
+  test('updates draft by componentKey from published response', async () => {
+    const created = await strapi.documents('api::with-key-compo.with-key-compo').create({
+      data: {
+        title: 'round-trip',
+        blocks: [{ name: 'one' }, { name: 'two' }],
+      },
+      populate: ['blocks'],
+    });
+
+    await strapi.documents('api::with-key-compo.with-key-compo').publish({
+      documentId: created.documentId,
+    });
+
+    const published = await strapi.documents('api::with-key-compo.with-key-compo').findOne({
+      documentId: created.documentId,
+      status: 'published',
+      populate: ['blocks'],
+    });
+
+    const targetKey = published.blocks[0].componentKey;
+
+    const updated = await strapi.documents('api::with-key-compo.with-key-compo').update({
+      documentId: created.documentId,
+      data: {
+        blocks: [
+          { componentKey: targetKey, name: 'one-updated' },
+          { componentKey: published.blocks[1].componentKey, name: 'two' },
+        ],
+      },
+      populate: ['blocks'],
+    });
+
+    const updatedBlock = updated.blocks.find((b) => b.componentKey === targetKey);
+    expect(updatedBlock.name).toBe('one-updated');
+
+    // Published unchanged until next publish
+    const stillPublished = await strapi.documents('api::with-key-compo.with-key-compo').findOne({
+      documentId: created.documentId,
+      status: 'published',
+      populate: ['blocks'],
+    });
+    expect(stillPublished.blocks.find((b) => b.componentKey === targetKey).name).toBe('one');
+  });
+
+  test('omit-id full replace still works (non-breaking)', async () => {
+    const created = await strapi.documents('api::with-key-compo.with-key-compo').create({
+      data: {
+        title: 'replace',
+        blocks: [{ name: 'old' }],
+      },
+      populate: ['blocks'],
+    });
+
+    const updated = await strapi.documents('api::with-key-compo.with-key-compo').update({
+      documentId: created.documentId,
+      data: {
+        blocks: [{ name: 'new-a' }, { name: 'new-b' }],
+      },
+      populate: ['blocks'],
+    });
+
+    expect(updated.blocks).toHaveLength(2);
+    expect(updated.blocks.map((b) => b.name).sort()).toEqual(['new-a', 'new-b']);
+    expect(updated.blocks.every((b) => typeof b.componentKey === 'string')).toBe(true);
+  });
+
+  test.todo('REST Content API GET published → PUT with componentKey');
+  test.todo('unknown componentKey returns 400');
+});

--- a/tests/api/core/strapi/document-service/component-key.test.api.ts
+++ b/tests/api/core/strapi/document-service/component-key.test.api.ts
@@ -1,22 +1,46 @@
 'use strict';
 
 /**
- * Draft coverage for durable componentKey across Draft & Publish.
+ * Durable componentKey across Draft & Publish.
  * @see docs/docs/rfcs/03-component-key.md
  */
 
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
-const { createAuthRequest } = require('api-tests/request');
+const { createAuthRequest, createContentAPIRequest } = require('api-tests/request');
 
 const builder = createTestBuilder();
 
 let strapi;
+let rq;
+
+const nestedComponent = {
+  displayName: 'key-nested',
+  attributes: {
+    label: {
+      type: 'string',
+    },
+  },
+};
 
 const component = {
   displayName: 'key-compo',
   attributes: {
     name: {
+      type: 'string',
+    },
+    nested: {
+      type: 'component',
+      component: 'default.key-nested',
+      repeatable: false,
+    },
+  },
+};
+
+const dzComponent = {
+  displayName: 'key-dz',
+  attributes: {
+    heading: {
       type: 'string',
     },
   },
@@ -36,16 +60,36 @@ const ct = {
       component: 'default.key-compo',
       repeatable: true,
     },
+    zones: {
+      type: 'dynamiczone',
+      components: ['default.key-dz', 'default.key-compo'],
+    },
+  },
+};
+
+const UID = 'api::with-key-compo.with-key-compo';
+const populate = {
+  blocks: { populate: ['nested'] },
+  zones: {
+    on: {
+      'default.key-dz': true,
+      'default.key-compo': { populate: ['nested'] },
+    },
   },
 };
 
 describe('Document Service — componentKey', () => {
   beforeAll(async () => {
-    await builder.addComponent(component).addContentType(ct).build();
+    await builder
+      .addComponent(nestedComponent)
+      .addComponent(component)
+      .addComponent(dzComponent)
+      .addContentType(ct)
+      .build();
 
     strapi = await createStrapiInstance();
-    // Auth request kept for follow-up REST / Content Manager cases
     await createAuthRequest({ strapi });
+    rq = await createContentAPIRequest({ strapi });
   });
 
   afterAll(async () => {
@@ -54,7 +98,7 @@ describe('Document Service — componentKey', () => {
   });
 
   test('assigns componentKey on create and preserves it across publish', async () => {
-    const created = await strapi.documents('api::with-key-compo.with-key-compo').create({
+    const created = await strapi.documents(UID).create({
       data: {
         title: 'hello',
         blocks: [{ name: 'a' }, { name: 'b' }],
@@ -69,11 +113,11 @@ describe('Document Service — componentKey', () => {
 
     const draftKeys = created.blocks.map((b) => b.componentKey);
 
-    await strapi.documents('api::with-key-compo.with-key-compo').publish({
+    await strapi.documents(UID).publish({
       documentId: created.documentId,
     });
 
-    const published = await strapi.documents('api::with-key-compo.with-key-compo').findOne({
+    const published = await strapi.documents(UID).findOne({
       documentId: created.documentId,
       status: 'published',
       populate: ['blocks'],
@@ -89,8 +133,83 @@ describe('Document Service — componentKey', () => {
     }
   });
 
+  test('preserves componentKey across discardDraft', async () => {
+    const created = await strapi.documents(UID).create({
+      data: {
+        title: 'discard',
+        blocks: [{ name: 'keep-me' }],
+      },
+      populate: ['blocks'],
+    });
+
+    await strapi.documents(UID).publish({ documentId: created.documentId });
+
+    const published = await strapi.documents(UID).findOne({
+      documentId: created.documentId,
+      status: 'published',
+      populate: ['blocks'],
+    });
+    const publishedKey = published.blocks[0].componentKey;
+
+    // Mutate draft so discard has something to restore from published
+    await strapi.documents(UID).update({
+      documentId: created.documentId,
+      data: {
+        blocks: [{ componentKey: publishedKey, name: 'draft-only' }],
+      },
+    });
+
+    await strapi.documents(UID).discardDraft({ documentId: created.documentId });
+
+    const draft = await strapi.documents(UID).findOne({
+      documentId: created.documentId,
+      status: 'draft',
+      populate: ['blocks'],
+    });
+
+    expect(draft.blocks[0].componentKey).toBe(publishedKey);
+    expect(draft.blocks[0].name).toBe('keep-me');
+  });
+
+  test('clone mints new componentKeys (does not copy source keys)', async () => {
+    const created = await strapi.documents(UID).create({
+      data: {
+        title: 'clone-source',
+        blocks: [{ name: 'a', nested: { label: 'n' } }],
+        zones: [
+          { __component: 'default.key-dz', heading: 'z1' },
+          { __component: 'default.key-compo', name: 'z2' },
+        ],
+      },
+      populate,
+    });
+
+    const sourceBlockKey = created.blocks[0].componentKey;
+    const sourceNestedKey = created.blocks[0].nested.componentKey;
+    const sourceZoneKeys = created.zones.map((z) => z.componentKey);
+
+    const { entries } = await strapi.documents(UID).clone({
+      documentId: created.documentId,
+      populate,
+    });
+
+    expect(entries).toHaveLength(1);
+    const cloned = entries[0];
+
+    expect(cloned.blocks[0].componentKey).toEqual(expect.any(String));
+    expect(cloned.blocks[0].componentKey).not.toBe(sourceBlockKey);
+    expect(cloned.blocks[0].nested.componentKey).toEqual(expect.any(String));
+    expect(cloned.blocks[0].nested.componentKey).not.toBe(sourceNestedKey);
+
+    expect(cloned.zones).toHaveLength(2);
+    cloned.zones.forEach((zone, i) => {
+      expect(zone.componentKey).toEqual(expect.any(String));
+      expect(zone.componentKey).not.toBe(sourceZoneKeys[i]);
+    });
+  });
+
   test('updates draft by componentKey from published response', async () => {
-    const created = await strapi.documents('api::with-key-compo.with-key-compo').create({
+    const created = await strapi.documents(UID).create({
       data: {
         title: 'round-trip',
         blocks: [{ name: 'one' }, { name: 'two' }],
@@ -98,11 +217,11 @@ describe('Document Service — componentKey', () => {
       populate: ['blocks'],
     });
 
-    await strapi.documents('api::with-key-compo.with-key-compo').publish({
+    await strapi.documents(UID).publish({
       documentId: created.documentId,
     });
 
-    const published = await strapi.documents('api::with-key-compo.with-key-compo').findOne({
+    const published = await strapi.documents(UID).findOne({
       documentId: created.documentId,
       status: 'published',
       populate: ['blocks'],
@@ -110,7 +229,7 @@ describe('Document Service — componentKey', () => {
 
     const targetKey = published.blocks[0].componentKey;
 
-    const updated = await strapi.documents('api::with-key-compo.with-key-compo').update({
+    const updated = await strapi.documents(UID).update({
       documentId: created.documentId,
       data: {
         blocks: [
@@ -125,7 +244,7 @@ describe('Document Service — componentKey', () => {
     expect(updatedBlock.name).toBe('one-updated');
 
     // Published unchanged until next publish
-    const stillPublished = await strapi.documents('api::with-key-compo.with-key-compo').findOne({
+    const stillPublished = await strapi.documents(UID).findOne({
       documentId: created.documentId,
       status: 'published',
       populate: ['blocks'],
@@ -134,7 +253,7 @@ describe('Document Service — componentKey', () => {
   });
 
   test('omit-id full replace still works (non-breaking)', async () => {
-    const created = await strapi.documents('api::with-key-compo.with-key-compo').create({
+    const created = await strapi.documents(UID).create({
       data: {
         title: 'replace',
         blocks: [{ name: 'old' }],
@@ -142,7 +261,7 @@ describe('Document Service — componentKey', () => {
       populate: ['blocks'],
     });
 
-    const updated = await strapi.documents('api::with-key-compo.with-key-compo').update({
+    const updated = await strapi.documents(UID).update({
       documentId: created.documentId,
       data: {
         blocks: [{ name: 'new-a' }, { name: 'new-b' }],
@@ -155,6 +274,159 @@ describe('Document Service — componentKey', () => {
     expect(updated.blocks.every((b) => typeof b.componentKey === 'string')).toBe(true);
   });
 
-  test.todo('REST Content API GET published → PUT with componentKey');
-  test.todo('unknown componentKey returns 400');
+  test('unknown componentKey throws ApplicationError', async () => {
+    const created = await strapi.documents(UID).create({
+      data: {
+        title: 'unknown-key',
+        blocks: [{ name: 'only' }],
+      },
+      populate: ['blocks'],
+    });
+
+    await expect(
+      strapi.documents(UID).update({
+        documentId: created.documentId,
+        data: {
+          blocks: [{ componentKey: 'does-not-exist-on-this-entity', name: 'nope' }],
+        },
+      })
+    ).rejects.toMatchObject({
+      name: 'ApplicationError',
+      message: 'Some of the provided components in blocks are not related to the entity',
+    });
+  });
+
+  test('nested component and dynamic zone keys round-trip on update', async () => {
+    const created = await strapi.documents(UID).create({
+      data: {
+        title: 'nested-dz',
+        blocks: [{ name: 'outer', nested: { label: 'inner' } }],
+        zones: [
+          { __component: 'default.key-dz', heading: 'first' },
+          { __component: 'default.key-compo', name: 'second', nested: { label: 'dz-nested' } },
+        ],
+      },
+      populate,
+    });
+
+    const blockKey = created.blocks[0].componentKey;
+    const nestedKey = created.blocks[0].nested.componentKey;
+    const dzKey = created.zones[0].componentKey;
+    const dzCompoKey = created.zones[1].componentKey;
+    const dzNestedKey = created.zones[1].nested.componentKey;
+
+    await strapi.documents(UID).publish({ documentId: created.documentId });
+
+    const updated = await strapi.documents(UID).update({
+      documentId: created.documentId,
+      data: {
+        blocks: [
+          {
+            componentKey: blockKey,
+            name: 'outer-updated',
+            nested: { componentKey: nestedKey, label: 'inner-updated' },
+          },
+        ],
+        zones: [
+          { __component: 'default.key-dz', componentKey: dzKey, heading: 'first-updated' },
+          {
+            __component: 'default.key-compo',
+            componentKey: dzCompoKey,
+            name: 'second-updated',
+            nested: { componentKey: dzNestedKey, label: 'dz-nested-updated' },
+          },
+        ],
+      },
+      populate,
+    });
+
+    expect(updated.blocks[0].componentKey).toBe(blockKey);
+    expect(updated.blocks[0].name).toBe('outer-updated');
+    expect(updated.blocks[0].nested.componentKey).toBe(nestedKey);
+    expect(updated.blocks[0].nested.label).toBe('inner-updated');
+
+    expect(updated.zones[0].componentKey).toBe(dzKey);
+    expect(updated.zones[0].heading).toBe('first-updated');
+    expect(updated.zones[1].componentKey).toBe(dzCompoKey);
+    expect(updated.zones[1].name).toBe('second-updated');
+    expect(updated.zones[1].nested.componentKey).toBe(dzNestedKey);
+    expect(updated.zones[1].nested.label).toBe('dz-nested-updated');
+  });
+
+  describe('REST Content API', () => {
+    test('GET published → PUT with componentKey updates the entry', async () => {
+      const created = await strapi.documents(UID).create({
+        data: {
+          title: 'rest-round-trip',
+          blocks: [{ name: 'alpha' }, { name: 'beta' }],
+        },
+        populate: ['blocks'],
+      });
+
+      await strapi.documents(UID).publish({ documentId: created.documentId });
+
+      const {
+        statusCode: getStatus,
+        body: { data: published },
+      } = await rq({
+        method: 'GET',
+        url: `/with-key-compos/${created.documentId}`,
+        qs: { populate: ['blocks'] },
+      });
+
+      expect(getStatus).toBe(200);
+      expect(published.blocks[0].componentKey).toEqual(expect.any(String));
+
+      const targetKey = published.blocks[0].componentKey;
+
+      const { statusCode: putStatus, body: putBody } = await rq({
+        method: 'PUT',
+        url: `/with-key-compos/${created.documentId}`,
+        body: {
+          data: {
+            title: 'rest-round-trip',
+            blocks: [
+              { componentKey: targetKey, name: 'alpha-updated' },
+              { componentKey: published.blocks[1].componentKey, name: 'beta' },
+            ],
+          },
+        },
+        qs: { populate: ['blocks'] },
+      });
+
+      expect(putStatus).toBe(200);
+      expect(putBody.data.blocks.find((b) => b.componentKey === targetKey).name).toBe(
+        'alpha-updated'
+      );
+    });
+
+    test('unknown componentKey returns 400', async () => {
+      const created = await strapi.documents(UID).create({
+        data: {
+          title: 'rest-unknown',
+          blocks: [{ name: 'only' }],
+        },
+        populate: ['blocks'],
+      });
+
+      await strapi.documents(UID).publish({ documentId: created.documentId });
+
+      const { statusCode, body } = await rq({
+        method: 'PUT',
+        url: `/with-key-compos/${created.documentId}`,
+        body: {
+          data: {
+            blocks: [{ componentKey: 'foreign-or-unknown-key', name: 'nope' }],
+          },
+        },
+        qs: { populate: ['blocks'] },
+      });
+
+      expect(statusCode).toBe(400);
+      expect(body.error).toMatchObject({
+        name: 'ApplicationError',
+        message: 'Some of the provided components in blocks are not related to the entity',
+      });
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9415,6 +9415,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/data-transfer@workspace:packages/core/data-transfer"
   dependencies:
+    "@paralleldrive/cuid2": "npm:2.2.2"
     "@strapi/database": "npm:5.51.1"
     "@strapi/logger": "npm:5.51.1"
     "@strapi/types": "npm:5.51.1"


### PR DESCRIPTION
### What does it do?

Draft implementation of a durable **`componentKey`** on nested components so Content API clients can round-trip updates under Draft & Publish without relying on status-local numeric `id`s.

- **Non-breaking:** omit-`id` full-array replace still works; draft-`id` updates (Content Manager) still work.
- **Honest identity:** no silent published→draft `id` remapping.
- **RFC:** [`docs/docs/rfcs/03-component-key.md`](https://github.com/strapi/strapi/blob/feat/component-key/docs/docs/rfcs/03-component-key.md)

| Area | Change |
|------|--------|
| Schema | System `componentKey` on component models (`transform-content-types-to-models`) |
| Create / publish / discard | Mint key on create; **preserve** on publish/discard |
| Document clone | Strip source keys so clones mint **new** `componentKey`s |
| Update | Resolve `componentKey` → row `id` on the parent being updated (fail closed) |
| Validation | `componentKey` in `ID_FIELDS` + reserved `component_key` |
| Migration | `5.0.0-07-component-key` adds column + backfills unique keys per row |
| i18n | Strip `componentKey` (with `id`) in `copyNonLocalizedAttributes` so locale sync recreates component rows |
| data-transfer | `createComponent` preserves/mints `componentKey` (parity with document-service) |
| Tests | Document service + REST Content API (round-trip, unknown-key 400, nested, DZ, clone, discard) |
| Types | `Data.Component` includes optional `componentKey` |

### Why is it needed?

Under Draft & Publish, component numeric `id`s are row-local (draft vs published differ). Content API clients that GET a published document and PUT the same payload against draft cannot reliably update nested components by `id`. That led to the documented “do not update repeatable components with the Document Service API” workaround (closed as by-design in #22680).

`componentKey` is a durable identity shared across draft/published clones so clients can round-trip updates without silent remapping.

### How to test it?

- [x] CI API shards green (CE + EE) after i18n strip + CTB reserved-name assertion
- [x] `yarn test:api -- component-key.test.api.ts` (9/9: create/publish/discard/clone/REST/unknown-key/nested+DZ)
- [x] Manual-equivalent: create → publish → GET published → update via `componentKey` → published unchanged until re-publish
- [x] Omit-id full replace still recreates components
- [ ] Upgrade path: existing app boots, component tables gain `component_key`, backfill non-null

### Stacked follow-up PRs

- [x] GraphQL + OpenAPI surfacing → https://github.com/strapi/strapi/pull/27192
- [x] Best-effort twinning migration for existing draft/published pairs → https://github.com/strapi/strapi/pull/27206
- [ ] Public docs once behavior is solid; retire “not recommended” guidance
- [ ] Linear ticket + milestone

### Related issue(s)/PR(s)

- Docs (breaking change / workaround): https://docs.strapi.io/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api
- Closed as by-design: #22680
- Interim docs workaround (draft): https://github.com/strapi/documentation/pull/3345
- GraphQL/OpenAPI (stacked): #27192
- Twinning migration (stacked): #27206
