### PR TITLE
feat(i18n): add locale codes for Corsican

### DIFF
--- a/packages/plugins/i18n/server/src/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/src/constants/iso-locales.json
@@ -436,6 +436,14 @@
     "name": "Croatian (Croatia) (hr-HR)"
   },
   {
+    "code": "co",
+    "name": "Corsican (co)"
+  },
+  {
+    "code": "co-cos",
+    "name": "Corsican (Corsica) (co-cos)"
+  },
+  {
     "code": "cs",
     "name": "Czech (cs)"
   },

--- a/packages/plugins/i18n/server/src/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/src/constants/iso-locales.json
@@ -428,20 +428,20 @@
     "name": "Cornish (United Kingdom) (kw-GB)"
   },
   {
+    "code": "co",
+    "name": "Corsican (co)"
+  },
+  {
+    "code": "co-FR",
+    "name": "Corsican (France) (co-FR)"
+  },
+  {
     "code": "hr",
     "name": "Croatian (hr)"
   },
   {
     "code": "hr-HR",
     "name": "Croatian (Croatia) (hr-HR)"
-  },
-  {
-    "code": "co",
-    "name": "Corsican (co)"
-  },
-  {
-    "code": "co-cos",
-    "name": "Corsican (Corsica) (co-cos)"
   },
   {
     "code": "cs",

--- a/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
+++ b/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
@@ -440,11 +440,11 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "co",
-    "name": "Corsican (co)"
+    "name": "Corsican (co)",
   },
   {
     "code": "co-cos",
-    "name": "Corsican (Corsica) (co-cos)"
+    "name": "Corsican (Corsica) (co-cos)",
   },
   {
     "code": "cs",

--- a/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
+++ b/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
@@ -439,6 +439,14 @@ exports[`ISO locales getIsoLocales 1`] = `
     "name": "Croatian (Croatia) (hr-HR)",
   },
   {
+    "code": "co",
+    "name": "Corsican (co)"
+  },
+  {
+    "code": "co-cos",
+    "name": "Corsican (Corsica) (co-cos)"
+  },
+  {
     "code": "cs",
     "name": "Czech (cs)",
   },

--- a/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
+++ b/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
@@ -431,20 +431,20 @@ exports[`ISO locales getIsoLocales 1`] = `
     "name": "Cornish (United Kingdom) (kw-GB)",
   },
   {
+    "code": "co",
+    "name": "Corsican (co)",
+  },
+  {
+    "code": "co-FR",
+    "name": "Corsican (France) (co-FR)",
+  },
+  {
     "code": "hr",
     "name": "Croatian (hr)",
   },
   {
     "code": "hr-HR",
     "name": "Croatian (Croatia) (hr-HR)",
-  },
-  {
-    "code": "co",
-    "name": "Corsican (co)",
-  },
-  {
-    "code": "co-cos",
-    "name": "Corsican (Corsica) (co-cos)",
   },
   {
     "code": "cs",


### PR DESCRIPTION
### What does it do?

Add the locale codes for Corsican.
This language is alive and used in Corsica, as well as by the diaspora around the world.

Language codes are the official ISO codes found in the [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) list.

### Why is it needed?

Add language support for the Corsican language.

---
Fixes CPR-458