### PR TITLE
chore(email): centralize provider types in @strapi/types

### DIFF
--- a/packages/core/email/admin/src/pages/Settings.tsx
+++ b/packages/core/email/admin/src/pages/Settings.tsx
@@ -24,7 +24,8 @@ import { PERMISSIONS } from '../constants';
 import { getYupInnerErrors } from '../utils/getYupInnerErrors';
 import { schema } from '../utils/schema';
 
-import type { EmailSettings, ProviderCapabilities } from '../../../shared/types';
+import type { EmailSettings } from '../../../shared/types';
+import type { Providers } from '@strapi/types';
 
 const DocumentationLink = styled.a`
   color: ${({ theme }) => theme.colors.primary600};
@@ -62,7 +63,7 @@ const CapabilitiesSection = ({
   isIdle,
   formatMessage,
 }: {
-  capabilities: ProviderCapabilities;
+  capabilities: Providers.Email.Capabilities;
   isIdle?: boolean;
   formatMessage: (msg: { id: string; defaultMessage: string }) => string;
 }) => {

--- a/packages/core/email/server/src/bootstrap.ts
+++ b/packages/core/email/server/src/bootstrap.ts
@@ -1,27 +1,9 @@
-import type { Core } from '@strapi/types';
-import type { ProviderCapabilities } from '../../shared/types';
-import type { EmailConfig, SendOptions } from './types';
-
-interface EmailProvider {
-  send: (options: SendOptions) => Promise<any>;
-  verify?: () => Promise<boolean>;
-  isIdle?: () => boolean;
-  close?: () => void;
-  getCapabilities?: () => ProviderCapabilities;
-}
-
-interface EmailProviderModule {
-  init: (
-    options: EmailConfig['providerOptions'],
-    settings: EmailConfig['settings']
-  ) => EmailProvider;
-  name?: string;
-  provider?: string;
-}
+import type { Core, Providers } from '@strapi/types';
+import type { EmailConfig } from './types';
 
 const createProvider = (emailConfig: EmailConfig) => {
   const providerName = emailConfig.provider.toLowerCase();
-  let provider: EmailProviderModule;
+  let provider: Providers.Email.Factory;
 
   let modulePath: string;
   try {

--- a/packages/core/email/server/src/controllers/email.ts
+++ b/packages/core/email/server/src/controllers/email.ts
@@ -3,6 +3,7 @@ import { errors } from '@strapi/utils';
 
 import type Koa from 'koa';
 import type {} from 'koa-body';
+import type { Providers } from '@strapi/types';
 import type { EmailConfig, SendOptions } from '../types';
 
 const { ApplicationError } = errors;
@@ -65,7 +66,7 @@ const emailController = {
 
   async getSettings(ctx: Koa.Context) {
     const config: EmailConfig = strapi.plugin('email').service('email').getProviderSettings();
-    const provider = strapi.plugin('email').provider;
+    const provider = strapi.plugin('email').provider as Providers.Email.Provider;
 
     // Check if provider supports verify method
     const supportsVerify = typeof provider?.verify === 'function';
@@ -89,7 +90,7 @@ const emailController = {
   },
 
   async verify(ctx: Koa.Context) {
-    const provider = strapi.plugin('email').provider;
+    const provider = strapi.plugin('email').provider as Providers.Email.Provider;
 
     if (!provider?.verify || typeof provider.verify !== 'function') {
       throw new ApplicationError('This email provider does not support connection verification');

--- a/packages/core/email/server/src/services/email.ts
+++ b/packages/core/email/server/src/services/email.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { objects, template } from '@strapi/utils';
 
+import type { Providers } from '@strapi/types';
 import type {
   EmailConfig,
   EmailOptions,
@@ -13,7 +14,10 @@ const { createStrictInterpolationRegExp } = template;
 
 const getProviderSettings = (): EmailConfig => strapi.config.get('plugin::email');
 
-const send = async (options: SendOptions) => strapi.plugin('email').provider.send(options);
+const send = async (options: SendOptions) => {
+  const provider = strapi.plugin('email').provider as Providers.Email.Provider;
+  return provider.send(options);
+};
 
 /**
  * fill subject, text and html using lodash template
@@ -51,7 +55,9 @@ const sendTemplatedEmail = (
     {}
   );
 
-  return strapi.plugin('email').provider.send({ ...emailOptions, ...templatedAttributes });
+  const provider: Providers.Email.Provider = strapi.plugin('email').provider;
+
+  return provider.send({ ...emailOptions, ...templatedAttributes });
 };
 
 const emailService = () => ({

--- a/packages/core/email/server/src/types.ts
+++ b/packages/core/email/server/src/types.ts
@@ -1,11 +1,9 @@
-import type { Plugin } from '@strapi/types';
+import type { Plugin, Providers } from '@strapi/types';
 
 export interface EmailConfig extends Record<string, unknown> {
   provider: string;
   providerOptions?: object;
-  settings?: {
-    defaultFrom?: string;
-  };
+  settings?: Providers.Email.Settings;
 }
 
 type LoadedPluginConfig = Plugin.LoadedPlugin['config'];

--- a/packages/core/email/shared/types.ts
+++ b/packages/core/email/shared/types.ts
@@ -1,29 +1,13 @@
-export interface ProviderCapabilities {
-  transport?: {
-    host?: string;
-    port?: number;
-    secure?: boolean;
-    pool?: boolean;
-    maxConnections?: number;
-  };
-  auth?: {
-    type?: string;
-    user?: string;
-  };
-  features?: string[];
-}
+import type { Providers } from '@strapi/types';
 
 export interface EmailSettings {
   config: ConfigSettings;
   supportsVerify: boolean;
-  capabilities?: ProviderCapabilities;
+  capabilities?: Providers.Email.Capabilities;
   isIdle?: boolean;
 }
 
 export interface ConfigSettings {
   provider: string;
-  settings: {
-    defaultFrom: string;
-    defaultReplyTo: string;
-  };
+  settings: Providers.Email.Settings;
 }

--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -5,6 +5,7 @@ export type * as Data from './data';
 export type * as Internal from './internal';
 export type * as Modules from './modules';
 export type * as Plugin from './plugin';
+export type * as Providers from './providers';
 export type * as Public from './public';
 export type * as Schema from './schema';
 export type * as Utils from './utils';

--- a/packages/core/types/src/providers/email.ts
+++ b/packages/core/types/src/providers/email.ts
@@ -1,0 +1,31 @@
+export interface Factory {
+  init(options: object | undefined, settings: Settings | undefined): Provider;
+}
+
+export interface Provider {
+  send: (options: any) => Promise<any>;
+  verify?: () => Promise<boolean>;
+  isIdle?: () => boolean;
+  close?: () => void;
+  getCapabilities?: () => Capabilities;
+}
+
+export interface Settings {
+  defaultFrom: string;
+  defaultReplyTo?: string;
+}
+
+export interface Capabilities {
+  transport?: {
+    host?: string;
+    port?: number;
+    secure?: boolean;
+    pool?: boolean;
+    maxConnections?: number;
+  };
+  auth?: {
+    type?: string;
+    user?: string;
+  };
+  features?: string[];
+}

--- a/packages/core/types/src/providers/index.ts
+++ b/packages/core/types/src/providers/index.ts
@@ -1,0 +1,1 @@
+export * as Email from './email';

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -48,11 +48,15 @@
     "@strapi/utils": "5.51.0"
   },
   "devDependencies": {
+    "@strapi/types": "5.51.0",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.51.0",
     "tsconfig": "5.51.0",
     "vitest": "catalog:",
     "vitest-config": "5.51.0"
+  },
+  "peerDependencies": {
+    "@strapi/types": "^5.0.0"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/email-amazon-ses/src/index.ts
+++ b/packages/providers/email-amazon-ses/src/index.ts
@@ -1,15 +1,15 @@
 import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
 
+import type { Providers } from '@strapi/types';
 import {
   buildSendEmailCommandInput,
   getClientConfig,
   type ProviderOptions,
-  type ProviderSettings,
   type SendOptions,
 } from './utils';
 
 export default {
-  init(providerOptions: ProviderOptions, settings: ProviderSettings) {
+  init(providerOptions: ProviderOptions, settings: Providers.Email.Settings) {
     const client = new SESClient(getClientConfig(providerOptions));
 
     return {
@@ -18,4 +18,4 @@ export default {
       },
     };
   },
-};
+} satisfies Providers.Email.Factory;

--- a/packages/providers/email-amazon-ses/src/utils.ts
+++ b/packages/providers/email-amazon-ses/src/utils.ts
@@ -1,4 +1,5 @@
 import type { SendEmailCommandInput, SESClientConfig } from '@aws-sdk/client-ses';
+import type { Providers } from '@strapi/types';
 
 /** Default SES API host when `amazon` is omitted (same as legacy node-ses). */
 export const DEFAULT_SES_ENDPOINT = 'https://email.us-east-1.amazonaws.com';
@@ -16,11 +17,6 @@ export interface ProviderOptions extends Omit<SESClientConfig, 'credentials'> {
   key?: string;
   secret?: string;
   amazon?: string;
-}
-
-export interface ProviderSettings {
-  defaultFrom: string;
-  defaultReplyTo: string | string[];
 }
 
 export interface SendOptions {
@@ -173,7 +169,7 @@ export const getClientConfig = (providerOptions: ProviderOptions): SESClientConf
 /** Builds SendEmail input (html → Html body, text → Text body; legacy node-ses message/altText). */
 export const buildSendEmailCommandInput = (
   options: SendOptions,
-  settings: ProviderSettings
+  settings: Providers.Email.Settings
 ): SendEmailCommandInput => {
   const { from, to, cc, bcc, replyTo, subject, text, html, ...rest } = options;
 

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -53,11 +53,15 @@
     "mailgun.js": "10.2.1"
   },
   "devDependencies": {
+    "@strapi/types": "5.51.0",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.51.0",
     "tsconfig": "5.51.0",
     "vitest": "catalog:",
     "vitest-config": "5.51.0"
+  },
+  "peerDependencies": {
+    "@strapi/types": "^5.0.0"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/email-mailgun/src/index.ts
+++ b/packages/providers/email-mailgun/src/index.ts
@@ -1,11 +1,7 @@
 import assert from 'node:assert';
 import formData from 'form-data';
 import Mailgun, { type MailgunClientOptions } from 'mailgun.js';
-
-interface Settings {
-  defaultFrom: string;
-  defaultReplyTo: string;
-}
+import type { Providers } from '@strapi/types';
 
 interface SendOptions {
   from?: string;
@@ -28,7 +24,7 @@ const DEFAULT_OPTIONS = {
 };
 
 export default {
-  init(providerOptions: ProviderOptions, settings: Settings) {
+  init(providerOptions: ProviderOptions, settings: Providers.Email.Settings) {
     assert(providerOptions.key, 'Mailgun API key is required');
     assert(providerOptions.domain, 'Mailgun domain is required');
 
@@ -58,4 +54,4 @@ export default {
       },
     };
   },
-};
+} satisfies Providers.Email.Factory;

--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -77,12 +77,16 @@
     "nodemailer": "9.0.1"
   },
   "devDependencies": {
+    "@strapi/types": "5.51.0",
     "@types/node": "20.19.41",
     "@types/nodemailer": "7.0.11",
     "eslint-config-custom": "5.51.0",
     "tsconfig": "5.51.0",
     "vitest": "catalog:",
     "vitest-config": "5.51.0"
+  },
+  "peerDependencies": {
+    "@strapi/types": "^5.0.0"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/email-nodemailer/src/index.ts
+++ b/packages/providers/email-nodemailer/src/index.ts
@@ -1,10 +1,6 @@
+import type { Providers } from '@strapi/types';
 import nodemailer from 'nodemailer';
 import type { Transporter, SendMailOptions, SentMessageInfo } from 'nodemailer';
-
-interface Settings {
-  defaultFrom: string;
-  defaultReplyTo: string;
-}
 
 interface SendOptions {
   // --- Core addressing ---
@@ -118,23 +114,8 @@ interface SendOptions {
 
 type ProviderOptions = Parameters<typeof nodemailer.createTransport>[0];
 
-interface ProviderCapabilities {
-  transport?: {
-    host?: string;
-    port?: number;
-    secure?: boolean;
-    pool?: boolean;
-    maxConnections?: number;
-  };
-  auth?: {
-    type?: string;
-    user?: string;
-  };
-  features?: string[];
-}
-
-function getCapabilitiesFromOptions(opts: ProviderOptions): ProviderCapabilities {
-  const capabilities: ProviderCapabilities = {};
+function getCapabilitiesFromOptions(opts: ProviderOptions): Providers.Email.Capabilities {
+  const capabilities: Providers.Email.Capabilities = {};
   const features: string[] = [];
 
   if (opts && typeof opts === 'object') {
@@ -178,7 +159,7 @@ function getCapabilitiesFromOptions(opts: ProviderOptions): ProviderCapabilities
 }
 
 export default {
-  init(providerOptions: ProviderOptions, settings: Settings) {
+  init(providerOptions: ProviderOptions, settings: Providers.Email.Settings) {
     const transporter: Transporter = nodemailer.createTransport(providerOptions);
 
     return {
@@ -307,9 +288,9 @@ export default {
         transporter.close();
       },
 
-      getCapabilities(): ProviderCapabilities {
+      getCapabilities(): Providers.Email.Capabilities {
         return getCapabilitiesFromOptions(providerOptions);
       },
     };
   },
-};
+} satisfies Providers.Email.Factory;

--- a/packages/providers/email-sendgrid/package.json
+++ b/packages/providers/email-sendgrid/package.json
@@ -50,9 +50,13 @@
     "@strapi/utils": "5.51.0"
   },
   "devDependencies": {
+    "@strapi/types": "5.51.0",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.51.0",
     "tsconfig": "5.51.0"
+  },
+  "peerDependencies": {
+    "@strapi/types": "^5.0.0"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/email-sendgrid/src/index.ts
+++ b/packages/providers/email-sendgrid/src/index.ts
@@ -1,9 +1,5 @@
-import sendgrid, { MailDataRequired } from '@sendgrid/mail';
-
-interface Settings {
-  defaultFrom: string;
-  defaultReplyTo: string;
-}
+import sendgrid, { type MailDataRequired } from '@sendgrid/mail';
+import type { Providers } from '@strapi/types';
 
 interface SendOptions {
   from?: string;
@@ -23,7 +19,7 @@ interface ProviderOptions {
 }
 
 export default {
-  init(providerOptions: ProviderOptions, settings: Settings) {
+  init(providerOptions: ProviderOptions, settings: Providers.Email.Settings) {
     sendgrid.setApiKey(providerOptions.apiKey);
 
     if (providerOptions.region) {
@@ -58,4 +54,4 @@ export default {
       },
     };
   },
-};
+} satisfies Providers.Email.Factory;

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -50,12 +50,16 @@
     "nodemailer": "9.0.1"
   },
   "devDependencies": {
+    "@strapi/types": "5.51.0",
     "@types/node": "20.19.41",
     "@types/nodemailer": "7.0.11",
     "eslint-config-custom": "5.51.0",
     "tsconfig": "5.51.0",
     "vitest": "catalog:",
     "vitest-config": "5.51.0"
+  },
+  "peerDependencies": {
+    "@strapi/types": "^5.0.0"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/email-sendmail/src/index.ts
+++ b/packages/providers/email-sendmail/src/index.ts
@@ -1,5 +1,6 @@
 import type { SendMailOptions } from 'nodemailer';
 
+import type { Providers } from '@strapi/types';
 import { sendDirectSmtp } from './direct-smtp';
 import type { ProviderSendmailOptions, Settings } from './types';
 
@@ -42,6 +43,6 @@ export default {
       },
     };
   },
-};
+} satisfies Providers.Email.Factory;
 
 export type { ProviderSendmailOptions, Settings } from './types';

--- a/packages/providers/email-sendmail/src/types.ts
+++ b/packages/providers/email-sendmail/src/types.ts
@@ -1,3 +1,5 @@
+import type { Providers } from '@strapi/types';
+
 /**
  * Options passed through from Strapi `plugin::email` config `providerOptions`,
  * historically compatible with `require('sendmail')` (guileen/node-sendmail).
@@ -27,7 +29,4 @@ export interface ProviderSendmailOptions {
   autoEHLO?: boolean;
 }
 
-export interface Settings {
-  defaultFrom: string;
-  defaultReplyTo?: string;
-}
+export type Settings = Providers.Email.Settings;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9814,12 +9814,15 @@ __metadata:
   resolution: "@strapi/provider-email-amazon-ses@workspace:packages/providers/email-amazon-ses"
   dependencies:
     "@aws-sdk/client-ses": "npm:3.1023.0"
+    "@strapi/types": "npm:5.51.0"
     "@strapi/utils": "npm:5.51.0"
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.51.0"
     tsconfig: "npm:5.51.0"
     vitest: "catalog:"
     vitest-config: "npm:5.51.0"
+  peerDependencies:
+    "@strapi/types": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -9827,6 +9830,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-mailgun@workspace:packages/providers/email-mailgun"
   dependencies:
+    "@strapi/types": "npm:5.51.0"
     "@strapi/utils": "npm:5.51.0"
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.51.0"
@@ -9835,6 +9839,8 @@ __metadata:
     tsconfig: "npm:5.51.0"
     vitest: "catalog:"
     vitest-config: "npm:5.51.0"
+  peerDependencies:
+    "@strapi/types": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -9842,6 +9848,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-nodemailer@workspace:packages/providers/email-nodemailer"
   dependencies:
+    "@strapi/types": "npm:5.51.0"
     "@types/node": "npm:20.19.41"
     "@types/nodemailer": "npm:7.0.11"
     eslint-config-custom: "npm:5.51.0"
@@ -9849,6 +9856,8 @@ __metadata:
     tsconfig: "npm:5.51.0"
     vitest: "catalog:"
     vitest-config: "npm:5.51.0"
+  peerDependencies:
+    "@strapi/types": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -9857,10 +9866,13 @@ __metadata:
   resolution: "@strapi/provider-email-sendgrid@workspace:packages/providers/email-sendgrid"
   dependencies:
     "@sendgrid/mail": "npm:8.1.3"
+    "@strapi/types": "npm:5.51.0"
     "@strapi/utils": "npm:5.51.0"
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.51.0"
     tsconfig: "npm:5.51.0"
+  peerDependencies:
+    "@strapi/types": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -9868,6 +9880,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-sendmail@workspace:packages/providers/email-sendmail"
   dependencies:
+    "@strapi/types": "npm:5.51.0"
     "@types/node": "npm:20.19.41"
     "@types/nodemailer": "npm:7.0.11"
     eslint-config-custom: "npm:5.51.0"
@@ -9875,6 +9888,8 @@ __metadata:
     tsconfig: "npm:5.51.0"
     vitest: "catalog:"
     vitest-config: "npm:5.51.0"
+  peerDependencies:
+    "@strapi/types": ^5.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Adds a shared `Providers.Email` namespace to `@strapi/types` (`Factory`, `Provider`, `Settings`, `Capabilities`) and routes the email plugin and all five email providers through it:

- **`@strapi/types`** — new `src/providers/email.ts` exported as `Providers.Email`.
- **email plugin** — `server` (bootstrap, controllers, services, types), `admin` (Settings page), and `shared` types now import from `@strapi/types` instead of redefining `ProviderCapabilities` / provider / settings interfaces.
- **providers** (`amazon-ses`, `mailgun`, `nodemailer`, `sendgrid`, `sendmail`) — each typed via `Providers.Email.Factory` and extends `Providers.Email.Settings`; `nodemailer`'s local `ProviderCapabilities` duplicate removed.
- Each provider declares `@strapi/types` as a dev + `^5.0.0` peer dependency.
- `verbatimModuleSyntax: false` added to the shared tsconfig base so type-only default exports keep compiling.

### Why is it needed?

The provider contract (`init`/`send`/`verify`/`getCapabilities`) and the `ProviderCapabilities` shape were duplicated across the email plugin and every provider package, drifting independently. Centralizing them in `@strapi/types` gives one source of truth and makes provider authors' types check against the real contract.

No runtime behavior change — types only.

### How to test it?

`yarn build && yarn test:ts` — email plugin and provider packages type-check against the shared `Providers.Email` types. Email send/verify flows are unchanged.

### Related issue(s)/PR(s)

Follows the same centralize-in-`@strapi/types` pattern as the upload/File type work.