### PR TITLE
fix(strapi): prevent duplicate public assets in Vite builds

### DIFF
--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -32,6 +32,9 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
   return {
     root: ctx.cwd,
     base: ctx.basePath,
+    // Public files are served by the strapi::public middleware at runtime, so they do not need to
+    // be copied into the admin build output.
+    publicDir: false,
     build: {
       emptyOutDir: false, // Rely on CLI to do this
       outDir: ctx.distDir,

--- a/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
+++ b/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
@@ -1,7 +1,7 @@
 import http from 'node:http';
 
 import { ADMIN_VITE_SINGLETON_MODULES } from '../core/admin-vite-alias-modules';
-import { resolveDevelopmentConfig } from './config';
+import { resolveDevelopmentConfig, resolveProductionConfig } from './config';
 import type { BuildContext } from '../create-build-context';
 
 jest.mock('browserslist-to-esbuild', () => ({
@@ -9,7 +9,37 @@ jest.mock('browserslist-to-esbuild', () => ({
   default: jest.fn(() => ['chrome100']),
 }));
 
-describe('resolveDevelopmentConfig (Vite admin dev)', () => {
+describe('Vite admin configuration', () => {
+  it('does not copy public files into the admin build output', async () => {
+    const ctx = {
+      cwd: process.cwd(),
+      target: ['last 3 major versions'],
+      basePath: '/admin',
+      adminPath: '/admin',
+      distDir: 'dist/build',
+      appDir: process.cwd(),
+      entry: '.strapi/client/app.js',
+      distPath: `${process.cwd()}/dist/build`,
+      env: {},
+      runtimeDir: `${process.cwd()}/.strapi/client`,
+      logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn() },
+      strapi: { internal_config: {}, server: { httpServer: http.createServer() } },
+      bundler: 'vite' as const,
+      options: {
+        minify: true,
+        sourcemaps: false,
+      },
+      plugins: [],
+      tsconfig: undefined,
+      customisations: undefined,
+      features: undefined,
+    } as unknown as BuildContext;
+
+    const config = await resolveProductionConfig(ctx);
+
+    expect(config.publicDir).toBe(false);
+  });
+
   it('allows proxied hosts and pins HMR to the Strapi HTTP server without a separate clientPort (#23491)', async () => {
     const mockHttpServer = http.createServer();
     const ctx = {


### PR DESCRIPTION
Title: fix(strapi): prevent Vite from copying public files into admin builds

### What does it do?

Disables Vite's default `publicDir` handling for Strapi admin builds.

Strapi already serves the project's public files at runtime through the `strapi::public` middleware, so copying them into the admin build output is unnecessary.

This also adds a regression test to ensure production Vite builds keep `publicDir` disabled.

### Why is it needed?

I ran into this while deploying a Strapi v5 application that uses the local upload provider.

Vite copies the entire `public` directory into the admin build output by default. In my case, `public/uploads` contained a large amount of media, so every `strapi build` duplicated all uploaded files into the `build` directory. This made builds take a very long time, consumed additional disk space, and put unnecessary pressure on the server's storage.

The admin build only needs to generate the admin panel. Uploaded media and other public files should remain in `public` and continue to be served by `strapi::public` at runtime.

### How to test it?

1. Create or use a Strapi v5 project with the Vite bundler.
2. Add files to the project's `public` directory, for example `public/uploads`.
3. Run `yarn strapi build`.
4. Verify that the files are not copied into the admin build output.
5. Start Strapi and verify that the same files are still served correctly from the public directory.

### Related issue(s)/PR(s)

No existing issue found.

---
Fixes CPR-457