### PR TITLE
fix(content-manager): pass useField props to history custom fields

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -390,6 +390,10 @@ const VersionInputRenderer = ({
     edit: { components: componentsLayout },
   } = useDocLayout();
 
+  // Pass field to Custom Fields for backward compatibility with value/onChange props
+  // (same contract as Edit View InputRenderer — see #21163 / #27137).
+  const field = useField(props.name);
+
   if (!visible) {
     return null;
   }
@@ -444,6 +448,7 @@ const VersionInputRenderer = ({
       return (
         <CustomInput
           {...props}
+          {...field}
           // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
           hint={hint}
           labelAction={customLabelAction}

--- a/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
+++ b/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
@@ -10,13 +10,57 @@
  *   - admin-user relation sanitized server-side to a plain user object
  *   - a relation attribute removed from the schema, whose stored historical
  *     value is the raw payload (server's populate skipped it)
+ *
+ * Also covers #27137 — custom fields that read `value`/`onChange` from props
+ * (not `useField`) must receive the form field bag, matching Edit View.
  */
+import * as React from 'react';
+
 import { Form } from '@strapi/admin/strapi-admin';
 import { render as renderRTL, screen } from '@tests/utils';
 
-import { CustomRelationInput, resolveComponentRenderResources } from '../VersionInputRenderer';
+import { type HistoryContextValue, HistoryProvider } from '../../pages/History';
+import {
+  CustomRelationInput,
+  resolveComponentRenderResources,
+  VersionInputRenderer,
+} from '../VersionInputRenderer';
 
 import type { RelationsFieldProps } from '../../../pages/EditView/components/FormInputs/Relations/Relations';
+import type { UID } from '@strapi/types';
+
+jest.mock('../../../hooks/useDocument', () => ({
+  useDoc: () => ({ id: 'doc-1', components: {} }),
+  useDocument: () => ({ isLoading: false, components: {} }),
+}));
+
+jest.mock('../../../hooks/useDocumentLayout', () => ({
+  useDocLayout: () => ({
+    edit: { components: {} },
+  }),
+  useDocumentLayout: () => ({
+    edit: { components: {} },
+  }),
+}));
+
+/**
+ * Simulates a custom field that only reads `value` from props (TinyMCE / CKEditor
+ * style) — the contract restored for Edit View in #21163 and missing in History.
+ */
+jest.mock('../../../hooks/useLazyComponents', () => ({
+  useLazyComponents: () => ({
+    isLazyLoading: false,
+    lazyComponentStore: {
+      'plugin::test.prop-based': ({ value }: { value?: unknown }) =>
+        React.createElement(
+          'div',
+          { 'data-testid': 'prop-based-custom-field' },
+          value == null || value === '' ? 'MISSING_VALUE' : String(value)
+        ),
+    },
+    cleanup: jest.fn(),
+  }),
+}));
 
 const baseAttribute = {
   type: 'relation' as const,
@@ -167,5 +211,61 @@ describe('resolveComponentRenderResources', () => {
 
   it('returns null when all three dicts are empty', () => {
     expect(resolveComponentRenderResources('default.kept', {}, {}, {})).toBeNull();
+  });
+});
+
+/**
+ * #27137 — History must pass `...useField(name)` into custom field Inputs so
+ * plugins that bind `value`/`onChange` from props (docs / Edit View contract)
+ * show the historical value instead of rendering empty.
+ */
+describe('VersionInputRenderer custom fields (#27137)', () => {
+  const HISTORY_VALUE = '<p>hello from history</p>';
+
+  const selectedVersion = {
+    id: '26',
+    contentType: 'api::article.article' as UID.ContentType,
+    relatedDocumentId: 'doc-1',
+    createdAt: '2022-01-01T00:00:00Z',
+    status: 'draft' as const,
+    schema: {},
+    componentsSchemas: {},
+    locale: null,
+    data: {
+      custom_body: HISTORY_VALUE,
+    },
+    meta: {
+      unknownAttributes: {
+        added: {},
+        removed: {},
+      },
+    },
+  };
+
+  const historyContext = {
+    selectedVersion,
+    configuration: { contentType: { metadatas: {} }, components: {} },
+  } as Partial<HistoryContextValue>;
+
+  it('passes the form field value to custom fields that read value from props', async () => {
+    renderRTL(
+      // @ts-expect-error — partial HistoryContext is enough for this path
+      <HistoryProvider {...historyContext}>
+        <Form method="POST" initialValues={{ custom_body: HISTORY_VALUE }} onSubmit={jest.fn()}>
+          <VersionInputRenderer
+            visible
+            shouldIgnoreRBAC
+            name="custom_body"
+            label="Custom body"
+            type="string"
+            // @ts-expect-error — minimal attribute shape for a custom field
+            attribute={{ type: 'string', customField: 'plugin::test.prop-based' }}
+          />
+        </Form>
+      </HistoryProvider>
+    );
+
+    expect(await screen.findByTestId('prop-based-custom-field')).toHaveTextContent(HISTORY_VALUE);
+    expect(screen.queryByText('MISSING_VALUE')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### What does it do?

Aligns Content History’s `VersionInputRenderer` with Edit View’s `InputRenderer` by calling `useField(props.name)` and spreading `{...field}` into custom field Inputs so plugins that bind `value` / `onChange` from props receive the historical value.

### Why is it needed?

Custom fields that rely on `value`/`onChange` props (docs contract, restored for Edit View in #21163) rendered empty on the Content History page. History loaded the data correctly (`GET /content-manager/history-versions`) and restore still worked, but `VersionInputRenderer` never passed the form field bag into custom Inputs.

### How to test it?

**Automated**
```bash
yarn test:front packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx --runInBand
```

**Manual**
1. Add a custom field that uses `value`/`onChange` props (e.g. TinyMCE / CKEditor) on a collection type.
2. Create/update an entry so a history version exists.
3. Open Content History for that entry.
4. Confirm the custom field shows the historical value (not empty), while string fields still render correctly.

### Related issue(s)/PR(s)

- Fixes #27137
- Related to #21163