### PR TITLE
enhancement(core): look models up on the registries in getModel

### DIFF
--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -584,13 +584,20 @@ class Strapi extends Container implements Core.Strapi {
   getModel(uid: UID.ContentType): Schema.ContentType;
   getModel(uid: UID.Component): Schema.Component;
   getModel<TUID extends UID.Schema>(uid: TUID): Schema.ContentType | Schema.Component | undefined {
-    if (uid in this.contentTypes) {
-      return this.contentTypes[uid as UID.ContentType];
+    // Looked up on the registries directly rather than through the `contentTypes` /
+    // `components` getters. Those getters call `getAll()`, and the content-type registry
+    // builds a fresh copy of every registered schema on each call. Reading `uid in
+    // this.contentTypes` and then `this.contentTypes[uid]` therefore built that copy
+    // twice per lookup, and a component uid built it four times over. `getModel` runs
+    // once per relation, component, media and dynamic-zone node of every sanitized
+    // response, which made this the single hottest path in a REST request.
+    const contentType = this.get('content-types').get(uid as UID.ContentType);
+
+    if (contentType !== undefined) {
+      return contentType;
     }
 
-    if (uid in this.components) {
-      return this.components[uid as UID.Component];
-    }
+    return this.get('components').get(uid as UID.Component);
   }
 
   /**


### PR DESCRIPTION
### What does it do?

Changes `Strapi.getModel()` to read the content-type and component registries directly
instead of going through the `contentTypes` / `components` getters.

Those getters call the registry's `getAll()`. The content-type registry's `getAll()` is:

```ts
getAll(namespace: string) {
  return pickBy((_, uid) => hasNamespace(uid, namespace))(contentTypes);
}
```

`getModel` calls it with no namespace, and `hasNamespace(uid, undefined)` returns `true`
for everything, so the lodash/fp `pickBy` walks every registered content type and
allocates a fresh copy of the whole map — a filter that filters nothing.

The method then paid for that twice, because it tested membership and read the value as
two separate accesses:

```ts
if (uid in this.contentTypes) {      // builds a full copy of the registry
  return this.contentTypes[uid];     // builds it again
}

if (uid in this.components) { ... }  // and twice more for a component uid
```

So a content-type lookup rebuilt the registry twice and a component uid rebuilt it four
times. `get()` on the registry returns the same object without building anything.

Note the `components` registry's `getAll()` already returns the live object rather than a
copy, so only the content-type side was paying this.

### Why is it needed?

`getModel` is called once per relation, component, media and dynamic-zone node while
sanitizing a response, so a page of entities calls it thousands of times.

Profiling a REST request with a V8 sampling profiler put lodash at 36% of on-CPU time,
and 73% of that lodash time sat under `getModel` -> `getAll` -> `pickBy` — roughly **26%
of total on-CPU time spent building registry copies that are thrown away immediately**.
It was the single hottest path in a REST request, ahead of anything in the sanitization
layer itself.

After this change lodash drops from 36% to 14% of on-CPU time.

### How to test it?

Behaviour should be identical — this returns the same object, just without building an
intermediate map.

Equivalence was checked by capturing REST responses on `develop` and on this branch for
the same requests against the same database and diffing them: 9 endpoints covering
`populate=*`, field selection, filters, sorting, locales, a 403 from a restricted
relation and two 400s from `strictParams`. All byte-identical.

To reproduce the performance result:

```bash
cd examples/getstarted
DB=postgres yarn develop          # seed a few hundred entries with relations/components
# then, against develop and against this branch:
autocannon -c 10 -d 20 "http://127.0.0.1:1337/api/kitchensinks?populate=*&pagination[pageSize]=25"
```

Measured on `examples/getstarted` against PostgreSQL with 1000 kitchensink documents,
`GET /api/kitchensinks?populate=*&pagination[pageSize]=25`, concurrency 10, Node 22,
median of 3 runs:

| | develop | this PR |
| --- | ---: | ---: |
| throughput | 14.5 req/s | **20.4 req/s (1.41x)** |

This PR is measured standalone against `develop`, not stacked with any other performance
PR.

### Related issue(s)/PR(s)

Part of a REST pipeline performance investigation. Independent of, and measured
separately from:

- #27140 — memoize private attributes in `sanitizeOutput`
- #27141 — traversal output construction
- #27142 — sanitization advisory regression tests

No dependency between them; they touch different packages and can merge in any order.
