### PR TITLE
fix(users-permissions): return caller permissions from content-api endpoint

### DIFF
--- a/packages/plugins/users-permissions/documentation/content-api.yaml
+++ b/packages/plugins/users-permissions/documentation/content-api.yaml
@@ -294,7 +294,11 @@ paths:
     get:
       tags:
         - Users-Permissions - Users & Roles
-      summary: Get default generated permissions
+      summary: Get the permissions of the requesting user's role
+      description:
+        Returns the whole permissions tree, with `enabled` set to `true` for every action the
+        role of the requesting user holds. Requests without a token are resolved against the
+        public role.
       responses:
         200:
           description: Returns the permissions tree
@@ -311,7 +315,7 @@ paths:
                     controllers:
                       controllerA:
                         find:
-                          enabled: false
+                          enabled: true
                           policy: ''
                         findOne:
                           enabled: false

--- a/packages/plugins/users-permissions/documentation/content-api.yaml
+++ b/packages/plugins/users-permissions/documentation/content-api.yaml
@@ -294,11 +294,11 @@ paths:
     get:
       tags:
         - Users-Permissions - Users & Roles
-      summary: Get the permissions of the requesting user's role
+      summary: Get the permissions of the caller
       description:
         Returns the whole permissions tree, with `enabled` set to `true` for every action the
-        role of the requesting user holds. Requests without a token are resolved against the
-        public role.
+        caller holds. Requests without a token are resolved against the public role, and
+        requests authenticated with an API token against that token's own permissions.
       responses:
         200:
           description: Returns the permissions tree

--- a/packages/plugins/users-permissions/server/controllers/__tests__/permissions.test.js
+++ b/packages/plugins/users-permissions/server/controllers/__tests__/permissions.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/* eslint-env jest */
+
+const permissionsController = require('../permissions');
+
+const CATALOGUE = {
+  'api::article': {
+    controllers: {
+      article: {
+        find: { enabled: false, policy: '' },
+        findOne: { enabled: false, policy: '' },
+      },
+    },
+  },
+  'plugin::users-permissions': {
+    controllers: {
+      permissions: {
+        getPermissions: { enabled: false, policy: '' },
+      },
+    },
+  },
+};
+
+const usersPermissionsService = {
+  getActions: jest.fn(() => JSON.parse(JSON.stringify(CATALOGUE))),
+  getActionsForPermissions(permissions = []) {
+    const actions = this.getActions();
+
+    permissions.forEach(({ action }) => {
+      const [type, controller, actionName] = action.split('.');
+      actions[type].controllers[controller][actionName] = { enabled: true, policy: '' };
+    });
+
+    return actions;
+  },
+};
+
+const permissionService = {
+  findRolePermissions: jest.fn(),
+  findPublicPermissions: jest.fn(),
+};
+
+const makeCtx = ({ routeType, user } = {}) => ({
+  state: {
+    route: routeType ? { info: { type: routeType } } : undefined,
+    user,
+  },
+  send: jest.fn(),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // The unit setup derives `strapi.plugin(name).service(name)` from `strapi.plugins`
+  global.strapi = {
+    plugins: {
+      'users-permissions': {
+        services: {
+          permission: permissionService,
+          'users-permissions': usersPermissionsService,
+        },
+      },
+    },
+  };
+});
+
+describe('getPermissions', () => {
+  test('returns the all-disabled action catalogue on the admin router', async () => {
+    const ctx = makeCtx({ routeType: 'admin' });
+
+    await permissionsController.getPermissions(ctx);
+
+    expect(ctx.send).toHaveBeenCalledWith({ permissions: CATALOGUE });
+    expect(permissionService.findRolePermissions).not.toHaveBeenCalled();
+    expect(permissionService.findPublicPermissions).not.toHaveBeenCalled();
+  });
+
+  test("returns the authenticated caller's role permissions on the content API", async () => {
+    permissionService.findRolePermissions.mockResolvedValue([
+      { action: 'plugin::users-permissions.permissions.getPermissions' },
+      { action: 'api::article.article.find' },
+    ]);
+
+    const ctx = makeCtx({ routeType: 'content-api', user: { role: { id: 2 } } });
+
+    await permissionsController.getPermissions(ctx);
+
+    expect(permissionService.findRolePermissions).toHaveBeenCalledWith(2);
+    expect(permissionService.findPublicPermissions).not.toHaveBeenCalled();
+
+    const { permissions } = ctx.send.mock.calls[0][0];
+
+    expect(permissions['plugin::users-permissions'].controllers.permissions.getPermissions).toEqual(
+      { enabled: true, policy: '' }
+    );
+    expect(permissions['api::article'].controllers.article.find).toEqual({
+      enabled: true,
+      policy: '',
+    });
+    expect(permissions['api::article'].controllers.article.findOne).toEqual({
+      enabled: false,
+      policy: '',
+    });
+  });
+
+  test('falls back to the public role permissions when there is no user', async () => {
+    permissionService.findPublicPermissions.mockResolvedValue([
+      { action: 'api::article.article.find' },
+    ]);
+
+    const ctx = makeCtx({ routeType: 'content-api' });
+
+    await permissionsController.getPermissions(ctx);
+
+    expect(permissionService.findPublicPermissions).toHaveBeenCalled();
+    expect(permissionService.findRolePermissions).not.toHaveBeenCalled();
+
+    const { permissions } = ctx.send.mock.calls[0][0];
+
+    expect(permissions['api::article'].controllers.article.find).toEqual({
+      enabled: true,
+      policy: '',
+    });
+    expect(permissions['plugin::users-permissions'].controllers.permissions.getPermissions).toEqual(
+      { enabled: false, policy: '' }
+    );
+  });
+});

--- a/packages/plugins/users-permissions/server/controllers/__tests__/permissions.test.js
+++ b/packages/plugins/users-permissions/server/controllers/__tests__/permissions.test.js
@@ -4,36 +4,16 @@
 
 const permissionsController = require('../permissions');
 
-const CATALOGUE = {
-  'api::article': {
-    controllers: {
-      article: {
-        find: { enabled: false, policy: '' },
-        findOne: { enabled: false, policy: '' },
-      },
-    },
-  },
-  'plugin::users-permissions': {
-    controllers: {
-      permissions: {
-        getPermissions: { enabled: false, policy: '' },
-      },
-    },
-  },
-};
+// Sentinels: the merge itself is covered by the users-permissions service tests
+const CATALOGUE = Symbol('catalogue');
+const FULL_CATALOGUE = Symbol('catalogue with every action enabled');
+const MERGED = Symbol('merged permissions');
 
 const usersPermissionsService = {
-  getActions: jest.fn(() => JSON.parse(JSON.stringify(CATALOGUE))),
-  getActionsForPermissions(permissions = []) {
-    const actions = this.getActions();
-
-    permissions.forEach(({ action }) => {
-      const [type, controller, actionName] = action.split('.');
-      actions[type].controllers[controller][actionName] = { enabled: true, policy: '' };
-    });
-
-    return actions;
-  },
+  getActions: jest.fn(({ defaultEnable = false } = {}) =>
+    defaultEnable ? FULL_CATALOGUE : CATALOGUE
+  ),
+  getActionsForPermissions: jest.fn(() => MERGED),
 };
 
 const permissionService = {
@@ -41,13 +21,19 @@ const permissionService = {
   findPublicPermissions: jest.fn(),
 };
 
-const makeCtx = ({ routeType, user } = {}) => ({
+const makeCtx = ({ routeType, user, strategy = 'users-permissions', credentials } = {}) => ({
   state: {
     route: routeType ? { info: { type: routeType } } : undefined,
+    auth: { strategy: { name: strategy }, credentials },
     user,
   },
   send: jest.fn(),
 });
+
+const expectNoRoleLookup = () => {
+  expect(permissionService.findRolePermissions).not.toHaveBeenCalled();
+  expect(permissionService.findPublicPermissions).not.toHaveBeenCalled();
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -67,20 +53,21 @@ beforeEach(() => {
 
 describe('getPermissions', () => {
   test('returns the all-disabled action catalogue on the admin router', async () => {
-    const ctx = makeCtx({ routeType: 'admin' });
+    const ctx = makeCtx({ routeType: 'admin', strategy: 'admin' });
 
     await permissionsController.getPermissions(ctx);
 
     expect(ctx.send).toHaveBeenCalledWith({ permissions: CATALOGUE });
-    expect(permissionService.findRolePermissions).not.toHaveBeenCalled();
-    expect(permissionService.findPublicPermissions).not.toHaveBeenCalled();
+    expect(usersPermissionsService.getActionsForPermissions).not.toHaveBeenCalled();
+    expectNoRoleLookup();
   });
 
   test("returns the authenticated caller's role permissions on the content API", async () => {
-    permissionService.findRolePermissions.mockResolvedValue([
+    const rolePermissions = [
       { action: 'plugin::users-permissions.permissions.getPermissions' },
       { action: 'api::article.article.find' },
-    ]);
+    ];
+    permissionService.findRolePermissions.mockResolvedValue(rolePermissions);
 
     const ctx = makeCtx({ routeType: 'content-api', user: { role: { id: 2 } } });
 
@@ -88,26 +75,13 @@ describe('getPermissions', () => {
 
     expect(permissionService.findRolePermissions).toHaveBeenCalledWith(2);
     expect(permissionService.findPublicPermissions).not.toHaveBeenCalled();
-
-    const { permissions } = ctx.send.mock.calls[0][0];
-
-    expect(permissions['plugin::users-permissions'].controllers.permissions.getPermissions).toEqual(
-      { enabled: true, policy: '' }
-    );
-    expect(permissions['api::article'].controllers.article.find).toEqual({
-      enabled: true,
-      policy: '',
-    });
-    expect(permissions['api::article'].controllers.article.findOne).toEqual({
-      enabled: false,
-      policy: '',
-    });
+    expect(usersPermissionsService.getActionsForPermissions).toHaveBeenCalledWith(rolePermissions);
+    expect(ctx.send).toHaveBeenCalledWith({ permissions: MERGED });
   });
 
   test('falls back to the public role permissions when there is no user', async () => {
-    permissionService.findPublicPermissions.mockResolvedValue([
-      { action: 'api::article.article.find' },
-    ]);
+    const publicPermissions = [{ action: 'api::article.article.find' }];
+    permissionService.findPublicPermissions.mockResolvedValue(publicPermissions);
 
     const ctx = makeCtx({ routeType: 'content-api' });
 
@@ -115,15 +89,55 @@ describe('getPermissions', () => {
 
     expect(permissionService.findPublicPermissions).toHaveBeenCalled();
     expect(permissionService.findRolePermissions).not.toHaveBeenCalled();
-
-    const { permissions } = ctx.send.mock.calls[0][0];
-
-    expect(permissions['api::article'].controllers.article.find).toEqual({
-      enabled: true,
-      policy: '',
-    });
-    expect(permissions['plugin::users-permissions'].controllers.permissions.getPermissions).toEqual(
-      { enabled: false, policy: '' }
+    expect(usersPermissionsService.getActionsForPermissions).toHaveBeenCalledWith(
+      publicPermissions
     );
+    expect(ctx.send).toHaveBeenCalledWith({ permissions: MERGED });
+  });
+
+  test('enables every action for a full-access API token', async () => {
+    const ctx = makeCtx({
+      routeType: 'content-api',
+      strategy: 'content-api-token',
+      credentials: { type: 'full-access' },
+    });
+
+    await permissionsController.getPermissions(ctx);
+
+    expect(usersPermissionsService.getActions).toHaveBeenCalledWith({ defaultEnable: true });
+    expect(ctx.send).toHaveBeenCalledWith({ permissions: FULL_CATALOGUE });
+    expectNoRoleLookup();
+  });
+
+  test("returns a custom API token's own actions", async () => {
+    const ctx = makeCtx({
+      routeType: 'content-api',
+      strategy: 'content-api-token',
+      credentials: {
+        type: 'custom',
+        permissions: ['api::article.article.find'],
+      },
+    });
+
+    await permissionsController.getPermissions(ctx);
+
+    expect(usersPermissionsService.getActionsForPermissions).toHaveBeenCalledWith([
+      { action: 'api::article.article.find' },
+    ]);
+    expect(ctx.send).toHaveBeenCalledWith({ permissions: MERGED });
+    expectNoRoleLookup();
+  });
+
+  test('never reports the public role permissions to an API token caller', async () => {
+    const ctx = makeCtx({
+      routeType: 'content-api',
+      strategy: 'content-api-token',
+      credentials: { type: 'read-only' },
+    });
+
+    await permissionsController.getPermissions(ctx);
+
+    expect(ctx.send).toHaveBeenCalledWith({ permissions: CATALOGUE });
+    expectNoRoleLookup();
   });
 });

--- a/packages/plugins/users-permissions/server/controllers/permissions.js
+++ b/packages/plugins/users-permissions/server/controllers/permissions.js
@@ -3,6 +3,46 @@
 const _ = require('lodash');
 const { getService } = require('../utils');
 
+const API_TOKEN_STRATEGY = 'content-api-token';
+const API_TOKEN_TYPE = {
+  FULL_ACCESS: 'full-access',
+  CUSTOM: 'custom',
+};
+
+/**
+ * API tokens are a content API credential of their own: they carry their own action list and
+ * are not backed by a users-permissions role.
+ */
+const getApiTokenPermissions = (apiToken) => {
+  const usersPermissionsService = getService('users-permissions');
+
+  if (apiToken?.type === API_TOKEN_TYPE.FULL_ACCESS) {
+    return usersPermissionsService.getActions({ defaultEnable: true });
+  }
+
+  if (apiToken?.type === API_TOKEN_TYPE.CUSTOM) {
+    return usersPermissionsService.getActionsForPermissions(
+      (apiToken.permissions ?? []).map((action) => ({ action }))
+    );
+  }
+
+  // Read-only tokens cannot reach this route, as its scope is not a read scope
+  return usersPermissionsService.getActions();
+};
+
+const getRolePermissions = async (ctx) => {
+  const permissionService = getService('permission');
+  const roleId = ctx.state.user?.role?.id;
+
+  // Without a user, the request was authorized through the public role, which is also how the
+  // authentication strategy built the ability for it.
+  const permissions = roleId
+    ? await permissionService.findRolePermissions(roleId)
+    : await permissionService.findPublicPermissions();
+
+  return getService('users-permissions').getActionsForPermissions(permissions);
+};
+
 module.exports = {
   async getPermissions(ctx) {
     // The admin router serves the full action catalogue (all disabled), used to build the
@@ -13,18 +53,12 @@ module.exports = {
       return;
     }
 
-    const permissionService = getService('permission');
-    const roleId = ctx.state.user?.role?.id;
+    const permissions =
+      ctx.state.auth?.strategy?.name === API_TOKEN_STRATEGY
+        ? getApiTokenPermissions(ctx.state.auth.credentials)
+        : await getRolePermissions(ctx);
 
-    // A request without a user reached this route through the public role, which is also how
-    // the authentication strategy built the ability for it.
-    const permissions = roleId
-      ? await permissionService.findRolePermissions(roleId)
-      : await permissionService.findPublicPermissions();
-
-    ctx.send({
-      permissions: getService('users-permissions').getActionsForPermissions(permissions),
-    });
+    ctx.send({ permissions });
   },
 
   async getPolicies(ctx) {

--- a/packages/plugins/users-permissions/server/controllers/permissions.js
+++ b/packages/plugins/users-permissions/server/controllers/permissions.js
@@ -5,9 +5,26 @@ const { getService } = require('../utils');
 
 module.exports = {
   async getPermissions(ctx) {
-    const permissions = await getService('users-permissions').getActions();
+    // The admin router serves the full action catalogue (all disabled), used to build the
+    // role matrix. On the content API, callers get their own effective permissions.
+    if (ctx.state.route?.info?.type !== 'content-api') {
+      ctx.send({ permissions: getService('users-permissions').getActions() });
 
-    ctx.send({ permissions });
+      return;
+    }
+
+    const permissionService = getService('permission');
+    const roleId = ctx.state.user?.role?.id;
+
+    // A request without a user reached this route through the public role, which is also how
+    // the authentication strategy built the ability for it.
+    const permissions = roleId
+      ? await permissionService.findRolePermissions(roleId)
+      : await permissionService.findPublicPermissions();
+
+    ctx.send({
+      permissions: getService('users-permissions').getActionsForPermissions(permissions),
+    });
   },
 
   async getPolicies(ctx) {

--- a/packages/plugins/users-permissions/server/services/__tests__/users-permissions.test.js
+++ b/packages/plugins/users-permissions/server/services/__tests__/users-permissions.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/* eslint-env jest */
+
+const createUsersPermissionsService = require('../users-permissions');
+
+const contentApiAction = () => {
+  const action = () => {};
+  action[Symbol.for('__type__')] = ['content-api'];
+  return action;
+};
+
+const adminOnlyAction = () => {
+  const action = () => {};
+  action[Symbol.for('__type__')] = ['admin'];
+  return action;
+};
+
+const createService = () =>
+  createUsersPermissionsService({
+    strapi: {
+      apis: {
+        article: {
+          controllers: {
+            article: { find: contentApiAction(), findOne: contentApiAction() },
+          },
+        },
+      },
+      plugins: {
+        'users-permissions': {
+          controllers: {
+            permissions: { getPermissions: contentApiAction(), getPolicies: adminOnlyAction() },
+          },
+        },
+      },
+    },
+  });
+
+describe('getActions', () => {
+  test('only lists content-api actions, all disabled by default', () => {
+    expect(createService().getActions()).toEqual({
+      'api::article': {
+        controllers: {
+          article: {
+            find: { enabled: false, policy: '' },
+            findOne: { enabled: false, policy: '' },
+          },
+        },
+      },
+      'plugin::users-permissions': {
+        controllers: {
+          permissions: {
+            getPermissions: { enabled: false, policy: '' },
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('getActionsForPermissions', () => {
+  test('enables the actions held by the given permissions and leaves the rest disabled', () => {
+    const actions = createService().getActionsForPermissions([
+      { action: 'api::article.article.find' },
+      { action: 'plugin::users-permissions.permissions.getPermissions' },
+    ]);
+
+    expect(actions['api::article'].controllers.article.find).toEqual({
+      enabled: true,
+      policy: '',
+    });
+    expect(actions['plugin::users-permissions'].controllers.permissions.getPermissions).toEqual({
+      enabled: true,
+      policy: '',
+    });
+    expect(actions['api::article'].controllers.article.findOne).toEqual({
+      enabled: false,
+      policy: '',
+    });
+  });
+
+  test('returns the untouched catalogue for an empty permission list', () => {
+    const service = createService();
+
+    expect(service.getActionsForPermissions([])).toEqual(service.getActions());
+    expect(service.getActionsForPermissions()).toEqual(service.getActions());
+  });
+});

--- a/packages/plugins/users-permissions/server/services/role.js
+++ b/packages/plugins/users-permissions/server/services/role.js
@@ -50,21 +50,9 @@ module.exports = ({ strapi }) => ({
       throw new NotFoundError('Role not found');
     }
 
-    const allActions = getService('users-permissions').getActions();
-
-    // Group by `type`.
-    role.permissions.forEach((permission) => {
-      const [type, controller, action] = permission.action.split('.');
-
-      _.set(allActions, `${type}.controllers.${controller}.${action}`, {
-        enabled: true,
-        policy: '',
-      });
-    });
-
     return {
       ...role,
-      permissions: allActions,
+      permissions: getService('users-permissions').getActionsForPermissions(role.permissions),
     };
   },
 

--- a/packages/plugins/users-permissions/server/services/users-permissions.js
+++ b/packages/plugins/users-permissions/server/services/users-permissions.js
@@ -108,6 +108,25 @@ module.exports = ({ strapi }) => ({
     return _.cloneDeep(actionMap);
   },
 
+  /**
+   * Merge a flat list of permissions ({ action: 'api::a.b.find' }) onto the action map,
+   * enabling every action the list contains.
+   */
+  getActionsForPermissions(permissions = []) {
+    const actions = this.getActions();
+
+    permissions.forEach(({ action }) => {
+      const [type, controller, actionName] = action.split('.');
+
+      _.set(actions, `${type}.controllers.${controller}.${actionName}`, {
+        enabled: true,
+        policy: '',
+      });
+    });
+
+    return actions;
+  },
+
   async getRoutes() {
     const routesMap = {};
 

--- a/tests/api/plugins/users-permissions/content-api/permissions.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/permissions.test.api.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createRequest } = require('api-tests/request');
+const { createAuthenticatedUser } = require('../utils');
+
+const GET_PERMISSIONS_ACTION = 'plugin::users-permissions.permissions.getPermissions';
+
+let strapi;
+
+const internals = {
+  user: {
+    username: 'permissions-test',
+    email: 'permissions-test@strapi.io',
+    password: 'Test1234',
+    confirmed: true,
+    provider: 'local',
+  },
+};
+
+const data = {};
+
+const grantGetPermissions = async (roleType) => {
+  const role = await strapi.db
+    .query('plugin::users-permissions.role')
+    .findOne({ where: { type: roleType } });
+
+  await strapi.db
+    .query('plugin::users-permissions.permission')
+    .create({ data: { action: GET_PERMISSIONS_ACTION, role: role.id } });
+
+  return role;
+};
+
+const getPermissionsFor = (action, permissions) => {
+  const [type, controller, actionName] = action.split('.');
+
+  return permissions?.[type]?.controllers?.[controller]?.[actionName];
+};
+
+describe('Permissions API', () => {
+  beforeAll(async () => {
+    strapi = await createStrapiInstance({ bypassAuth: false });
+
+    await grantGetPermissions('authenticated');
+    await grantGetPermissions('public');
+
+    const { jwt, user } = await createAuthenticatedUser({ strapi, userInfo: internals.user });
+
+    data.user = user;
+    data.jwt = jwt;
+  });
+
+  afterAll(async () => {
+    await strapi.db
+      .query('plugin::users-permissions.permission')
+      .deleteMany({ where: { action: GET_PERMISSIONS_ACTION } });
+    await strapi.db.query('plugin::users-permissions.user').deleteMany();
+    await strapi.destroy();
+  });
+
+  test("Returns the authenticated caller's own permissions", async () => {
+    const rq = createRequest({ strapi }).setToken(data.jwt);
+
+    const res = await rq({ method: 'GET', url: '/api/users-permissions/permissions' });
+
+    expect(res.statusCode).toBe(200);
+
+    // The action being called must be reported as enabled — see strapi/strapi#15378
+    expect(getPermissionsFor(GET_PERMISSIONS_ACTION, res.body.permissions)).toEqual({
+      enabled: true,
+      policy: '',
+    });
+
+    // An action only the public role holds must stay disabled for this caller
+    expect(
+      getPermissionsFor('plugin::users-permissions.auth.register', res.body.permissions)
+    ).toEqual({ enabled: false, policy: '' });
+  });
+
+  test('Returns the public role permissions for an anonymous caller', async () => {
+    const rq = createRequest({ strapi });
+
+    const res = await rq({ method: 'GET', url: '/api/users-permissions/permissions' });
+
+    expect(res.statusCode).toBe(200);
+    expect(getPermissionsFor(GET_PERMISSIONS_ACTION, res.body.permissions)).toEqual({
+      enabled: true,
+      policy: '',
+    });
+    expect(
+      getPermissionsFor('plugin::users-permissions.auth.register', res.body.permissions)
+    ).toEqual({ enabled: true, policy: '' });
+  });
+});

--- a/tests/api/plugins/users-permissions/content-api/permissions.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/permissions.test.api.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { createStrapiInstance } = require('api-tests/strapi');
-const { createRequest } = require('api-tests/request');
+const { createRequest, createAuthRequest } = require('api-tests/request');
 const { createAuthenticatedUser } = require('../utils');
 
 const GET_PERMISSIONS_ACTION = 'plugin::users-permissions.permissions.getPermissions';
@@ -38,6 +38,24 @@ const getPermissionsFor = (action, permissions) => {
   return permissions?.[type]?.controllers?.[controller]?.[actionName];
 };
 
+const createFullAccessToken = async () => {
+  const adminRq = await createAuthRequest({ strapi });
+
+  const res = await adminRq({
+    method: 'POST',
+    url: '/admin/api-tokens',
+    body: {
+      name: 'U&P permissions - full access',
+      description: '',
+      type: 'full-access',
+      lifespan: null,
+      permissions: null,
+    },
+  });
+
+  return res.body.data.accessKey;
+};
+
 describe('Permissions API', () => {
   beforeAll(async () => {
     strapi = await createStrapiInstance({ bypassAuth: false });
@@ -49,6 +67,7 @@ describe('Permissions API', () => {
 
     data.user = user;
     data.jwt = jwt;
+    data.apiToken = await createFullAccessToken();
   });
 
   afterAll(async () => {
@@ -56,6 +75,7 @@ describe('Permissions API', () => {
       .query('plugin::users-permissions.permission')
       .deleteMany({ where: { action: GET_PERMISSIONS_ACTION } });
     await strapi.db.query('plugin::users-permissions.user').deleteMany();
+    await strapi.db.query('admin::api-token').deleteMany();
     await strapi.destroy();
   });
 
@@ -91,5 +111,21 @@ describe('Permissions API', () => {
     expect(
       getPermissionsFor('plugin::users-permissions.auth.register', res.body.permissions)
     ).toEqual({ enabled: true, policy: '' });
+  });
+
+  test('Reports every action as enabled for a full-access API token', async () => {
+    const rq = createRequest({ strapi }).setToken(data.apiToken);
+
+    const res = await rq({ method: 'GET', url: '/api/users-permissions/permissions' });
+
+    expect(res.statusCode).toBe(200);
+
+    // A token is not backed by a role, so it must not be answered with the public role's tree
+    const allActions = Object.values(res.body.permissions).flatMap((group) =>
+      Object.values(group.controllers).flatMap((controller) => Object.values(controller))
+    );
+
+    expect(allActions.length).toBeGreaterThan(0);
+    expect(allActions.every(({ enabled }) => enabled === true)).toBe(true);
   });
 });


### PR DESCRIPTION
### What does it do?

`GET /api/users-permissions/permissions` (content API) returned the action catalogue built by `getActions()`, which stamps every leaf `{ enabled: false, policy: '' }` and never looks at the request.

- `users-permissions` service: new `getActionsForPermissions(permissions)` — merges a flat permission list onto the catalogue, enabling the actions it holds. `role.findOne` now reuses it (that merge loop was duplicated there); no behaviour change on the admin side.
- `permissions.getPermissions` controller: on the content API, resolves the caller's permissions through the existing `permission` service — `findRolePermissions(ctx.state.user.role.id)` for a JWT caller, `findPublicPermissions()` for an anonymous one, mirroring how the auth strategy builds the request's ability. The admin router keeps serving the all-disabled catalogue, which the role *Create* page needs.
- API tokens are handled separately: they are a content API credential that isn't backed by a role, and `content-api-token` never populates `ctx.state.user`, so they would otherwise be answered with the *public role's* tree. A full-access token now gets `getActions({ defaultEnable: true })`, a custom token its own permission list. (Read-only tokens can't reach this route — its scope isn't a read scope.)

The branch is on `ctx.state.route.info.type` rather than a separate handler on purpose: route auth scopes are generated from the handler name, so renaming the action would invalidate every stored `plugin::users-permissions.permissions.getPermissions` row.

Response shape is unchanged, so the existing zod contract in `routes/content-api/validation.js` still holds — only the `enabled` values change. The endpoint's OpenAPI summary/example in `documentation/content-api.yaml` said "default generated permissions" with all `false`; updated.

Tests: unit tests for the controller (admin catalogue, JWT caller, anonymous caller, full-access token, custom token) and for `getActionsForPermissions`, plus `tests/api/plugins/users-permissions/content-api/permissions.test.api.js` reproducing the issue's steps. Verified the API tests fail without the controller change and pass with it.

### Why is it needed?

Consumers can't ask the API what the current user is allowed to do — the endpoint answers `false` even for the action being called. The reported workaround is to call the admin endpoint `/users-permissions/roles/:id` instead.

### How to test it?

```bash
yarn test:unit --testPathPattern users-permissions
yarn test:generate-app && yarn test:api --testPathPattern users-permissions
```

Manually, in `examples/getstarted`: enable `users-permissions → permissions → getPermissions` for the *Authenticated* role, then call `GET /api/users-permissions/permissions` with that user's JWT — `permissions["plugin::users-permissions"].controllers.permissions.getPermissions.enabled` is now `true`, and actions the role doesn't hold stay `false`. Same for the *Public* role with no `Authorization` header, and a full-access API token gets every action enabled.

### Related issue(s)/PR(s)

Fix #15378
