### PR TITLE
enhancement(database): reduce per-column work when mapping rows to entities

### DIFF
--- a/packages/core/database/src/fields/datetime.ts
+++ b/packages/core/database/src/fields/datetime.ts
@@ -1,5 +1,3 @@
-import * as dateFns from 'date-fns';
-
 import { parseDateTimeOrTimestamp } from './shared/parsers';
 import Field from './field';
 
@@ -9,7 +7,11 @@ export default class DatetimeField extends Field {
   }
 
   fromDB(value: unknown) {
-    const cast = new Date(value as any);
-    return dateFns.isValid(cast) ? cast.toISOString() : null;
+    // Drivers already hand back a `Date` for timestamp columns, so the constructor was
+    // re-parsing a value that had just been parsed — once per datetime column of every
+    // row. For a `Date`, `dateFns.isValid` reduces to a NaN check on the timestamp, which
+    // is what this does without the argument normalisation date-fns performs first.
+    const cast = value instanceof Date ? value : new Date(value as any);
+    return Number.isNaN(cast.getTime()) ? null : cast.toISOString();
   }
 }

--- a/packages/core/database/src/fields/index.ts
+++ b/packages/core/database/src/fields/index.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash/fp';
-
 import Field from './field';
 import StringField from './string';
 import JSONField from './json';
@@ -35,12 +33,35 @@ const typeToFieldMap: Record<string, typeof Field> = {
   blocks: JSONField,
 };
 
+/**
+ * One instance per type, shared.
+ *
+ * Every call site constructs with an empty config and no subclass reads `this.config` —
+ * `toDB`/`fromDB` are pure functions of their argument — so the instances are
+ * interchangeable. They were being allocated once per scalar column per row, which on a
+ * page of entities with relations and components ran into the thousands and showed up as
+ * GC pressure rather than as time in this function.
+ */
+const fieldInstances = new Map<string, Field>();
+
 export const createField = (attribute: Attribute): Field => {
   const { type } = attribute;
 
-  if (_.has(type, typeToFieldMap)) {
-    return new typeToFieldMap[type]({});
+  const cached = fieldInstances.get(type);
+
+  if (cached !== undefined) {
+    return cached;
   }
 
-  throw new Error(`Undefined field for type ${type}`);
+  // Own-property check: `type` comes from a schema, and an inherited key such as
+  // `constructor` must not resolve to a field class. This is also what lodash's `has`
+  // did, minus the path parsing it ran on every column of every row.
+  if (!Object.prototype.hasOwnProperty.call(typeToFieldMap, type)) {
+    throw new Error(`Undefined field for type ${type}`);
+  }
+
+  const field = new typeToFieldMap[type]({});
+  fieldInstances.set(type, field);
+
+  return field;
 };

--- a/packages/core/database/src/fields/timestamp.ts
+++ b/packages/core/database/src/fields/timestamp.ts
@@ -1,5 +1,3 @@
-import * as dateFns from 'date-fns';
-
 import { parseDateTimeOrTimestamp } from './shared/parsers';
 import Field from './field';
 
@@ -9,7 +7,10 @@ export default class TimestampField extends Field {
   }
 
   fromDB(value: unknown) {
-    const cast = new Date(value as any);
-    return dateFns.isValid(cast) ? dateFns.format(cast, 'T') : null;
+    // Same redundant re-parse as `datetime`. `format(cast, 'T')` is the epoch in
+    // milliseconds as a string, which `getTime()` already gives us.
+    const cast = value instanceof Date ? value : new Date(value as any);
+    const time = cast.getTime();
+    return Number.isNaN(time) ? null : String(time);
   }
 }

--- a/packages/core/database/src/query/helpers/transform.ts
+++ b/packages/core/database/src/query/helpers/transform.ts
@@ -18,7 +18,10 @@ const fromSingleRow = (meta: Meta, row: Row): Rec => {
   const obj: Rec = {};
 
   for (const column in row) {
-    if (!_.has(column, meta.columnToAttribute)) {
+    // `_.has` from lodash/fp treats its first argument as a property *path*, so every
+    // column of every row was run through lodash's path parser before this simple
+    // membership test. Column names are literal keys, never paths.
+    if (!Object.prototype.hasOwnProperty.call(meta.columnToAttribute, column)) {
       continue;
     }
 


### PR DESCRIPTION
### What does it do?

Three changes to the code that maps database rows back into entities, all of it running
once per column of every returned row.

**1. Field instances are shared instead of allocated per column, per row.**

`createField` did `new typeToFieldMap[type]({})` on every call. Every call site passes an
empty config, and no subclass reads `this.config` — `toDB` and `fromDB` are pure
functions of their argument — so the instances are interchangeable. One per type is now
created and reused. The discarded allocations did not show up as time inside
`createField`; they showed up as GC.

**2. lodash/fp `has` replaced with an own-property check.**

`fromSingleRow` and `createField` both used `_.has(key, obj)`. `has` from lodash/fp
treats its first argument as a property **path**, so each column name and each field type
was run through lodash's path parser before a simple membership test. Column names and
type names are literal keys, never paths.

Kept as an *own*-property check (`Object.prototype.hasOwnProperty.call`) rather than
`in`, so an inherited key such as `constructor` still cannot resolve to a field class —
same guarantee lodash's `has` provided.

**3. `datetime` / `timestamp` `fromDB` no longer re-parse an already-parsed value.**

Drivers return a `Date` for timestamp columns. `fromDB` passed that `Date` back through
the `Date` constructor, then called `dateFns.isValid` on the result — which for a `Date`
reduces to a NaN check on its timestamp, after date-fns normalises the argument. Both are
skipped when the value is already a `Date`.

`timestamp` additionally used `dateFns.format(cast, 'T')`. That token is the epoch in
milliseconds, which is what `getTime()` returns; verified equal across positive, zero and
negative epochs. This removes date-fns from the row-mapping path entirely.

### Why is it needed?

These run per column of every row, so they scale with page size and with how much is
populated. A profile of a REST request attributed roughly 16% of on-CPU time to
`@strapi/database`, with the row transform and `createField` the largest contributors
inside it, plus the allocation churn appearing separately as GC pressure.

None of this changes what is returned; it is the same work done once instead of
repeatedly, or done natively instead of through a general-purpose helper.

### How to test it?

Existing `@strapi/database` unit tests cover the field types and the row transform.

Equivalence was also checked end to end by capturing REST responses on `develop` and on
this branch against the same database and diffing: 9 endpoints covering `populate=*`,
field selection, filters, sorting, locales, a 403 and two 400s. All byte-identical —
including every `createdAt` / `updatedAt` / `publishedAt` value, which is what exercises
the datetime change.

Worth exercising on more than SQLite, since the datetime change depends on what the
driver returns: the CI matrix covers PostgreSQL, MySQL and MariaDB.

Measured on `examples/getstarted` against PostgreSQL with 1000 kitchensink documents,
`GET /api/kitchensinks?populate=*&pagination[pageSize]=25`, concurrency 10, Node 22,
median of 3 runs:

| | develop | this PR |
| --- | ---: | ---: |
| throughput | 14.5 req/s | **15.4 req/s (1.06x)** |

Measured standalone against `develop`, not stacked with any other performance PR. Worth
noting the honest caveat: on its own this is a modest 6%, because a larger cost elsewhere
dominates the request (see #27143). With that one also applied, the remaining costs —
including these — account for a proportionally larger share.

### Related issue(s)/PR(s)

Part of a REST pipeline performance investigation. Independent of, and measured
separately from:

- #27143 — `getModel` registry lookup
- #27140 / #27141 / #27142 — sanitization layer

No dependency between them; they touch different packages and can merge in any order.
