### PR TITLE
future(upload): normalize drag preview icon size

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/components/Dnd/DragOverlayChip.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/Dnd/DragOverlayChip.tsx
@@ -7,6 +7,13 @@ import { getTranslationKey } from '../../../../utils/translations';
 
 import type { DragItemData } from '../../../../types/dnd';
 
+// Folder & File (@strapi/icons) share viewBox 0 0 32 32 but File's glyph is
+// narrower/lighter. Rendering File a few px larger inside a fixed square box makes
+// the two previews read at the same visual size without shifting the chip layout.
+const FOLDER_ICON_SIZE = 20;
+const FILE_ICON_SIZE = 24;
+const ICON_BOX = 24;
+
 const Chip = styled(Flex)`
   position: relative;
   align-items: center;
@@ -31,6 +38,14 @@ const CompositeChip = styled(Chip)`
 const CountGroup = styled(Flex)`
   align-items: center;
   gap: ${({ theme }) => theme.spaces[1]};
+`;
+
+const IconBox = styled(Flex)`
+  flex-shrink: 0;
+  width: ${ICON_BOX}px;
+  height: ${ICON_BOX}px;
+  align-items: center;
+  justify-content: center;
 `;
 
 const TotalBadge = styled(Flex)`
@@ -59,11 +74,15 @@ export const DragOverlayChip = ({ items }: DragOverlayChipProps) => {
 
   if (items.length === 1) {
     const item = items[0];
-    const Icon = item.kind === 'folder' ? FolderIcon : FileIcon;
+    const isFolder = item.kind === 'folder';
+    const Icon = isFolder ? FolderIcon : FileIcon;
+    const size = isFolder ? FOLDER_ICON_SIZE : FILE_ICON_SIZE;
 
     return (
       <Chip>
-        <Icon width={20} height={20} />
+        <IconBox>
+          <Icon width={size} height={size} />
+        </IconBox>
         <Typography textColor="neutral800" fontWeight="semiBold" ellipsis>
           {item.name}
         </Typography>
@@ -79,7 +98,9 @@ export const DragOverlayChip = ({ items }: DragOverlayChipProps) => {
     <CompositeChip gap={3}>
       {folderCount > 0 ? (
         <CountGroup>
-          <FolderIcon width={20} height={20} />
+          <IconBox>
+            <FolderIcon width={FOLDER_ICON_SIZE} height={FOLDER_ICON_SIZE} />
+          </IconBox>
           <Typography textColor="neutral800" fontWeight="semiBold">
             {formatMessage(
               {
@@ -93,7 +114,9 @@ export const DragOverlayChip = ({ items }: DragOverlayChipProps) => {
       ) : null}
       {fileCount > 0 ? (
         <CountGroup>
-          <FileIcon width={20} height={20} />
+          <IconBox>
+            <FileIcon width={FILE_ICON_SIZE} height={FILE_ICON_SIZE} />
+          </IconBox>
           <Typography textColor="neutral800" fontWeight="semiBold">
             {formatMessage(
               {

--- a/packages/core/upload/admin/src/future/pages/Assets/components/Dnd/tests/DragOverlayChip.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/Dnd/tests/DragOverlayChip.test.tsx
@@ -18,6 +18,40 @@ describe('DragOverlayChip', () => {
     expect(screen.getByText('hero.png')).toBeInTheDocument();
   });
 
+  it('renders the single file icon at the enlarged size', () => {
+    const item: DragItemData = {
+      kind: 'file',
+      id: 10,
+      name: 'hero.png',
+      folderId: 1,
+    };
+
+    const { container } = render(<DragOverlayChip items={[item]} />);
+
+    // @strapi/icons render an unnamed <svg>, so there is no accessible query for it.
+    // eslint-disable-next-line testing-library/no-container
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+  });
+
+  it('renders the single folder icon at the base size', () => {
+    const item: DragItemData = {
+      kind: 'folder',
+      id: 1,
+      name: 'A',
+      parentId: null,
+    };
+
+    const { container } = render(<DragOverlayChip items={[item]} />);
+
+    // @strapi/icons render an unnamed <svg>, so there is no accessible query for it.
+    // eslint-disable-next-line testing-library/no-container
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '20');
+    expect(svg).toHaveAttribute('height', '20');
+  });
+
   it('renders folder and file counts with a total badge for multiple items', () => {
     const items: DragItemData[] = [
       { kind: 'folder', id: 1, name: 'A', parentId: null },
@@ -32,6 +66,23 @@ describe('DragOverlayChip', () => {
     expect(screen.getByText('2 folders')).toBeInTheDocument();
     expect(screen.getByText('3 files')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('sizes the composite folder and file count icons to match visually', () => {
+    const items: DragItemData[] = [
+      { kind: 'folder', id: 1, name: 'A', parentId: null },
+      { kind: 'file', id: 10, name: 'a.png', folderId: null },
+    ];
+
+    const { container } = render(<DragOverlayChip items={items} />);
+
+    // @strapi/icons render unnamed <svg>s, so there is no accessible query for them.
+    // eslint-disable-next-line testing-library/no-container
+    const [folderSvg, fileSvg] = Array.from(container.querySelectorAll('svg'));
+    expect(folderSvg).toHaveAttribute('width', '20');
+    expect(folderSvg).toHaveAttribute('height', '20');
+    expect(fileSvg).toHaveAttribute('width', '24');
+    expect(fileSvg).toHaveAttribute('height', '24');
   });
 
   it('omits the folder count when the drag set is files only', () => {


### PR DESCRIPTION
### What does it do?

Normalizes the icon sizing in the drag preview chip (`DragOverlayChip`) used by the
Upload asset drag-and-drop feature.

### Why is it needed?

In the drag overlay, the `Folder` and `File` icons were both rendered at 20px. Because
the `File` glyph is visually lighter/narrower than the `Folder` glyph, the file preview
looked smaller than the folder preview, and icons weren't consistently boxed, causing
minor layout shifts between preview states. This change makes the previews visually
consistent.

### How to test it?

1. Run the Upload admin in the `future` asset manager.
2. Drag a single file, a single folder, and a mixed selection of files and folders.
3. Verify the drag preview chip icons appear the same visual size and the chip layout
   stays stable across each preview.

Automated:

```bash
yarn test:front packages/core/upload/admin/src/future/pages/Assets/components/Dnd/tests/DragOverlayChip.test.tsx