### PR TITLE
feat: record MCP actions in audit logs

### DIFF
--- a/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
@@ -78,12 +78,16 @@ const createAuditLogsLifecycleService = (strapi: Core.Strapi) => {
   const processEvent = (name: string, ...args: any) => {
     const requestState = strapi.requestContext.get()?.state;
 
-    // Ignore events with auth strategies different from admin
+    // Only audit admin-authenticated actions, plus MCP actions flagged via auditSource.
     const isUsingAdminAuth = requestState?.route.info.type === 'admin';
+    const auditSource = requestState?.auditSource;
+    const isMcpAdminAction = auditSource === 'mcp';
     const user = requestState?.user;
-    if (!isUsingAdminAuth || !user) {
+    if ((!isUsingAdminAuth && !isMcpAdminAction) || !user) {
       return null;
     }
+
+    const origin = auditSource ?? 'admin';
 
     const getPayload = eventMap[name];
 
@@ -102,7 +106,7 @@ const createAuditLogsLifecycleService = (strapi: Core.Strapi) => {
     return {
       action: name,
       date: new Date().toISOString(),
-      payload: getPayload(...args) || {},
+      payload: { ...(getPayload(...args) || {}), origin },
       userId: user.id,
     };
   };

--- a/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
@@ -1,4 +1,4 @@
-import type { Core } from '@strapi/types';
+import type { Core, Modules } from '@strapi/types';
 
 const DEFAULT_RETENTION_DAYS = 90;
 
@@ -87,7 +87,7 @@ const createAuditLogsLifecycleService = (strapi: Core.Strapi) => {
       return null;
     }
 
-    const origin = auditSource ?? 'admin';
+    const origin: Modules.AuditLogs.AuditSource = auditSource ?? 'admin';
 
     const getPayload = eventMap[name];
 

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -1,5 +1,5 @@
 import * as qs from 'qs';
-import type { Core, Modules } from '@strapi/types';
+import type { Core } from '@strapi/types';
 
 import Strapi, { type StrapiOptions } from './Strapi';
 import { destroyOnSignal, resolveWorkingDirectories, createUpdateNotifier } from './utils';
@@ -40,11 +40,5 @@ declare module 'koa' {
 
     get query(): ParsedQuery;
     set query(obj: any);
-  }
-
-  // Documents the field's shape; Koa's DefaultState is `any`-based, so this is
-  // intent, not a compile-time guard. The union is enforced where it's read.
-  interface DefaultState {
-    auditSource?: Modules.AuditLogs.AuditSource;
   }
 }

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -1,5 +1,5 @@
 import * as qs from 'qs';
-import type { Core } from '@strapi/types';
+import type { Core, Modules } from '@strapi/types';
 
 import Strapi, { type StrapiOptions } from './Strapi';
 import { destroyOnSignal, resolveWorkingDirectories, createUpdateNotifier } from './utils';
@@ -40,5 +40,11 @@ declare module 'koa' {
 
     get query(): ParsedQuery;
     set query(obj: any);
+  }
+
+  // Documents the field's shape; Koa's DefaultState is `any`-based, so this is
+  // intent, not a compile-time guard. The union is enforced where it's read.
+  interface DefaultState {
+    auditSource?: Modules.AuditLogs.AuditSource;
   }
 }

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
@@ -247,6 +247,37 @@ describe('handlePost', () => {
     expect(mockMcpServer.close).toHaveBeenCalledTimes(1);
   });
 
+  test('should expose the authenticated user and mcp audit source on ctx.state', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn().mockReturnValue({
+        mcpServer: {
+          connect: jest.fn().mockResolvedValue(undefined),
+          close: jest.fn().mockResolvedValue(undefined),
+        },
+        registries: {},
+      }),
+      capabilityDefinitions: {} as any,
+    };
+
+    const { StreamableHTTPServerTransport } = jest.requireMock(
+      '@modelcontextprotocol/sdk/server/streamableHttp.js'
+    );
+    StreamableHTTPServerTransport.mockImplementation(() => ({
+      handleRequest: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    const handler = createPostHandler(deps);
+    const ctx = makeCtx(makeReq(), { headersSent: false } as unknown as ServerResponse);
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(ctx.state.user).toEqual({ id: 1 });
+    expect(ctx.state.auditSource).toBe('mcp');
+  });
+
   test('should call withTimeout with connectTimeoutMs for connect and requestTimeoutMs for handleRequest', async () => {
     const mockMcpServer = {
       connect: jest.fn().mockResolvedValue(undefined),

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
@@ -52,9 +52,11 @@ describe('handlePost', () => {
     mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
     mockAuthenticationStrategy = {
       authenticate: jest.fn().mockResolvedValue({
+        // Distinct ids so assertions can tell the token owner (user) apart
+        // from the token itself (credentials).
         authenticated: true,
-        credentials: { id: 1 },
-        user: { id: 1 },
+        credentials: { id: 7 },
+        user: { id: 42 },
         ability: { can: jest.fn(() => true) },
       }),
     };
@@ -238,7 +240,7 @@ describe('handlePost', () => {
       definitions: capabilityDefinitions,
       isDevMode: mockConfig.isDevMode(),
       ability: expect.objectContaining({ can: expect.any(Function) }),
-      user: { id: 1 },
+      user: { id: 42 },
     });
     expect(StreamableHTTPServerTransport).toHaveBeenCalledWith({ sessionIdGenerator: undefined });
     expect(mockMcpServer.connect).toHaveBeenCalledWith(mockTransport);
@@ -274,7 +276,8 @@ describe('handlePost', () => {
 
     await handler(ctx, () => Promise.resolve());
 
-    expect(ctx.state.user).toEqual({ id: 1 });
+    // user (id 42), not credentials (id 7) — the actor is the token owner.
+    expect(ctx.state.user).toEqual({ id: 42 });
     expect(ctx.state.auditSource).toBe('mcp');
   });
 

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
@@ -61,7 +61,7 @@ describe('handlePost', () => {
   });
 
   const makeCtx = (req: IncomingMessage, res: ServerResponse, body?: unknown) =>
-    ({ req, res, request: { body }, respond: true }) as any;
+    ({ req, res, request: { body }, respond: true, state: {} }) as any;
 
   const makeRes = () => {
     const writeHeadSpy = jest.fn();

--- a/packages/core/core/src/services/mcp/handlers/handlePost.ts
+++ b/packages/core/core/src/services/mcp/handlers/handlePost.ts
@@ -41,6 +41,10 @@ export const createPostHandler = (deps: McpHandlerDependencies): Core.Middleware
       hadAuthenticatedMcpRequest = true;
       sendDidUseMcpServer(strapi);
 
+      // Let audit logs pick up MCP actions and tag their origin.
+      ctx.state.user = authResult.user;
+      ctx.state.auditSource = 'mcp';
+
       const { mcpServer } = createServerWithRegistries({
         strapi,
         definitions: capabilityDefinitions,

--- a/packages/core/types/src/modules/audit-logs.ts
+++ b/packages/core/types/src/modules/audit-logs.ts
@@ -1,0 +1,5 @@
+/**
+ * Where an audited action originated. The audit-logs gate and the payload
+ * label share this union so they stay exhaustive together.
+ */
+export type AuditSource = 'admin' | 'mcp';

--- a/packages/core/types/src/modules/index.ts
+++ b/packages/core/types/src/modules/index.ts
@@ -4,6 +4,7 @@ export type * as Documents from './documents';
 export type * as AI from './ai';
 
 // individual files
+export type * as AuditLogs from './audit-logs';
 export type * as Auth from './auth';
 export type * as ContentAPI from './content-api';
 export type * as CoreStore from './core-store';

--- a/tests/api/core/mcp/mcp-audit-logs.test.api.ts
+++ b/tests/api/core/mcp/mcp-audit-logs.test.api.ts
@@ -1,9 +1,9 @@
 import { describeOnCondition } from 'api-tests/utils';
 import { createTestBuilder } from 'api-tests/builder';
 import { createStrapiInstance } from 'api-tests/strapi';
-import { createAgent } from 'api-tests/agent';
 import { createAuthRequest } from 'api-tests/request';
 import type { Core, UID } from '@strapi/types';
+import { createMcpClient, type AdminPermission, type AdminToken } from './utils/mcp-client';
 
 /**
  * Empirical test: are actions performed through the MCP server recorded in audit-logs?
@@ -18,7 +18,6 @@ import type { Core, UID } from '@strapi/types';
 
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
 
-const MCP_PROTOCOL_VERSION = '2025-06-18';
 const MODEL_UID = 'api::mcp-audit-doc.mcp-audit-doc';
 const SLUG = 'mcp-audit-doc';
 
@@ -39,32 +38,12 @@ const ct = {
   },
 };
 
-type AdminPermission = {
-  action: string;
-  subject: string | null;
-  conditions: string[];
-  properties: Record<string, unknown>;
-};
-
-type AdminToken = { id: number; name: string; accessKey: string };
-
-type JsonRpcResponse = {
-  jsonrpc?: '2.0';
-  id?: number | string | null;
-  result?: {
-    structuredContent?: Record<string, unknown>;
-    content?: Array<{ type: string; text?: string }>;
-    isError?: boolean;
-  };
-  error?: { code: number; message: string };
-};
-
 describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
   const builder = createTestBuilder();
   let strapi: Core.Strapi;
   let rq: Awaited<ReturnType<typeof createAuthRequest>>;
+  let mcp: ReturnType<typeof createMcpClient>;
   let tokenCount = 0;
-  let rpcId = 0;
 
   const deleteAllAdminTokens = async () => {
     await strapi.db.query('admin::api-token').deleteMany({ where: { kind: 'admin' } });
@@ -86,8 +65,6 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     return logs.filter((log: { payload?: { uid?: string } }) => log.payload?.uid === MODEL_UID);
   };
 
-  const findEntryCreateLogs = async () => findLogsForModel('entry.create');
-
   beforeAll(async () => {
     await builder.addContentType(ct).build();
 
@@ -101,6 +78,7 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     strapi.config.set('admin.secrets.encryptionKey', 'test-encryption-key');
 
     rq = await createAuthRequest({ strapi });
+    mcp = createMcpClient(strapi, 'strapi-mcp-audit-test');
     await deleteAllAdminTokens();
   });
 
@@ -118,67 +96,6 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     await deleteAllAuditLogs();
   });
 
-  // ---------------------------------------------------------------------------
-  // Helpers (adapted from mcp-content-manager-rbac.test.api.ts)
-  // ---------------------------------------------------------------------------
-
-  const parseMcpResponse = (res: { body?: unknown; text?: string }): JsonRpcResponse => {
-    if (res.body !== undefined && Object.keys(res.body as Record<string, unknown>).length > 0) {
-      return res.body as JsonRpcResponse;
-    }
-
-    if (typeof res.text === 'string' && res.text.length > 0) {
-      const dataLines = res.text
-        .split('\n')
-        .filter((line) => line.startsWith('data: '))
-        .map((line) => line.slice('data: '.length).trim())
-        .filter((line) => line.length > 0 && line !== '[DONE]');
-
-      if (dataLines.length > 0) {
-        return JSON.parse(dataLines[dataLines.length - 1]);
-      }
-
-      return JSON.parse(res.text);
-    }
-
-    return {};
-  };
-
-  const mcpPost = async (accessKey: string, body: Record<string, unknown>) =>
-    createAgent(strapi)({
-      url: '/mcp',
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessKey}`,
-      },
-      body,
-    });
-
-  const mcpRpc = async (accessKey: string, method: string, params?: Record<string, unknown>) => {
-    rpcId += 1;
-    return mcpPost(accessKey, { jsonrpc: '2.0', id: rpcId, method, params });
-  };
-
-  const initializeMcpSession = async (accessKey: string): Promise<void> => {
-    rpcId += 1;
-    const initRes = await mcpPost(accessKey, {
-      jsonrpc: '2.0',
-      id: rpcId,
-      method: 'initialize',
-      params: {
-        protocolVersion: MCP_PROTOCOL_VERSION,
-        capabilities: {},
-        clientInfo: { name: 'strapi-mcp-audit-test', version: '1.0.0' },
-      },
-    });
-
-    expect(initRes.statusCode).toBe(200);
-
-    await mcpPost(accessKey, { jsonrpc: '2.0', method: 'notifications/initialized' });
-  };
-
   const createAdminToken = async (adminPermissions: AdminPermission[]): Promise<AdminToken> => {
     tokenCount += 1;
     const res = await rq({
@@ -188,15 +105,6 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     });
     expect(res.statusCode).toBe(201);
     return res.body.data;
-  };
-
-  const callTool = async (
-    accessKey: string,
-    name: string,
-    args: Record<string, unknown>
-  ): Promise<JsonRpcResponse> => {
-    const res = await mcpRpc(accessKey, 'tools/call', { name, arguments: args });
-    return parseMcpResponse(res);
   };
 
   const fieldPermission = (action: string, fields: string[]): AdminPermission => ({
@@ -214,9 +122,15 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     properties: {},
   });
 
-  // entry.* events fire on a microtask after commit; let the subscriber run.
-  const flushEvents = async () => {
-    await new Promise((resolve) => setTimeout(resolve, 200));
+  // entry.* events fire on a microtask after commit, so poll rather than sleep.
+  const waitForAuditLog = async (action: string, timeout = 2000) => {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      const [log] = await findLogsForModel(action);
+      if (log) return log;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`Expected a ${action} audit log within ${timeout}ms`);
   };
 
   // ---------------------------------------------------------------------------
@@ -231,11 +145,8 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     });
     expect(statusCode).toBe(201);
 
-    await flushEvents();
-
-    const logs = await findEntryCreateLogs();
-    expect(logs).toHaveLength(1);
-    expect(logs[0].payload).toMatchObject({ origin: 'admin' });
+    const log = await waitForAuditLog('entry.create');
+    expect(log.payload).toMatchObject({ origin: 'admin' });
   });
 
   test('a create through MCP is audited and tagged with the mcp origin', async () => {
@@ -243,9 +154,9 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
       fieldPermission(CM_ACTIONS.create, ['title']),
       fieldPermission(CM_ACTIONS.read, ['title']),
     ]);
-    await initializeMcpSession(token.accessKey);
+    await mcp.initializeSession(token.accessKey);
 
-    const response = await callTool(token.accessKey, `create_${SLUG}`, {
+    const response = await mcp.callTool(token.accessKey, `create_${SLUG}`, {
       data: { title: 'created via mcp' },
     });
 
@@ -255,11 +166,8 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     expect(stored).toHaveLength(1);
     expect(stored[0].title).toBe('created via mcp');
 
-    await flushEvents();
-
-    const logs = await findEntryCreateLogs();
-    expect(logs).toHaveLength(1);
-    expect(logs[0].payload).toMatchObject({ origin: 'mcp' });
+    const log = await waitForAuditLog('entry.create');
+    expect(log.payload).toMatchObject({ origin: 'mcp' });
   });
 
   test('a read through MCP is NOT audited', async () => {
@@ -267,18 +175,28 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
       data: { title: 'seed for read' },
     });
 
-    const token = await createAdminToken([fieldPermission(CM_ACTIONS.read, ['title'])]);
-    await initializeMcpSession(token.accessKey);
+    const token = await createAdminToken([
+      fieldPermission(CM_ACTIONS.read, ['title']),
+      fieldPermission(CM_ACTIONS.create, ['title']),
+    ]);
+    await mcp.initializeSession(token.accessKey);
 
-    const response = await callTool(token.accessKey, `list_${SLUG}`, {});
-    expect(response.error).toBeUndefined();
-    expect(response.result?.isError).not.toBe(true);
+    const read = await mcp.callTool(token.accessKey, `list_${SLUG}`, {});
+    expect(read.error).toBeUndefined();
+    expect(read.result?.isError).not.toBe(true);
 
-    await flushEvents();
+    // Reads emit no entry.* event. Fire a create afterwards and wait for its
+    // log: once it lands, the subscriber has processed everything before it in
+    // order, so the read having produced nothing is now a deterministic check.
+    const create = await mcp.callTool(token.accessKey, `create_${SLUG}`, {
+      data: { title: 'after read' },
+    });
+    expect(create.result?.isError).not.toBe(true);
+    await waitForAuditLog('entry.create');
 
-    // Reads don't emit entry.* events, so nothing is recorded.
     const logs = await findLogsForModel();
-    expect(logs).toHaveLength(0);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].action).toBe('entry.create');
   });
 
   test('a delete through MCP is audited and tagged with the mcp origin', async () => {
@@ -290,18 +208,15 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
       actionPermission(CM_ACTIONS.delete),
       fieldPermission(CM_ACTIONS.read, ['title']),
     ]);
-    await initializeMcpSession(token.accessKey);
+    await mcp.initializeSession(token.accessKey);
 
-    const response = await callTool(token.accessKey, `delete_${SLUG}`, {
+    const response = await mcp.callTool(token.accessKey, `delete_${SLUG}`, {
       documentId: seeded.documentId,
     });
     expect(response.error).toBeUndefined();
     expect(response.result?.isError).not.toBe(true);
 
-    await flushEvents();
-
-    const logs = await findLogsForModel('entry.delete');
-    expect(logs).toHaveLength(1);
-    expect(logs[0].payload).toMatchObject({ origin: 'mcp' });
+    const log = await waitForAuditLog('entry.delete');
+    expect(log.payload).toMatchObject({ origin: 'mcp' });
   });
 });

--- a/tests/api/core/mcp/mcp-audit-logs.test.api.ts
+++ b/tests/api/core/mcp/mcp-audit-logs.test.api.ts
@@ -1,4 +1,4 @@
-import { describeOnCondition } from 'api-tests/utils';
+import { describeOnCondition, createUtils } from 'api-tests/utils';
 import { createTestBuilder } from 'api-tests/builder';
 import { createStrapiInstance } from 'api-tests/strapi';
 import { createAuthRequest } from 'api-tests/request';
@@ -41,9 +41,19 @@ const ct = {
 describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
   const builder = createTestBuilder();
   let strapi: Core.Strapi;
+  // Requests are issued by a dedicated admin (not the default super admin) so
+  // that asserting the audited actor is the token owner is discriminating.
   let rq: Awaited<ReturnType<typeof createAuthRequest>>;
+  let tokenOwnerId: number;
   let mcp: ReturnType<typeof createMcpClient>;
   let tokenCount = 0;
+
+  const tokenOwner = {
+    email: 'mcp-audit-owner@test.com',
+    firstname: 'Mcp',
+    lastname: 'Owner',
+    password: 'Password123',
+  };
 
   const deleteAllAdminTokens = async () => {
     await strapi.db.query('admin::api-token').deleteMany({ where: { kind: 'admin' } });
@@ -66,14 +76,6 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     return logs.filter((log: { payload?: { uid?: string } }) => log.payload?.uid === MODEL_UID);
   };
 
-  // Admin tokens are owned by the super admin creating them via createAuthRequest.
-  const getTokenOwnerId = async () => {
-    const owner = await strapi.db
-      .query('admin::user')
-      .findOne({ where: { email: 'admin@strapi.io' } });
-    return owner.id;
-  };
-
   beforeAll(async () => {
     await builder.addContentType(ct).build();
 
@@ -86,7 +88,14 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     });
     strapi.config.set('admin.secrets.encryptionKey', 'test-encryption-key');
 
-    rq = await createAuthRequest({ strapi });
+    // A second admin (super-admin role) owns the tokens, so the actor
+    // assertion distinguishes the token owner from the default super admin.
+    const utils = createUtils(strapi);
+    const superAdminRole = await utils.getSuperAdminRole();
+    const owner = await utils.createUser({ ...tokenOwner, roles: [superAdminRole.id] });
+    tokenOwnerId = owner.id;
+
+    rq = await createAuthRequest({ strapi, userInfo: tokenOwner });
     mcp = createMcpClient(strapi, 'strapi-mcp-audit-test');
     await deleteAllAdminTokens();
   });
@@ -205,7 +214,7 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     const log = await expectExactlyOneLog('entry.create');
     expect(log.payload).toMatchObject({ origin: 'mcp' });
     // The audited actor is the admin token's owner.
-    expect(log.user.id).toBe(await getTokenOwnerId());
+    expect(log.user.id).toBe(tokenOwnerId);
   });
 
   test('a read through MCP is NOT audited', async () => {
@@ -223,6 +232,8 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     // A test subscriber registered now runs after the audit-logs subscriber in
     // the emit loop, so when it sees the sentinel's entry.create the audit row
     // is already committed — an explicit completion signal, not a timed guess.
+    // Assumes the audit subscriber isn't re-registered mid-test (ee.enable/update
+    // re-push it to the end); EE is on at boot here, so that never happens.
     let onSentinelAudited!: () => void;
     const sentinelAudited = new Promise<void>((resolve) => {
       onSentinelAudited = resolve;
@@ -276,6 +287,6 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
 
     const log = await expectExactlyOneLog('entry.delete');
     expect(log.payload).toMatchObject({ origin: 'mcp' });
-    expect(log.user.id).toBe(await getTokenOwnerId());
+    expect(log.user.id).toBe(tokenOwnerId);
   });
 });

--- a/tests/api/core/mcp/mcp-audit-logs.test.api.ts
+++ b/tests/api/core/mcp/mcp-audit-logs.test.api.ts
@@ -45,6 +45,7 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
   // that asserting the audited actor is the token owner is discriminating.
   let rq: Awaited<ReturnType<typeof createAuthRequest>>;
   let tokenOwnerId: number;
+  let utils: ReturnType<typeof createUtils>;
   let mcp: ReturnType<typeof createMcpClient>;
   let tokenCount = 0;
 
@@ -90,7 +91,7 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
 
     // A second admin (super-admin role) owns the tokens, so the actor
     // assertion distinguishes the token owner from the default super admin.
-    const utils = createUtils(strapi);
+    utils = createUtils(strapi);
     const superAdminRole = await utils.getSuperAdminRole();
     const owner = await utils.createUser({ ...tokenOwner, roles: [superAdminRole.id] });
     tokenOwnerId = owner.id;
@@ -104,6 +105,8 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     await deleteAllDocuments();
     await deleteAllAdminTokens();
     await deleteAllAuditLogs();
+    // Remove the token owner so reruns don't accumulate duplicate admins.
+    await utils.deleteUserById(tokenOwnerId);
     await strapi.destroy();
     await builder.cleanup();
   });

--- a/tests/api/core/mcp/mcp-audit-logs.test.api.ts
+++ b/tests/api/core/mcp/mcp-audit-logs.test.api.ts
@@ -1,0 +1,307 @@
+import { describeOnCondition } from 'api-tests/utils';
+import { createTestBuilder } from 'api-tests/builder';
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createAgent } from 'api-tests/agent';
+import { createAuthRequest } from 'api-tests/request';
+import type { Core, UID } from '@strapi/types';
+
+/**
+ * Empirical test: are actions performed through the MCP server recorded in audit-logs?
+ *
+ * This boots a real Strapi (EE, with MCP enabled), performs a document `create`
+ * through the MCP server, and checks whether an `entry.create` audit-log row is
+ * written. It contrasts it with the same create through the admin content-manager
+ * API, which IS audited today — isolating the MCP path as the difference.
+ *
+ * Audit-logs require the EE license, so the suite is skipped in CE.
+ */
+
+const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
+
+const MCP_PROTOCOL_VERSION = '2025-06-18';
+const MODEL_UID = 'api::mcp-audit-doc.mcp-audit-doc';
+const SLUG = 'mcp-audit-doc';
+
+const CM_ACTIONS = {
+  read: 'plugin::content-manager.explorer.read',
+  create: 'plugin::content-manager.explorer.create',
+  delete: 'plugin::content-manager.explorer.delete',
+} as const;
+
+const ct = {
+  kind: 'collectionType',
+  displayName: 'mcp-audit-doc',
+  singularName: 'mcp-audit-doc',
+  pluralName: 'mcp-audit-docs',
+  draftAndPublish: false,
+  attributes: {
+    title: { type: 'string' },
+  },
+};
+
+type AdminPermission = {
+  action: string;
+  subject: string | null;
+  conditions: string[];
+  properties: Record<string, unknown>;
+};
+
+type AdminToken = { id: number; name: string; accessKey: string };
+
+type JsonRpcResponse = {
+  jsonrpc?: '2.0';
+  id?: number | string | null;
+  result?: {
+    structuredContent?: Record<string, unknown>;
+    content?: Array<{ type: string; text?: string }>;
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+};
+
+describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
+  const builder = createTestBuilder();
+  let strapi: Core.Strapi;
+  let rq: Awaited<ReturnType<typeof createAuthRequest>>;
+  let tokenCount = 0;
+  let rpcId = 0;
+
+  const deleteAllAdminTokens = async () => {
+    await strapi.db.query('admin::api-token').deleteMany({ where: { kind: 'admin' } });
+  };
+
+  const deleteAllDocuments = async () => {
+    await strapi.db.query(MODEL_UID).deleteMany({});
+  };
+
+  const deleteAllAuditLogs = async () => {
+    await strapi.db.query('admin::audit-log').deleteMany();
+  };
+
+  // Scope to this suite's own content type, isolated from other suites' rows.
+  const findLogsForModel = async (action?: string) => {
+    const logs = await strapi.db
+      .query('admin::audit-log')
+      .findMany(action ? { where: { action } } : {});
+    return logs.filter((log: { payload?: { uid?: string } }) => log.payload?.uid === MODEL_UID);
+  };
+
+  const findEntryCreateLogs = async () => findLogsForModel('entry.create');
+
+  beforeAll(async () => {
+    await builder.addContentType(ct).build();
+
+    strapi = await createStrapiInstance({
+      register({ strapi: instance }) {
+        instance.config.set('features.future.adminTokens', true);
+        instance.config.set('server.mcp.enabled', true);
+      },
+      bootstrap() {},
+    });
+    strapi.config.set('admin.secrets.encryptionKey', 'test-encryption-key');
+
+    rq = await createAuthRequest({ strapi });
+    await deleteAllAdminTokens();
+  });
+
+  afterAll(async () => {
+    await deleteAllDocuments();
+    await deleteAllAdminTokens();
+    await deleteAllAuditLogs();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  afterEach(async () => {
+    await deleteAllDocuments();
+    await deleteAllAdminTokens();
+    await deleteAllAuditLogs();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Helpers (adapted from mcp-content-manager-rbac.test.api.ts)
+  // ---------------------------------------------------------------------------
+
+  const parseMcpResponse = (res: { body?: unknown; text?: string }): JsonRpcResponse => {
+    if (res.body !== undefined && Object.keys(res.body as Record<string, unknown>).length > 0) {
+      return res.body as JsonRpcResponse;
+    }
+
+    if (typeof res.text === 'string' && res.text.length > 0) {
+      const dataLines = res.text
+        .split('\n')
+        .filter((line) => line.startsWith('data: '))
+        .map((line) => line.slice('data: '.length).trim())
+        .filter((line) => line.length > 0 && line !== '[DONE]');
+
+      if (dataLines.length > 0) {
+        return JSON.parse(dataLines[dataLines.length - 1]);
+      }
+
+      return JSON.parse(res.text);
+    }
+
+    return {};
+  };
+
+  const mcpPost = async (accessKey: string, body: Record<string, unknown>) =>
+    createAgent(strapi)({
+      url: '/mcp',
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessKey}`,
+      },
+      body,
+    });
+
+  const mcpRpc = async (accessKey: string, method: string, params?: Record<string, unknown>) => {
+    rpcId += 1;
+    return mcpPost(accessKey, { jsonrpc: '2.0', id: rpcId, method, params });
+  };
+
+  const initializeMcpSession = async (accessKey: string): Promise<void> => {
+    rpcId += 1;
+    const initRes = await mcpPost(accessKey, {
+      jsonrpc: '2.0',
+      id: rpcId,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'strapi-mcp-audit-test', version: '1.0.0' },
+      },
+    });
+
+    expect(initRes.statusCode).toBe(200);
+
+    await mcpPost(accessKey, { jsonrpc: '2.0', method: 'notifications/initialized' });
+  };
+
+  const createAdminToken = async (adminPermissions: AdminPermission[]): Promise<AdminToken> => {
+    tokenCount += 1;
+    const res = await rq({
+      url: '/admin/admin-tokens',
+      method: 'POST',
+      body: { name: `mcp-audit-token-${tokenCount}`, adminPermissions },
+    });
+    expect(res.statusCode).toBe(201);
+    return res.body.data;
+  };
+
+  const callTool = async (
+    accessKey: string,
+    name: string,
+    args: Record<string, unknown>
+  ): Promise<JsonRpcResponse> => {
+    const res = await mcpRpc(accessKey, 'tools/call', { name, arguments: args });
+    return parseMcpResponse(res);
+  };
+
+  const fieldPermission = (action: string, fields: string[]): AdminPermission => ({
+    action,
+    subject: MODEL_UID,
+    conditions: [],
+    properties: { fields },
+  });
+
+  // The delete action carries no `fields` (passing one is rejected with a 400).
+  const actionPermission = (action: string): AdminPermission => ({
+    action,
+    subject: MODEL_UID,
+    conditions: [],
+    properties: {},
+  });
+
+  // entry.* events fire on a microtask after commit; let the subscriber run.
+  const flushEvents = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  };
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  test('sanity: a create through the admin content-manager IS audited', async () => {
+    const { statusCode } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${MODEL_UID}`,
+      body: { title: 'created via admin' },
+    });
+    expect(statusCode).toBe(201);
+
+    await flushEvents();
+
+    const logs = await findEntryCreateLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0].payload).toMatchObject({ origin: 'admin' });
+  });
+
+  test('a create through MCP is audited and tagged with the mcp origin', async () => {
+    const token = await createAdminToken([
+      fieldPermission(CM_ACTIONS.create, ['title']),
+      fieldPermission(CM_ACTIONS.read, ['title']),
+    ]);
+    await initializeMcpSession(token.accessKey);
+
+    const response = await callTool(token.accessKey, `create_${SLUG}`, {
+      data: { title: 'created via mcp' },
+    });
+
+    expect(response.error).toBeUndefined();
+    expect(response.result?.isError).not.toBe(true);
+    const stored = await strapi.documents(MODEL_UID as UID.CollectionType).findMany({});
+    expect(stored).toHaveLength(1);
+    expect(stored[0].title).toBe('created via mcp');
+
+    await flushEvents();
+
+    const logs = await findEntryCreateLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0].payload).toMatchObject({ origin: 'mcp' });
+  });
+
+  test('a read through MCP is NOT audited', async () => {
+    await strapi.documents(MODEL_UID as UID.CollectionType).create({
+      data: { title: 'seed for read' },
+    });
+
+    const token = await createAdminToken([fieldPermission(CM_ACTIONS.read, ['title'])]);
+    await initializeMcpSession(token.accessKey);
+
+    const response = await callTool(token.accessKey, `list_${SLUG}`, {});
+    expect(response.error).toBeUndefined();
+    expect(response.result?.isError).not.toBe(true);
+
+    await flushEvents();
+
+    // Reads don't emit entry.* events, so nothing is recorded.
+    const logs = await findLogsForModel();
+    expect(logs).toHaveLength(0);
+  });
+
+  test('a delete through MCP is audited and tagged with the mcp origin', async () => {
+    const seeded = await strapi.documents(MODEL_UID as UID.CollectionType).create({
+      data: { title: 'to be deleted via mcp' },
+    });
+
+    const token = await createAdminToken([
+      actionPermission(CM_ACTIONS.delete),
+      fieldPermission(CM_ACTIONS.read, ['title']),
+    ]);
+    await initializeMcpSession(token.accessKey);
+
+    const response = await callTool(token.accessKey, `delete_${SLUG}`, {
+      documentId: seeded.documentId,
+    });
+    expect(response.error).toBeUndefined();
+    expect(response.result?.isError).not.toBe(true);
+
+    await flushEvents();
+
+    const logs = await findLogsForModel('entry.delete');
+    expect(logs).toHaveLength(1);
+    expect(logs[0].payload).toMatchObject({ origin: 'mcp' });
+  });
+});

--- a/tests/api/core/mcp/mcp-audit-logs.test.api.ts
+++ b/tests/api/core/mcp/mcp-audit-logs.test.api.ts
@@ -59,10 +59,19 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
 
   // Scope to this suite's own content type, isolated from other suites' rows.
   const findLogsForModel = async (action?: string) => {
-    const logs = await strapi.db
-      .query('admin::audit-log')
-      .findMany(action ? { where: { action } } : {});
+    const logs = await strapi.db.query('admin::audit-log').findMany({
+      ...(action ? { where: { action } } : {}),
+      populate: ['user'],
+    });
     return logs.filter((log: { payload?: { uid?: string } }) => log.payload?.uid === MODEL_UID);
+  };
+
+  // Admin tokens are owned by the super admin creating them via createAuthRequest.
+  const getTokenOwnerId = async () => {
+    const owner = await strapi.db
+      .query('admin::user')
+      .findOne({ where: { email: 'admin@strapi.io' } });
+    return owner.id;
   };
 
   beforeAll(async () => {
@@ -93,7 +102,9 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
   afterEach(async () => {
     await deleteAllDocuments();
     await deleteAllAdminTokens();
-    await deleteAllAuditLogs();
+    // Deferred audit writes may still be in flight; drain then clear so a
+    // pending row can't leak into the next test.
+    await quiesceAuditLogs();
   });
 
   const createAdminToken = async (adminPermissions: AdminPermission[]): Promise<AdminToken> => {
@@ -122,15 +133,40 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     properties: {},
   });
 
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
   // entry.* events fire on a microtask after commit, so poll rather than sleep.
   const waitForAuditLog = async (action: string, timeout = 2000) => {
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
       const [log] = await findLogsForModel(action);
       if (log) return log;
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await sleep(50);
     }
     throw new Error(`Expected a ${action} audit log within ${timeout}ms`);
+  };
+
+  // Assert exactly one row landed, catching a late duplicate from a second
+  // subscription/emission that arrives after the first row appears.
+  const expectExactlyOneLog = async (action: string) => {
+    await waitForAuditLog(action);
+    await sleep(200);
+    const logs = await findLogsForModel(action);
+    expect(logs).toHaveLength(1);
+    return logs[0];
+  };
+
+  // Delete audit rows, then drain any deferred write still in flight so it
+  // can't leak into the next test.
+  const quiesceAuditLogs = async (timeout = 2000) => {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      await deleteAllAuditLogs();
+      await sleep(150);
+      const [leaked] = await findLogsForModel();
+      if (!leaked) return;
+    }
+    throw new Error('Audit logs did not quiesce; a deferred write kept landing');
   };
 
   // ---------------------------------------------------------------------------
@@ -145,7 +181,7 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     });
     expect(statusCode).toBe(201);
 
-    const log = await waitForAuditLog('entry.create');
+    const log = await expectExactlyOneLog('entry.create');
     expect(log.payload).toMatchObject({ origin: 'admin' });
   });
 
@@ -166,11 +202,14 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     expect(stored).toHaveLength(1);
     expect(stored[0].title).toBe('created via mcp');
 
-    const log = await waitForAuditLog('entry.create');
+    const log = await expectExactlyOneLog('entry.create');
     expect(log.payload).toMatchObject({ origin: 'mcp' });
+    // The audited actor is the admin token's owner.
+    expect(log.user.id).toBe(await getTokenOwnerId());
   });
 
   test('a read through MCP is NOT audited', async () => {
+    // Seed before subscribing below, so its create event can't match the signal.
     await strapi.documents(MODEL_UID as UID.CollectionType).create({
       data: { title: 'seed for read' },
     });
@@ -181,19 +220,38 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     ]);
     await mcp.initializeSession(token.accessKey);
 
-    const read = await mcp.callTool(token.accessKey, `list_${SLUG}`, {});
-    expect(read.error).toBeUndefined();
-    expect(read.result?.isError).not.toBe(true);
-
-    // Reads emit no entry.* event. Fire a create afterwards and wait for its
-    // log: once it lands, the subscriber has processed everything before it in
-    // order, so the read having produced nothing is now a deterministic check.
-    const create = await mcp.callTool(token.accessKey, `create_${SLUG}`, {
-      data: { title: 'after read' },
+    // A test subscriber registered now runs after the audit-logs subscriber in
+    // the emit loop, so when it sees the sentinel's entry.create the audit row
+    // is already committed — an explicit completion signal, not a timed guess.
+    let onSentinelAudited!: () => void;
+    const sentinelAudited = new Promise<void>((resolve) => {
+      onSentinelAudited = resolve;
     });
-    expect(create.result?.isError).not.toBe(true);
-    await waitForAuditLog('entry.create');
+    const unsubscribe = strapi.eventHub.subscribe(async (name: string, ...args: any[]) => {
+      if (name === 'entry.create' && args[0]?.uid === MODEL_UID) onSentinelAudited();
+    });
 
+    try {
+      const read = await mcp.callTool(token.accessKey, `list_${SLUG}`, {});
+      expect(read.error).toBeUndefined();
+      expect(read.result?.isError).not.toBe(true);
+      // Guard against an empty/failed read silently passing: it must return rows.
+      const readResults = read.result?.structuredContent?.results as unknown[] | undefined;
+      expect(Array.isArray(readResults)).toBe(true);
+      expect(readResults?.length).toBeGreaterThan(0);
+
+      // The read emits no entry.* event. Fire a sentinel create and wait for the
+      // subscriber signal confirming its audit row was written.
+      const create = await mcp.callTool(token.accessKey, `create_${SLUG}`, {
+        data: { title: 'after read' },
+      });
+      expect(create.result?.isError).not.toBe(true);
+      await sentinelAudited;
+    } finally {
+      unsubscribe();
+    }
+
+    // The sentinel's row is the only one: the read produced nothing.
     const logs = await findLogsForModel();
     expect(logs).toHaveLength(1);
     expect(logs[0].action).toBe('entry.create');
@@ -216,7 +274,8 @@ describeOnCondition(edition === 'EE')('MCP actions in audit-logs (api)', () => {
     expect(response.error).toBeUndefined();
     expect(response.result?.isError).not.toBe(true);
 
-    const log = await waitForAuditLog('entry.delete');
+    const log = await expectExactlyOneLog('entry.delete');
     expect(log.payload).toMatchObject({ origin: 'mcp' });
+    expect(log.user.id).toBe(await getTokenOwnerId());
   });
 });

--- a/tests/api/core/mcp/utils/mcp-client.ts
+++ b/tests/api/core/mcp/utils/mcp-client.ts
@@ -1,0 +1,116 @@
+import { createAgent } from 'api-tests/agent';
+import type { Core } from '@strapi/types';
+
+export const MCP_PROTOCOL_VERSION = '2025-06-18';
+
+export type JsonRpcResponse = {
+  jsonrpc?: '2.0';
+  id?: number | string | null;
+  result?: {
+    tools?: Array<{ name: string }>;
+    structuredContent?: Record<string, unknown>;
+    content?: Array<{ type: string; text?: string }>;
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+};
+
+export type AdminPermission = {
+  action: string;
+  subject: string | null;
+  conditions: string[];
+  properties: Record<string, unknown>;
+};
+
+export type AdminToken = { id: number; name: string; accessKey: string };
+
+// The MCP transport can answer as JSON or as an SSE stream; read both.
+const parseMcpResponse = (res: { body?: unknown; text?: string }): JsonRpcResponse => {
+  if (res.body !== undefined && Object.keys(res.body as Record<string, unknown>).length > 0) {
+    return res.body as JsonRpcResponse;
+  }
+
+  if (typeof res.text === 'string' && res.text.length > 0) {
+    const dataLines = res.text
+      .split('\n')
+      .filter((line) => line.startsWith('data: '))
+      .map((line) => line.slice('data: '.length).trim())
+      .filter((line) => line.length > 0 && line !== '[DONE]');
+
+    if (dataLines.length > 0) {
+      return JSON.parse(dataLines[dataLines.length - 1]);
+    }
+
+    return JSON.parse(res.text);
+  }
+
+  return {};
+};
+
+/**
+ * Shared MCP API-test client: JSON-RPC transport, session init and tool calls
+ * over `POST /mcp`. Bind it to a booted Strapi instance and an access key.
+ */
+export const createMcpClient = (strapi: Core.Strapi, clientName = 'strapi-mcp-test') => {
+  let rpcId = 0;
+
+  const post = async (accessKey: string, body: Record<string, unknown>) =>
+    createAgent(strapi)({
+      url: '/mcp',
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessKey}`,
+      },
+      body,
+    });
+
+  const rpc = async (accessKey: string, method: string, params?: Record<string, unknown>) => {
+    rpcId += 1;
+    return post(accessKey, { jsonrpc: '2.0', id: rpcId, method, params });
+  };
+
+  const initializeSession = async (accessKey: string): Promise<void> => {
+    rpcId += 1;
+    const initRes = await post(accessKey, {
+      jsonrpc: '2.0',
+      id: rpcId,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: clientName, version: '1.0.0' },
+      },
+    });
+
+    expect(initRes.statusCode).toBe(200);
+    const parsed = parseMcpResponse(initRes);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.result).toBeDefined();
+
+    const notifiedRes = await post(accessKey, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+    expect([200, 202]).toContain(notifiedRes.statusCode);
+  };
+
+  const callTool = async (
+    accessKey: string,
+    name: string,
+    args: Record<string, unknown>
+  ): Promise<JsonRpcResponse> => {
+    const res = await rpc(accessKey, 'tools/call', { name, arguments: args });
+    return parseMcpResponse(res);
+  };
+
+  const listToolNames = async (accessKey: string): Promise<string[]> => {
+    const res = await rpc(accessKey, 'tools/list');
+    const parsed = parseMcpResponse(res);
+    expect(parsed.error).toBeUndefined();
+    return parsed.result?.tools?.map((tool) => tool.name) ?? [];
+  };
+
+  return { post, rpc, initializeSession, callTool, listToolNames, parseMcpResponse };
+};

--- a/tests/api/core/mcp/utils/mcp-client.ts
+++ b/tests/api/core/mcp/utils/mcp-client.ts
@@ -102,7 +102,11 @@ export const createMcpClient = (strapi: Core.Strapi, clientName = 'strapi-mcp-te
     args: Record<string, unknown>
   ): Promise<JsonRpcResponse> => {
     const res = await rpc(accessKey, 'tools/call', { name, arguments: args });
-    return parseMcpResponse(res);
+    expect(res.statusCode).toBe(200);
+    const parsed = parseMcpResponse(res);
+    // A failed transport parses to {}; require a real JSON-RPC envelope.
+    expect(parsed.result ?? parsed.error).toBeDefined();
+    return parsed;
   };
 
   const listToolNames = async (accessKey: string): Promise<string[]> => {


### PR DESCRIPTION
### What does it do?

Records actions performed through the MCP server in the EE audit logs.

- The MCP handler (`handlePost.ts`) sets the authenticated admin user (the token owner) on the request state and marks the action's origin via `ctx.state.auditSource = 'mcp'`. The route type is left untouched — MCP is admin-authenticated but is not an admin route, so we don't fabricate one.
- The audit-logs guard (`lifecycles.ts`) records an event when it's a normal admin action **or** carries the MCP marker, and tags every recorded action's `payload.origin` with its origin (`'mcp'` or `'admin'`).

Backwards compatible (new JSON key in the payload, nothing else changes) and reversible in a few lines. Reads are not audited (they don't emit `entry.*` events).

### Why is it needed?

MCP-triggered writes were silently dropped by the audit-logs guard: MCP requests don't come through an admin route (`route.info.type !== 'admin'`) and don't set `ctx.state.user`, so the guard discarded their events even though the Document Service emitted them.

### How to test it?

Requires an Enterprise license that **includes the `audit-logs` feature** (Growth does not).

1. Start `examples/getstarted` with `mcp.enabled` and `features.future.adminTokens` on (already set locally), `PORT=1338 yarn develop`.
2. Create a Full-access **Admin API Token** in Settings → Admin API Tokens.
3. Via MCP (`POST /mcp`, initialize then `tools/call`): create an entry, list entries, delete the entry.
4. In Settings → Audit Logs: the create and delete appear with `payload.origin === "mcp"`; the list/read produces **no** log. Admin-panel actions keep `payload.origin === "admin"`.

Automated coverage: `STRAPI_LICENSE=<license-with-audit-logs> yarn test:api -- tests/api/core/mcp/mcp-audit-logs.test.api.ts` (admin create audited, MCP create audited, MCP read not audited, MCP delete audited).

### Related issue(s)/PR(s)

[EE-39](https://linear.app/strapi/issue/EE-39/audit-logs-compatibility)