### PR TITLE
fix(database): return [] for empty morphMany on read

### DIFF
--- a/packages/core/database/src/query/helpers/populate/__tests__/apply-morph-many.test.ts
+++ b/packages/core/database/src/query/helpers/populate/__tests__/apply-morph-many.test.ts
@@ -5,18 +5,13 @@ import applyPopulate from '../apply';
  *
  * Empty collections must serialize as `[]`, matching oneToMany/manyToMany —
  * not `null` (issue #24927 symptom 2).
+ *
+ * Covers both morphX target branches (`morphToMany` join table and `morphToOne`
+ * inverse), including the `_.isEmpty(referencedValues)` early return.
  */
 
 jest.mock('../../transform', () => ({
-  fromRow: jest.fn((_meta: unknown, row: unknown) => {
-    if (row == null) {
-      return null;
-    }
-    if (Array.isArray(row)) {
-      return row;
-    }
-    return row;
-  }),
+  fromRow: jest.fn((_meta: unknown, row: unknown) => (row == null ? null : row)),
 }));
 
 const SOURCE_UID = 'api::article.article';
@@ -51,7 +46,26 @@ const buildTargetMorphToMany = () => ({
   },
 });
 
-const buildCtx = (joinRows: Record<string, unknown>[]) => {
+const buildTargetMorphToOne = () => ({
+  type: 'relation' as const,
+  relation: 'morphToOne' as const,
+  morphColumn: {
+    idColumn: {
+      name: 'related_id',
+      referencedColumn: 'id',
+    },
+    typeColumn: {
+      name: 'related_type',
+    },
+  },
+});
+
+type TargetBuilder = typeof buildTargetMorphToMany | typeof buildTargetMorphToOne;
+
+const buildCtx = (
+  joinRows: Record<string, unknown>[],
+  buildTarget: TargetBuilder = buildTargetMorphToMany
+) => {
   const mockQb = {
     alias: 't',
     getAlias: jest.fn().mockReturnValue('lnk'),
@@ -76,7 +90,7 @@ const buildCtx = (joinRows: Record<string, unknown>[]) => {
           return {
             columnToAttribute: {},
             attributes: {
-              related: buildTargetMorphToMany(),
+              related: buildTarget(),
             },
           };
         }
@@ -99,36 +113,83 @@ const buildCtx = (joinRows: Record<string, unknown>[]) => {
 };
 
 describe('morphMany populate', () => {
-  it('returns [] when an entry has no related morph rows (empty multiple media)', async () => {
-    const { ctx } = buildCtx([]);
+  describe('morphToMany target (e.g. upload media)', () => {
+    it('returns [] when an entry has no related morph rows (empty multiple media)', async () => {
+      const { ctx } = buildCtx([]);
 
-    const results: Record<string, unknown>[] = [{ id: 1 }];
+      const results: Record<string, unknown>[] = [{ id: 1 }];
 
-    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+      await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
 
-    expect(results[0][ATTRIBUTE_NAME]).toEqual([]);
+      expect(results[0][ATTRIBUTE_NAME]).toEqual([]);
+    });
+
+    it('returns [] when all results have nil ids (empty referencedValues early return)', async () => {
+      const { ctx, mockQb } = buildCtx([]);
+
+      const results: Record<string, unknown>[] = [{}];
+
+      await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+      expect(results[0][ATTRIBUTE_NAME]).toEqual([]);
+      expect(mockQb.execute).not.toHaveBeenCalled();
+    });
+
+    it('returns populated rows when morph links exist', async () => {
+      const fileRow = { id: 42, name: 'photo.jpg', related_id: 1, related_type: SOURCE_UID };
+      const { ctx } = buildCtx([fileRow]);
+
+      const results: Record<string, unknown>[] = [{ id: 1 }];
+
+      await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+      expect(results[0][ATTRIBUTE_NAME]).toEqual([fileRow]);
+    });
+
+    it('returns [] for entries without matches in a mixed result set', async () => {
+      const fileRow = { id: 42, name: 'photo.jpg', related_id: 1, related_type: SOURCE_UID };
+      const { ctx } = buildCtx([fileRow]);
+
+      const results: Record<string, unknown>[] = [{ id: 1 }, { id: 2 }];
+
+      await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+      expect(results[0][ATTRIBUTE_NAME]).toEqual([fileRow]);
+      expect(results[1][ATTRIBUTE_NAME]).toEqual([]);
+    });
   });
 
-  it('returns populated rows when morph links exist', async () => {
-    const fileRow = { id: 42, name: 'photo.jpg', related_id: 1, related_type: SOURCE_UID };
-    const { ctx } = buildCtx([fileRow]);
+  describe('morphToOne target', () => {
+    it('returns [] when an entry has no related morph rows', async () => {
+      const { ctx } = buildCtx([], buildTargetMorphToOne);
 
-    const results: Record<string, unknown>[] = [{ id: 1 }];
+      const results: Record<string, unknown>[] = [{ id: 1 }];
 
-    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+      await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
 
-    expect(results[0][ATTRIBUTE_NAME]).toEqual([fileRow]);
-  });
+      expect(results[0][ATTRIBUTE_NAME]).toEqual([]);
+    });
 
-  it('returns [] for entries without matches in a mixed result set', async () => {
-    const fileRow = { id: 42, name: 'photo.jpg', related_id: 1, related_type: SOURCE_UID };
-    const { ctx } = buildCtx([fileRow]);
+    it('returns [] when all results have nil ids (empty referencedValues early return)', async () => {
+      const { ctx, mockQb } = buildCtx([], buildTargetMorphToOne);
 
-    const results: Record<string, unknown>[] = [{ id: 1 }, { id: 2 }];
+      const results: Record<string, unknown>[] = [{}];
 
-    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+      await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
 
-    expect(results[0][ATTRIBUTE_NAME]).toEqual([fileRow]);
-    expect(results[1][ATTRIBUTE_NAME]).toEqual([]);
+      expect(results[0][ATTRIBUTE_NAME]).toEqual([]);
+      expect(mockQb.execute).not.toHaveBeenCalled();
+    });
+
+    it('returns populated rows when morph links exist', async () => {
+      const fileRow = { id: 42, name: 'photo.jpg', related_id: 1, related_type: SOURCE_UID };
+      const { ctx } = buildCtx([fileRow], buildTargetMorphToOne);
+
+      const results: Record<string, unknown>[] = [{ id: 1 }];
+
+      await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+      expect(results[0][ATTRIBUTE_NAME]).toEqual([fileRow]);
+    });
   });
 });

--- a/packages/core/database/src/query/helpers/populate/__tests__/apply-morph-many.test.ts
+++ b/packages/core/database/src/query/helpers/populate/__tests__/apply-morph-many.test.ts
@@ -1,0 +1,134 @@
+import applyPopulate from '../apply';
+
+/**
+ * morphMany populate (e.g. `type: 'media', multiple: true`).
+ *
+ * Empty collections must serialize as `[]`, matching oneToMany/manyToMany —
+ * not `null` (issue #24927 symptom 2).
+ */
+
+jest.mock('../../transform', () => ({
+  fromRow: jest.fn((_meta: unknown, row: unknown) => {
+    if (row == null) {
+      return null;
+    }
+    if (Array.isArray(row)) {
+      return row;
+    }
+    return row;
+  }),
+}));
+
+const SOURCE_UID = 'api::article.article';
+const TARGET_UID = 'plugin::upload.file';
+const ATTRIBUTE_NAME = 'gallery';
+
+const buildMorphManyAttribute = () => ({
+  type: 'relation' as const,
+  relation: 'morphMany' as const,
+  target: TARGET_UID,
+  morphBy: 'related',
+});
+
+const buildTargetMorphToMany = () => ({
+  type: 'relation' as const,
+  relation: 'morphToMany' as const,
+  joinTable: {
+    name: 'files_related_morphs',
+    joinColumn: {
+      name: 'file_id',
+      referencedColumn: 'id',
+    },
+    morphColumn: {
+      idColumn: {
+        name: 'related_id',
+        referencedColumn: 'id',
+      },
+      typeColumn: {
+        name: 'related_type',
+      },
+    },
+  },
+});
+
+const buildCtx = (joinRows: Record<string, unknown>[]) => {
+  const mockQb = {
+    alias: 't',
+    getAlias: jest.fn().mockReturnValue('lnk'),
+    init: jest.fn().mockReturnThis(),
+    join: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue(joinRows),
+  };
+
+  const db = {
+    metadata: {
+      get: jest.fn((type: string) => {
+        if (type === SOURCE_UID) {
+          return {
+            attributes: {
+              [ATTRIBUTE_NAME]: buildMorphManyAttribute(),
+            },
+          };
+        }
+        if (type === TARGET_UID) {
+          return {
+            columnToAttribute: {},
+            attributes: {
+              related: buildTargetMorphToMany(),
+            },
+          };
+        }
+        return { columnToAttribute: {}, attributes: {} };
+      }),
+    },
+    entityManager: {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+    },
+  };
+
+  return {
+    ctx: {
+      db,
+      uid: SOURCE_UID,
+      qb: { state: { filters: {} } },
+    },
+    mockQb,
+  };
+};
+
+describe('morphMany populate', () => {
+  it('returns [] when an entry has no related morph rows (empty multiple media)', async () => {
+    const { ctx } = buildCtx([]);
+
+    const results: Record<string, unknown>[] = [{ id: 1 }];
+
+    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+    expect(results[0][ATTRIBUTE_NAME]).toEqual([]);
+  });
+
+  it('returns populated rows when morph links exist', async () => {
+    const fileRow = { id: 42, name: 'photo.jpg', related_id: 1, related_type: SOURCE_UID };
+    const { ctx } = buildCtx([fileRow]);
+
+    const results: Record<string, unknown>[] = [{ id: 1 }];
+
+    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+    expect(results[0][ATTRIBUTE_NAME]).toEqual([fileRow]);
+  });
+
+  it('returns [] for entries without matches in a mixed result set', async () => {
+    const fileRow = { id: 42, name: 'photo.jpg', related_id: 1, related_type: SOURCE_UID };
+    const { ctx } = buildCtx([fileRow]);
+
+    const results: Record<string, unknown>[] = [{ id: 1 }, { id: 2 }];
+
+    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+    expect(results[0][ATTRIBUTE_NAME]).toEqual([fileRow]);
+    expect(results[1][ATTRIBUTE_NAME]).toEqual([]);
+  });
+});

--- a/packages/core/database/src/query/helpers/populate/apply.ts
+++ b/packages/core/database/src/query/helpers/populate/apply.ts
@@ -424,7 +424,7 @@ const morphX = async (
 
     if (_.isEmpty(referencedValues)) {
       results.forEach((result) => {
-        result[attributeName] = null;
+        result[attributeName] = attribute.relation === 'morphOne' ? null : [];
       });
 
       return;
@@ -442,8 +442,9 @@ const morphX = async (
     results.forEach((result) => {
       const matchingRows = map[result[idColumn.referencedColumn] as string];
 
+      // Match oneToMany/manyToMany: empty morphMany collections serialize as [], not null.
       const matchingValue =
-        attribute.relation === 'morphOne' ? _.first(matchingRows) : matchingRows;
+        attribute.relation === 'morphOne' ? _.first(matchingRows) : matchingRows || [];
 
       result[attributeName] = fromTargetRow(matchingValue);
     });
@@ -497,8 +498,9 @@ const morphX = async (
     results.forEach((result) => {
       const matchingRows = map[result[idColumn.referencedColumn] as string];
 
+      // Match oneToMany/manyToMany: empty morphMany collections serialize as [], not null.
       const matchingValue =
-        attribute.relation === 'morphOne' ? _.first(matchingRows) : matchingRows;
+        attribute.relation === 'morphOne' ? _.first(matchingRows) : matchingRows || [];
 
       result[attributeName] = fromTargetRow(matchingValue);
     });

--- a/tests/api/core/content-manager/media/required-media.test.api.js
+++ b/tests/api/core/content-manager/media/required-media.test.api.js
@@ -6,10 +6,11 @@
  * The `api.documents.strictRelations` flag controls enforcement of required media
  * (and required relations) on non-draft writes:
  *
- *   - Flag OFF / unset (legacy): required media is NOT enforced and an empty
- *     `multiple` media reads back as `null`. Existing projects must be untouched.
- *   - Flag ON (strict): publishing an entry with an empty required media returns 400;
- *     an empty non-required `multiple` media reads back as `[]`.
+ *   - Flag OFF / unset (legacy): required media is NOT enforced on publish.
+ *   - Flag ON (strict): publishing an entry with an empty required media returns 400.
+ *
+ * Empty `multiple` media always reads back as `[]` (aligned with other to-many
+ * relations), regardless of the flag — see the gallery read-back assertion below.
  *
  * Drafts stay lenient under both modes (mirrors scalar `required`), which also
  * side-steps the 2023 form-data-upload regression (#14670 → #16002): a create
@@ -109,7 +110,7 @@ describe('Required media field validation (issue #24927)', () => {
       expect(res.statusCode).toBe(200);
     });
 
-    test('empty required multiple media reads back as null (unchanged)', async () => {
+    test('empty required multiple media reads back as []', async () => {
       const creation = await createEntry(MULTIPLE_UID, {}, { populate: ['gallery'] });
       expect(creation.statusCode).toBe(201);
 
@@ -118,7 +119,7 @@ describe('Required media field validation (issue #24927)', () => {
         { qs: { populate: ['gallery'] } }
       );
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body.data.gallery).toBe(null);
+      expect(getRes.body.data.gallery).toEqual([]);
     });
   });
 


### PR DESCRIPTION
### What does it do?

Empty `morphMany` relations now serialize as `[]` when populated, matching `oneToMany` / `manyToMany`, instead of returning `null`.

That includes multiple media (`type: 'media', multiple: true`) and any custom `morphMany` attribute in user schemas.

Root cause was in DB populate `morphX`: missing morphMany groups were passed to `fromRow(undefined)` → `null`, while fixed to-many relations already use `map[...] || []`. The `morphToMany` empty-`referencedValues` early return already returned `[]` for morphMany; this aligns the remaining paths (including the `morphToOne` target branch).

Unconditional (not gated by `strictRelations`).

### Why is it needed?

Clients that treat these fields as collections (`.map`, `.length`) crash on `null` for the empty state. Reported as symptom 2 of strapi/strapi#24927 (multiple media); deliberately deferred from strapi/strapi#27028 (write-path `strictRelations` only) as a read-path consistency fix.

### How to test it?

1. Create a content type with a multiple media field (e.g. `gallery`) or any `morphMany`
2. Create an entry with no related targets attached
3. `GET` the entry with that field populated
4. Expect `"gallery": []` (not `null`)

Automated:

* Unit: `packages/core/database/.../apply-morph-many.test.ts` (morphToMany + morphToOne targets, including empty `referencedValues`)
* API: `tests/api/core/content-manager/media/required-media.test.api.js` (“empty required multiple media reads back as \[\]”)

### Recommended release note

> **Empty** `morphMany` **relations (including multiple media) now return** `[]` **instead of** `null` **when populated.**
>
> Populated empty to-many morph relations — most commonly `type: 'media', multiple: true` fields such as a gallery, but also any custom `morphMany` attribute — serialize as an empty array, consistent with `oneToMany` / `manyToMany`.
>
> **Migration:** If client code, webhooks, or integrations branch on `field === null` (or treat `null` as “no value”) for an empty populated morphMany / multiple media field, update them to treat `[]` as the empty state (e.g. `!field?.length`). This change is unconditional and is not controlled by `api.documents.strictRelations`.

### Related issue(s)/PR(s)

* Fixes [CMS-1429](https://linear.app/strapi/issue/CMS-1429/empty-multiple-media-reads-back-as-null-instead-of)
* Fixes strapi/strapi#24927 (symptom 2 — empty multiple media / morphMany read-back)
* Follow-up to strapi/strapi#27028 (required enforcement; this was the deferred read-path piece)