### PR TITLE
fix: Handle i18n conflict and local rights

### DIFF
--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -73,7 +73,7 @@ const Layout = () => {
     const requestedLocale = query.plugins?.i18n?.locale;
     const localeScopedPermissions = permissions.filter(
       (permission) =>
-        permission.action.startsWith('plugin::content-manager.explorer.') &&
+        permission.action === 'plugin::content-manager.explorer.read' &&
         Array.isArray(permission.properties?.locales)
     );
     const contentTypePermissions = localeScopedPermissions.filter(

--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -1,7 +1,17 @@
 /* eslint-disable check-file/filename-naming-convention */
 import * as React from 'react';
 
-import { Page, Layouts, SubNav, useIsMobile, LazyOutlet } from '@strapi/admin/strapi-admin';
+import {
+  Page,
+  Layouts,
+  SubNav,
+  useIsMobile,
+  LazyOutlet,
+  useQueryParams,
+  useNotification,
+  useAuth,
+} from '@strapi/admin/strapi-admin';
+import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
 import { Navigate, useLocation, useMatch } from 'react-router-dom';
 
@@ -17,6 +27,7 @@ import { getTranslation } from './utils/translations';
 import type { CardDragPreviewProps } from './components/DragPreviews/CardDragPreview';
 import type { ComponentDragPreviewProps } from './components/DragPreviews/ComponentDragPreview';
 import type { RelationDragPreviewProps } from './components/DragPreviews/RelationDragPreview';
+import type { To } from 'react-router-dom';
 
 /* -------------------------------------------------------------------------------------------------
  * Layout
@@ -33,6 +44,8 @@ const Layout = () => {
 
   const { pathname } = useLocation();
   const { formatMessage } = useIntl();
+  const [{ query }] = useQueryParams<{ plugins?: { i18n?: { locale?: string } } }>();
+  const permissions = useAuth('Layout', (state) => state.permissions);
 
   if (isLoading) {
     return (
@@ -57,16 +70,53 @@ const Layout = () => {
     supportedModelsToDisplay.length > 0 &&
     pathname !== '/content-manager/403'
   ) {
-    return <Navigate to="/403" />;
+    const requestedLocale = query.plugins?.i18n?.locale;
+    const localeScopedPermissions = permissions.filter(
+      (permission) =>
+        permission.action.startsWith('plugin::content-manager.explorer.') &&
+        Array.isArray(permission.properties?.locales)
+    );
+    const contentTypePermissions = localeScopedPermissions.filter(
+      (permission) => permission.subject === contentTypeMatch?.params.uid
+    );
+    const accessibleLocales = Array.from(
+      new Set(
+        (contentTypePermissions.length > 0
+          ? contentTypePermissions
+          : localeScopedPermissions
+        ).flatMap((permission) => permission.properties?.locales as string[])
+      )
+    );
+
+    if (typeof requestedLocale === 'string' && accessibleLocales.length > 0) {
+      if (!accessibleLocales.includes(requestedLocale)) {
+        const search = stringify({
+          ...query,
+          plugins: {
+            ...query.plugins,
+            i18n: { ...query.plugins?.i18n, locale: accessibleLocales[0] },
+          },
+        });
+
+        return <NavigateWithLocaleWarning to={{ pathname, search }} />;
+      }
+    } else {
+      return <Navigate to="/content-manager/403" replace />;
+    }
   }
 
   // Redirect the user to the create content type page
-  if (supportedModelsToDisplay.length === 0 && pathname !== '/no-content-types') {
-    return <Navigate to="/no-content-types" />;
+  if (supportedModelsToDisplay.length === 0 && pathname !== '/content-manager/no-content-types') {
+    return <Navigate to="/content-manager/no-content-types" replace />;
   }
 
   // On /content-manager base route
-  if (!contentTypeMatch && authorisedModels.length > 0) {
+  if (
+    !contentTypeMatch &&
+    authorisedModels.length > 0 &&
+    pathname !== '/content-manager/403' &&
+    pathname !== '/content-manager/no-content-types'
+  ) {
     // On desktop: redirect to first collection type
     if (!isMobile) {
       return (
@@ -110,6 +160,24 @@ const Layout = () => {
       </Layouts.Root>
     </>
   );
+};
+
+const NavigateWithLocaleWarning = ({ to }: { to: To }) => {
+  const { toggleNotification } = useNotification();
+  const { formatMessage } = useIntl();
+
+  React.useEffect(() => {
+    toggleNotification({
+      type: 'warning',
+      message: formatMessage({
+        id: getTranslation('permissions.not-allowed.locale'),
+        defaultMessage:
+          "You don't have the permissions to access this content for the requested locale",
+      }),
+    });
+  }, [toggleNotification, formatMessage]);
+
+  return <Navigate to={to} replace />;
 };
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/core/content-manager/admin/src/tests/layout.test.tsx
+++ b/packages/core/content-manager/admin/src/tests/layout.test.tsx
@@ -180,6 +180,45 @@ describe('Content Manager | Layout', () => {
     expect(screen.queryByText('No permissions page')).not.toBeInTheDocument();
   });
 
+  it('does not redirect to a locale the user can only update, since it cannot be displayed', async () => {
+    jest.mocked(useContentManagerInitData).mockImplementation(() => {
+      const { search } = useLocation();
+      const isBlockedLocale = search.includes('fr');
+
+      return {
+        isLoading: false,
+        collectionTypeLinks: isBlockedLocale ? [] : [ARTICLE_LINK],
+        singleTypeLinks: [],
+        components: [],
+        fieldSizes: {},
+        models: [ARTICLE_MODEL],
+      };
+    });
+
+    renderLayout(
+      '/content-manager/collection-types/api::article.article/1?plugins[i18n][locale]=fr',
+      [
+        EN_ONLY_READ_PERMISSION,
+        // An update-only locale is not displayable: requesting it must redirect
+        // to a readable locale instead of rendering an error page.
+        {
+          ...EN_ONLY_READ_PERMISSION,
+          id: 1002,
+          action: 'plugin::content-manager.explorer.update',
+          properties: { locales: ['fr'] },
+        },
+      ]
+    );
+
+    expect(await screen.findByText('Edit page')).toBeInTheDocument();
+    expect(screen.getByTestId('search')).toHaveTextContent('plugins[i18n][locale]=en');
+    expect(
+      screen.getByText(
+        "You don't have the permissions to access this content for the requested locale"
+      )
+    ).toBeInTheDocument();
+  });
+
   it('renders the route instead of redirecting when the requested locale is accessible but the links are stale', async () => {
     // The links are authorized asynchronously against the previous URL: an
     // accessible locale with no authorised links means they are out of date.

--- a/packages/core/content-manager/admin/src/tests/layout.test.tsx
+++ b/packages/core/content-manager/admin/src/tests/layout.test.tsx
@@ -1,0 +1,211 @@
+/* eslint-disable check-file/filename-naming-convention */
+import { render, screen } from '@tests/utils';
+import { Route, Routes, useLocation } from 'react-router-dom';
+
+import { useContentManagerInitData } from '../hooks/useContentManagerInitData';
+import { Layout } from '../layout';
+
+import type { ContentManagerLink } from '../hooks/useContentManagerInitData';
+import type { AppState } from '../modules/app';
+import type { Permission } from '@strapi/admin/strapi-admin';
+
+jest.mock('../hooks/useContentManagerInitData');
+
+const ARTICLE_MODEL = {
+  uid: 'api::article.article',
+  isDisplayed: true,
+  apiID: 'article',
+  kind: 'collectionType',
+  info: {
+    displayName: 'Article',
+    singularName: 'article',
+    pluralName: 'articles',
+  },
+  attributes: {},
+} as unknown as AppState['models'][number];
+
+const ARTICLE_LINK: ContentManagerLink = {
+  permissions: [],
+  search: null,
+  kind: 'collectionType',
+  title: 'Article',
+  to: '/content-manager/collection-types/api::article.article',
+  uid: 'api::article.article',
+  name: 'api::article.article',
+  isDisplayed: true,
+};
+
+const EN_ONLY_READ_PERMISSION = {
+  id: 1000,
+  action: 'plugin::content-manager.explorer.read',
+  subject: 'api::article.article',
+  properties: { locales: ['en'] },
+  conditions: [],
+  actionParameters: {},
+} as Permission;
+
+const mockInitData = (overrides: Partial<AppState>) => {
+  jest.mocked(useContentManagerInitData).mockReturnValue({
+    isLoading: false,
+    collectionTypeLinks: [],
+    singleTypeLinks: [],
+    components: [],
+    fieldSizes: {},
+    models: [],
+    ...overrides,
+  });
+};
+
+const EditPageProbe = () => {
+  const { search } = useLocation();
+
+  return (
+    <>
+      <div>Edit page</div>
+      <div data-testid="search">{decodeURIComponent(search)}</div>
+    </>
+  );
+};
+
+const renderLayout = (initialEntry: string, permissions: Permission[] = []) =>
+  render(
+    <Routes>
+      <Route path="/content-manager" element={<Layout />}>
+        <Route path="403" element={<div>No permissions page</div>} />
+        <Route path="no-content-types" element={<div>No content types page</div>} />
+        <Route path=":collectionType/:slug" element={<div>List page</div>} />
+        <Route path=":collectionType/:slug/:id" element={<EditPageProbe />} />
+      </Route>
+      <Route path="*" element={<div>Not found page</div>} />
+    </Routes>,
+    { initialEntries: [initialEntry], providerOptions: { permissions } }
+  );
+
+describe('Content Manager | Layout', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to the content-manager 403 page when no model is authorised for the user', async () => {
+    mockInitData({ models: [ARTICLE_MODEL] });
+
+    renderLayout('/content-manager/collection-types/api::article.article/1');
+
+    expect(await screen.findByText('No permissions page')).toBeInTheDocument();
+    expect(screen.queryByText('Not found page')).not.toBeInTheDocument();
+  });
+
+  it('redirects to the content-manager no-content-types page when there is no content type to display', async () => {
+    mockInitData({ models: [] });
+
+    renderLayout('/content-manager/collection-types/api::article.article/1');
+
+    expect(await screen.findByText('No content types page')).toBeInTheDocument();
+    expect(screen.queryByText('Not found page')).not.toBeInTheDocument();
+  });
+
+  it('does not redirect when the user has access to at least one content type', async () => {
+    mockInitData({ models: [ARTICLE_MODEL], collectionTypeLinks: [ARTICLE_LINK] });
+
+    renderLayout('/content-manager/collection-types/api::article.article/1');
+
+    expect(await screen.findByText('Edit page')).toBeInTheDocument();
+    expect(screen.queryByText('Not found page')).not.toBeInTheDocument();
+  });
+
+  it('redirects to an accessible locale and warns the user when the permissions are denied for the requested locale', async () => {
+    // Simulate the i18n RBAC middleware: the links are only authorized while
+    // the URL carries a locale the user has access to.
+    jest.mocked(useContentManagerInitData).mockImplementation(() => {
+      const { search } = useLocation();
+      const isBlockedLocale = search.includes('fr');
+
+      return {
+        isLoading: false,
+        collectionTypeLinks: isBlockedLocale ? [] : [ARTICLE_LINK],
+        singleTypeLinks: [],
+        components: [],
+        fieldSizes: {},
+        models: [ARTICLE_MODEL],
+      };
+    });
+
+    renderLayout(
+      '/content-manager/collection-types/api::article.article/1?plugins[i18n][locale]=fr',
+      [EN_ONLY_READ_PERMISSION]
+    );
+
+    expect(await screen.findByText('Edit page')).toBeInTheDocument();
+    expect(screen.getByTestId('search')).toHaveTextContent('plugins[i18n][locale]=en');
+    expect(
+      screen.getByText(
+        "You don't have the permissions to access this content for the requested locale"
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No permissions page')).not.toBeInTheDocument();
+  });
+
+  it('redirects to a locale accessible for the visited content type rather than another one', async () => {
+    jest.mocked(useContentManagerInitData).mockImplementation(() => {
+      const { search } = useLocation();
+      const isBlockedLocale = search.includes('fr');
+
+      return {
+        isLoading: false,
+        collectionTypeLinks: isBlockedLocale ? [] : [ARTICLE_LINK],
+        singleTypeLinks: [],
+        components: [],
+        fieldSizes: {},
+        models: [ARTICLE_MODEL],
+      };
+    });
+
+    renderLayout(
+      '/content-manager/collection-types/api::article.article/1?plugins[i18n][locale]=fr',
+      [
+        // A locale scoped to another content type must not win over the
+        // one scoped to the content type being visited.
+        {
+          ...EN_ONLY_READ_PERMISSION,
+          id: 1001,
+          subject: 'api::page.page',
+          properties: { locales: ['de'] },
+        },
+        EN_ONLY_READ_PERMISSION,
+      ]
+    );
+
+    expect(await screen.findByText('Edit page')).toBeInTheDocument();
+    expect(screen.getByTestId('search')).toHaveTextContent('plugins[i18n][locale]=en');
+    expect(screen.queryByText('No permissions page')).not.toBeInTheDocument();
+  });
+
+  it('renders the route instead of redirecting when the requested locale is accessible but the links are stale', async () => {
+    // The links are authorized asynchronously against the previous URL: an
+    // accessible locale with no authorised links means they are out of date.
+    mockInitData({ models: [ARTICLE_MODEL] });
+
+    renderLayout(
+      '/content-manager/collection-types/api::article.article/1?plugins[i18n][locale]=en',
+      [EN_ONLY_READ_PERMISSION]
+    );
+
+    expect(await screen.findByText('Edit page')).toBeInTheDocument();
+    expect(screen.queryByText('No permissions page')).not.toBeInTheDocument();
+  });
+
+  /**
+   * The i18n RBAC middleware can grant permissions on the 403 page (no locale in
+   * the URL) that it denies on a content-type page (unauthorised locale in the
+   * URL). Redirecting away from the 403 page in that situation causes an infinite
+   * redirect loop between the two pages.
+   */
+  it('stays on the 403 page even when the user has authorised models', async () => {
+    mockInitData({ models: [ARTICLE_MODEL], collectionTypeLinks: [ARTICLE_LINK] });
+
+    renderLayout('/content-manager/403');
+
+    expect(await screen.findByText('No permissions page')).toBeInTheDocument();
+    expect(screen.queryByText('List page')).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -242,6 +242,7 @@
   "pages.NoContentType.button": "Create your first Content-Type",
   "pages.NoContentType.text": "You don't have any content yet, we recommend you to create your first Content-Type.",
   "permissions.not-allowed.create": "You are not allowed to create a document",
+  "permissions.not-allowed.locale": "You don't have the permissions to access this content for the requested locale",
   "permissions.not-allowed.update": "You are not allowed to see this document",
   "plugin.description.long": "Quick way to see, edit and delete the data in your database.",
   "plugin.description.short": "Quick way to see, edit and delete the data in your database.",

--- a/packages/core/content-manager/admin/tests/utils.tsx
+++ b/packages/core/content-manager/admin/tests/utils.tsx
@@ -35,7 +35,7 @@ const render = (
 ): ReturnType<typeof renderAdmin> =>
   renderAdmin(ui, {
     ...options,
-    providerOptions: { storeConfig: storeConfig() },
+    providerOptions: { ...options.providerOptions, storeConfig: storeConfig() },
   });
 
 const renderHook: typeof renderHookAdmin = (hook, options) =>

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -189,14 +189,17 @@ const LocalePickerAction = ({
     }
     /**
      * Handle the case where the current locale query param doesn't exist
-     * in the list of available locales, so we redirect to the default locale.
+     * in the list of available locales, so we redirect to the default locale
+     * when the user has access to it, or the first locale they can access.
      */
     const doesLocaleExist = locales.find((loc) => loc.code === currentDesiredLocale);
-    const defaultLocale = locales.find((locale) => locale.isDefault);
-    if (!doesLocaleExist && defaultLocale?.code) {
-      handleSelect(defaultLocale.code);
+    const accessibleLocales = locales.filter((locale) => canRead.includes(locale.code));
+    const targetLocale =
+      accessibleLocales.find((locale) => locale.isDefault) ?? accessibleLocales[0];
+    if (!doesLocaleExist && targetLocale?.code) {
+      handleSelect(targetLocale.code);
     }
-  }, [handleSelect, hasI18n, locales, currentDesiredLocale]);
+  }, [handleSelect, hasI18n, locales, currentDesiredLocale, canRead]);
 
   const currentLocale = Array.isArray(locales)
     ? locales.find((locale) => locale.code === currentDesiredLocale)

--- a/packages/plugins/i18n/admin/src/components/LocalePicker.tsx
+++ b/packages/plugins/i18n/admin/src/components/LocalePicker.tsx
@@ -43,15 +43,20 @@ const LocalePicker = () => {
     }
     /**
      * Handle the case where the current locale query param doesn't exist
-     * in the list of available locales, so we redirect to the default locale.
+     * in the list of available locales, so we redirect to the default locale
+     * when the user has access to it, or the first locale they can access.
      */
     const currentDesiredLocale = query.plugins?.i18n?.locale;
     const doesLocaleExist = locales.find((loc) => loc.code === currentDesiredLocale);
-    const defaultLocale = locales.find((locale) => locale.isDefault);
-    if (!doesLocaleExist && defaultLocale?.code) {
-      handleChange(defaultLocale.code, true);
+    const accessibleLocales = locales.filter(
+      (locale) => canCreate.includes(locale.code) || canRead.includes(locale.code)
+    );
+    const targetLocale =
+      accessibleLocales.find((locale) => locale.isDefault) ?? accessibleLocales[0];
+    if (!doesLocaleExist && targetLocale?.code) {
+      handleChange(targetLocale.code, true);
     }
-  }, [hasI18n, handleChange, locales, query.plugins?.i18n?.locale]);
+  }, [hasI18n, handleChange, locales, query.plugins?.i18n?.locale, canCreate, canRead]);
 
   const sortedLocaleOptions = React.useMemo(() => {
     const displayedLocales = Array.isArray(locales)

--- a/packages/plugins/i18n/admin/src/components/LocalePicker.tsx
+++ b/packages/plugins/i18n/admin/src/components/LocalePicker.tsx
@@ -44,19 +44,17 @@ const LocalePicker = () => {
     /**
      * Handle the case where the current locale query param doesn't exist
      * in the list of available locales, so we redirect to the default locale
-     * when the user has access to it, or the first locale they can access.
+     * when the user can read it, or the first locale they can read: the list
+     * cannot be displayed for the other locales.
      */
     const currentDesiredLocale = query.plugins?.i18n?.locale;
     const doesLocaleExist = locales.find((loc) => loc.code === currentDesiredLocale);
-    const accessibleLocales = locales.filter(
-      (locale) => canCreate.includes(locale.code) || canRead.includes(locale.code)
-    );
-    const targetLocale =
-      accessibleLocales.find((locale) => locale.isDefault) ?? accessibleLocales[0];
+    const readableLocales = locales.filter((locale) => canRead.includes(locale.code));
+    const targetLocale = readableLocales.find((locale) => locale.isDefault) ?? readableLocales[0];
     if (!doesLocaleExist && targetLocale?.code) {
       handleChange(targetLocale.code, true);
     }
-  }, [hasI18n, handleChange, locales, query.plugins?.i18n?.locale, canCreate, canRead]);
+  }, [hasI18n, handleChange, locales, query.plugins?.i18n?.locale, canRead]);
 
   const sortedLocaleOptions = React.useMemo(() => {
     const displayedLocales = Array.isArray(locales)


### PR DESCRIPTION
### What does it do?

A specific toast message and a redirection to a working page has been implemented:
<img width="1367" height="198" alt="image" src="https://github.com/user-attachments/assets/a940d4e1-03df-4b5f-8722-4dcd6a2601e0" />

### Why is it needed?

Atm, if a user has no access to a local then he is seeing this on the content page of the local:
<img width="1276" height="400" alt="image" src="https://github.com/user-attachments/assets/3b91544b-493b-49ff-91a0-b0f0b42ad436" />

### How to test it?

1. Add a new local (`Settings > Internationalization`).
2. Create new content in at least 2 available locals (some published and some draft content).
3. Create a new role (`Settings > Administration panel > Roles`); select the wanted Collection Types (create/read/update) + open the dropdown to reach Locales permissions and play with the checkbox (eg. FR allowed, EN non-allowed).
4. Create a new user (`Settings > Administration panel > Users`).
5. Log in with this new user, and in the content, play with the local via the url (eg. replace FR by EN in the url).


Different tests (non exhaustive):

| Locals setup | Conclusions |
|---|---|
| EN (default)+ FR | nothing unusual, you should have access to both and no error message are ever displayed |
| no local at all | this should not be possible as `The Create, Read, and Update actions must apply to at least one locale.` |
| EN (default) | you don't see the FR local in the UI, and when changing it in the URL (content page, content draft page, and content published page), then you are always redirected to EN one |
| FR (non-default) | you don't see the EN local in the UI, and when changing it in the URL (content page, content draft page, and content published page), then you are always redirected to FR one |
| a mix (cf. screenshot) | who would do that?! |

<img width="506" height="146" alt="image" src="https://github.com/user-attachments/assets/8e802d4d-9375-4856-a769-d242236f6881" />

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/26707
Fixes EE-19
Fixes EE-110