### PR TITLE
fix(i18n): reject writes for unconfigured locales

### DIFF
--- a/packages/core/core/src/services/document-service/internationalization.ts
+++ b/packages/core/core/src/services/document-service/internationalization.ts
@@ -16,6 +16,14 @@ const getDefaultLocale = async (): Promise<string> => {
   return strapi.plugin('i18n').service('locales').getDefaultLocale();
 };
 
+const assertLocaleExists = async (locale: string) => {
+  const foundLocale = await strapi.plugin('i18n').service('locales').findByCode(locale);
+
+  if (!foundLocale) {
+    throw new errors.ValidationError(`Locale ${locale} not found`);
+  }
+};
+
 const defaultLocale: AsyncTransform = async (contentType, params) => {
   if (!strapi.plugin('i18n').service('content-types').isLocalizedContentType(contentType)) {
     return params;
@@ -73,7 +81,7 @@ const multiLocaleToLookup: Transform = (contentType, params) => {
 /**
  * Translate locale status parameter into the data that will be saved
  */
-const localeToData: Transform = (contentType, params) => {
+const localeToData: AsyncTransform = async (contentType, params) => {
   if (!strapi.plugin('i18n').service('content-types').isLocalizedContentType(contentType)) {
     return params;
   }
@@ -81,6 +89,7 @@ const localeToData: Transform = (contentType, params) => {
   if (params.locale) {
     const isValidLocale = typeof params.locale === 'string' && params.locale !== '*';
     if (isValidLocale) {
+      await assertLocaleExists(params.locale);
       return assoc(['data', 'locale'], params.locale, params);
     }
 

--- a/tests/api/plugins/i18n/content-api/content-api.test.api.js
+++ b/tests/api/plugins/i18n/content-api/content-api.test.api.js
@@ -85,6 +85,7 @@ const categories = [
 ];
 
 const data = {};
+const UNCONFIGURED_LOCALE = 'en-GB';
 
 describe('i18n - Content API', () => {
   const builder = createTestBuilder();
@@ -144,6 +145,96 @@ describe('i18n - Content API', () => {
       expect(Array.isArray(body.data)).toBe(true);
       expect(body.data).toHaveLength(1);
       expect(body.data[0]).toMatchObject(transformToRESTResource(data.categories[1]));
+    });
+
+    test('Can create an entry in a configured locale', async () => {
+      const categoryName = 'configured locale category';
+
+      const res = await rq({
+        method: 'POST',
+        url: '/categories?locale=ko',
+        body: {
+          data: {
+            name: categoryName,
+          },
+        },
+      });
+
+      const createdEntry = await strapi.db.query('api::category.category').findOne({
+        where: {
+          name: categoryName,
+          locale: 'ko',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(createdEntry).toMatchObject({
+        name: categoryName,
+        locale: 'ko',
+      });
+    });
+
+    test('Cannot create an entry in an unconfigured locale', async () => {
+      const categoryName = 'unconfigured locale category';
+
+      const res = await rq({
+        method: 'POST',
+        url: `/categories?locale=${UNCONFIGURED_LOCALE}`,
+        body: {
+          data: {
+            name: categoryName,
+          },
+        },
+      });
+
+      const createdEntries = await strapi.db.query('api::category.category').findMany({
+        where: {
+          name: categoryName,
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error.name).toBe('ValidationError');
+      expect(res.body.error.message).toContain(`Locale ${UNCONFIGURED_LOCALE} not found`);
+      expect(createdEntries).toHaveLength(0);
+    });
+
+    test('Cannot update an entry in an unconfigured locale', async () => {
+      const categoryBefore = await strapi.db.query('api::category.category').findOne({
+        where: {
+          documentId: data.categories[0].documentId,
+          locale: 'en',
+        },
+      });
+
+      const res = await rq({
+        method: 'PUT',
+        url: `/categories/${data.categories[0].documentId}?locale=${UNCONFIGURED_LOCALE}`,
+        body: {
+          data: {
+            name: 'unconfigured locale update',
+          },
+        },
+      });
+
+      const categoryAfter = await strapi.db.query('api::category.category').findOne({
+        where: {
+          documentId: data.categories[0].documentId,
+          locale: 'en',
+        },
+      });
+
+      const updatedEntries = await strapi.db.query('api::category.category').findMany({
+        where: {
+          name: 'unconfigured locale update',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error.name).toBe('ValidationError');
+      expect(res.body.error.message).toContain(`Locale ${UNCONFIGURED_LOCALE} not found`);
+      expect(categoryAfter.name).toBe(categoryBefore.name);
+      expect(updatedEntries).toHaveLength(0);
     });
   });
 

--- a/tests/api/plugins/i18n/content-api/content-api.test.api.js
+++ b/tests/api/plugins/i18n/content-api/content-api.test.api.js
@@ -174,6 +174,33 @@ describe('i18n - Content API', () => {
       });
     });
 
+    test('Can create an entry using the default locale', async () => {
+      const categoryName = 'default locale category';
+
+      const res = await rq({
+        method: 'POST',
+        url: '/categories',
+        body: {
+          data: {
+            name: categoryName,
+          },
+        },
+      });
+
+      const createdEntry = await strapi.db.query('api::category.category').findOne({
+        where: {
+          name: categoryName,
+          locale: 'en',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(createdEntry).toMatchObject({
+        name: categoryName,
+        locale: 'en',
+      });
+    });
+
     test('Cannot create an entry in an unconfigured locale', async () => {
       const categoryName = 'unconfigured locale category';
 
@@ -261,6 +288,42 @@ describe('i18n - Content API', () => {
 
       expect(statusCode).toBe(200);
       expect(body.data).toMatchObject(transformToRESTResource(data.homepages[1]));
+    });
+
+    test('Cannot update an entry in an unconfigured locale', async () => {
+      const homepageBefore = await strapi.db.query('api::homepage.homepage').findOne({
+        where: {
+          locale: 'en',
+        },
+      });
+
+      const res = await rq({
+        method: 'PUT',
+        url: `/homepage?locale=${UNCONFIGURED_LOCALE}`,
+        body: {
+          data: {
+            title: 'unconfigured locale homepage update',
+          },
+        },
+      });
+
+      const homepageAfter = await strapi.db.query('api::homepage.homepage').findOne({
+        where: {
+          locale: 'en',
+        },
+      });
+
+      const updatedEntries = await strapi.db.query('api::homepage.homepage').findMany({
+        where: {
+          title: 'unconfigured locale homepage update',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error.name).toBe('ValidationError');
+      expect(res.body.error.message).toContain(`Locale ${UNCONFIGURED_LOCALE} not found`);
+      expect(homepageAfter.title).toBe(homepageBefore.title);
+      expect(updatedEntries).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## What

- Reject document create and update requests when the requested locale is not configured
- Keep writes in configured locales working
- Add Content API coverage for configured-locale creates and unconfigured-locale create/update rejections

## Testing

- `yarn workspace @strapi/core build:code`
- `yarn test:api tests/api/plugins/i18n/content-api/content-api.test.api.js`
- `yarn prettier --check packages/core/core/src/services/document-service/internationalization.ts tests/api/plugins/i18n/content-api/content-api.test.api.js`
- `git diff --check`

Fixes #27108
