### PR TITLE
chore(eslint): lint shared contracts in content-releases, email, i18n

### DIFF
--- a/packages/core/content-releases/.eslintrc.cjs
+++ b/packages/core/content-releases/.eslintrc.cjs
@@ -14,7 +14,7 @@ const config = {
   overrides: [
     {
       files: ['**'],
-      excludedFiles: ['admin/**/*', 'server/**/*'],
+      excludedFiles: ['admin/**/*', 'server/**/*', 'shared/**/*'],
       extends: ['eslint-config-custom/back'],
     },
   ],

--- a/packages/core/email/.eslintrc.cjs
+++ b/packages/core/email/.eslintrc.cjs
@@ -15,7 +15,7 @@ const config = {
   overrides: [
     {
       files: ['**/*'],
-      excludedFiles: ['admin/**/*', 'server/**/*'],
+      excludedFiles: ['admin/**/*', 'server/**/*', 'shared/**/*'],
       extends: ['eslint-config-custom/back'],
     },
   ],

--- a/packages/core/email/shared/.eslintrc.cjs
+++ b/packages/core/email/shared/.eslintrc.cjs
@@ -1,0 +1,14 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  extends: ['eslint-config-custom/back/typescript'],
+  ignorePatterns: ['.eslintrc.cjs'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.eslint.json'],
+  },
+};
+
+module.exports = config;

--- a/packages/core/email/shared/tsconfig.eslint.json
+++ b/packages/core/email/shared/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../server/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/plugins/i18n/.eslintrc.cjs
+++ b/packages/plugins/i18n/.eslintrc.cjs
@@ -13,7 +13,7 @@ const config = {
   overrides: [
     {
       files: ['**'],
-      excludedFiles: ['admin/**/*', 'server/**/*'],
+      excludedFiles: ['admin/**/*', 'server/**/*', 'shared/**/*'],
       extends: ['eslint-config-custom/back'],
     },
   ],

--- a/packages/plugins/i18n/shared/.eslintrc.cjs
+++ b/packages/plugins/i18n/shared/.eslintrc.cjs
@@ -1,0 +1,27 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  extends: ['eslint-config-custom/back/typescript'],
+  ignorePatterns: ['.eslintrc.cjs'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.eslint.json'],
+  },
+  overrides: [
+    {
+      // Contract files use declare namespace + empty object request shapes by convention.
+      files: ['contracts/**'],
+      rules: {
+        '@typescript-eslint/no-namespace': 'off',
+        '@typescript-eslint/ban-types': 'off',
+        '@typescript-eslint/no-empty-interface': 'off',
+        '@typescript-eslint/naming-convention': 'off',
+        'node/no-extraneous-import': 'off',
+      },
+    },
+  ],
+};
+
+module.exports = config;

--- a/packages/plugins/i18n/shared/tsconfig.eslint.json
+++ b/packages/plugins/i18n/shared/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../server/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### What does it do?

Adds a `shared/.eslintrc.cjs` (`root: true`, TS-aware — extends `back/typescript`) and a `shared/tsconfig.eslint.json` to the `email` and `i18n` packages, and excludes `shared/**/*` from the root (CJS) `back` override of `content-releases`, `email`, and `i18n`.

`content-releases` already received its `shared/.eslintrc.cjs` and `shared/tsconfig.eslint.json` on `develop`, so the only change left for it here is the `shared/**/*` exclusion in its root config — the nested config is `root: true`, so this exclusion is for consistency with the existing `admin/**/*` and `server/**/*` entries rather than a behaviour change.

This is the same pattern applied in #27066 for `admin`, `content-manager`, and `review-workflows`.

### Why is it needed?

The `shared/` folder had no ESLint config of its own, so its `*.ts` files were being linted incorrectly:

- Each package's `admin/` and `server/` folders have their **own** nested `.eslintrc.cjs` (each `root: true`), so those files pick the right (TS-aware) config.
- `shared/` had none, so its files fell through to the **parent** root config's override, which applies `eslint-config-custom/back` (JS-only espree, no TS parser) to everything outside `admin/`/`server/`. That parser cannot handle `shared/*.ts` syntax and fails with `Parsing error: The keyword 'import' is reserved` (or `The keyword 'export' is reserved`, depending on the file).

This stayed hidden because the two lint entry points behave differently:

- The **`lint` command** (CI, `nx … eslint .`) relies on extension-based discovery, which only picks up `*.js`. `shared/*.ts` is never linted, so no error surfaces.
- **`lint-staged`** passes the **explicit staged file paths** to ESLint, bypassing extension discovery. So a staged `shared/*.ts` file does get linted — against the wrong (JS-only) parent config — and fails to parse.

Giving `shared/` its own `root: true` TS-aware config means lint-staged's explicit `.ts` paths resolve to the correct config instead of the JS-only parent, matching how `@strapi/admin` and the packages in #27066 already handle it.

### How to test it?

```bash
npx eslint packages/core/content-releases/shared
npx eslint packages/core/email/shared
npx eslint packages/plugins/i18n/shared
```

All report `ESLint: No issues found`. Staging any `shared/*.ts` file in these packages and committing (which triggers lint-staged) now passes instead of erroring on parse.

### Related issue(s)/PR(s)

- Follows the pattern established in #27066
