### PR TITLE
fix(content-manager): guard list-view filters against missing field config

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
@@ -89,7 +89,7 @@ const Root = ({ disabled, schema, layout, children }: FiltersProps) => {
     return acc;
   }, []);
 
-  const { data: userData, isLoading: isLoadingAdminUsers } = useAdminUsers(
+  const { data: userData } = useAdminUsers(
     { filters: { id: { $in: selectedUserIds } } },
     {
       // fetch the list of admin users only if the filter contains users and the
@@ -182,11 +182,16 @@ const Root = ({ disabled, schema, layout, children }: FiltersProps) => {
 
         const attribute = attributes[name];
 
-        if (NOT_ALLOWED_FILTERS.includes(attribute.type)) {
+        if (!attribute || NOT_ALLOWED_FILTERS.includes(attribute.type)) {
           return null;
         }
 
-        const { mainField: mainFieldName = '', label } = metadata[name].list;
+        const fieldMetadata = metadata[name];
+        if (!fieldMetadata) {
+          return null;
+        }
+
+        const { mainField: mainFieldName = '', label } = fieldMetadata.list;
 
         let filter: Filters.Filter = {
           name,

--- a/packages/core/content-manager/admin/src/pages/ListView/components/tests/Filters.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/tests/Filters.test.tsx
@@ -1,0 +1,45 @@
+import { mockData } from '@tests/mockData';
+import { render, screen, server } from '@tests/utils';
+import { http, HttpResponse } from 'msw';
+
+import { listViewFilters } from '../Filters';
+
+// #26396 — omits creator attributes (missing from the schema) and drops `slug` from the
+// configuration metadatas below, so the filter builder hits both missing-field lookups.
+const HOMEPAGE_SCHEMA = {
+  uid: 'api::homepage.homepage',
+  options: {},
+  attributes: {
+    id: { type: 'integer' },
+    documentId: { type: 'string' },
+    title: { type: 'string' },
+    slug: { type: 'string' },
+    createdAt: { type: 'datetime' },
+    updatedAt: { type: 'datetime' },
+  },
+} as unknown as Parameters<typeof listViewFilters.Root>[0]['schema'];
+
+const LAYOUT = { options: {} } as Parameters<typeof listViewFilters.Root>[0]['layout'];
+
+const renderFilters = () =>
+  render(
+    <listViewFilters.Root schema={HOMEPAGE_SCHEMA} layout={LAYOUT}>
+      <listViewFilters.Trigger />
+    </listViewFilters.Root>
+  );
+
+describe('ListView Filters (#26396)', () => {
+  it('does not crash when filter fields are missing from the schema or configuration', async () => {
+    server.use(
+      http.get('/content-manager/content-types/:model/configuration', () => {
+        const config = structuredClone(mockData.contentManager.singleTypeConfiguration);
+        delete (config.contentType.metadatas as Record<string, unknown>).slug;
+        return HttpResponse.json({ data: config });
+      })
+    );
+
+    renderFilters();
+
+    expect(await screen.findByRole('button', { name: /filters/i })).toBeInTheDocument();
+  });
+});

--- a/packages/core/content-manager/admin/src/utils/attributes.ts
+++ b/packages/core/content-manager/admin/src/utils/attributes.ts
@@ -33,10 +33,10 @@ const getMainField = (
 
   const mainFieldType =
     attribute.type === 'component'
-      ? components[attribute.component].attributes[mainFieldName].type
+      ? components[attribute.component]?.attributes[mainFieldName]?.type
       : // @ts-expect-error – `targetModel` does exist on the attribute for a relation.
         schemas.find((schema) => schema.uid === attribute.targetModel)?.attributes[mainFieldName]
-          .type;
+          ?.type;
 
   return {
     name: mainFieldName,

--- a/packages/core/content-manager/admin/src/utils/tests/attributes.test.ts
+++ b/packages/core/content-manager/admin/src/utils/tests/attributes.test.ts
@@ -1,6 +1,38 @@
-import { checkIfAttributeIsDisplayable } from '../attributes';
+import { checkIfAttributeIsDisplayable, getMainField } from '../attributes';
+
+import type { Schema } from '../../hooks/useDocument';
 
 describe('attributes', () => {
+  describe('getMainField (missing schema/config falls back to string)', () => {
+    it('falls back to string when a component attribute references an absent component schema', () => {
+      const attribute = {
+        type: 'component',
+        component: 'basic.missing',
+        repeatable: false,
+      } as const;
+
+      expect(getMainField(attribute, 'name', { schemas: [], components: {} })).toEqual({
+        name: 'name',
+        type: 'string',
+      });
+    });
+
+    it('falls back to string when the relation target schema is missing the mainField attribute', () => {
+      const attribute = {
+        type: 'relation',
+        relation: 'oneToOne',
+        target: 'api::cat.cat',
+        targetModel: 'api::cat.cat',
+      } as const;
+      const schemas = [{ uid: 'api::cat.cat', attributes: {} }] as unknown as Schema[];
+
+      expect(getMainField(attribute, 'name', { schemas, components: {} })).toEqual({
+        name: 'name',
+        type: 'string',
+      });
+    });
+  });
+
   describe('checkIfAttributeIsDisplayable', () => {
     it('should return false if the relation is morph', () => {
       const attribute = {


### PR DESCRIPTION
### What does it do?

Hardens Content Manager list-view filter building so missing schema attributes or view-configuration metadata no longer crash the admin.

- `Filters.tsx`: skip filter fields when `attributes[name]` or `metadata[name]` is missing instead of reading `.type` / `.list` on `undefined`
- `getMainField`: optional-chain component/relation schema lookups so the existing `'string'` fallback is reachable when the target schema or main field is gone
- Adds regression coverage for both paths

### Why is it needed?

Opening collections/single types can crash with:

`TypeError: Cannot read properties of undefined (reading 'list')`

This happens when view configuration is still loading (`metadata` is `{}`), or when schema and persisted metadatas are out of sync (field added/renamed/removed). The error is caught by the router error boundary and shows the “Something went wrong” screen.

### How to test it?

**Automated**

```bash
yarn test:front packages/core/content-manager/admin/src/pages/ListView/components/tests/Filters.test.tsx --runInBand
yarn test:front packages/core/content-manager/admin/src/utils/tests/attributes.test.ts --runInBand
```

**Manual**

1. Open Content Manager list view for a collection or single type
2. Confirm the page loads (Filters button present) even if configuration is stale or still resolving
3. Confirm filterable fields still appear when schema + metadatas are complete

### Related issue(s)/PR(s)

- Fixes #26396
- Related to #26237