### PR TITLE
fix(admin): SSO remote logout infinite redirect (cookie path)

### DIFF
--- a/docs/docs/docs/01-core/authentication/00-sessions-and-jwt.md
+++ b/docs/docs/docs/01-core/authentication/00-sessions-and-jwt.md
@@ -83,7 +83,7 @@ Configuration:
 - Cookie options:
   - `admin.auth.cookie.name` (default `jwtToken`) — name of the non-httpOnly access-token cookie used for session logins (when `rememberMe` is false) and EE SSO handoff. Rename to avoid collisions with another app on a shared parent domain that sets a `jwtToken` cookie. Requires an admin rebuild after change (value is inlined into the admin bundle at build time).
   - `admin.auth.cookie.domain` (or `admin.auth.domain`) — applied to `strapi_admin_refresh`
-  - `admin.auth.cookie.path` (default `/admin`) — applied to `strapi_admin_refresh`
+  - `admin.auth.cookie.path` (default `/admin`) — applied to `strapi_admin_refresh` and to the non-httpOnly access-token cookie written by the admin client (and EE SSO). Requires an admin rebuild after change (value is inlined into the admin bundle at build time). Use a distinct path per instance when hosting multiple Strapis under the same parent domain.
   - `admin.auth.cookie.sameSite` (default `lax`) — applied to `strapi_admin_refresh`
 
 Key files:

--- a/docs/docs/docs/01-core/authentication/00-sessions-and-jwt.md
+++ b/docs/docs/docs/01-core/authentication/00-sessions-and-jwt.md
@@ -82,7 +82,7 @@ Configuration:
 - `admin.auth.options.*` — Use `admin.auth.sessions.options.*` instead
 - Cookie options:
   - `admin.auth.cookie.name` (default `jwtToken`) — name of the non-httpOnly access-token cookie used for session logins (when `rememberMe` is false) and EE SSO handoff. Rename to avoid collisions with another app on a shared parent domain that sets a `jwtToken` cookie. Requires an admin rebuild after change (value is inlined into the admin bundle at build time).
-  - `admin.auth.cookie.domain` (or `admin.auth.domain`) — applied to `strapi_admin_refresh`
+  - `admin.auth.cookie.domain` (or `admin.auth.domain`) — applied to `strapi_admin_refresh` and to the non-httpOnly access-token cookie written by the admin client (and EE SSO). Defaults to a host-only cookie when unset. Requires an admin rebuild after change (value is inlined into the admin bundle at build time). Set a parent domain to share the admin session across subdomains; leave unset to keep each host isolated.
   - `admin.auth.cookie.path` (default `/admin`) — applied to `strapi_admin_refresh` and to the non-httpOnly access-token cookie written by the admin client (and EE SSO). Requires an admin rebuild after change (value is inlined into the admin bundle at build time). Use a distinct path per instance when hosting multiple Strapis under the same parent domain.
   - `admin.auth.cookie.sameSite` (default `lax`) — applied to `strapi_admin_refresh`
 

--- a/packages/core/admin/admin/src/utils/cookies.ts
+++ b/packages/core/admin/admin/src/utils/cookies.ts
@@ -1,3 +1,4 @@
+import { resolveAuthCookieDomain } from '../../../shared/utils/auth-cookie-domain';
 import { resolveAuthCookieName } from '../../../shared/utils/auth-cookie-name';
 import { resolveAuthCookiePath } from '../../../shared/utils/auth-cookie-path';
 
@@ -13,11 +14,21 @@ export const AUTH_COOKIE_NAME = resolveAuthCookieName(process.env.STRAPI_ADMIN_A
  */
 export const AUTH_COOKIE_PATH = resolveAuthCookiePath(process.env.STRAPI_ADMIN_AUTH_COOKIE_PATH);
 
+/**
+ * Resolved once at module load: the build inlines `admin.auth.cookie.domain`
+ * into the bundle as `STRAPI_ADMIN_AUTH_COOKIE_DOMAIN`. `undefined` means the
+ * cookie is host-only.
+ */
+export const AUTH_COOKIE_DOMAIN = resolveAuthCookieDomain(
+  process.env.STRAPI_ADMIN_AUTH_COOKIE_DOMAIN
+);
+
 /** Paths previously used by the client for the access cookie; cleared on set/delete. */
 const LEGACY_AUTH_COOKIE_PATHS = ['/'] as const;
 
-const expireCookieAtPath = (name: string, path: string): void => {
-  document.cookie = `${name}=; Path=${path}; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+const expireCookieAt = (name: string, path: string, domain?: string): void => {
+  const domainAttr = domain ? `; Domain=${domain}` : '';
+  document.cookie = `${name}=; Path=${path}${domainAttr}; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 };
 
 /**
@@ -40,8 +51,9 @@ export const getCookieValue = (name: string): string | null => {
 
 /**
  * Sets a cookie with the given name, value, and optional expiration time.
- * Uses `admin.auth.cookie.path` (inlined at build time) so the access cookie
- * stays scoped to the same path as the httpOnly refresh cookie.
+ * Uses `admin.auth.cookie.path` and `admin.auth.cookie.domain` (both inlined
+ * at build time) so the access cookie stays scoped to the same path and domain
+ * as the httpOnly refresh cookie and the EE SSO access cookie.
  *
  * @param name - The name of the cookie.
  * @param value - The value of the cookie.
@@ -55,25 +67,42 @@ export const setCookie = (name: string, value: string, days?: number): void => {
     expires = `; Expires=${date.toUTCString()}`;
   }
 
-  // Drop legacy Path=/ copies so login does not leave a duplicate root cookie.
+  // Drop legacy Path=/ copies (host-only and domain-scoped) so login does not
+  // leave a duplicate root cookie.
   for (const legacyPath of LEGACY_AUTH_COOKIE_PATHS) {
     if (legacyPath !== AUTH_COOKIE_PATH) {
-      expireCookieAtPath(name, legacyPath);
+      expireCookieAt(name, legacyPath, undefined);
+      if (AUTH_COOKIE_DOMAIN) {
+        expireCookieAt(name, legacyPath, AUTH_COOKIE_DOMAIN);
+      }
     }
   }
 
-  document.cookie = `${name}=${encodeURIComponent(value)}; Path=${AUTH_COOKIE_PATH}${expires}`;
+  const domainAttr = AUTH_COOKIE_DOMAIN ? `; Domain=${AUTH_COOKIE_DOMAIN}` : '';
+  document.cookie = `${name}=${encodeURIComponent(value)}; Path=${AUTH_COOKIE_PATH}${domainAttr}${expires}`;
 };
 
 /**
  * Deletes a cookie by setting its expiration date to a past date.
- * Clears both the configured path and legacy Path=/ so logout works after upgrades.
+ *
+ * Expires every combination of {configured path, legacy Path=/} and
+ * {configured domain, host-only}. A `Domain`-scoped cookie is a distinct entry
+ * from a host-only one in the browser cookie store, so both must be cleared or
+ * remote logout leaves the EE SSO cookie (written with `Domain` by the server)
+ * behind, rehydrating a dead session into an infinite login redirect.
  *
  * @param name - The name of the cookie to delete.
  */
 export const deleteCookie = (name: string): void => {
   const paths = new Set<string>([AUTH_COOKIE_PATH, ...LEGACY_AUTH_COOKIE_PATHS]);
+  const domains: Array<string | undefined> = [undefined];
+  if (AUTH_COOKIE_DOMAIN) {
+    domains.push(AUTH_COOKIE_DOMAIN);
+  }
+
   for (const path of paths) {
-    expireCookieAtPath(name, path);
+    for (const domain of domains) {
+      expireCookieAt(name, path, domain);
+    }
   }
 };

--- a/packages/core/admin/admin/src/utils/cookies.ts
+++ b/packages/core/admin/admin/src/utils/cookies.ts
@@ -1,10 +1,24 @@
 import { resolveAuthCookieName } from '../../../shared/utils/auth-cookie-name';
+import { resolveAuthCookiePath } from '../../../shared/utils/auth-cookie-path';
 
 /**
  * Resolved once at module load: the build inlines `admin.auth.cookie.name`
  * into the bundle as `STRAPI_ADMIN_AUTH_COOKIE_NAME`.
  */
 export const AUTH_COOKIE_NAME = resolveAuthCookieName(process.env.STRAPI_ADMIN_AUTH_COOKIE_NAME);
+
+/**
+ * Resolved once at module load: the build inlines `admin.auth.cookie.path`
+ * into the bundle as `STRAPI_ADMIN_AUTH_COOKIE_PATH`.
+ */
+export const AUTH_COOKIE_PATH = resolveAuthCookiePath(process.env.STRAPI_ADMIN_AUTH_COOKIE_PATH);
+
+/** Paths previously used by the client for the access cookie; cleared on set/delete. */
+const LEGACY_AUTH_COOKIE_PATHS = ['/'] as const;
+
+const expireCookieAtPath = (name: string, path: string): void => {
+  document.cookie = `${name}=; Path=${path}; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+};
 
 /**
  * Retrieves the value of a specified cookie.
@@ -26,6 +40,8 @@ export const getCookieValue = (name: string): string | null => {
 
 /**
  * Sets a cookie with the given name, value, and optional expiration time.
+ * Uses `admin.auth.cookie.path` (inlined at build time) so the access cookie
+ * stays scoped to the same path as the httpOnly refresh cookie.
  *
  * @param name - The name of the cookie.
  * @param value - The value of the cookie.
@@ -38,14 +54,26 @@ export const setCookie = (name: string, value: string, days?: number): void => {
     date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
     expires = `; Expires=${date.toUTCString()}`;
   }
-  document.cookie = `${name}=${encodeURIComponent(value)}; Path=/${expires}`;
+
+  // Drop legacy Path=/ copies so login does not leave a duplicate root cookie.
+  for (const legacyPath of LEGACY_AUTH_COOKIE_PATHS) {
+    if (legacyPath !== AUTH_COOKIE_PATH) {
+      expireCookieAtPath(name, legacyPath);
+    }
+  }
+
+  document.cookie = `${name}=${encodeURIComponent(value)}; Path=${AUTH_COOKIE_PATH}${expires}`;
 };
 
 /**
  * Deletes a cookie by setting its expiration date to a past date.
+ * Clears both the configured path and legacy Path=/ so logout works after upgrades.
  *
  * @param name - The name of the cookie to delete.
  */
 export const deleteCookie = (name: string): void => {
-  document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+  const paths = new Set<string>([AUTH_COOKIE_PATH, ...LEGACY_AUTH_COOKIE_PATHS]);
+  for (const path of paths) {
+    expireCookieAtPath(name, path);
+  }
 };

--- a/packages/core/admin/admin/src/utils/cookies.ts
+++ b/packages/core/admin/admin/src/utils/cookies.ts
@@ -32,6 +32,25 @@ const expireCookieAt = (name: string, path: string, domain?: string): void => {
 };
 
 /**
+ * Every `(path, domain)` key the access cookie may live under: the configured
+ * key plus the legacy-path and host-only variants written by older versions or
+ * previous configs. The browser cookie store keys entries by
+ * `(name, domain, path)`, so each combination is a distinct entry.
+ */
+const cookieKeyMatrix = (): Array<{ path: string; domain: string | undefined }> => {
+  const paths = new Set<string>([AUTH_COOKIE_PATH, ...LEGACY_AUTH_COOKIE_PATHS]);
+  const domains = new Set<string | undefined>([undefined, AUTH_COOKIE_DOMAIN]);
+
+  const matrix: Array<{ path: string; domain: string | undefined }> = [];
+  for (const path of paths) {
+    for (const domain of domains) {
+      matrix.push({ path, domain });
+    }
+  }
+  return matrix;
+};
+
+/**
  * Retrieves the value of a specified cookie.
  *
  * @param name - The name of the cookie to retrieve.
@@ -67,14 +86,13 @@ export const setCookie = (name: string, value: string, days?: number): void => {
     expires = `; Expires=${date.toUTCString()}`;
   }
 
-  // Drop legacy Path=/ copies (host-only and domain-scoped) so login does not
-  // leave a duplicate root cookie.
-  for (const legacyPath of LEGACY_AUTH_COOKIE_PATHS) {
-    if (legacyPath !== AUTH_COOKIE_PATH) {
-      expireCookieAt(name, legacyPath, undefined);
-      if (AUTH_COOKIE_DOMAIN) {
-        expireCookieAt(name, legacyPath, AUTH_COOKIE_DOMAIN);
-      }
+  // Expire every other key the cookie may live under (legacy Path=/, host-only
+  // copies written before a domain was configured). A stale same-name entry at
+  // an equal-length path sorts first in document.cookie by creation time
+  // (RFC 6265 §5.4), so leaving one behind would shadow the token written below.
+  for (const { path, domain } of cookieKeyMatrix()) {
+    if (path !== AUTH_COOKIE_PATH || domain !== AUTH_COOKIE_DOMAIN) {
+      expireCookieAt(name, path, domain);
     }
   }
 
@@ -94,15 +112,7 @@ export const setCookie = (name: string, value: string, days?: number): void => {
  * @param name - The name of the cookie to delete.
  */
 export const deleteCookie = (name: string): void => {
-  const paths = new Set<string>([AUTH_COOKIE_PATH, ...LEGACY_AUTH_COOKIE_PATHS]);
-  const domains: Array<string | undefined> = [undefined];
-  if (AUTH_COOKIE_DOMAIN) {
-    domains.push(AUTH_COOKIE_DOMAIN);
-  }
-
-  for (const path of paths) {
-    for (const domain of domains) {
-      expireCookieAt(name, path, domain);
-    }
+  for (const { path, domain } of cookieKeyMatrix()) {
+    expireCookieAt(name, path, domain);
   }
 };

--- a/packages/core/admin/admin/src/utils/cookies.ts
+++ b/packages/core/admin/admin/src/utils/cookies.ts
@@ -72,7 +72,8 @@ export const getCookieValue = (name: string): string | null => {
  * Sets a cookie with the given name, value, and optional expiration time.
  * Uses `admin.auth.cookie.path` and `admin.auth.cookie.domain` (both inlined
  * at build time) so the access cookie stays scoped to the same path and domain
- * as the httpOnly refresh cookie and the EE SSO access cookie.
+ * as the httpOnly refresh cookie and the EE SSO access cookie. The cookie is
+ * marked `Secure` whenever the page is served over TLS.
  *
  * @param name - The name of the cookie.
  * @param value - The value of the cookie.
@@ -97,7 +98,15 @@ export const setCookie = (name: string, value: string, days?: number): void => {
   }
 
   const domainAttr = AUTH_COOKIE_DOMAIN ? `; Domain=${AUTH_COOKIE_DOMAIN}` : '';
-  document.cookie = `${name}=${encodeURIComponent(value)}; Path=${AUTH_COOKIE_PATH}${domainAttr}${expires}`;
+  // Mark the token Secure when the page itself is served over TLS — the
+  // browser's own criterion — so it is never attached to plain-http requests.
+  // Expiry writes stay flag-free on purpose: deletion targets the (name,
+  // domain, path) key regardless of Secure, and from an http origin a
+  // flag-free write can still clear non-Secure entries (no origin can carry
+  // the Secure flag over http, and Secure entries are untouchable from there
+  // either way).
+  const secureAttr = window.location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie = `${name}=${encodeURIComponent(value)}; Path=${AUTH_COOKIE_PATH}${domainAttr}${expires}${secureAttr}`;
 };
 
 /**

--- a/packages/core/admin/admin/src/utils/tests/cookies.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/cookies.test.ts
@@ -2,7 +2,7 @@ import { getCookieValue, setCookie, deleteCookie } from '../cookies';
 
 describe('Cookie Utilities', () => {
   beforeEach(() => {
-    // Clear all cookies before each test
+    // Clear all cookies before each test (jsdom ignores Path, so a single expire is enough)
     document.cookie.split(';').forEach((cookie) => {
       const [name] = cookie.split('=');
       document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
@@ -67,6 +67,36 @@ describe('Cookie Utilities', () => {
       process.env = { ...ORIGINAL_ENV, STRAPI_ADMIN_AUTH_COOKIE_NAME: 'my_custom_auth_cookie' };
 
       expect(loadAuthCookieName()).toBe('my_custom_auth_cookie');
+    });
+  });
+
+  describe('AUTH_COOKIE_PATH', () => {
+    const ORIGINAL_ENV = process.env;
+
+    afterEach(() => {
+      process.env = ORIGINAL_ENV;
+    });
+
+    const loadAuthCookiePath = (): string => {
+      let path = '';
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        path = require('../cookies').AUTH_COOKIE_PATH;
+      });
+      return path;
+    };
+
+    it('should default to /admin', () => {
+      process.env = { ...ORIGINAL_ENV };
+      delete process.env.STRAPI_ADMIN_AUTH_COOKIE_PATH;
+
+      expect(loadAuthCookiePath()).toBe('/admin');
+    });
+
+    it('should use STRAPI_ADMIN_AUTH_COOKIE_PATH when set', () => {
+      process.env = { ...ORIGINAL_ENV, STRAPI_ADMIN_AUTH_COOKIE_PATH: '/strapi-de/admin' };
+
+      expect(loadAuthCookiePath()).toBe('/strapi-de/admin');
     });
   });
 });

--- a/packages/core/admin/admin/src/utils/tests/cookies.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/cookies.test.ts
@@ -99,4 +99,115 @@ describe('Cookie Utilities', () => {
       expect(loadAuthCookiePath()).toBe('/strapi-de/admin');
     });
   });
+
+  describe('AUTH_COOKIE_DOMAIN', () => {
+    const ORIGINAL_ENV = process.env;
+
+    afterEach(() => {
+      process.env = ORIGINAL_ENV;
+    });
+
+    const loadAuthCookieDomain = (): string | undefined => {
+      let domain: string | undefined;
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        domain = require('../cookies').AUTH_COOKIE_DOMAIN;
+      });
+      return domain;
+    };
+
+    it('should default to a host-only cookie (undefined)', () => {
+      process.env = { ...ORIGINAL_ENV };
+      delete process.env.STRAPI_ADMIN_AUTH_COOKIE_DOMAIN;
+
+      expect(loadAuthCookieDomain()).toBeUndefined();
+    });
+
+    it('should use STRAPI_ADMIN_AUTH_COOKIE_DOMAIN when set', () => {
+      process.env = { ...ORIGINAL_ENV, STRAPI_ADMIN_AUTH_COOKIE_DOMAIN: 'strapi.test' };
+
+      expect(loadAuthCookieDomain()).toBe('strapi.test');
+    });
+  });
+
+  // jsdom's cookie store ignores Path/Domain, so assert on the emitted
+  // `document.cookie` write strings instead — that is where the domain-aware
+  // logout fix lives.
+  describe('domain-scoped set/delete write strings', () => {
+    const ORIGINAL_ENV = process.env;
+
+    afterEach(() => {
+      process.env = ORIGINAL_ENV;
+      jest.restoreAllMocks();
+    });
+
+    const withEnv = (
+      env: Record<string, string | undefined>,
+      fn: (writes: string[], mod: typeof import('../cookies')) => void
+    ): void => {
+      const nextEnv = { ...ORIGINAL_ENV, ...env };
+      // Explicit `undefined` in `env` means "unset this var" (host-only case).
+      for (const [key, value] of Object.entries(env)) {
+        if (value === undefined) {
+          delete nextEnv[key];
+        }
+      }
+      process.env = nextEnv;
+      const writes: string[] = [];
+      const spy = jest
+        .spyOn(document, 'cookie', 'set')
+        .mockImplementation((value: string) => writes.push(value));
+      try {
+        jest.isolateModules(() => {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const mod = require('../cookies');
+          fn(writes, mod);
+        });
+      } finally {
+        spy.mockRestore();
+      }
+    };
+
+    it('sets the cookie with the configured Domain and Path', () => {
+      withEnv(
+        { STRAPI_ADMIN_AUTH_COOKIE_DOMAIN: 'strapi.test', STRAPI_ADMIN_AUTH_COOKIE_PATH: '/admin' },
+        (writes, mod) => {
+          mod.setCookie('jwtToken', 'abc');
+          const setWrite = writes.find((w) => w.startsWith('jwtToken=abc'));
+          expect(setWrite).toContain('Path=/admin');
+          expect(setWrite).toContain('Domain=strapi.test');
+        }
+      );
+    });
+
+    it('deletes across both the configured Domain and host-only', () => {
+      withEnv(
+        { STRAPI_ADMIN_AUTH_COOKIE_DOMAIN: 'strapi.test', STRAPI_ADMIN_AUTH_COOKIE_PATH: '/admin' },
+        (writes, mod) => {
+          mod.deleteCookie('jwtToken');
+          const expiries = writes.filter((w) => w.includes('Expires=Thu, 01 Jan 1970'));
+          // configured path × {host-only, domain} and legacy Path=/ × {host-only, domain}
+          expect(
+            expiries.some((w) => w.includes('Path=/admin') && w.includes('Domain=strapi.test'))
+          ).toBe(true);
+          expect(expiries.some((w) => w.includes('Path=/admin') && !w.includes('Domain='))).toBe(
+            true
+          );
+          expect(
+            expiries.some((w) => w.includes('Path=/') && w.includes('Domain=strapi.test'))
+          ).toBe(true);
+        }
+      );
+    });
+
+    it('omits the Domain attribute entirely when host-only', () => {
+      withEnv(
+        { STRAPI_ADMIN_AUTH_COOKIE_PATH: '/admin', STRAPI_ADMIN_AUTH_COOKIE_DOMAIN: undefined },
+        (writes, mod) => {
+          mod.deleteCookie('jwtToken');
+          expect(writes.every((w) => !w.includes('Domain='))).toBe(true);
+        }
+      );
+    });
+  });
 });

--- a/packages/core/admin/admin/src/utils/tests/cookies.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/cookies.test.ts
@@ -180,6 +180,31 @@ describe('Cookie Utilities', () => {
       );
     });
 
+    it('expires the host-only copy at the configured path before a domain-scoped set', () => {
+      withEnv(
+        { STRAPI_ADMIN_AUTH_COOKIE_DOMAIN: 'strapi.test', STRAPI_ADMIN_AUTH_COOKIE_PATH: '/admin' },
+        (writes, mod) => {
+          mod.setCookie('jwtToken', 'abc');
+          const expiries = writes.filter((w) => w.includes('Expires=Thu, 01 Jan 1970'));
+          // Upgrade shadow: a pre-domain client wrote a host-only Path=/admin
+          // cookie; being older, it would sort before (and shadow) the
+          // domain-scoped token at the same path, so set must expire it.
+          expect(expiries.some((w) => w.includes('Path=/admin') && !w.includes('Domain='))).toBe(
+            true
+          );
+          // ...but never the exact key being written.
+          expect(
+            expiries.some((w) => w.includes('Path=/admin') && w.includes('Domain=strapi.test'))
+          ).toBe(false);
+          // Legacy root-path copies are still cleared in both flavours.
+          expect(expiries.some((w) => w.includes('Path=/;') && !w.includes('Domain='))).toBe(true);
+          expect(
+            expiries.some((w) => w.includes('Path=/;') && w.includes('Domain=strapi.test'))
+          ).toBe(true);
+        }
+      );
+    });
+
     it('deletes across both the configured Domain and host-only', () => {
       withEnv(
         { STRAPI_ADMIN_AUTH_COOKIE_DOMAIN: 'strapi.test', STRAPI_ADMIN_AUTH_COOKIE_PATH: '/admin' },

--- a/packages/core/admin/admin/src/utils/tests/cookies.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/cookies.test.ts
@@ -225,6 +225,16 @@ describe('Cookie Utilities', () => {
       );
     });
 
+    it('omits the Secure attribute when the page is served over plain http', () => {
+      // This suite runs at the preset's http://localhost:1337/admin URL; the
+      // https counterpart lives in cookiesSecure.test.ts (jsdom pins the
+      // page URL per environment, so the two halves need separate files).
+      withEnv({}, (writes, mod) => {
+        mod.setCookie('jwtToken', 'abc');
+        expect(writes.every((w) => !w.includes('Secure'))).toBe(true);
+      });
+    });
+
     it('omits the Domain attribute entirely when host-only', () => {
       withEnv(
         { STRAPI_ADMIN_AUTH_COOKIE_PATH: '/admin', STRAPI_ADMIN_AUTH_COOKIE_DOMAIN: undefined },

--- a/packages/core/admin/admin/src/utils/tests/cookiesSecure.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/cookiesSecure.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The auth cookie must be marked Secure when (and only when) the page itself
+ * is served over TLS. jsdom pins the page URL per test environment, so the
+ * https half of that behaviour lives in this separate file; the http half is
+ * asserted in cookies.test.ts at the preset's default http URL.
+ *
+ * @jest-environment-options {"url": "https://cms.strapi.test/admin", "customExportConditions": [""]}
+ */
+
+describe('cookie writes on an https page', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const collectWrites = (fn: (mod: typeof import('../cookies')) => void): string[] => {
+    const writes: string[] = [];
+    const spy = jest
+      .spyOn(document, 'cookie', 'set')
+      .mockImplementation((value: string) => writes.push(value));
+    try {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        fn(require('../cookies'));
+      });
+    } finally {
+      spy.mockRestore();
+    }
+    return writes;
+  };
+
+  it('marks the token Secure on set', () => {
+    const writes = collectWrites((mod) => mod.setCookie('jwtToken', 'abc'));
+
+    const setWrite = writes.find((w) => w.startsWith('jwtToken=abc'));
+    expect(setWrite).toContain('; Secure');
+  });
+
+  it('keeps expiry writes flag-free (deletion targets the key, not the flag)', () => {
+    const writes = collectWrites((mod) => mod.deleteCookie('jwtToken'));
+
+    expect(writes.length).toBeGreaterThan(0);
+    expect(writes.every((w) => !w.includes('Secure'))).toBe(true);
+  });
+});

--- a/packages/core/admin/ee/server/src/controllers/authentication-utils/__tests__/middlewares.test.ts
+++ b/packages/core/admin/ee/server/src/controllers/authentication-utils/__tests__/middlewares.test.ts
@@ -149,6 +149,56 @@ describe('redirectWithAuth', () => {
     );
   });
 
+  test('respects admin.auth.cookie.domain for the access cookie', async () => {
+    (global.strapi.config.get as jest.Mock).mockImplementation(
+      (key: string, defaultValue?: unknown) => {
+        if (key === 'admin.auth.cookie.domain') return 'strapi.test';
+        if (key === 'admin.auth.cookie.secure') return false;
+        if (key === 'admin.auth.cookie.name') return undefined;
+        if (key === 'admin.auth.cookie.path') return undefined;
+        if (key === 'admin.auth.domain') return undefined;
+        return defaultValue;
+      }
+    );
+
+    const ctx = createCtx();
+
+    await redirectWithAuth(ctx as any, jest.fn());
+
+    expect(ctx.cookiesSet).toHaveBeenCalledWith(
+      DEFAULT_AUTH_COOKIE_NAME,
+      'access-token',
+      expect.objectContaining({
+        domain: 'strapi.test',
+      })
+    );
+  });
+
+  test('falls back to admin.auth.domain for the access cookie domain', async () => {
+    (global.strapi.config.get as jest.Mock).mockImplementation(
+      (key: string, defaultValue?: unknown) => {
+        if (key === 'admin.auth.domain') return 'legacy.strapi.test';
+        if (key === 'admin.auth.cookie.secure') return false;
+        if (key === 'admin.auth.cookie.name') return undefined;
+        if (key === 'admin.auth.cookie.path') return undefined;
+        if (key === 'admin.auth.cookie.domain') return undefined;
+        return defaultValue;
+      }
+    );
+
+    const ctx = createCtx();
+
+    await redirectWithAuth(ctx as any, jest.fn());
+
+    expect(ctx.cookiesSet).toHaveBeenCalledWith(
+      DEFAULT_AUTH_COOKIE_NAME,
+      'access-token',
+      expect.objectContaining({
+        domain: 'legacy.strapi.test',
+      })
+    );
+  });
+
   test('still sets the refresh cookie via buildCookieOptionsWithExpiry', async () => {
     const ctx = createCtx();
 

--- a/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
+++ b/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
@@ -7,6 +7,8 @@ import {
   buildCookieOptionsWithExpiry,
   buildSessionMetadataFromContext,
   getAccessCookieName,
+  getAccessCookiePath,
+  getAccessCookieDomain,
   getSessionManager,
   generateDeviceId,
 } from '../../../../../shared/utils/session-auth';
@@ -138,8 +140,11 @@ export const redirectWithAuth: Core.MiddlewareHandler = async (ctx) => {
     const isProduction = process.env.NODE_ENV === 'production';
     const isSecure = typeof configuredSecure === 'boolean' ? configuredSecure : isProduction;
 
-    const domain: string | undefined = strapi.config.get('admin.auth.domain');
-    const path: string = strapi.config.get('admin.auth.cookie.path', '/admin');
+    // Resolve through the shared helpers so the server write agrees with the
+    // client set/delete (which read the same config inlined at build time);
+    // any divergence leaves a cookie the admin panel cannot clear on logout.
+    const domain = getAccessCookieDomain();
+    const path = getAccessCookiePath();
 
     ctx.cookies.set(getAccessCookieName(), accessToken, {
       httpOnly: false,

--- a/packages/core/admin/shared/utils/__tests__/auth-cookie-domain.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/auth-cookie-domain.test.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_AUTH_COOKIE_DOMAIN, resolveAuthCookieDomain } from '../auth-cookie-domain';
+
+describe('resolveAuthCookieDomain', () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  afterEach(() => {
+    warnSpy.mockClear();
+  });
+
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('defaults to a host-only cookie when unset or blank', () => {
+    expect(resolveAuthCookieDomain()).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+    expect(resolveAuthCookieDomain('')).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+    expect(resolveAuthCookieDomain('   ')).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+  });
+
+  it('returns a configured bare host name', () => {
+    expect(resolveAuthCookieDomain('strapi.test')).toBe('strapi.test');
+    expect(resolveAuthCookieDomain('.strapi.test')).toBe('.strapi.test');
+    expect(resolveAuthCookieDomain('cms.strapi.test')).toBe('cms.strapi.test');
+  });
+
+  it('rejects domains with schemes, paths, ports, or attribute separators', () => {
+    expect(resolveAuthCookieDomain('https://strapi.test')).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+    expect(resolveAuthCookieDomain('strapi.test/admin')).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+    expect(resolveAuthCookieDomain('strapi.test:1337')).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+    expect(resolveAuthCookieDomain('strapi.test;HttpOnly')).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/core/admin/shared/utils/__tests__/auth-cookie-domain.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/auth-cookie-domain.test.ts
@@ -30,4 +30,13 @@ describe('resolveAuthCookieDomain', () => {
     expect(resolveAuthCookieDomain('strapi.test;HttpOnly')).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
     expect(warnSpy).toHaveBeenCalled();
   });
+
+  it('routes the warning through the provided warn callback instead of console', () => {
+    const warn = jest.fn();
+
+    expect(resolveAuthCookieDomain('strapi.test:1337', warn)).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('strapi.test:1337'));
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/admin/shared/utils/__tests__/auth-cookie-path.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/auth-cookie-path.test.ts
@@ -1,0 +1,30 @@
+import { DEFAULT_AUTH_COOKIE_PATH, resolveAuthCookiePath } from '../auth-cookie-path';
+
+describe('resolveAuthCookiePath', () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  afterEach(() => {
+    warnSpy.mockClear();
+  });
+
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('defaults to /admin when unset or blank', () => {
+    expect(resolveAuthCookiePath()).toBe(DEFAULT_AUTH_COOKIE_PATH);
+    expect(resolveAuthCookiePath('')).toBe(DEFAULT_AUTH_COOKIE_PATH);
+    expect(resolveAuthCookiePath('   ')).toBe(DEFAULT_AUTH_COOKIE_PATH);
+  });
+
+  it('returns a configured absolute path', () => {
+    expect(resolveAuthCookiePath('/strapi-de/admin')).toBe('/strapi-de/admin');
+    expect(resolveAuthCookiePath('/admin')).toBe('/admin');
+  });
+
+  it('rejects relative or invalid paths', () => {
+    expect(resolveAuthCookiePath('admin')).toBe(DEFAULT_AUTH_COOKIE_PATH);
+    expect(resolveAuthCookiePath('/admin;HttpOnly')).toBe(DEFAULT_AUTH_COOKIE_PATH);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
@@ -105,10 +105,16 @@ describe('getAccessCookieDomain', () => {
 });
 
 describe('getRefreshCookieOptions', () => {
+  const logWarn = jest.fn();
+
   beforeEach(() => {
+    logWarn.mockReset();
     global.strapi = {
       config: {
         get: jest.fn(() => undefined),
+      },
+      log: {
+        warn: logWarn,
       },
     } as any;
   });
@@ -121,14 +127,13 @@ describe('getRefreshCookieOptions', () => {
     expect(getRefreshCookieOptions().domain).toBe('strapi.test');
   });
 
-  test('falls back to a host-only cookie when the configured domain is invalid', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  test('falls back to a host-only cookie and warns via strapi.log when the configured domain is invalid', () => {
     global.strapi.config.get = jest.fn((key: string) =>
       key === 'admin.auth.cookie.domain' ? 'strapi.test:1337' : undefined
     ) as any;
 
     expect(getRefreshCookieOptions().domain).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
-    warnSpy.mockRestore();
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining('strapi.test:1337'));
   });
 });
 

--- a/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
@@ -1,5 +1,6 @@
-import { getAccessCookieName, resolveLogoutDeviceId } from '../session-auth';
+import { getAccessCookieName, getAccessCookiePath, resolveLogoutDeviceId } from '../session-auth';
 import { DEFAULT_AUTH_COOKIE_NAME } from '../auth-cookie-name';
+import { DEFAULT_AUTH_COOKIE_PATH } from '../auth-cookie-path';
 
 describe('getAccessCookieName', () => {
   beforeEach(() => {
@@ -31,6 +32,28 @@ describe('getAccessCookieName', () => {
     } finally {
       process.env = ORIGINAL_ENV;
     }
+  });
+});
+
+describe('getAccessCookiePath', () => {
+  beforeEach(() => {
+    global.strapi = {
+      config: {
+        get: jest.fn(() => undefined),
+      },
+    } as any;
+  });
+
+  test('defaults to /admin', () => {
+    expect(getAccessCookiePath()).toBe(DEFAULT_AUTH_COOKIE_PATH);
+  });
+
+  test('uses the admin.auth.cookie.path config', () => {
+    global.strapi.config.get = jest.fn((key: string) =>
+      key === 'admin.auth.cookie.path' ? '/strapi-de/admin' : undefined
+    ) as any;
+
+    expect(getAccessCookiePath()).toBe('/strapi-de/admin');
   });
 });
 

--- a/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
@@ -2,6 +2,7 @@ import {
   getAccessCookieName,
   getAccessCookiePath,
   getAccessCookieDomain,
+  getRefreshCookieOptions,
   resolveLogoutDeviceId,
 } from '../session-auth';
 import { DEFAULT_AUTH_COOKIE_NAME } from '../auth-cookie-name';
@@ -100,6 +101,34 @@ describe('getAccessCookieDomain', () => {
     }) as any;
 
     expect(getAccessCookieDomain()).toBe('cookie.strapi.test');
+  });
+});
+
+describe('getRefreshCookieOptions', () => {
+  beforeEach(() => {
+    global.strapi = {
+      config: {
+        get: jest.fn(() => undefined),
+      },
+    } as any;
+  });
+
+  test('resolves the domain through the shared helper so it agrees with the access cookie', () => {
+    global.strapi.config.get = jest.fn((key: string) =>
+      key === 'admin.auth.cookie.domain' ? 'strapi.test' : undefined
+    ) as any;
+
+    expect(getRefreshCookieOptions().domain).toBe('strapi.test');
+  });
+
+  test('falls back to a host-only cookie when the configured domain is invalid', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    global.strapi.config.get = jest.fn((key: string) =>
+      key === 'admin.auth.cookie.domain' ? 'strapi.test:1337' : undefined
+    ) as any;
+
+    expect(getRefreshCookieOptions().domain).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+    warnSpy.mockRestore();
   });
 });
 

--- a/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
@@ -1,6 +1,12 @@
-import { getAccessCookieName, getAccessCookiePath, resolveLogoutDeviceId } from '../session-auth';
+import {
+  getAccessCookieName,
+  getAccessCookiePath,
+  getAccessCookieDomain,
+  resolveLogoutDeviceId,
+} from '../session-auth';
 import { DEFAULT_AUTH_COOKIE_NAME } from '../auth-cookie-name';
 import { DEFAULT_AUTH_COOKIE_PATH } from '../auth-cookie-path';
+import { DEFAULT_AUTH_COOKIE_DOMAIN } from '../auth-cookie-domain';
 
 describe('getAccessCookieName', () => {
   beforeEach(() => {
@@ -54,6 +60,46 @@ describe('getAccessCookiePath', () => {
     ) as any;
 
     expect(getAccessCookiePath()).toBe('/strapi-de/admin');
+  });
+});
+
+describe('getAccessCookieDomain', () => {
+  beforeEach(() => {
+    global.strapi = {
+      config: {
+        get: jest.fn(() => undefined),
+      },
+    } as any;
+  });
+
+  test('defaults to a host-only cookie', () => {
+    expect(getAccessCookieDomain()).toBe(DEFAULT_AUTH_COOKIE_DOMAIN);
+  });
+
+  test('uses the admin.auth.cookie.domain config', () => {
+    global.strapi.config.get = jest.fn((key: string) =>
+      key === 'admin.auth.cookie.domain' ? 'strapi.test' : undefined
+    ) as any;
+
+    expect(getAccessCookieDomain()).toBe('strapi.test');
+  });
+
+  test('falls back to admin.auth.domain', () => {
+    global.strapi.config.get = jest.fn((key: string) =>
+      key === 'admin.auth.domain' ? 'legacy.strapi.test' : undefined
+    ) as any;
+
+    expect(getAccessCookieDomain()).toBe('legacy.strapi.test');
+  });
+
+  test('prefers admin.auth.cookie.domain over admin.auth.domain', () => {
+    global.strapi.config.get = jest.fn((key: string) => {
+      if (key === 'admin.auth.cookie.domain') return 'cookie.strapi.test';
+      if (key === 'admin.auth.domain') return 'legacy.strapi.test';
+      return undefined;
+    }) as any;
+
+    expect(getAccessCookieDomain()).toBe('cookie.strapi.test');
   });
 });
 

--- a/packages/core/admin/shared/utils/auth-cookie-domain.ts
+++ b/packages/core/admin/shared/utils/auth-cookie-domain.ts
@@ -1,0 +1,43 @@
+/**
+ * Domain attribute of the admin auth (access) token cookie, configurable
+ * through `admin.auth.cookie.domain` (falling back to `admin.auth.domain`) so
+ * multiple Strapi instances under the same parent domain share, or stay
+ * isolated to, the intended host.
+ *
+ * Browser-safe single source for both sides of the handoff: the admin panel
+ * cannot read server config, so the build transports the config value into
+ * the bundle through the internal `STRAPI_ADMIN_AUTH_COOKIE_DOMAIN` variable
+ * (see create-build-context.ts in @strapi/strapi); the server resolves the
+ * same config at runtime. Changing the domain requires an admin rebuild, like
+ * any other admin config change.
+ *
+ * Defaults to `undefined` (host-only cookie) to match the browser default and
+ * the refresh-cookie behaviour in `getRefreshCookieOptions` when no domain is
+ * configured. A host-only cookie and a `Domain`-scoped cookie are distinct
+ * entries in the browser cookie store, so set and delete must agree on the
+ * domain or logout leaves a colliding copy behind.
+ */
+export const DEFAULT_AUTH_COOKIE_DOMAIN = undefined;
+
+const isValidCookieDomain = (domain: string): boolean => {
+  // RFC 6265 domain-av: a host name. No leading dot required, no scheme, no
+  // path, no port, and none of the control/attribute-separator characters.
+  return !/[\x00-\x1F\x7F;,\s/:]/.test(domain);
+};
+
+export const resolveAuthCookieDomain = (configuredDomain?: string): string | undefined => {
+  const cookieDomain = (configuredDomain || '').trim();
+
+  if (!cookieDomain) {
+    return DEFAULT_AUTH_COOKIE_DOMAIN;
+  }
+
+  if (!isValidCookieDomain(cookieDomain)) {
+    console.warn(
+      `Ignoring invalid admin auth cookie domain "${cookieDomain}" (must be a bare host name); using a host-only cookie instead.`
+    );
+    return DEFAULT_AUTH_COOKIE_DOMAIN;
+  }
+
+  return cookieDomain;
+};

--- a/packages/core/admin/shared/utils/auth-cookie-domain.ts
+++ b/packages/core/admin/shared/utils/auth-cookie-domain.ts
@@ -25,7 +25,10 @@ const isValidCookieDomain = (domain: string): boolean => {
   return !/[\x00-\x1F\x7F;,\s/:]/.test(domain);
 };
 
-export const resolveAuthCookieDomain = (configuredDomain?: string): string | undefined => {
+export const resolveAuthCookieDomain = (
+  configuredDomain?: string,
+  warn: (message: string) => void = console.warn
+): string | undefined => {
   const cookieDomain = (configuredDomain || '').trim();
 
   if (!cookieDomain) {
@@ -33,7 +36,7 @@ export const resolveAuthCookieDomain = (configuredDomain?: string): string | und
   }
 
   if (!isValidCookieDomain(cookieDomain)) {
-    console.warn(
+    warn(
       `Ignoring invalid admin auth cookie domain "${cookieDomain}" (must be a bare host name); using a host-only cookie instead.`
     );
     return DEFAULT_AUTH_COOKIE_DOMAIN;

--- a/packages/core/admin/shared/utils/auth-cookie-name.ts
+++ b/packages/core/admin/shared/utils/auth-cookie-name.ts
@@ -15,7 +15,10 @@ export const DEFAULT_AUTH_COOKIE_NAME = 'jwtToken';
 // RFC 6265 cookie-name token characters.
 const VALID_COOKIE_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
-export const resolveAuthCookieName = (configuredName?: string): string => {
+export const resolveAuthCookieName = (
+  configuredName?: string,
+  warn: (message: string) => void = console.warn
+): string => {
   const cookieName = (configuredName || '').trim();
 
   if (!cookieName) {
@@ -23,7 +26,7 @@ export const resolveAuthCookieName = (configuredName?: string): string => {
   }
 
   if (!VALID_COOKIE_NAME.test(cookieName)) {
-    console.warn(
+    warn(
       `Ignoring invalid admin auth cookie name "${cookieName}" (must only contain RFC 6265 cookie-name characters); using "${DEFAULT_AUTH_COOKIE_NAME}" instead.`
     );
     return DEFAULT_AUTH_COOKIE_NAME;

--- a/packages/core/admin/shared/utils/auth-cookie-path.ts
+++ b/packages/core/admin/shared/utils/auth-cookie-path.ts
@@ -1,0 +1,42 @@
+/**
+ * Path attribute of the admin auth (access) token cookie, configurable
+ * through `admin.auth.cookie.path` so multiple Strapi instances on the same
+ * parent domain can keep separate cookies (e.g. `/strapi-de/admin`).
+ *
+ * Browser-safe single source for both sides of the handoff: the admin panel
+ * cannot read server config, so the build transports the config value into
+ * the bundle through the internal `STRAPI_ADMIN_AUTH_COOKIE_PATH` variable
+ * (see create-build-context.ts in @strapi/strapi); the server resolves the
+ * same config at runtime. Changing the path requires an admin rebuild, like
+ * any other admin config change.
+ *
+ * Defaults to `/admin` to match the refresh-cookie path used by
+ * `getRefreshCookieOptions`.
+ */
+export const DEFAULT_AUTH_COOKIE_PATH = '/admin';
+
+const isValidCookiePath = (path: string): boolean => {
+  if (!path.startsWith('/')) {
+    return false;
+  }
+
+  // RFC 6265 path-av: any CHAR except CTLs or ";".
+  return !/[\x00-\x1F\x7F;]/.test(path);
+};
+
+export const resolveAuthCookiePath = (configuredPath?: string): string => {
+  const cookiePath = (configuredPath || '').trim();
+
+  if (!cookiePath) {
+    return DEFAULT_AUTH_COOKIE_PATH;
+  }
+
+  if (!isValidCookiePath(cookiePath)) {
+    console.warn(
+      `Ignoring invalid admin auth cookie path "${cookiePath}" (must be an absolute path without ";"); using "${DEFAULT_AUTH_COOKIE_PATH}" instead.`
+    );
+    return DEFAULT_AUTH_COOKIE_PATH;
+  }
+
+  return cookiePath;
+};

--- a/packages/core/admin/shared/utils/auth-cookie-path.ts
+++ b/packages/core/admin/shared/utils/auth-cookie-path.ts
@@ -24,7 +24,10 @@ const isValidCookiePath = (path: string): boolean => {
   return !/[\x00-\x1F\x7F;]/.test(path);
 };
 
-export const resolveAuthCookiePath = (configuredPath?: string): string => {
+export const resolveAuthCookiePath = (
+  configuredPath?: string,
+  warn: (message: string) => void = console.warn
+): string => {
   const cookiePath = (configuredPath || '').trim();
 
   if (!cookiePath) {
@@ -32,7 +35,7 @@ export const resolveAuthCookiePath = (configuredPath?: string): string => {
   }
 
   if (!isValidCookiePath(cookiePath)) {
-    console.warn(
+    warn(
       `Ignoring invalid admin auth cookie path "${cookiePath}" (must be an absolute path without ";"); using "${DEFAULT_AUTH_COOKIE_PATH}" instead.`
     );
     return DEFAULT_AUTH_COOKIE_PATH;

--- a/packages/core/admin/shared/utils/session-auth.ts
+++ b/packages/core/admin/shared/utils/session-auth.ts
@@ -5,6 +5,7 @@ import { buildSessionMetadata } from '@strapi/utils';
 
 import { resolveAuthCookieName } from './auth-cookie-name';
 import { resolveAuthCookiePath } from './auth-cookie-path';
+import { resolveAuthCookieDomain } from './auth-cookie-domain';
 
 const ADMIN_ORIGIN = 'admin';
 const SESSION_CONTENT_TYPE = 'admin::session';
@@ -19,6 +20,12 @@ export const getAccessCookieName = (): string => {
 export const getAccessCookiePath = (): string => {
   const configured: string | undefined = strapi.config.get('admin.auth.cookie.path');
   return resolveAuthCookiePath(configured);
+};
+
+export const getAccessCookieDomain = (): string | undefined => {
+  const configured: string | undefined =
+    strapi.config.get('admin.auth.cookie.domain') || strapi.config.get('admin.auth.domain');
+  return resolveAuthCookieDomain(configured);
 };
 
 export const DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN = 30 * 24 * 60 * 60;

--- a/packages/core/admin/shared/utils/session-auth.ts
+++ b/packages/core/admin/shared/utils/session-auth.ts
@@ -4,6 +4,7 @@ import type { Modules } from '@strapi/types';
 import { buildSessionMetadata } from '@strapi/utils';
 
 import { resolveAuthCookieName } from './auth-cookie-name';
+import { resolveAuthCookiePath } from './auth-cookie-path';
 
 const ADMIN_ORIGIN = 'admin';
 const SESSION_CONTENT_TYPE = 'admin::session';
@@ -13,6 +14,11 @@ export const REFRESH_COOKIE_NAME = 'strapi_admin_refresh';
 export const getAccessCookieName = (): string => {
   const configured: string | undefined = strapi.config.get('admin.auth.cookie.name');
   return resolveAuthCookieName(configured);
+};
+
+export const getAccessCookiePath = (): string => {
+  const configured: string | undefined = strapi.config.get('admin.auth.cookie.path');
+  return resolveAuthCookiePath(configured);
 };
 
 export const DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN = 30 * 24 * 60 * 60;
@@ -26,7 +32,7 @@ export const getRefreshCookieOptions = (secureRequest?: boolean) => {
 
   const domain: string | undefined =
     strapi.config.get('admin.auth.cookie.domain') || strapi.config.get('admin.auth.domain');
-  const path: string = strapi.config.get('admin.auth.cookie.path', '/admin');
+  const path = getAccessCookiePath();
 
   const sameSite: boolean | 'lax' | 'strict' | 'none' =
     strapi.config.get('admin.auth.cookie.sameSite') ?? 'lax';

--- a/packages/core/admin/shared/utils/session-auth.ts
+++ b/packages/core/admin/shared/utils/session-auth.ts
@@ -37,8 +37,7 @@ export const getRefreshCookieOptions = (secureRequest?: boolean) => {
   const configuredSecure = strapi.config.get('admin.auth.cookie.secure');
   const isProduction = process.env.NODE_ENV === 'production';
 
-  const domain: string | undefined =
-    strapi.config.get('admin.auth.cookie.domain') || strapi.config.get('admin.auth.domain');
+  const domain = getAccessCookieDomain();
   const path = getAccessCookiePath();
 
   const sameSite: boolean | 'lax' | 'strict' | 'none' =

--- a/packages/core/admin/shared/utils/session-auth.ts
+++ b/packages/core/admin/shared/utils/session-auth.ts
@@ -12,20 +12,27 @@ const SESSION_CONTENT_TYPE = 'admin::session';
 
 export const REFRESH_COOKIE_NAME = 'strapi_admin_refresh';
 
+// The resolvers are browser-shared (also inlined into the admin bundle) so
+// they default to console.warn; on the server, route their warnings through
+// the Strapi logger instead.
+const warnViaStrapiLog = (message: string): void => {
+  strapi.log.warn(message);
+};
+
 export const getAccessCookieName = (): string => {
   const configured: string | undefined = strapi.config.get('admin.auth.cookie.name');
-  return resolveAuthCookieName(configured);
+  return resolveAuthCookieName(configured, warnViaStrapiLog);
 };
 
 export const getAccessCookiePath = (): string => {
   const configured: string | undefined = strapi.config.get('admin.auth.cookie.path');
-  return resolveAuthCookiePath(configured);
+  return resolveAuthCookiePath(configured, warnViaStrapiLog);
 };
 
 export const getAccessCookieDomain = (): string | undefined => {
   const configured: string | undefined =
     strapi.config.get('admin.auth.cookie.domain') || strapi.config.get('admin.auth.domain');
-  return resolveAuthCookieDomain(configured);
+  return resolveAuthCookieDomain(configured, warnViaStrapiLog);
 };
 
 export const DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN = 30 * 24 * 60 * 60;

--- a/packages/core/strapi/src/node/__tests__/create-build-context.test.ts
+++ b/packages/core/strapi/src/node/__tests__/create-build-context.test.ts
@@ -20,7 +20,12 @@ jest.mock('node:fs/promises', () => ({
   rm: jest.fn().mockResolvedValue(undefined),
 }));
 
-const buildStrapiMock = (cookieName?: string, cookiePath?: string): Core.Strapi =>
+const buildStrapiMock = (
+  cookieName?: string,
+  cookiePath?: string,
+  cookieDomain?: string,
+  legacyAuthDomain?: string
+): Core.Strapi =>
   ({
     config: {
       get: jest.fn((key: string, def?: unknown) => {
@@ -38,6 +43,12 @@ const buildStrapiMock = (cookieName?: string, cookiePath?: string): Core.Strapi 
         }
         if (key === 'admin.auth.cookie.path') {
           return cookiePath;
+        }
+        if (key === 'admin.auth.cookie.domain') {
+          return cookieDomain;
+        }
+        if (key === 'admin.auth.domain') {
+          return legacyAuthDomain;
         }
         if (key === 'features') {
           return undefined;
@@ -140,5 +151,42 @@ describe('createBuildContext', () => {
     const ctx = await createBuildContext(buildArgs(strapi));
 
     expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_PATH).toBe('/config/admin');
+  });
+
+  it('transports admin.auth.cookie.domain into STRAPI_ADMIN_AUTH_COOKIE_DOMAIN', async () => {
+    const strapi = buildStrapiMock(undefined, undefined, 'strapi.test');
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_DOMAIN).toBe('strapi.test');
+  });
+
+  it('falls back to admin.auth.domain for STRAPI_ADMIN_AUTH_COOKIE_DOMAIN', async () => {
+    const strapi = buildStrapiMock(undefined, undefined, undefined, 'legacy.strapi.test');
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_DOMAIN).toBe('legacy.strapi.test');
+  });
+
+  it('prefers admin.auth.cookie.domain over admin.auth.domain', async () => {
+    const strapi = buildStrapiMock(
+      undefined,
+      undefined,
+      'cookie.strapi.test',
+      'legacy.strapi.test'
+    );
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_DOMAIN).toBe('cookie.strapi.test');
+  });
+
+  it('sets an empty STRAPI_ADMIN_AUTH_COOKIE_DOMAIN when config is unset', async () => {
+    const strapi = buildStrapiMock(undefined, undefined, undefined, undefined);
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_DOMAIN).toBe('');
   });
 });

--- a/packages/core/strapi/src/node/__tests__/create-build-context.test.ts
+++ b/packages/core/strapi/src/node/__tests__/create-build-context.test.ts
@@ -20,7 +20,7 @@ jest.mock('node:fs/promises', () => ({
   rm: jest.fn().mockResolvedValue(undefined),
 }));
 
-const buildStrapiMock = (cookieName?: string): Core.Strapi =>
+const buildStrapiMock = (cookieName?: string, cookiePath?: string): Core.Strapi =>
   ({
     config: {
       get: jest.fn((key: string, def?: unknown) => {
@@ -35,6 +35,9 @@ const buildStrapiMock = (cookieName?: string): Core.Strapi =>
         }
         if (key === 'admin.auth.cookie.name') {
           return cookieName;
+        }
+        if (key === 'admin.auth.cookie.path') {
+          return cookiePath;
         }
         if (key === 'features') {
           return undefined;
@@ -108,5 +111,34 @@ describe('createBuildContext', () => {
     const ctx = await createBuildContext(buildArgs(strapi));
 
     expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_NAME).toBe('');
+  });
+
+  it('transports admin.auth.cookie.path into STRAPI_ADMIN_AUTH_COOKIE_PATH', async () => {
+    const strapi = buildStrapiMock(undefined, '/strapi-de/admin');
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_PATH).toBe('/strapi-de/admin');
+  });
+
+  it('sets an empty STRAPI_ADMIN_AUTH_COOKIE_PATH when config is unset', async () => {
+    const strapi = buildStrapiMock(undefined, undefined);
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_PATH).toBe('');
+  });
+
+  it('overrides ambient STRAPI_ADMIN_AUTH_COOKIE_PATH from process.env with config', async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      STRAPI_ADMIN_AUTH_COOKIE_PATH: '/env/admin',
+    };
+
+    const strapi = buildStrapiMock(undefined, '/config/admin');
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_PATH).toBe('/config/admin');
   });
 });

--- a/packages/core/strapi/src/node/create-build-context.ts
+++ b/packages/core/strapi/src/node/create-build-context.ts
@@ -99,10 +99,12 @@ const createBuildContext = async <TOptions extends BaseOptions>({
     STRAPI_ANALYTICS_URL: process.env.STRAPI_ANALYTICS_URL || 'https://analytics.strapi.io',
   });
 
-  // NOTE: Transports `admin.auth.cookie.name` into the bundle; always assigned so an
-  // ambient STRAPI_ADMIN_AUTH_COOKIE_NAME cannot make the bundle disagree with the server.
+  // NOTE: Transports `admin.auth.cookie.name` / `path` into the bundle; always assigned so
+  // ambient STRAPI_ADMIN_AUTH_COOKIE_* env vars cannot make the bundle disagree with the server.
   env.STRAPI_ADMIN_AUTH_COOKIE_NAME =
     strapiInstance.config.get<string | undefined>('admin.auth.cookie.name') || '';
+  env.STRAPI_ADMIN_AUTH_COOKIE_PATH =
+    strapiInstance.config.get<string | undefined>('admin.auth.cookie.path') || '';
 
   const envKeys = Object.keys(env);
 

--- a/packages/core/strapi/src/node/create-build-context.ts
+++ b/packages/core/strapi/src/node/create-build-context.ts
@@ -99,12 +99,17 @@ const createBuildContext = async <TOptions extends BaseOptions>({
     STRAPI_ANALYTICS_URL: process.env.STRAPI_ANALYTICS_URL || 'https://analytics.strapi.io',
   });
 
-  // NOTE: Transports `admin.auth.cookie.name` / `path` into the bundle; always assigned so
-  // ambient STRAPI_ADMIN_AUTH_COOKIE_* env vars cannot make the bundle disagree with the server.
+  // NOTE: Transports `admin.auth.cookie.name` / `path` / `domain` into the bundle; always
+  // assigned so ambient STRAPI_ADMIN_AUTH_COOKIE_* env vars cannot make the bundle disagree
+  // with the server. Domain falls back to `admin.auth.domain`, matching the server resolution.
   env.STRAPI_ADMIN_AUTH_COOKIE_NAME =
     strapiInstance.config.get<string | undefined>('admin.auth.cookie.name') || '';
   env.STRAPI_ADMIN_AUTH_COOKIE_PATH =
     strapiInstance.config.get<string | undefined>('admin.auth.cookie.path') || '';
+  env.STRAPI_ADMIN_AUTH_COOKIE_DOMAIN =
+    strapiInstance.config.get<string | undefined>('admin.auth.cookie.domain') ||
+    strapiInstance.config.get<string | undefined>('admin.auth.domain') ||
+    '';
 
   const envKeys = Object.keys(env);
 


### PR DESCRIPTION
### What does it do?

Cherry-picks the client half of the `admin.auth.cookie.path` fix (strapi/strapi#27041) onto `releases/5.51.0` so logout / session-expiry clears the SSO access cookie.

* Build transports `admin.auth.cookie.path` into the admin bundle as `STRAPI_ADMIN_AUTH_COOKIE_PATH`
* Client `setCookie` / `deleteCookie` use that path (default `/admin`) instead of hardcoded `Path=/`
* On set/delete, also clears legacy `Path=/` copies so upgrades do not leave a colliding root cookie

### Why is it needed?

On experimental `0.0.0-experimental.9b436ac35c246f087c48e2517b110d3e4591d4a1` (`releases/5.51.0`), remotely ending another SSO session leaves the second browser in an infinite login redirect loop.

Root cause (not a regression in strapi/strapi#26872's logout deviceId logic itself):

1. strapi/strapi#26300 made EE SSO write the access cookie with `Path=/admin`
2. The admin client still wrote/deleted with `Path=/`, so logout cleared only the root cookie and left the `Path=/admin` SSO cookie behind
3. strapi/strapi#26872 made Active Devices correctly list/revoke SSO sessions, so remote revoke now actually kills the server session — and the leftover cookie rehydrates a dead JWT on the next load → `AuthPage` sees a token and redirects to `/` → API 401 → login → repeat

Password login was unaffected (token is stored client-side with `Path=/` only). strapi/strapi#27041 already fixes this on `develop`; this PR is the release backport.

### How to test it?

Automated:

```bash
yarn workspace @strapi/admin test:unit --testPathPattern='auth-cookie-path|session-auth'
yarn workspace @strapi/admin test:front --testPathPattern='cookies.test'
yarn workspace @strapi/strapi test:unit --testPathPattern='create-build-context'
```

Manual (SSO):

1. Configure Google SSO
2. Log in on two browsers via SSO
3. From browser A, end browser B's session under Active Devices
4. In browser B, refresh or navigate
5. Expect a single redirect to `/auth/login` that stays there (no loop); DevTools → Application → Cookies should show no leftover `jwtToken` under `/admin`

### Related issue(s)/PR(s)

* Cherry-pick of strapi/strapi#27041 onto `releases/5.51.0`
* Completes client half of strapi/strapi#26300 / strapi/strapi#25478
* Surfaces after strapi/strapi#26872 (SSO Active Devices revoke now works)
* Fixes [CMS-1456](https://linear.app/strapi/issue/CMS-1456/fixadmin-access-token-cookie-ignores-adminauthcookiepath)