### PR TITLE
chore(upload): consolidate File type into shared UploadFile

### DIFF
--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -32,13 +32,6 @@
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
-    "./_internal/shared": {
-      "types": "./dist/shared/index.d.ts",
-      "source": "./shared/index.ts",
-      "import": "./dist/shared/index.mjs",
-      "require": "./dist/shared/index.js",
-      "default": "./dist/shared/index.js"
-    },
     "./strapi-server": {
       "types": "./dist/server/src/index.d.ts",
       "source": "./server/src/index.ts",

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -355,9 +355,9 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     });
 
     const replaceFormat = async (key: string, newFormat: UploadableFile) => {
-      const oldFormat = oldFile.formats?.[key] as File | undefined;
+      const oldFormat = oldFile.formats?.[key];
       if (oldFormat) {
-        await getService('provider').replace(newFormat, oldFormat);
+        await getService('provider').replace(newFormat, oldFormat as File);
       } else {
         await getService('provider').upload(newFormat);
       }
@@ -396,7 +396,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     ) {
       for (const oldKey of Object.keys(oldFile.formats)) {
         if (!newFormatKeys.has(oldKey)) {
-          const oldFormat = oldFile.formats[oldKey] as File;
+          const oldFormat = oldFile.formats[oldKey];
           promises.push(strapi.plugin('upload').provider.delete(oldFormat));
         }
       }
@@ -502,9 +502,10 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
           // they're orphaned in storage since the DB record no longer tracks them.
           await getService('provider').replace(fileData, dbFile);
           if (dbFile.formats) {
+            const formats = dbFile.formats;
             await Promise.all(
-              Object.keys(dbFile.formats).map((key) =>
-                strapi.plugin('upload').provider.delete(dbFile.formats![key] as File)
+              Object.keys(formats).map((key) =>
+                strapi.plugin('upload').provider.delete(formats[key])
               )
             );
           }
@@ -698,11 +699,12 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       await strapi.plugin('upload').provider.delete(file);
 
       if (file.formats) {
-        const keys = Object.keys(file.formats);
+        const formats = file.formats;
+        const keys = Object.keys(formats);
 
         await Promise.all(
           keys.map((key) => {
-            return strapi.plugin('upload').provider.delete(file.formats![key]);
+            return strapi.plugin('upload').provider.delete(formats[key]);
           })
         );
       }

--- a/packages/core/upload/server/src/types.ts
+++ b/packages/core/upload/server/src/types.ts
@@ -1,4 +1,5 @@
 import type { File as FormidableFile } from 'formidable';
+import type { FocalPoint, UploadFile } from '../../shared/contracts/files';
 
 export type InputFile = FormidableFile & {
   path?: string;
@@ -6,43 +7,10 @@ export type InputFile = FormidableFile & {
   provider?: string;
 };
 
-export interface FocalPoint {
-  x: number;
-  y: number;
-}
-
-export interface File {
-  id: number;
-  name: string;
-  alternativeText?: string | null;
-  caption?: string | null;
-  focalPoint?: FocalPoint | null;
-  width?: number;
-  height?: number;
-  formats?: Record<string, unknown>;
-  hash: string;
-  ext?: string;
-  mime?: string;
-  size?: number;
-  sizeInBytes?: number;
-  url?: string;
-  previewUrl?: string;
-  path?: string | null;
-  provider?: string;
-  provider_metadata?: Record<string, unknown>;
-  isUrlSigned?: boolean;
-  folder?: number | null;
-  folderPath?: string;
-  related?: {
-    id: string | number;
-    __type: string;
-    __pivot: { field: string };
-  }[];
-  createdAt?: string;
-  updatedAt?: string;
-  createdBy?: number;
-  updatedBy?: number;
-}
+/**
+ * @deprecated use {@linkcode UploadFile} instead. {@linkcode File} often gets shadowed by {@linkcode global.File}
+ */
+export type File = UploadFile;
 
 export interface Folder {
   id: number;

--- a/packages/core/upload/shared/contracts/files.ts
+++ b/packages/core/upload/shared/contracts/files.ts
@@ -61,7 +61,10 @@ export interface FocalPoint {
   y: number;
 }
 
-export interface File {
+/**
+ * Upload Content-Type File (content-types/file.ts)
+ */
+export interface UploadFile {
   id: number;
   name: string;
   alternativeText?: string | null;
@@ -69,14 +72,10 @@ export interface File {
   focalPoint?: FocalPoint | null;
   width?: number | null;
   height?: number | null;
-  formats?:
-    | Record<string, FileFormat>
-    | {
-        thumbnail: {
-          url: string;
-        };
-      }
-    | null;
+  formats?: {
+    thumbnail?: FileFormat | { url: string } | undefined;
+    [size: string]: FileFormat | { url: string } | undefined;
+  } | null;
   hash: string;
   ext?: string;
   mime?: string;
@@ -102,6 +101,11 @@ export interface File {
   updatedBy?: number;
   isLocal?: boolean;
 }
+
+/**
+ * @deprecated use {@linkcode UploadFile} instead. {@linkcode File} often gets shadowed by {@linkcode global.File}
+ */
+export type File = UploadFile;
 
 export type UploadFileInfo = Pick<
   File,


### PR DESCRIPTION
### What does it do?

- Consolidates the duplicated upload `File` type. It was defined twice — in `server/src/types.ts` and in `shared/contracts/files.ts`. The shared contract is now the single source of truth via `UploadFile`; both locations re-export a deprecated `File` alias (the bare `File` name is easily shadowed by `global.File`).
- Tightens the `formats` shape: keyed by size name (or `thumbnail`) with `Partial<FileFormat>` values, instead of the previous loose union.
- Removes the `./_internal/shared` package export from `packages/core/upload/package.json`. It pointed at a non-existent `dist/shared` build output and has no importers anywhere in the monorepo.
- Adjusts a few casts in `server/src/services/upload.ts` to match the consolidated type.

### Why is it needed?

Two divergent `File` definitions for the same content type are a maintenance hazard and drift over time. The dead `_internal/shared` export advertised a subpath that never resolves to a real build artifact.

### How to test it?

Type-only / dead-export change — no runtime behaviour changes.

```bash
yarn nx run @strapi/upload:test:ts:back
yarn nx run @strapi/upload:test:ts:front
yarn nx run @strapi/upload:lint
yarn nx run @strapi/upload:test:unit
```

All pass locally (211 unit tests).

### Related issue(s)/PR(s)

N/A