### PR TITLE
chore(typescript): enable composite in base and client tsconfig

### DIFF
--- a/packages/core/admin/admin/tsconfig.json
+++ b/packages/core/admin/admin/tsconfig.json
@@ -6,5 +6,12 @@
     },
     "types": ["@testing-library/jest-dom", "jest"]
   },
-  "include": ["../package.json", "./src", "../shared", "./tests", "./custom.d.ts"]
+  "include": [
+    "../package.json",
+    "./src",
+    "../shared",
+    "../ee/admin/src",
+    "./tests",
+    "./custom.d.ts"
+  ]
 }

--- a/packages/core/admin/ee/admin/custom.d.ts
+++ b/packages/core/admin/ee/admin/custom.d.ts
@@ -23,6 +23,7 @@ declare global {
         REVIEW_WORKFLOWS: 'review-workflows';
         isEnabled: (featureName?: string) => boolean;
       };
+      isTrialLicense: boolean;
       flags: {
         promoteEE?: boolean;
         nps?: boolean;

--- a/packages/core/admin/ee/admin/tsconfig.json
+++ b/packages/core/admin/ee/admin/tsconfig.json
@@ -6,5 +6,12 @@
     },
     "types": ["@testing-library/jest-dom", "jest"]
   },
-  "include": ["./src", "../../shared", "./tests", "./custom.d.ts"]
+  "include": [
+    "./src",
+    "../../admin/src",
+    "../../admin/tests",
+    "../../shared",
+    "./tests",
+    "./custom.d.ts"
+  ]
 }

--- a/packages/core/admin/ee/server/tsconfig.json
+++ b/packages/core/admin/ee/server/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src"],
+  "include": ["src", "../../server/src", "../../server/test-utils", "../../shared"],
   "compilerOptions": {
     "types": ["node", "jest"]
   }

--- a/packages/core/admin/server/tsconfig.json
+++ b/packages/core/admin/server/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src"],
+  "include": ["src", "test-utils", "../shared", "../ee/server/src"],
   "compilerOptions": {
     "types": ["node", "jest"]
   }

--- a/packages/core/admin/tsconfig.json
+++ b/packages/core/admin/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "types": ["@testing-library/jest-dom"]
   },
-  "include": ["_internal"]
+  "include": [
+    "_internal",
+    "admin/src/components/DefaultDocument.tsx",
+    "admin/src/components/NoJavascript.tsx"
+  ]
 }

--- a/packages/core/content-manager/server/tsconfig.json
+++ b/packages/core/content-manager/server/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["./src"],
+  "include": ["./src", "../shared"],
   "compilerOptions": {
     "types": ["node", "jest"]
   }

--- a/packages/core/content-manager/server/tsconfig.preview-script.json
+++ b/packages/core/content-manager/server/tsconfig.preview-script.json
@@ -6,5 +6,8 @@
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "types": []
   },
-  "include": ["./src/preview/controllers/previewScript.js"]
+  "include": [
+    "./src/preview/controllers/previewScript.js",
+    "../admin/src/preview/utils/constants.ts"
+  ]
 }

--- a/packages/core/upload/server/tsconfig.json
+++ b/packages/core/upload/server/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["./src"],
+  "include": ["./src", "../shared"],
   "compilerOptions": {
     "types": ["node", "jest"]
   }

--- a/packages/plugins/documentation/admin/tsconfig.json
+++ b/packages/plugins/documentation/admin/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "tsconfig/client.json",
-  "include": ["./src"],
+  "include": ["./src", "../tests"],
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest"]
   }

--- a/packages/utils/tsconfig/base.json
+++ b/packages/utils/tsconfig/base.json
@@ -2,6 +2,7 @@
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/packages/utils/tsconfig/client.json
+++ b/packages/utils/tsconfig/client.json
@@ -16,6 +16,7 @@
     "noEmit": true,
     "noImplicitAny": true,
     "declaration": true,
+    "composite": true,
     "jsx": "react-jsx",
     "types": [],
     "noUncheckedSideEffectImports": true,


### PR DESCRIPTION
### What does it do?

Enables `composite: true` in the two shared tsconfig presets:

- `packages/utils/tsconfig/base.json` (backend)
- `packages/utils/tsconfig/client.json` (frontend)

`composite` makes TypeScript require every imported file to be covered by an
`include` glob. That surfaced a set of `TS6307` errors where package tsconfigs
reference sibling sources outside their own `src`. The affected configs are
extended to list what they already import:

- `admin` server / ee-server / admin / ee-admin / package-root configs
- `content-manager` server + preview-script configs
- `upload` server config
- `documentation` admin config

It also adds the missing `isTrialLicense` field to `ee/admin/custom.d.ts`,
whose `window.strapi` type had drifted from the CE `admin/custom.d.ts`
declaration. This only surfaced once `ee/admin` began type-checking the CE
`render.ts` under the wider include set.

> [!NOTE]
> The `ee/admin/custom.d.ts` change is a temporary shim. #26213 centralises
> `BrowserStrapi` into `@strapi/types` and deletes these per-package
> `custom.d.ts` files, which fixes the drift at the source. Once #26213 lands,
> this line should be dropped on rebase.

### Why is it needed?

Groundwork toward TypeScript project references / incremental builds. Turning on
`composite` first makes the existing implicit cross-project file references
explicit and catches drift (like the `isTrialLicense` case) that was previously
invisible.

This PR intentionally uses `include` widening rather than proper project
`references` — the `references` conversion is a follow-up.

### How to test it?

```bash
yarn test:ts
```

All 36 projects pass.

### Related issue(s)/PR(s)

- Depends on / superseded in part by #26213 (BrowserStrapi centralisation)