### PR TITLE
fix(database): honour connect/disconnect deltas on media morph relations

### DIFF
--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -991,7 +991,16 @@ export const createEntityManager = (db: Database): EntityManager => {
               .execute();
 
             if (hasSet) {
-              const rows = (cleanRelationData.set ?? []).map((data, idx) => ({
+              // Single media (morphOne) is last-wins for multi-item set/array shapes too,
+              // mirroring create and `normalizeXToOneRelationValue` for xToOne relations.
+              // Without the slice, `{ set: [B, C] }` would insert both rows and — because
+              // morphOne populate reads `order asc` + first — leave B observable with a
+              // hidden C row, the same phantom-row defect the connect path guards against.
+              const setData = isSingle
+                ? (cleanRelationData.set ?? []).slice(-1)
+                : (cleanRelationData.set ?? []);
+
+              const rows = setData.map((data, idx) => ({
                 [joinColumn.name]: data.id,
                 [idColumn.name]: id,
                 [typeColumn.name]: uid,

--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -607,22 +607,33 @@ export const createEntityManager = (db: Database): EntityManager => {
 
             const { idColumn, typeColumn } = morphColumn;
 
-            if (isEmpty(cleanRelationData.set)) {
+            // At create there is nothing to delta against, so a connect is equivalent to a
+            // set — honour `set || connect` like regular joinTable relations do. Without this,
+            // create-with-connect (`{ connect: [file] }`) on media silently attaches nothing.
+            // `disconnect` at create is meaningless and is ignored (same as relations).
+            const attachData = !isEmpty(cleanRelationData.set)
+              ? cleanRelationData.set
+              : cleanRelationData.connect;
+
+            if (isEmpty(attachData)) {
               continue;
             }
 
-            const rows =
-              cleanRelationData.set?.map((data, idx) => {
-                return {
-                  [joinColumn.name]: data.id,
-                  [idColumn.name]: id,
-                  [typeColumn.name]: uid,
-                  ...('on' in joinTable && joinTable.on),
-                  ...data.__pivot,
-                  order: idx + 1,
-                  field: attributeName,
-                };
-              }) ?? [];
+            // Single media (morphOne) is last-wins and holds at most one file.
+            const dataset =
+              attribute.relation === 'morphOne' ? (attachData ?? []).slice(-1) : (attachData ?? []);
+
+            const rows = dataset.map((data, idx) => {
+              return {
+                [joinColumn.name]: data.id,
+                [idColumn.name]: id,
+                [typeColumn.name]: uid,
+                ...('on' in joinTable && joinTable.on),
+                ...data.__pivot,
+                order: idx + 1,
+                field: attributeName,
+              };
+            });
 
             await batchInsertJoinTable(db, joinTable.name, rows, trx);
           }
@@ -869,40 +880,73 @@ export const createEntityManager = (db: Database): EntityManager => {
 
             const { idColumn, typeColumn } = morphColumn;
 
-            const hasSet = !isEmpty(cleanRelationData.set);
+            const isSingle = attribute.relation === 'morphOne';
             const hasConnect = !isEmpty(cleanRelationData.connect);
-            const hasDisconnect = !isEmpty(cleanRelationData.disconnect);
+            const hasSet = !isEmpty(cleanRelationData.set);
 
-            // for connect/disconnect without a set, only modify those relations
-            if (!hasSet && (hasConnect || hasDisconnect)) {
-              // delete disconnects and connects (to prevent duplicates when we add them later)
-              const idsToDelete = [
-                ...(cleanRelationData.disconnect || []),
-                ...(cleanRelationData.connect || []),
-              ];
+            // A partial update is a connect/disconnect delta payload (no `set` key),
+            // which must modify only the listed relations — as opposed to a `set`/
+            // scalar/array/null payload, which replaces the whole field. Gate on the
+            // payload *shape* (like regular joinTable relations at `!has('set', …)`),
+            // not on content, so that an empty delta (`{ connect: [] }` /
+            // `{ disconnect: [] }`) is a no-op instead of wiping the field.
+            const isPartialUpdate = !has('set', cleanRelationData);
 
-              if (!isEmpty(idsToDelete)) {
-                const where = {
-                  $or: idsToDelete.map((item: any) => {
-                    return {
-                      [idColumn.name]: id,
-                      [typeColumn.name]: uid,
-                      [joinColumn.name]: item.id,
-                      ...joinTable.on,
-                      field: attributeName,
-                    };
-                  }),
-                };
-
+            if (isPartialUpdate) {
+              // For single media (morphOne) a connect is last-wins and the field holds
+              // at most one file, so a connect replaces whatever is attached: delete ALL
+              // existing rows for this field first (not just the connected ids). Upload
+              // files have no draft & publish, so we enforce exactly one physical row —
+              // do not copy the xToOne-relation looseness that tolerates two rows.
+              // For multiple media (morphMany) only the listed connect/disconnect ids are
+              // deleted (dedup before re-insert / removal).
+              if (isSingle && hasConnect) {
                 await this.createQueryBuilder(joinTable.name)
                   .delete()
-                  .where(where)
+                  .where({
+                    [idColumn.name]: id,
+                    [typeColumn.name]: uid,
+                    ...joinTable.on,
+                    field: attributeName,
+                  })
                   .transacting(trx)
                   .execute();
+              } else {
+                // delete disconnects and connects (to prevent duplicates when we add them later)
+                const idsToDelete = [
+                  ...(cleanRelationData.disconnect || []),
+                  ...(cleanRelationData.connect || []),
+                ];
+
+                if (!isEmpty(idsToDelete)) {
+                  const where = {
+                    $or: idsToDelete.map((item: any) => {
+                      return {
+                        [idColumn.name]: id,
+                        [typeColumn.name]: uid,
+                        [joinColumn.name]: item.id,
+                        ...joinTable.on,
+                        field: attributeName,
+                      };
+                    }),
+                  };
+
+                  await this.createQueryBuilder(joinTable.name)
+                    .delete()
+                    .where(where)
+                    .transacting(trx)
+                    .execute();
+                }
               }
 
               // connect relations
               if (hasConnect) {
+                // Single media is last-wins: keep only the final connected file so the
+                // field ends with exactly one row. Multiple media appends all connects.
+                const connects = isSingle
+                  ? (cleanRelationData.connect ?? []).slice(-1)
+                  : (cleanRelationData.connect ?? []);
+
                 // Query database to find the order of the last relation
                 const start = await this.createQueryBuilder(joinTable.name)
                   .where({
@@ -918,7 +962,7 @@ export const createEntityManager = (db: Database): EntityManager => {
 
                 const startOrder = (start as any)?.max || 0;
 
-                const rows = (cleanRelationData.connect ?? []).map((data, idx) => ({
+                const rows = connects.map((data, idx) => ({
                   [joinColumn.name]: data.id,
                   [idColumn.name]: id,
                   [typeColumn.name]: uid,

--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -146,6 +146,20 @@ type Assocs =
       disconnect?: Array<ScalarAssoc> | null;
     };
 
+/**
+ * Media attributes are modelled as morph relations targeting the upload file model
+ * (see transformAttribute in @strapi/core: `media` -> morphOne/morphMany on
+ * `plugin::upload.file`). Single media is last-wins and holds at most one file.
+ *
+ * `morphOne` on its own is NOT a media marker — it is a generic inverse polymorphic
+ * relation available to any content type — so last-wins truncation must be gated on
+ * the upload target rather than on the relation kind.
+ */
+const UPLOAD_FILE_UID = 'plugin::upload.file';
+
+const isSingleMediaAttribute = (attribute: { relation?: string; target?: string }) =>
+  attribute.relation === 'morphOne' && attribute.target === UPLOAD_FILE_UID;
+
 const toAssocs = (data: Assocs) => {
   if (
     isArray(data) ||
@@ -159,7 +173,12 @@ const toAssocs = (data: Assocs) => {
     };
   }
 
-  if (data?.set) {
+  // Check for the `set` key by presence, not truthiness: `{ set: null }` is a valid
+  // "clear this field" payload. A truthiness check let it fall through to the
+  // connect/disconnect branch below, where it arrived without a `set` key and was
+  // then indistinguishable from a delta payload — silently preserving the relation
+  // instead of clearing it.
+  if (isRecord(data) && has('set', data) && data.set !== undefined) {
     return {
       set: isNull(data.set) ? data.set : toIdArray(data.set),
     };
@@ -619,9 +638,23 @@ export const createEntityManager = (db: Database): EntityManager => {
               continue;
             }
 
-            // Single media (morphOne) is last-wins and holds at most one file.
-            const dataset =
-              attribute.relation === 'morphOne' ? (attachData ?? []).slice(-1) : (attachData ?? []);
+            // Single media is last-wins and holds at most one file. Gate on the upload
+            // target, not on `morphOne`: `morphOne` is a generic inverse polymorphic
+            // relation that users can author against any content type. For a non-D&P
+            // source targeting a D&P model the Document Service deliberately expands one
+            // documentId into both the draft and published entity ids, so truncating a
+            // generic morphOne here would drop a legitimate row.
+            //
+            // Then deduplicate by target id before ordering/insert: toIdArray dedups with
+            // uniqWith(isEqual) *before* scalar and object entries are given a common
+            // shape, so `[B, { id: B }]` survives as two structurally different entries and
+            // would insert two identical morph rows — the join table has no composite
+            // uniqueness guard. Regular joinTable relations already guard this with
+            // uniqBy('id', ...); do the same here.
+            const dataset = uniqBy(
+              'id',
+              isSingleMediaAttribute(attribute) ? (attachData ?? []).slice(-1) : (attachData ?? [])
+            );
 
             const rows = dataset.map((data, idx) => {
               return {
@@ -880,7 +913,9 @@ export const createEntityManager = (db: Database): EntityManager => {
 
             const { idColumn, typeColumn } = morphColumn;
 
-            const isSingle = attribute.relation === 'morphOne';
+            // Single *media* only — see isSingleMediaAttribute: a generic `morphOne`
+            // must keep every row the Document Service expanded for it.
+            const isSingle = isSingleMediaAttribute(attribute);
             const hasConnect = !isEmpty(cleanRelationData.connect);
             const hasSet = !isEmpty(cleanRelationData.set);
 
@@ -893,8 +928,8 @@ export const createEntityManager = (db: Database): EntityManager => {
             const isPartialUpdate = !has('set', cleanRelationData);
 
             if (isPartialUpdate) {
-              // For single media (morphOne) a connect is last-wins and the field holds
-              // at most one file, so a connect replaces whatever is attached: delete ALL
+              // For single media a connect is last-wins and the field holds at most one
+              // file, so a connect replaces whatever is attached: delete ALL
               // existing rows for this field first (not just the connected ids). Upload
               // files have no draft & publish, so we enforce exactly one physical row —
               // do not copy the xToOne-relation looseness that tolerates two rows.
@@ -943,9 +978,14 @@ export const createEntityManager = (db: Database): EntityManager => {
               if (hasConnect) {
                 // Single media is last-wins: keep only the final connected file so the
                 // field ends with exactly one row. Multiple media appends all connects.
-                const connects = isSingle
-                  ? (cleanRelationData.connect ?? []).slice(-1)
-                  : (cleanRelationData.connect ?? []);
+                // Dedup by id (see the create path): mixed scalar/object representations
+                // of the same file must produce exactly one physical row.
+                const connects = uniqBy(
+                  'id',
+                  isSingle
+                    ? (cleanRelationData.connect ?? []).slice(-1)
+                    : (cleanRelationData.connect ?? [])
+                );
 
                 // Query database to find the order of the last relation
                 const start = await this.createQueryBuilder(joinTable.name)
@@ -991,14 +1031,15 @@ export const createEntityManager = (db: Database): EntityManager => {
               .execute();
 
             if (hasSet) {
-              // Single media (morphOne) is last-wins for multi-item set/array shapes too,
+              // Single media is last-wins for multi-item set/array shapes too,
               // mirroring create and `normalizeXToOneRelationValue` for xToOne relations.
               // Without the slice, `{ set: [B, C] }` would insert both rows and — because
               // morphOne populate reads `order asc` + first — leave B observable with a
               // hidden C row, the same phantom-row defect the connect path guards against.
-              const setData = isSingle
-                ? (cleanRelationData.set ?? []).slice(-1)
-                : (cleanRelationData.set ?? []);
+              const setData = uniqBy(
+                'id',
+                isSingle ? (cleanRelationData.set ?? []).slice(-1) : (cleanRelationData.set ?? [])
+              );
 
               const rows = setData.map((data, idx) => ({
                 [joinColumn.name]: data.id,

--- a/tests/api/core/content-manager/content-manager/history/history.test.api.ts
+++ b/tests/api/core/content-manager/content-manager/history/history.test.api.ts
@@ -218,6 +218,9 @@ describeOnCondition(edition === 'EE')('History API', () => {
   let collectionTypeDocumentId;
   let singleTypeDocumentId;
   let relations;
+  // Hoisted so the deletion test can target this suite's own asset by id. Test files
+  // share a database within a CI shard, so upload ids are not stable across runs.
+  let imageA;
 
   const createEntry = async ({ uid, data, isCollectionType = true }: CreateEntryArgs) => {
     const type = isCollectionType ? 'collection-types' : 'single-types';
@@ -323,7 +326,8 @@ describeOnCondition(edition === 'EE')('History API', () => {
     const relationIds = relations.map((relation) => relation.data.documentId);
 
     // Upload media assets to be added to versions
-    const [imageA, imageB] = await uploadFiles();
+    let imageB;
+    [imageA, imageB] = await uploadFiles();
     const nestedComposWithImages = {
       rootImage: imageA.id,
       rootImageSibling: imageB.id,
@@ -715,10 +719,10 @@ describeOnCondition(edition === 'EE')('History API', () => {
         url: `/content-manager/history-versions?contentType=${collectionTypeUid}&documentId=${collectionTypeDocumentId}&page=1&pageSize=3&locale=en`,
       });
 
-      // Delete an asset
+      // Delete an asset — target this suite's own upload rather than a hardcoded id.
       await rq({
         method: 'DELETE',
-        url: `/upload/files/1`,
+        url: `/upload/files/${imageA.id}`,
       });
 
       // Restore the initial version containing the deleted asset

--- a/tests/api/core/content-manager/media/media-delta-payloads.test.api.js
+++ b/tests/api/core/content-manager/media/media-delta-payloads.test.api.js
@@ -1,0 +1,480 @@
+'use strict';
+
+/**
+ * Regression coverage for CMS-1428 — single (and multiple) media must honour
+ * `{ connect | disconnect }` delta payloads instead of treating them as a full replace.
+ *
+ * Three pre-existing defects are fixed and exercised here (all in the media morph path of
+ * `packages/core/database/src/entity-manager/index.ts`):
+ *
+ *   A. Empty delta wiped the field. `{ connect: [] }` / `{ disconnect: [] }` (a no-op)
+ *      fell through a content-based gate to the unconditional delete-all → the field emptied.
+ *      Now gated on payload *shape* (`has('set', …)`), so an empty delta is a no-op.
+ *
+ *   B. `{ connect: [B] }` on a populated single media appended a hidden stale join row —
+ *      A stayed observable (ascending order + `_.first`), B became a phantom row. Now single
+ *      media is last-wins: the connect deletes existing rows and inserts exactly one row.
+ *
+ *   C. Create-with-connect attached nothing (the create branch consumed only `set`). Now a
+ *      connect at create is treated as a set (nothing to delta against).
+ *
+ * The raw join-row count is asserted directly on the file's `related` morph join table so
+ * that phantom rows (defect B) are caught — the populated read alone would hide them.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+let strapi;
+let rq;
+
+const singleMediaCT = {
+  displayName: 'delta-single',
+  singularName: 'delta-single',
+  pluralName: 'delta-singles',
+  draftAndPublish: false,
+  attributes: {
+    cover: { type: 'media', multiple: false, required: false },
+    // A second single-media field to prove field-scoped deletes never clobber siblings.
+    thumbnail: { type: 'media', multiple: false, required: false },
+  },
+};
+
+const multipleMediaCT = {
+  displayName: 'delta-multiple',
+  singularName: 'delta-multiple',
+  pluralName: 'delta-multiples',
+  draftAndPublish: false,
+  attributes: {
+    gallery: { type: 'media', multiple: true, required: false },
+  },
+};
+
+const SINGLE_UID = 'api::delta-single.delta-single';
+const MULTIPLE_UID = 'api::delta-multiple.delta-multiple';
+const FILE_UID = 'plugin::upload.file';
+
+const createEntry = (uid, body = {}, qs = {}) =>
+  rq.post(`/content-manager/collection-types/${uid}`, { body, qs });
+
+const updateEntry = (uid, documentId, body = {}, qs = {}) =>
+  rq.put(`/content-manager/collection-types/${uid}/${documentId}`, { body, qs });
+
+const getEntry = (uid, documentId, populate) =>
+  rq.get(`/content-manager/collection-types/${uid}/${documentId}`, { qs: { populate } });
+
+const uploadImg = () =>
+  rq({
+    method: 'POST',
+    url: '/upload',
+    formData: {
+      files: fs.createReadStream(path.join(__dirname, 'rec.jpg')),
+    },
+  });
+
+// Resolve the file's `related` morph join table (name + columns) from metadata so the raw
+// row-count query is dialect-agnostic (physical column names are convention-derived).
+const morphJoinInfo = () => {
+  const { joinTable } = strapi.db.metadata.get(FILE_UID).attributes.related;
+  return {
+    tableName: joinTable.name,
+    joinColumn: joinTable.joinColumn.name, // file id column
+    idColumn: joinTable.morphColumn.idColumn.name, // related entry id
+    typeColumn: joinTable.morphColumn.typeColumn.name, // related entry uid
+  };
+};
+
+// Count physical join rows attaching files to a given entry id / field. This is the ground
+// truth that exposes phantom rows a populated read would hide.
+const countJoinRows = async (entryId, field) => {
+  const { tableName, idColumn, typeColumn } = morphJoinInfo();
+  const rows = await strapi.db
+    .getConnection(tableName)
+    .where({ [idColumn]: entryId, [typeColumn]: SINGLE_UID, field });
+  return rows.length;
+};
+
+const countGalleryRows = async (entryId) => {
+  const { tableName, idColumn, typeColumn } = morphJoinInfo();
+  const rows = await strapi.db
+    .getConnection(tableName)
+    .where({ [idColumn]: entryId, [typeColumn]: MULTIPLE_UID, field: 'gallery' });
+  return rows.length;
+};
+
+describe('CMS-1428 — media connect/disconnect delta payloads', () => {
+  const builder = createTestBuilder();
+  let fileA;
+  let fileB;
+  let fileC;
+
+  beforeAll(async () => {
+    await builder.addContentType(singleMediaCT).addContentType(multipleMediaCT).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const [a, b, c] = await Promise.all([uploadImg(), uploadImg(), uploadImg()]);
+    fileA = a.body[0].id;
+    fileB = b.body[0].id;
+    fileC = c.body[0].id;
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  // Create a single-media entry with `cover` = fileA and return its numeric + document ids.
+  const createWithCover = async () => {
+    const res = await createEntry(SINGLE_UID, { cover: fileA }, { populate: ['cover'] });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data.cover.id).toBe(fileA);
+    return { id: res.body.data.id, documentId: res.body.data.documentId };
+  };
+
+  const readCover = async (documentId) => {
+    const res = await getEntry(SINGLE_UID, documentId, ['cover']);
+    expect(res.statusCode).toBe(200);
+    return res.body.data.cover;
+  };
+
+  describe('Single media — defect A (empty delta is a no-op)', () => {
+    test('{ connect: [] } preserves the attached file', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { connect: [] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const cover = await readCover(documentId);
+      expect(cover).not.toBe(null);
+      expect(cover.id).toBe(fileA);
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+    });
+
+    test('{ disconnect: [] } preserves the attached file', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { disconnect: [] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const cover = await readCover(documentId);
+      expect(cover?.id).toBe(fileA);
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+    });
+
+    test('{ connect: [], disconnect: [] } (CM untouched shape) preserves the attached file', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { connect: [], disconnect: [] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const cover = await readCover(documentId);
+      expect(cover?.id).toBe(fileA);
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+    });
+  });
+
+  describe('Single media — defect B (connect is last-wins, exactly one row)', () => {
+    test('{ connect: [B] } on a populated cover attaches B, removes A, one row', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { connect: [fileB] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const cover = await readCover(documentId);
+      expect(cover.id).toBe(fileB);
+      // The observable value is B AND there is no phantom row for A.
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+    });
+
+    test('{ connect: [B, C] } is last-wins → C attached, one row', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { connect: [fileB, fileC] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const cover = await readCover(documentId);
+      expect(cover.id).toBe(fileC);
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+    });
+
+    test('same id in connect and disconnect → connect wins (file attached)', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { connect: [fileB], disconnect: [fileB] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const cover = await readCover(documentId);
+      expect(cover.id).toBe(fileB);
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+    });
+  });
+
+  describe('Single media — true delta disconnect', () => {
+    test('{ disconnect: [B] } when B is not attached preserves A', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { disconnect: [fileB] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const cover = await readCover(documentId);
+      expect(cover?.id).toBe(fileA);
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+    });
+
+    test('{ disconnect: [A] } empties the cover', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { disconnect: [fileA] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const cover = await readCover(documentId);
+      expect(cover).toBe(null);
+      expect(await countJoinRows(id, 'cover')).toBe(0);
+    });
+  });
+
+  describe('Single media — replace shapes unchanged (admin-panel path)', () => {
+    test('{ set: [B] } replaces A with B', async () => {
+      const { documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { set: [fileB] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+      expect((await readCover(documentId)).id).toBe(fileB);
+    });
+
+    test('scalar id B replaces A with B', async () => {
+      const { documentId } = await createWithCover();
+
+      const update = await updateEntry(SINGLE_UID, documentId, { cover: fileB }, {});
+      expect(update.statusCode).toBe(200);
+      expect((await readCover(documentId)).id).toBe(fileB);
+    });
+
+    test('array [B] replaces A with B', async () => {
+      const { documentId } = await createWithCover();
+
+      const update = await updateEntry(SINGLE_UID, documentId, { cover: [fileB] }, {});
+      expect(update.statusCode).toBe(200);
+      expect((await readCover(documentId)).id).toBe(fileB);
+    });
+
+    test('null empties the cover', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(SINGLE_UID, documentId, { cover: null }, {});
+      expect(update.statusCode).toBe(200);
+      expect(await readCover(documentId)).toBe(null);
+      expect(await countJoinRows(id, 'cover')).toBe(0);
+    });
+
+    test('{ set: [] } empties the cover', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(SINGLE_UID, documentId, { cover: { set: [] } }, {});
+      expect(update.statusCode).toBe(200);
+      expect(await readCover(documentId)).toBe(null);
+      expect(await countJoinRows(id, 'cover')).toBe(0);
+    });
+  });
+
+  describe('Single media — field scoping', () => {
+    test('updating cover never touches thumbnail rows', async () => {
+      const creation = await createEntry(
+        SINGLE_UID,
+        { cover: fileA, thumbnail: fileC },
+        { populate: ['cover', 'thumbnail'] }
+      );
+      expect(creation.statusCode).toBe(201);
+      const { id, documentId } = creation.body.data;
+
+      // Replace cover via a connect delta.
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { connect: [fileB] } },
+        { populate: ['cover', 'thumbnail'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const res = await getEntry(SINGLE_UID, documentId, ['cover', 'thumbnail']);
+      expect(res.body.data.cover.id).toBe(fileB);
+      expect(res.body.data.thumbnail.id).toBe(fileC);
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+      expect(await countJoinRows(id, 'thumbnail')).toBe(1);
+    });
+  });
+
+  describe('Single media — defect C (create with connect)', () => {
+    test('create with { connect: [B] } attaches B', async () => {
+      const res = await createEntry(
+        SINGLE_UID,
+        { cover: { connect: [fileB] } },
+        { populate: ['cover'] }
+      );
+      expect(res.statusCode).toBe(201);
+      expect(res.body.data.cover.id).toBe(fileB);
+      expect(await countJoinRows(res.body.data.id, 'cover')).toBe(1);
+    });
+
+    test('create with { connect: [B, C] } is last-wins → C attached, one row', async () => {
+      const res = await createEntry(
+        SINGLE_UID,
+        { cover: { connect: [fileB, fileC] } },
+        { populate: ['cover'] }
+      );
+      expect(res.statusCode).toBe(201);
+      expect(res.body.data.cover.id).toBe(fileC);
+      expect(await countJoinRows(res.body.data.id, 'cover')).toBe(1);
+    });
+  });
+
+  describe('Multiple media', () => {
+    const createGallery = async (files) => {
+      const res = await createEntry(MULTIPLE_UID, { gallery: files }, { populate: ['gallery'] });
+      expect(res.statusCode).toBe(201);
+      return { id: res.body.data.id, documentId: res.body.data.documentId };
+    };
+
+    const readGalleryIds = async (documentId) => {
+      const res = await getEntry(MULTIPLE_UID, documentId, ['gallery']);
+      expect(res.statusCode).toBe(200);
+      return res.body.data.gallery.map((f) => f.id);
+    };
+
+    test('empty delta is a no-op', async () => {
+      const { id, documentId } = await createGallery([fileA]);
+
+      const update = await updateEntry(
+        MULTIPLE_UID,
+        documentId,
+        { gallery: { connect: [], disconnect: [] } },
+        { populate: ['gallery'] }
+      );
+      expect(update.statusCode).toBe(200);
+      expect(await readGalleryIds(documentId)).toEqual([fileA]);
+      expect(await countGalleryRows(id)).toBe(1);
+    });
+
+    test('connect appends without wiping', async () => {
+      const { id, documentId } = await createGallery([fileA]);
+
+      const update = await updateEntry(
+        MULTIPLE_UID,
+        documentId,
+        { gallery: { connect: [fileB] } },
+        { populate: ['gallery'] }
+      );
+      expect(update.statusCode).toBe(200);
+      expect(await readGalleryIds(documentId)).toEqual(expect.arrayContaining([fileA, fileB]));
+      expect(await countGalleryRows(id)).toBe(2);
+    });
+
+    test('disconnect removes only the listed file', async () => {
+      const { id, documentId } = await createGallery([fileA, fileB]);
+
+      const update = await updateEntry(
+        MULTIPLE_UID,
+        documentId,
+        { gallery: { disconnect: [fileA] } },
+        { populate: ['gallery'] }
+      );
+      expect(update.statusCode).toBe(200);
+      expect(await readGalleryIds(documentId)).toEqual([fileB]);
+      expect(await countGalleryRows(id)).toBe(1);
+    });
+
+    test('set replaces the whole gallery', async () => {
+      const { id, documentId } = await createGallery([fileA, fileB]);
+
+      const update = await updateEntry(
+        MULTIPLE_UID,
+        documentId,
+        { gallery: { set: [fileC] } },
+        { populate: ['gallery'] }
+      );
+      expect(update.statusCode).toBe(200);
+      expect(await readGalleryIds(documentId)).toEqual([fileC]);
+      expect(await countGalleryRows(id)).toBe(1);
+    });
+
+    test('create with { connect: [A, B] } attaches both', async () => {
+      const res = await createEntry(
+        MULTIPLE_UID,
+        { gallery: { connect: [fileA, fileB] } },
+        { populate: ['gallery'] }
+      );
+      expect(res.statusCode).toBe(201);
+      const ids = res.body.data.gallery.map((f) => f.id);
+      expect(ids).toEqual(expect.arrayContaining([fileA, fileB]));
+      expect(await countGalleryRows(res.body.data.id)).toBe(2);
+    });
+  });
+
+  // Parity: the same payload shapes on a oneToOne relation behave identically to single media.
+  describe('oneToOne relation parity (sanity)', () => {
+    test('{ connect: [] } on a populated relation is a no-op (matches single media)', async () => {
+      // Covered structurally by the relation tests in strict-relations-publish.test.api.js;
+      // this asserts the media path now matches that relation behaviour for the empty delta.
+      const { documentId } = await createWithCover();
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { connect: [] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+      expect((await readCover(documentId))?.id).toBe(fileA);
+    });
+  });
+});

--- a/tests/api/core/content-manager/media/media-delta-payloads.test.api.js
+++ b/tests/api/core/content-manager/media/media-delta-payloads.test.api.js
@@ -54,8 +54,32 @@ const multipleMediaCT = {
   },
 };
 
+// A plain oneToOne relation used to prove the media morph path behaves identically to a
+// real relation for the same delta/replace payload shapes (the central CMS-1428 claim).
+const relationTargetCT = {
+  displayName: 'delta-target',
+  singularName: 'delta-target',
+  pluralName: 'delta-targets',
+  draftAndPublish: false,
+  attributes: {
+    label: { type: 'string' },
+  },
+};
+
+const relationHolderCT = {
+  displayName: 'delta-holder',
+  singularName: 'delta-holder',
+  pluralName: 'delta-holders',
+  draftAndPublish: false,
+  attributes: {
+    pick: { type: 'relation', relation: 'oneToOne', target: 'api::delta-target.delta-target' },
+  },
+};
+
 const SINGLE_UID = 'api::delta-single.delta-single';
 const MULTIPLE_UID = 'api::delta-multiple.delta-multiple';
+const TARGET_UID = 'api::delta-target.delta-target';
+const HOLDER_UID = 'api::delta-holder.delta-holder';
 const FILE_UID = 'plugin::upload.file';
 
 const createEntry = (uid, body = {}, qs = {}) =>
@@ -112,8 +136,17 @@ describe('CMS-1428 — media connect/disconnect delta payloads', () => {
   let fileB;
   let fileC;
 
+  let targetA;
+  let targetB;
+  let targetC;
+
   beforeAll(async () => {
-    await builder.addContentType(singleMediaCT).addContentType(multipleMediaCT).build();
+    await builder
+      .addContentType(singleMediaCT)
+      .addContentType(multipleMediaCT)
+      .addContentType(relationTargetCT)
+      .addContentType(relationHolderCT)
+      .build();
 
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
@@ -122,6 +155,15 @@ describe('CMS-1428 — media connect/disconnect delta payloads', () => {
     fileA = a.body[0].id;
     fileB = b.body[0].id;
     fileC = c.body[0].id;
+
+    const [ta, tb, tc] = await Promise.all([
+      createEntry(TARGET_UID, { label: 'A' }),
+      createEntry(TARGET_UID, { label: 'B' }),
+      createEntry(TARGET_UID, { label: 'C' }),
+    ]);
+    targetA = ta.body.data.documentId;
+    targetB = tb.body.data.documentId;
+    targetC = tc.body.data.documentId;
   });
 
   afterAll(async () => {
@@ -326,6 +368,35 @@ describe('CMS-1428 — media connect/disconnect delta payloads', () => {
       expect(await readCover(documentId)).toBe(null);
       expect(await countJoinRows(id, 'cover')).toBe(0);
     });
+
+    test('{ set: [B, C] } is last-wins → C attached, one row', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { set: [fileB, fileC] } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+      expect((await readCover(documentId)).id).toBe(fileC);
+      // No phantom row for B — single media holds exactly one physical row.
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+    });
+
+    test('array [B, C] is last-wins → C attached, one row', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: [fileB, fileC] },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+      expect((await readCover(documentId)).id).toBe(fileC);
+      expect(await countJoinRows(id, 'cover')).toBe(1);
+    });
   });
 
   describe('Single media — field scoping', () => {
@@ -371,6 +442,17 @@ describe('CMS-1428 — media connect/disconnect delta payloads', () => {
       const res = await createEntry(
         SINGLE_UID,
         { cover: { connect: [fileB, fileC] } },
+        { populate: ['cover'] }
+      );
+      expect(res.statusCode).toBe(201);
+      expect(res.body.data.cover.id).toBe(fileC);
+      expect(await countJoinRows(res.body.data.id, 'cover')).toBe(1);
+    });
+
+    test('create with { set: [B, C] } is last-wins → C attached, one row', async () => {
+      const res = await createEntry(
+        SINGLE_UID,
+        { cover: { set: [fileB, fileC] } },
         { populate: ['cover'] }
       );
       expect(res.statusCode).toBe(201);
@@ -461,20 +543,50 @@ describe('CMS-1428 — media connect/disconnect delta payloads', () => {
     });
   });
 
-  // Parity: the same payload shapes on a oneToOne relation behave identically to single media.
-  describe('oneToOne relation parity (sanity)', () => {
+  // Parity: the same payload shapes on a real oneToOne relation must behave identically to
+  // single media. This exercises an actual relation (`pick`) — it is the executable form of
+  // the central CMS-1428 claim that media now matches relation semantics. The CM write
+  // endpoints return a xToOne relation as a `{ count }` object, so the attached value is read
+  // back through the dedicated relations endpoint instead of the create/update response.
+  describe('oneToOne relation parity', () => {
+    // Returns the documentId of the single related entry, or null when the relation is empty.
+    const readPickId = async (documentId) => {
+      const res = await rq.get(`/content-manager/relations/${HOLDER_UID}/${documentId}/pick`);
+      expect(res.statusCode).toBe(200);
+      return res.body.results[0]?.documentId ?? null;
+    };
+
+    const createWithPick = async () => {
+      const res = await createEntry(HOLDER_UID, { pick: { connect: [{ documentId: targetA }] } });
+      expect(res.statusCode).toBe(201);
+      const { documentId } = res.body.data;
+      expect(await readPickId(documentId)).toBe(targetA);
+      return documentId;
+    };
+
     test('{ connect: [] } on a populated relation is a no-op (matches single media)', async () => {
-      // Covered structurally by the relation tests in strict-relations-publish.test.api.js;
-      // this asserts the media path now matches that relation behaviour for the empty delta.
-      const { documentId } = await createWithCover();
-      const update = await updateEntry(
-        SINGLE_UID,
-        documentId,
-        { cover: { connect: [] } },
-        { populate: ['cover'] }
-      );
+      const documentId = await createWithPick();
+      const update = await updateEntry(HOLDER_UID, documentId, { pick: { connect: [] } });
       expect(update.statusCode).toBe(200);
-      expect((await readCover(documentId))?.id).toBe(fileA);
+      expect(await readPickId(documentId)).toBe(targetA);
+    });
+
+    test('{ connect: [B] } on a populated relation attaches B (matches single media)', async () => {
+      const documentId = await createWithPick();
+      const update = await updateEntry(HOLDER_UID, documentId, {
+        pick: { connect: [{ documentId: targetB }] },
+      });
+      expect(update.statusCode).toBe(200);
+      expect(await readPickId(documentId)).toBe(targetB);
+    });
+
+    test('{ set: [B, C] } on a relation is last-wins → C attached (matches single media)', async () => {
+      const documentId = await createWithPick();
+      const update = await updateEntry(HOLDER_UID, documentId, {
+        pick: { set: [{ documentId: targetB }, { documentId: targetC }] },
+      });
+      expect(update.statusCode).toBe(200);
+      expect(await readPickId(documentId)).toBe(targetC);
     });
   });
 });

--- a/tests/api/core/content-manager/media/media-delta-payloads.test.api.js
+++ b/tests/api/core/content-manager/media/media-delta-payloads.test.api.js
@@ -76,10 +76,45 @@ const relationHolderCT = {
   },
 };
 
+// A *non-media* polymorphic pair. `morphOne` is a generic inverse polymorphic relation,
+// not a media marker: media merely happens to be modelled as morphOne/morphMany against
+// `plugin::upload.file`. These types prove the single-media last-wins truncation never
+// reaches a user-authored morphOne (which must keep every row written for it).
+const morphTargetCT = {
+  displayName: 'delta-morph-target',
+  singularName: 'delta-morph-target',
+  pluralName: 'delta-morph-targets',
+  draftAndPublish: false,
+  attributes: {
+    label: { type: 'string' },
+    // morphToMany (join-table backed), mirroring how `plugin::upload.file.related` is
+    // modelled. This is the branch the single-media last-wins truncation lives in; a
+    // morphToOne target would be an FK column and never reach it.
+    holder: { type: 'relation', relation: 'morphToMany' },
+  },
+};
+
+const morphHolderCT = {
+  displayName: 'delta-morph-holder',
+  singularName: 'delta-morph-holder',
+  pluralName: 'delta-morph-holders',
+  draftAndPublish: false,
+  attributes: {
+    tagged: {
+      type: 'relation',
+      relation: 'morphOne',
+      target: 'api::delta-morph-target.delta-morph-target',
+      morphBy: 'holder',
+    },
+  },
+};
+
 const SINGLE_UID = 'api::delta-single.delta-single';
 const MULTIPLE_UID = 'api::delta-multiple.delta-multiple';
 const TARGET_UID = 'api::delta-target.delta-target';
 const HOLDER_UID = 'api::delta-holder.delta-holder';
+const MORPH_TARGET_UID = 'api::delta-morph-target.delta-morph-target';
+const MORPH_HOLDER_UID = 'api::delta-morph-holder.delta-morph-holder';
 const FILE_UID = 'plugin::upload.file';
 
 const createEntry = (uid, body = {}, qs = {}) =>
@@ -146,6 +181,8 @@ describe('CMS-1428 — media connect/disconnect delta payloads', () => {
       .addContentType(multipleMediaCT)
       .addContentType(relationTargetCT)
       .addContentType(relationHolderCT)
+      .addContentType(morphTargetCT)
+      .addContentType(morphHolderCT)
       .build();
 
     strapi = await createStrapiInstance();
@@ -587,6 +624,157 @@ describe('CMS-1428 — media connect/disconnect delta payloads', () => {
       });
       expect(update.statusCode).toBe(200);
       expect(await readPickId(documentId)).toBe(targetC);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Review follow-ups (PR #27116)
+  // ---------------------------------------------------------------------------
+
+  describe('Single media — explicit { set: null } clears the field', () => {
+    // `toAssocs` used to test the `set` key by truthiness, so `{ set: null }` fell through
+    // to the connect/disconnect branch and arrived WITHOUT a `set` key — the shape-based
+    // partial-update gate then read it as an empty delta and preserved the relation.
+    // `{ set: null }` is a valid "clear this field" payload and must empty it.
+    test('{ set: null } empties the cover and leaves no rows', async () => {
+      const { id, documentId } = await createWithCover();
+
+      const update = await updateEntry(
+        SINGLE_UID,
+        documentId,
+        { cover: { set: null } },
+        { populate: ['cover'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      expect(await readCover(documentId)).toBe(null);
+      expect(await countJoinRows(id, 'cover')).toBe(0);
+    });
+
+    test('{ set: null } on multiple media empties the gallery and leaves no rows', async () => {
+      const create = await createEntry(
+        MULTIPLE_UID,
+        { gallery: [fileA, fileB] },
+        { populate: ['gallery'] }
+      );
+      expect(create.statusCode).toBe(201);
+      const { id, documentId } = create.body.data;
+      expect(await countGalleryRows(id)).toBe(2);
+
+      const update = await updateEntry(
+        MULTIPLE_UID,
+        documentId,
+        { gallery: { set: null } },
+        { populate: ['gallery'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const read = await getEntry(MULTIPLE_UID, documentId, ['gallery']);
+      expect(read.body.data.gallery).toEqual([]);
+      expect(await countGalleryRows(id)).toBe(0);
+    });
+  });
+
+  describe('Non-media morphOne is never truncated', () => {
+    // Last-wins truncation is gated on the upload target, not on `relation === 'morphOne'`.
+    // A user-authored morphOne must keep every row written for it — notably the draft +
+    // published entity rows the Document Service expands one documentId into.
+    //
+    // Driven through the query engine because that is the layer the truncation lives in
+    // (entity-manager), and the morphOne side is not writable through the content-manager
+    // REST payloads used elsewhere in this file.
+    // Join-table backed morph (same shape as `plugin::upload.file.related`), resolved
+    // from metadata so physical names stay dialect-agnostic.
+    const countMorphRows = async (holderId) => {
+      const { joinTable } = strapi.db.metadata.get(MORPH_TARGET_UID).attributes.holder;
+      const rows = await strapi.db.getConnection(joinTable.name).where({
+        [joinTable.morphColumn.idColumn.name]: holderId,
+        [joinTable.morphColumn.typeColumn.name]: MORPH_HOLDER_UID,
+      });
+      return rows.length;
+    };
+
+    test('a morphOne set with two target rows keeps both (no slice to one)', async () => {
+      const holder = await strapi.db.query(MORPH_HOLDER_UID).create({ data: {} });
+
+      // Two distinct target rows, mirroring the draft+published pair the Document Service
+      // expands a single documentId into for a non-D&P source pointing at a D&P model.
+      const t1 = await strapi.db.query(MORPH_TARGET_UID).create({ data: { label: 'one' } });
+      const t2 = await strapi.db.query(MORPH_TARGET_UID).create({ data: { label: 'two' } });
+
+      // Write both through the morphOne side — the join-table branch that used to slice(-1)
+      // for every morphOne, media or not.
+      await strapi.db.query(MORPH_HOLDER_UID).update({
+        where: { id: holder.id },
+        data: { tagged: [t1.id, t2.id] },
+      });
+
+      // Both rows must survive: last-wins truncation is media-only.
+      expect(await countMorphRows(holder.id)).toBe(2);
+    });
+  });
+
+  describe('Connect dedup — heterogeneous representations of one file', () => {
+    // toIdArray dedups with uniqWith(isEqual) *before* scalar and object entries are given
+    // a common shape, so `[B, { id: B }]` survived as two structurally different entries.
+    // The morph join table has no composite uniqueness guard, so that inserted two
+    // identical rows. Every path now dedups by target id before insert.
+    test('create with { connect: [B, { id: B }] } on multiple media inserts one row', async () => {
+      const create = await createEntry(
+        MULTIPLE_UID,
+        { gallery: { connect: [fileB, { id: fileB }] } },
+        { populate: ['gallery'] }
+      );
+      expect(create.statusCode).toBe(201);
+      const { id, documentId } = create.body.data;
+
+      const read = await getEntry(MULTIPLE_UID, documentId, ['gallery']);
+      expect(read.body.data.gallery.map((f) => f.id)).toEqual([fileB]);
+      expect(await countGalleryRows(id)).toBe(1);
+    });
+
+    test('update with { connect: [B, { id: B }] } on multiple media inserts one row', async () => {
+      const create = await createEntry(
+        MULTIPLE_UID,
+        { gallery: [fileA] },
+        { populate: ['gallery'] }
+      );
+      expect(create.statusCode).toBe(201);
+      const { id, documentId } = create.body.data;
+
+      const update = await updateEntry(
+        MULTIPLE_UID,
+        documentId,
+        { gallery: { connect: [fileB, { id: fileB }] } },
+        { populate: ['gallery'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const read = await getEntry(MULTIPLE_UID, documentId, ['gallery']);
+      expect(read.body.data.gallery.map((f) => f.id).sort()).toEqual([fileA, fileB].sort());
+      expect(await countGalleryRows(id)).toBe(2);
+    });
+
+    test('{ set: [B, { id: B }] } on multiple media inserts one row', async () => {
+      const create = await createEntry(
+        MULTIPLE_UID,
+        { gallery: [fileA] },
+        { populate: ['gallery'] }
+      );
+      expect(create.statusCode).toBe(201);
+      const { id, documentId } = create.body.data;
+
+      const update = await updateEntry(
+        MULTIPLE_UID,
+        documentId,
+        { gallery: { set: [fileB, { id: fileB }] } },
+        { populate: ['gallery'] }
+      );
+      expect(update.statusCode).toBe(200);
+
+      const read = await getEntry(MULTIPLE_UID, documentId, ['gallery']);
+      expect(read.body.data.gallery.map((f) => f.id)).toEqual([fileB]);
+      expect(await countGalleryRows(id)).toBe(1);
     });
   });
 });

--- a/tests/api/core/content-manager/media/strict-relations-publish.test.api.js
+++ b/tests/api/core/content-manager/media/strict-relations-publish.test.api.js
@@ -23,12 +23,10 @@
  * The same write-time-vs-publish-time split applies to required MEDIA, exercised below
  * with a real uploaded file so the disconnect/connect shapes go through the upload plugin.
  *
- * NOTE on a media/relation divergence surfaced by these tests: single media treats an
- * object-form payload (`{ connect | disconnect | set }`) as a full replace, so `{ connect: [] }`
- * EMPTIES a single media — whereas on a oneToOne relation `{ connect: [] }` is a no-op that
- * preserves the value. This is pre-existing media behaviour (reproduces with the flag off and
- * with an optional field), not something strictRelations introduces; the media cases below
- * assert the actual behaviour rather than assuming media mirrors relations.
+ * Media now mirrors relations for connect/disconnect deltas (CMS-1428): a no-op
+ * `{ connect: [] }` / `{ disconnect: [] }` preserves an already-attached single media
+ * instead of emptying it, so publish stays 200 — exactly like the oneToOne relation
+ * no-op case above. See `media-delta-payloads.test.api.js` for the full delta matrix.
  *
  * DISCONNECT-ONLY on TO-ONE / SINGLE-MEDIA is rejected at WRITE time (not deferred): a to-one
  * relation or single media holds at most one entry, so `{ disconnect: [...] }` (no `connect`/
@@ -309,14 +307,11 @@ describe('strictRelations — publish-time enforcement of connect/disconnect edg
         expect(publish.statusCode).toBe(400);
       });
 
-      // Divergence from relations: single media treats an object-form payload
-      // (`{ connect | disconnect | set }`) as a full replace, so a `{ connect: [] }` EMPTIES
-      // the cover — unlike a oneToOne relation, where `{ connect: [] }` is a no-op that
-      // preserves the value (see the relation "no-op" case above). This is pre-existing media
-      // behaviour, independent of strictRelations (it also empties with the flag off / field
-      // optional). Write-time still passes (the validator sees a connect object, not an empty
-      // value); the empty state is caught by the publish backstop → 400.
-      test('{ connect: [] } empties a required media (media replace semantics) → update 200, publish 400', async () => {
+      // Media now mirrors relations (CMS-1428): a no-op `{ connect: [] }` on an already-
+      // populated single media preserves the attached file instead of emptying it — just
+      // like the oneToOne relation no-op case above. The required cover stays populated, so
+      // publish succeeds.
+      test('no-op { connect: [] } on a populated required media then publishing → 200', async () => {
         const upload = await uploadImg();
         expect(upload.statusCode).toBe(201);
         const fileId = upload.body[0].id;
@@ -333,13 +328,13 @@ describe('strictRelations — publish-time enforcement of connect/disconnect edg
         );
         expect(update.statusCode).toBe(200);
 
-        // The cover was emptied by the connect-object replace…
+        // The existing cover is untouched by the no-op connect.
         const draft = await getMediaDraft(documentId);
-        expect(draft.body.data.cover).toBe(null);
+        expect(draft.body.data.cover).not.toBe(null);
+        expect(draft.body.data.cover.id).toBe(fileId);
 
-        // …so publishing the now-empty required media is rejected by the backstop.
         const publish = await publishEntry(MEDIA_UID, documentId);
-        expect(publish.statusCode).toBe(400);
+        expect(publish.statusCode).toBe(200);
       });
 
       // The publish check validates the *resulting* state: after disconnecting (which empties


### PR DESCRIPTION
### What does it do?

It makes media fields treat `connect` and `disconnect` the same way normal relations do, instead of wiping and replacing the whole field. Three separate bugs in the media code (`packages/core/database/src/entity-manager/index.ts`) are fixed:

- **An empty change no longer clears the field.** Sending `{ connect: [] }` or `{ disconnect: [] }` used to empty the field. Now it does nothing, which is what you'd expect.
- **`{ connect: [B] }` on a single-media field now actually swaps in B.** Before, the old file stayed visible and B was added as an invisible extra row in the database. Now the field holds exactly one file — the last one you connect. The same is true for `{ set: [B, C] }`: you get C, and only one row (no leftover hidden rows).
- **Connecting a file while creating an entry now works.** Creating an entry with `{ connect: [B] }` used to attach nothing at all. Now it attaches B.

A single-media field always keeps just one file in the database. This is stricter than normal relations, which can keep two rows (one for draft, one for published) — media files don't have draft/published versions, so there's no reason to keep more than one.

### Why is it needed?

CMS-1428: on a single-media field, sending `connect` or `disconnect` replaced the whole field instead of just adding or removing the listed file. So an empty change wiped the field, and connecting a file quietly did nothing while leaving junk rows in the database.

### How to test it?

**Automated:** `yarn test:api tests/api/core/content-manager/media/` (SQLite; run again with `--db=postgres` too). New tests are in `tests/api/core/content-manager/media/media-delta-payloads.test.api.js`, and the old tests in `strict-relations-publish.test.api.js` were updated to expect the field to be kept instead of wiped.

> Where the fix lives: the change is in `@strapi/database`, which sits underneath both the Content API and the admin API. Media values pass straight through to it unchanged, so the fix works no matter which API you use. The steps below use the **Content API**, because that's where real integrations actually send `connect`/`disconnect` for media. The admin panel only ever sends a plain id (or null) for media, so it was never affected by this bug.

**Manual (Content API):** Start a dev app (`cd examples/getstarted && yarn develop`). Create a collection type `doc` with a single-media field `cover` and a multiple-media field `gallery`. Give the Public role (or an API token) `find`, `create`, and `update` access to it. Upload three files and note their numeric ids — called `A`, `B`, `C` below. Content API bodies are wrapped in `{ "data": {...} }`.

```bash
# Create an entry with cover = A
curl -X POST "$HOST/api/docs?populate=cover" \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{ "data": { "cover": A } }'
# → the response shows cover A. Save the returned documentId as $ID.
```

Each row below is a `PUT $HOST/api/docs/$ID?populate=cover` with the body shown:

| # | Body | Old (buggy) behaviour | New behaviour |
|---|---|---|---|
| 1 | `{ "data": { "cover": { "connect": [] } } }` | field was **cleared** | unchanged, still A |
| 2 | `{ "data": { "cover": { "disconnect": [] } } }` | field was **cleared** | unchanged, still A |
| 3 | `{ "data": { "cover": { "connect": [], "disconnect": [] } } }` | field was **cleared** | unchanged, still A |
| 4 | `{ "data": { "cover": { "connect": [B] } } }` | still showed A, plus a **hidden B row** | cover is now B, one row only |
| 5 | `{ "data": { "cover": { "connect": [B, C] } } }` | showed A, two hidden rows | cover is now C (the last one), one row only |
| 6 | `{ "data": { "cover": { "disconnect": [B] } } }` (B isn't attached) | nothing changed | nothing changes, still A |
| 7 | `{ "data": { "cover": { "disconnect": [A] } } }` | field cleared | field cleared |
| 8 | `{ "data": { "cover": { "set": [B, C] } } }` | showed B, plus a **hidden C row** | cover is now C, one row only |

```bash
# Connect a file while creating the entry (used to attach nothing)
curl -X POST "$HOST/api/docs?populate=cover" \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{ "data": { "cover": { "connect": [B] } } }'
# Old: cover was empty. New: cover is B.
```

To check there are no leftover hidden rows (cases 4, 5, 8), look at the database directly — for example in SQLite: `SELECT * FROM files_related_morphs WHERE related_id = <entryId> AND field = 'cover';` should return exactly one row. You can repeat cases 1, 4, and the `set` cases on the `gallery` field (multiple media) to confirm connect adds without wiping and disconnect removes only the file you listed.

### Related issue(s)/PR(s)

- CMS-1428
- Follow-up to the strictRelations work in #27028 (this is a separate, older bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
