### PR TITLE
Fix deleteMany not working when filter by nested entity (#11998)

### DIFF
--- a/packages/core/database/src/entity-manager/__tests__/delete-many.test.ts
+++ b/packages/core/database/src/entity-manager/__tests__/delete-many.test.ts
@@ -76,4 +76,33 @@ describe('entity-manager deleteMany', () => {
       filters: { published: true },
     });
   });
+
+  it('handles nested entity filters with operators', async () => {
+    const init = jest.fn().mockReturnThis();
+    const deleteFn = jest.fn().mockReturnThis();
+    const execute = jest.fn().mockResolvedValue(3);
+
+    (createQueryBuilder as jest.Mock).mockReturnValue({
+      init,
+      delete: deleteFn,
+      execute,
+    });
+
+    const db = {
+      lifecycles: {
+        run: jest.fn(async () => undefined),
+      },
+    } as any;
+
+    const em = createEntityManager(db);
+    const params = { where: { B: { id: { $eq: 123 } } } };
+
+    const result = await em.deleteMany('api::test.test', params);
+
+    expect(createQueryBuilder).toHaveBeenCalledWith('api::test.test', db);
+    expect(init).toHaveBeenCalledWith({ where: { B: { id: { $eq: 123 } } } });
+    expect(deleteFn).toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledWith({ mapResults: false });
+    expect(result).toEqual({ count: 3 });
+  });
 });

--- a/packages/core/database/src/query/query-builder.ts
+++ b/packages/core/database/src/query/query-builder.ts
@@ -437,12 +437,17 @@ const createQueryBuilder = (
 
     runSubQuery() {
       const originalType = state.type;
+      const originalSelect = state.select;
 
       this.select('id');
       const subQB = this.getKnexQuery();
 
       const nestedSubQuery = db.getConnection().select('id').from(subQB.as('subQuery'));
       const connection = db.getConnection(tableName);
+
+      // Restore the original state after creating the subquery
+      state.type = originalType;
+      state.select = originalSelect;
 
       return (connection[originalType] as Knex)().whereIn('id', nestedSubQuery);
     },


### PR DESCRIPTION
## Description
Fixes issue #11998 where deleteMany fails when filtering by nested entities using operators like $eq.

## Changes
- Modified [runSubQuery()](cci:1://file:///C:/Users/Sasidhar_Mopuru/OneDrive%20-%20Dell%20Technologies/Microsoft%20Copilot%20Chat%20Files/strapi/packages/core/database/src/query/query-builder.ts:111:2-111:20) in [query-builder.ts](cci:7://file:///C:/Users/Sasidhar_Mopuru/OneDrive%20-%20Dell%20Technologies/Microsoft%20Copilot%20Chat%20Files/strapi/packages/core/database/src/query/query-builder.ts:0:0-0:0) to restore `state.type` and [state.select](cci:1://file:///C:/Users/Sasidhar_Mopuru/OneDrive%20-%20Dell%20Technologies/Microsoft%20Copilot%20Chat%20Files/strapi/packages/core/database/src/query/query-builder.ts:49:2-49:63) after creating the subquery
- Added test case for nested entity filters with operators in [delete-many.test.ts](cci:7://file:///C:/Users/Sasidhar_Mopuru/OneDrive%20-%20Dell%20Technologies/Microsoft%20Copilot%20Chat%20Files/strapi/packages/core/database/src/entity-manager/__tests__/delete-many.test.ts:0:0-0:0)

## Root Cause
When deleteMany is called with nested entity filters, the where helper creates joins. The query builder uses a subquery approach for delete operations with joins. However, the state was being modified (type changed to 'select') and not restored, which caused inconsistent state and prevented the joins from being properly applied.

## Fix
The fix saves the original `state.type` and [state.select](cci:1://file:///C:/Users/Sasidhar_Mopuru/OneDrive%20-%20Dell%20Technologies/Microsoft%20Copilot%20Chat%20Files/strapi/packages/core/database/src/query/query-builder.ts:49:2-49:63) before creating the subquery, then restores them after the subquery is created. This ensures the query builder state remains consistent and joins are properly preserved for nested entity filtering.

---
Fixes CPR-464