### PR TITLE
fix(create-strapi-app): missing @strapi/database dependency breaks pnpm builds

### DIFF
--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -167,6 +167,7 @@ async function run(args: string[]): Promise<void> {
     devDependencies: {},
     dependencies: {
       '@strapi/strapi': version,
+      '@strapi/database': version,
       '@strapi/plugin-users-permissions': version,
       '@strapi/plugin-cloud': version,
       // third party

--- a/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
+++ b/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
@@ -136,6 +136,8 @@ describe('create-strapi-app', () => {
       expect(fs.existsSync(path.join(projectDir, '.npmrc'))).toBe(false);
 
       const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), 'utf8'));
+      // Templates import @strapi/database directly; must be a direct dep for pnpm (#26949)
+      expect(pkg.dependencies['@strapi/database']).toBe(pkg.dependencies['@strapi/strapi']);
       // Align with @strapi/* peer ranges so strict npm peer resolution succeeds
       expect(pkg.dependencies['react-router-dom']).toBe('^6.30.3');
       expect(pkg.dependencies.react).toBe('^18.0.0');


### PR DESCRIPTION
### What does it do?

Adds `@strapi/database` to the generated app `dependencies` in `create-strapi-app` (same version as `@strapi/strapi`), and asserts that in the scaffold CLI test.

### Why is it needed?

After #26949, CSA templates import `isDatabaseClientKind` from `@strapi/database`, but the package was never added as a direct dependency of the generated app. Yarn/npm hoisting often masks this; pnpm does not, so `strapi build` fails with:

```text
TS2307: Cannot find module '@strapi/database'
```

in `config/database.ts`. Confirmed on experimental `0.0.0-experimental.936bdef…` (pnpm fail, yarn pass) vs release `5.50.2` (both pass). Adding `@strapi/database@$TAG` to a broken app restores the build.

### How to test it?

1. From this branch (or a `publish-experimental` tag of it):
   ```bash
   npx create-strapi-app@… test-app --quickstart --no-run --skip-cloud --typescript --use-pnpm
   cd test-app && pnpm run build
   ```
2. Expect build to succeed without `TS2307` for `@strapi/database`.
3. Optional: `yarn test:cli --domains create-strapi-app` — scaffold test asserts `@strapi/database` matches `@strapi/strapi` in generated `package.json`.

### Related issue(s)/PR(s)

- Regression from #26949
- Targets `releases/5.51.0`