### PR TITLE
fix: pre-bundle property-expr so yup ESM named imports don't blank th…

### DIFF
--- a/packages/core/strapi/src/node/core/admin-vite-aliases.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-aliases.ts
@@ -14,7 +14,51 @@ export const buildAdminViteResolveAliases = (): Record<string, string> =>
   Object.fromEntries([
     ...ADMIN_VITE_ALIAS_MODULES.map((mod) => [mod, getModulePath(mod)] as const),
     ...buildSingletonAliasEntries(),
+    ...buildYupCjsAliasEntries(),
   ]);
+
+/**
+ * CJS dependencies that yup's ESM build (`yup/es`) reaches through a *named* import
+ * (e.g. `import { getter } from 'property-expr'`). If they are served raw instead of
+ * pre-bundled, Vite cannot synthesize those named exports and the admin blank-crashes
+ * with "does not provide an export named 'getter'" (#27062).
+ *
+ * @internal
+ */
+export const YUP_CJS_NAMED_EXPORT_MODULES = ['property-expr'] as const;
+
+/**
+ * Resolve yup's CJS named-export deps from yup's own closure (where they always live,
+ * including under pnpm's strict layout), skipping any that cannot be resolved.
+ *
+ * @internal
+ */
+export const buildYupCjsAliasEntries = (): Array<readonly [string, string]> => {
+  const entries: Array<readonly [string, string]> = [];
+
+  for (const mod of YUP_CJS_NAMED_EXPORT_MODULES) {
+    try {
+      entries.push([mod, getModulePathFrom('yup', mod)] as const);
+    } catch {
+      // yup's CJS dep not resolvable here — skip rather than throwing, mirroring the
+      // singleton handling, so a missing dep never breaks the admin build.
+    }
+  }
+
+  return entries;
+};
+
+/**
+ * Names of yup's CJS named-export deps that actually resolve from yup's closure.
+ *
+ * Mirrors buildYupCjsAliasEntries so optimizeDeps.include stays in lockstep with
+ * resolve.alias: a dep that cannot be aliased must not be forced into pre-bundling
+ * either, or Vite chokes on an unresolvable optimizeDeps.include entry.
+ *
+ * @internal
+ */
+export const getResolvableYupCjsModules = (): string[] =>
+  buildYupCjsAliasEntries().map(([mod]) => mod);
 
 /**
  * Resolve the CodeMirror singleton aliases from @strapi/design-system's closure, skipping any

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -5,6 +5,7 @@ import { ADMIN_VITE_DEDUPE_MODULES } from '../core/admin-vite-alias-modules';
 import {
   buildAdminViteResolveAliases,
   getResolvableSingletonModules,
+  getResolvableYupCjsModules,
 } from '../core/admin-vite-aliases';
 import { collectAdminOptimizeDepsExclude } from '../core/admin-vite-optimize-exclude';
 import { isDesignSystemLinked } from '../core/linked-packages';
@@ -74,6 +75,11 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
         // CJS-only; required for @strapi/admin in dev (#26944, #26964, #27014).
         'lodash',
         'invariant',
+        // yup's ESM build named-imports `getter` from property-expr (CJS). Pre-bundle it for
+        // every app so it is never served raw — otherwise the admin blank-crashes with "does
+        // not provide an export named 'getter'" once a plugin trips the optimizeDeps auto-exclude
+        // (#27062). Resolvable subset only, kept in lockstep with resolve.alias (see #27014).
+        ...getResolvableYupCjsModules(),
         // UMD; without pre-bundling plugin chunks get empty namespace → "Prism is not defined" (#26964).
         'prismjs',
         // Content-manager Blocks code editor side-effect-imports these; they expect global `Prism`.

--- a/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
+++ b/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
@@ -72,6 +72,45 @@ describe('resolveDevelopmentConfig (Vite admin dev)', () => {
     });
   });
 
+  it('pre-bundles and aliases property-expr so yup ESM named imports never break (#27062)', async () => {
+    const mockHttpServer = http.createServer();
+    const ctx = {
+      cwd: process.cwd(),
+      target: ['last 3 major versions'],
+      basePath: '/admin',
+      adminPath: '/admin',
+      distDir: 'dist/build',
+      appDir: process.cwd(),
+      entry: '.strapi/client/app.js',
+      distPath: `${process.cwd()}/dist/build`,
+      env: {},
+      runtimeDir: `${process.cwd()}/.strapi/client`,
+      logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn() },
+      strapi: { internal_config: {}, server: { httpServer: mockHttpServer } },
+      bundler: 'vite' as const,
+      options: {
+        open: false,
+      },
+      plugins: [],
+      tsconfig: undefined,
+      customisations: undefined,
+      features: undefined,
+    } as unknown as BuildContext;
+
+    const config = await resolveDevelopmentConfig(ctx);
+
+    // property-expr is CJS and yup/es/Reference.js does `import { getter } from 'property-expr'`.
+    // It must stay pre-bundled (and aliased for pnpm) or the admin blank-crashes (#27062).
+    expect(config.optimizeDeps?.include).toEqual(expect.arrayContaining(['property-expr']));
+
+    const alias = config.resolve?.alias as Record<string, string> | undefined;
+    expect(alias?.['property-expr']).toEqual(expect.any(String));
+
+    await new Promise<void>((resolve) => {
+      mockHttpServer.close(() => resolve());
+    });
+  });
+
   it('pre-bundles prismjs language plugins for all apps (#26964)', async () => {
     const mockHttpServer = http.createServer();
     const ctx = {


### PR DESCRIPTION
…e admin

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Pins `property-expr` into the admin Vite `optimizeDeps.include` (always-on, for every app) and gives it a matching `resolve.alias` entry.

- Adds `YUP_CJS_NAMED_EXPORT_MODULES` + `buildYupCjsAliasEntries()` in `admin-vite-aliases.ts`, resolving the module from **yup's own closure** (`getModulePathFrom('yup', …)`) so it works under pnpm's strict layout, and skipping tolerantly if it can't be resolved (mirrors the CodeMirror-singleton handling).
- Exposes `getResolvableYupCjsModules()` and spreads it into `optimizeDeps.include` in `vite/config.ts`, keeping include in lockstep with `resolve.alias`.
- Adds a regression test asserting `property-expr` is both pre-bundled and aliased.

### Why is it needed?

After 5.50.2, the admin panel blank-crashes locally with:

```
Uncaught SyntaxError: The requested module '.../property-expr/index.js?v=...' does not provide an export named 'getter' (at Reference.js:1:10)
```

`property-expr` is a CJS module and yup's ESM build (`yup/es/Reference.js`) does `import { getter } from 'property-expr'` — a **named** import from a CJS module. That only works when Vite pre-bundles `property-expr` (its CJS→ESM interop synthesizes the named exports). The `optimizeDeps` auto-exclude added in #26944 can drag a plugin's `yup`/`property-expr` graph off the pre-bundling path, so `property-expr` gets served raw and the named import throws, blanking the admin. Forcing it into `optimizeDeps.include` guarantees it is always pre-bundled.

### How to test it?

- Environment: any Strapi 5 app running `strapi develop` (Vite dev server), especially one with a third-party admin plugin that ships a prebuilt ESM bundle with a React peer dependency.
- Unit test: `yarn workspace @strapi/strapi test:unit --testPathPattern=resolve-development-config` — the `#27062` case verifies `property-expr` is present in `optimizeDeps.include` and has a `resolve.alias` entry.
- Manual: start the admin in dev and confirm it loads without the `does not provide an export named 'getter'` console error / blank screen.

### Related issue(s)/PR(s)

- Fixes #27062
- Related: #26944, #26964, #27014 (admin `optimizeDeps` include/exclude + alias contract)
