### PR TITLE
chore(tests): speed up many-relations API suite setup

### DIFF
--- a/tests/api/core/content-manager/api/many-relations-update.test.api.js
+++ b/tests/api/core/content-manager/api/many-relations-update.test.api.js
@@ -6,6 +6,10 @@
  * Ensures create + publish succeed on all databases. On SQLite, batching keeps
  * join-table inserts ≤500 rows to avoid "too many terms in compound SELECT".
  *
+ * Member setup uses db.createMany (not N sequential CM HTTP creates) so MySQL CI
+ * stays under the per-test budget — the assertions still exercise CM update /
+ * publish / attachRelations at 550 links.
+ *
  * @see https://github.com/strapi/strapi/issues/25198
  */
 
@@ -77,21 +81,23 @@ const createOwnerWithMembers = async (name, memberDocumentIds) => {
   });
 };
 
+/**
+ * Bulk-create members for relation payload setup.
+ * Avoids hundreds of sequential CM HTTP round-trips (primary cause of MySQL
+ * 120s timeouts on this suite).
+ */
 const createMembers = async (count, namePrefix = 'member') => {
-  const documentIds = [];
-  for (let i = 0; i < count; i += 1) {
-    const res = await rq({
-      method: 'POST',
-      url: `/content-manager/collection-types/${UID_MEMBER}`,
-      body: { name: `${namePrefix}-${i}` },
-    });
-    expect(res.statusCode).toBe(201);
-    expect(res.body.data).toBeDefined();
-    const member = res.body.data;
-    documentIds.push(member.documentId);
-    data.members.push(member);
-  }
-  return documentIds;
+  const rows = Array.from({ length: count }, (_, i) => ({
+    documentId: `${namePrefix}-${i}`,
+    name: `${namePrefix}-${i}`,
+  }));
+
+  const res = await strapi.db.query(UID_MEMBER).createMany({ data: rows });
+  expect(res.count).toBe(count);
+  expect(res.ids).toHaveLength(count);
+
+  data.members.push(...rows);
+  return rows.map((row) => row.documentId);
 };
 
 describe('CM API - Many relations update (GH#25198)', () => {
@@ -145,7 +151,7 @@ describe('CM API - Many relations update (GH#25198)', () => {
   );
 
   /**
-   * Update (PUT) an entry with 550 relations exercises updateRelations + batched join-table insert.
+   * Update (PUT) an entry with 550 relations exercises updateRelations + dialect join-table insert.
    * On SQLite, batching keeps each batch ≤500 (GH#25198).
    */
   test('Update entry with 550 relations', async () => {


### PR DESCRIPTION
## Summary

- Fixes flaky `[EE] API Integration` MySQL timeouts on `many-relations-update.test.api.js` (seen on #27069 job [88574849741](https://github.com/strapi/strapi/actions/runs/29811545283/job/88574849741)): two tests hit Jest’s **120s** wall clock while creating 550 members via sequential CM HTTP POSTs.
- Same shard passed on Node 24/26; failure mode is slow setup, not wrong assertions.
- Replace member setup with `strapi.db.query(...).createMany` (keep 550-link CM update / publish / `attachRelations` contracts). **Do not** raise timeouts.
- Local SQLite: suite **~15s**, 4/4 pass (was **~393s** with 2 failures in CI).

### What does it do?

Speeds up GH#25198 many-relations API suite member fixture setup via `createMany` instead of N sequential Content Manager HTTP creates.

### Why is it needed?

MySQL CI intermittently exceeds the 120s per-test timeout on Update/attachRelations cases; raising the timeout would hide the cost. Setup was the bottleneck.

### How to test it?

```bash
yarn test:api --db=sqlite -- tests/api/core/content-manager/api/many-relations-update.test.api.js
```

Confirm three consecutive full Tests CI greens on the same commit.

### Related issue(s)/PR(s)

* Fixes CMS-1495
- Flake observed on https://github.com/strapi/strapi/pull/27069 (unrelated vitest migration; already merged)
- https://github.com/strapi/strapi/issues/25198 (original coverage)
