### PR TITLE
fix(upload): honor sharp limitInputPixels config in image manipulation

### DIFF
--- a/packages/core/upload/server/src/services/__tests__/image-manipulation-sharp-options.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/image-manipulation-sharp-options.test.ts
@@ -1,0 +1,198 @@
+import path from 'path';
+import fs from 'fs';
+import fse from 'fs-extra';
+import _ from 'lodash';
+import imageManipulation from '../image-manipulation';
+
+import type { UploadableFile } from '../../types';
+
+const uploadConfig: Record<string, unknown> = {
+  breakpoints: {
+    large: 1000,
+    medium: 750,
+    small: 500,
+  },
+};
+
+global.strapi = {
+  config: {
+    get: (configPath: any, defaultValue: any) =>
+      _.get({ 'plugin::upload': uploadConfig }, configPath, defaultValue),
+  },
+  plugins: {
+    upload: {
+      services: {
+        provider: { upload: jest.fn() },
+        upload: {
+          getSettings: () => ({ sizeOptimization: true, autoOrientation: false }),
+        },
+        'image-manipulation': imageManipulation,
+      },
+    },
+  },
+  plugin: (name: string) => (global.strapi as any).plugins[name],
+} as any;
+
+const staticPngPath = path.join(__dirname, 'upload', 'image.png');
+const animatedGifPath = path.join(__dirname, 'upload', 'animated-test.gif');
+const tmpDir = path.join(__dirname, 'tmp-sharp-options');
+
+const makeFile = (filePath: string, ext: string, mime: string, width: number, height: number) => ({
+  name: `test${ext}`,
+  hash: `test_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+  ext,
+  mime,
+  filepath: filePath,
+  path: null,
+  getStream: () => fs.createReadStream(filePath),
+  width,
+  height,
+  size: 1,
+  tmpWorkingDirectory: tmpDir,
+  folderPath: '/',
+});
+
+/** Upload pipeline can omit `filepath` and only supply streams (fresh stream each call). */
+const makeStreamOnlyFile = (
+  sourcePath: string,
+  ext: string,
+  mime: string,
+  width: number,
+  height: number
+): UploadableFile => ({
+  name: `test-stream${ext}`,
+  hash: `stream_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+  ext,
+  mime,
+  path: null,
+  getStream: () => fs.createReadStream(sourcePath),
+  width,
+  height,
+  size: 1,
+  tmpWorkingDirectory: tmpDir,
+  folderPath: '/',
+});
+
+describe('Image manipulation - sharp instance options (limitInputPixels)', () => {
+  beforeAll(async () => {
+    await fse.ensureDir(tmpDir);
+  });
+
+  afterAll(async () => {
+    await fse.remove(tmpDir);
+  });
+
+  afterEach(() => {
+    delete uploadConfig.sharp;
+  });
+
+  describe('limitInputPixels lower than the image pixel count', () => {
+    beforeEach(() => {
+      // image.png is 1417x1063 (~1.5M pixels); animated-test.gif is 200x200x3 frames
+      uploadConfig.sharp = { limitInputPixels: 1000 };
+    });
+
+    test('generateThumbnail rejects (file path input)', async () => {
+      const file = makeFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+
+      await expect(imageManipulation.generateThumbnail(file)).rejects.toThrow(/pixel limit/i);
+    });
+
+    test('generateThumbnail rejects (stream-only, no filepath)', async () => {
+      const file = makeStreamOnlyFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+
+      await expect(imageManipulation.generateThumbnail(file)).rejects.toThrow(/pixel limit/i);
+    });
+
+    test('generateThumbnail rejects for animated GIF (file path input)', async () => {
+      const file = makeFile(animatedGifPath, '.gif', 'image/gif', 200, 200);
+
+      await expect(imageManipulation.generateThumbnail(file)).rejects.toThrow(/pixel limit/i);
+    });
+
+    test('optimize rejects (file path input)', async () => {
+      const file = makeFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+
+      await expect(imageManipulation.optimize(file)).rejects.toThrow(/pixel limit/i);
+    });
+
+    test('isFaultyImage reports the image as faulty (file path input)', async () => {
+      const file = makeFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+
+      await expect(imageManipulation.isFaultyImage(file)).resolves.toBe(true);
+    });
+  });
+
+  describe('limitInputPixels: false disables the pixel limit', () => {
+    beforeEach(() => {
+      uploadConfig.sharp = { limitInputPixels: false };
+    });
+
+    test('generateThumbnail succeeds (file path input)', async () => {
+      const file = makeFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+      const thumb = await imageManipulation.generateThumbnail(file);
+
+      expect(thumb).not.toBeNull();
+      expect(thumb!.width).toBeLessThanOrEqual(245);
+      expect(thumb!.height).toBeLessThanOrEqual(156);
+    });
+
+    test('generateThumbnail succeeds (stream-only, no filepath)', async () => {
+      const file = makeStreamOnlyFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+      const thumb = await imageManipulation.generateThumbnail(file);
+
+      expect(thumb).not.toBeNull();
+    });
+
+    test('optimize succeeds (file path input)', async () => {
+      const file = makeFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+      const result = await imageManipulation.optimize(file);
+
+      expect(result.width).toBeDefined();
+      expect(result.height).toBeDefined();
+    });
+
+    test('isFaultyImage reports the image as valid (file path input)', async () => {
+      const file = makeFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+
+      await expect(imageManipulation.isFaultyImage(file)).resolves.toBe(false);
+    });
+  });
+
+  describe('limitInputPixels higher than the image pixel count', () => {
+    beforeEach(() => {
+      uploadConfig.sharp = { limitInputPixels: 10_000_000 };
+    });
+
+    test('generateThumbnail succeeds (file path input)', async () => {
+      const file = makeFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+      const thumb = await imageManipulation.generateThumbnail(file);
+
+      expect(thumb).not.toBeNull();
+    });
+
+    test('getDimensions succeeds (file path input)', async () => {
+      const file = makeFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+      const dims = await imageManipulation.getDimensions(file);
+
+      expect(dims.width).toBe(1417);
+      expect(dims.height).toBe(1063);
+    });
+  });
+
+  describe('no sharp config provided', () => {
+    test('generateThumbnail succeeds with sharp defaults (file path input)', async () => {
+      const file = makeFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+      const thumb = await imageManipulation.generateThumbnail(file);
+
+      expect(thumb).not.toBeNull();
+    });
+
+    test('generateThumbnail succeeds with sharp defaults (stream-only, no filepath)', async () => {
+      const file = makeStreamOnlyFile(staticPngPath, '.png', 'image/png', 1500, 1000);
+      const thumb = await imageManipulation.generateThumbnail(file);
+
+      expect(thumb).not.toBeNull();
+    });
+  });
+});

--- a/packages/core/upload/server/src/services/image-manipulation.ts
+++ b/packages/core/upload/server/src/services/image-manipulation.ts
@@ -6,7 +6,7 @@ import { strings, file as fileUtils } from '@strapi/utils';
 
 import { getService } from '../utils';
 
-import type { UploadableFile } from '../types';
+import type { Config, UploadableFile } from '../types';
 
 type Dimensions = {
   width: number | null;
@@ -21,6 +21,22 @@ declare module 'sharp' {
 }
 
 const { bytesToKbytes } = fileUtils;
+
+/**
+ * Instance-level sharp options from the plugin config (e.g. `limitInputPixels`).
+ * Global settings (`cache`, `concurrency`) are applied once in the plugin register phase.
+ * Returns `undefined` when nothing is configured so bare stream pipelines can use `sharp()`.
+ */
+const getSharpOptions = (): sharp.SharpOptions | undefined => {
+  const { limitInputPixels } =
+    strapi.config.get<Config['sharp']>('plugin::upload.sharp', {}) ?? {};
+
+  if (limitInputPixels === undefined) {
+    return undefined;
+  }
+
+  return { limitInputPixels };
+};
 
 const FORMATS_TO_RESIZE = ['jpeg', 'png', 'webp', 'tiff', 'gif'];
 const FORMATS_TO_PROCESS = ['jpeg', 'png', 'webp', 'tiff', 'svg', 'gif', 'avif'];
@@ -42,15 +58,17 @@ const writeStreamToFile = (stream: NodeJS.ReadWriteStream, path: string) =>
   });
 
 const getMetadata = (file: UploadableFile): Promise<sharp.Metadata> => {
+  const options = getSharpOptions();
+
   if (!file.filepath) {
     return new Promise((resolve, reject) => {
-      const pipeline = sharp();
+      const pipeline = options ? sharp(options) : sharp();
       pipeline.metadata().then(resolve).catch(reject);
       file.getStream().pipe(pipeline);
     });
   }
 
-  return sharp(file.filepath).metadata();
+  return sharp(file.filepath, options).metadata();
 };
 
 const getDimensions = async (file: UploadableFile): Promise<Dimensions> => {
@@ -80,7 +98,7 @@ const resizeFileTo = async (
 
   let newInfo;
   if (!file.filepath) {
-    const transform = sharp({ animated: true })
+    const transform = sharp({ ...getSharpOptions(), animated: true })
       .resize(options)
       .on('info', (info) => {
         newInfo = info;
@@ -88,7 +106,9 @@ const resizeFileTo = async (
 
     await writeStreamToFile(file.getStream().pipe(transform), filePath);
   } else {
-    newInfo = await sharp(file.filepath, { animated: true }).resize(options).toFile(filePath);
+    newInfo = await sharp(file.filepath, { ...getSharpOptions(), animated: true })
+      .resize(options)
+      .toFile(filePath);
   }
 
   const { width, height, size, pageHeight } = newInfo ?? {};
@@ -142,9 +162,9 @@ const optimize = async (file: UploadableFile) => {
   if ((sizeOptimization || autoOrientation) && isOptimizableFormat(format)) {
     let transformer;
     if (!file.filepath) {
-      transformer = sharp({ animated: true });
+      transformer = sharp({ ...getSharpOptions(), animated: true });
     } else {
-      transformer = sharp(file.filepath, { animated: true });
+      transformer = sharp(file.filepath, { ...getSharpOptions(), animated: true });
     }
     // reduce image quality
     transformer[format]({ quality: sizeOptimization ? 80 : 100 });
@@ -255,16 +275,18 @@ const breakpointSmallerThan = (breakpoint: number, { width, height }: Dimensions
  *  Applies a simple image transformation to see if the image is faulty/corrupted.
  */
 const isFaultyImage = async (file: UploadableFile) => {
+  const options = getSharpOptions();
+
   if (!file.filepath) {
     return new Promise((resolve, reject) => {
-      const pipeline = sharp();
+      const pipeline = options ? sharp(options) : sharp();
       pipeline.stats().then(resolve).catch(reject);
       file.getStream().pipe(pipeline);
     });
   }
 
   try {
-    await sharp(file.filepath).stats();
+    await sharp(file.filepath, options).stats();
     return false;
   } catch (e) {
     return true;

--- a/packages/core/upload/server/src/types.ts
+++ b/packages/core/upload/server/src/types.ts
@@ -68,6 +68,7 @@ export interface Config {
   sharp?: {
     cache?: boolean;
     concurrency?: number;
+    limitInputPixels?: number | boolean;
   };
   concurrentUploadSize?: number;
   security?: {


### PR DESCRIPTION
### What does it do?

Threads the `plugin::upload.sharp.limitInputPixels` config value into every sharp instance the upload plugin's image-manipulation service creates (getMetadata, resizeFileTo, optimize, isFaultyImage; both file-path and stream inputs), and adds `limitInputPixels?: number | boolean` to the plugin's `Config['sharp']` type. When unconfigured, the service falls back to a bare `sharp()` call (an empty options object breaks sharp's stream-input detection), so default behavior is unchanged.

### Why is it needed?

Fixes #27159, reported by @GrayYoung. The upload plugin advertises a `sharp` config block, but only the global `cache`/`concurrency` settings were ever applied; a configured `limitInputPixels` was silently ignored. Large images, notably animated GIFs whose stacked frames blow past sharp's default 268-megapixel limit under `animated: true`, always failed with "Input image exceeds pixel limit" regardless of configuration.

### How to test it?

Thirteen new tests in `image-manipulation-sharp-options.test.ts` (real sharp, existing fixtures) cover: the limit enforced when lowered, disabled via `false`, and harmless when unset or generous. Five of them fail without the fix. Full upload server suite: 224 passed, 0 failed (baseline 211, zero new failures). ESLint clean on touched files.

A docs note for the new option under the upload plugin's `sharp` config would make sense in strapi/documentation; happy to open that as a follow-up.

### Related issue(s)/PR(s)

Fixes #27159


---
Fixes CPR-465