### PR TITLE
fix(admin): blank admin in develop from prism language prebundle

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/CodeDecoratePrism.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/CodeDecoratePrism.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Regression: #25070 / #26964 — admin can blank-crash when `prismjs` is bundled so `import *` has no
  * top-level `.languages` and language plugins expect `Prism` global — `decorateCode` must resolve
- * Prism from `window` / bail safely (PR #25660). Vite must also pre-bundle `prismjs/components/*.js`
- * for all apps, not only monorepo examples (#26964).
+ * Prism from `window` / bail safely (PR #25660). Keep `prismjs` in Vite `optimizeDeps.include`;
+ * do not include `prismjs/components/*.js` (that language glob causes the blank-admin crash).
  *
  * This file mocks `prismjs` like Vite’s prebundle and clears `window.Prism`; **`develop` without
  * the fix throws**; **fix branch passes**. Ship with the `Code.tsx` change.

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/CodeDecoratePrism.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/CodeDecoratePrism.test.tsx
@@ -4,8 +4,7 @@
  * Prism from `window` / bail safely (PR #25660). Keep `prismjs` in Vite `optimizeDeps.include`;
  * do not include `prismjs/components/*.js` (that language glob causes the blank-admin crash).
  *
- * This file mocks `prismjs` like Vite’s prebundle and clears `window.Prism`; **`develop` without
- * the fix throws**; **fix branch passes**. Ship with the `Code.tsx` change.
+ * This file mocks `prismjs` like Vite’s prebundle and clears `window.Prism`.
  *
  * @see https://github.com/strapi/strapi/issues/25070
  */

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -76,10 +76,11 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
         'invariant',
         // UMD; without pre-bundling plugin chunks get empty namespace → "Prism is not defined" (#26964).
         'prismjs',
-        // Content-manager Blocks code editor side-effect-imports these; they expect global `Prism`.
-        // Must pre-bundle for all apps (not only monorepo examples) or fresh create-strapi-app
-        // projects blank-crash the admin (#25070, #26964).
-        'prismjs/components/*.js',
+        // Do NOT add `prismjs/components/*.js` to include. #26978 prebundled every language for
+        // all apps; combined with #27014's optimizeDeps contract, Vite evaluates those chunks in
+        // reverse import order so parents (e.g. basic before vbnet) load too late →
+        // `Cannot set properties of undefined (setting 'comment')` and a blank admin in develop.
+        // Keep `prismjs` only; let language components load as normal ESM side-effect imports.
         // CodeMirror must be a single instance across design-system, lang-json and uiw or the
         // JSON custom field crashes on instanceof checks. Pre-bundle for every build — dev and
         // production — not only monorepo examples. Use the resolvable subset so include stays in

--- a/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
+++ b/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
@@ -72,7 +72,7 @@ describe('resolveDevelopmentConfig (Vite admin dev)', () => {
     });
   });
 
-  it('pre-bundles prismjs language plugins for all apps (#26964)', async () => {
+  it('pre-bundles prismjs core but not language components (#26964 / blank-admin)', async () => {
     const mockHttpServer = http.createServer();
     const ctx = {
       cwd: process.cwd(),
@@ -100,7 +100,10 @@ describe('resolveDevelopmentConfig (Vite admin dev)', () => {
     const config = await resolveDevelopmentConfig(ctx);
     const include = config.optimizeDeps?.include ?? [];
 
-    expect(include).toEqual(expect.arrayContaining(['prismjs', 'prismjs/components/*.js']));
+    // Core stays prebundled (#26964). Language glob must stay out — #26978+#27014 reverse-order
+    // prebundle blanks the admin with TypeError setting 'comment'.
+    expect(include).toEqual(expect.arrayContaining(['prismjs']));
+    expect(include).not.toContain('prismjs/components/*.js');
 
     await new Promise<void>((resolve) => {
       mockHttpServer.close(() => resolve());


### PR DESCRIPTION
### What does it do?

Removes `prismjs/components/*.js` from Vite `optimizeDeps.include` while keeping `prismjs` itself prebundled. Language components load as normal ESM side-effect imports again. Unit test updated to assert the glob is not in `include`.

### Why is it needed?

strapi/strapi#26978 prebundled every Prism language for all apps so Blocks highlighting would not hit "Prism is not defined". After strapi/strapi#27014's optimizeDeps contract landed (merge of main into develop), Vite evaluates those prebundled language chunks in reverse import order, so parent languages (e.g. `basic`) load after children (e.g. `vbnet`) and throw `Cannot set properties of undefined (setting 'comment')` — blank admin on `strapi develop`.

Keeping only `prismjs` in `include` restores load order while still avoiding empty Prism namespaces in plugin chunks (strapi/strapi#26964).

### How to test it?

1. Unit: `cd packages/core/strapi && yarn test:unit --testPathPattern=resolve-development-config`
2. Consumer admin console: create-strapi-app (or existing app) on a build that includes strapi/strapi#26978+strapi/strapi#27014, run `yarn develop`, open admin login — page should render with no Prism `comment` TypeError in the browser console.
3. Optionally open a Blocks code block and confirm language highlighting still works (side-effect imports of language files).

### Related issue(s)/PR(s)

* Interaction of strapi/strapi#26978 and strapi/strapi#27014 (blank admin after merge)
* Related prior: strapi/strapi#26964 / strapi/strapi#25070 (Prism not defined — keep core prebundle)
* No Linear CMS ticket linked yet (Linear MCP unavailable at open time)