### PR TITLE
fix(admin): interpolate min/max values in validation error messages

### DIFF
--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { Box, Button, Flex, Grid, Typography, Link } from '@strapi/design-system';
 import omit from 'lodash/omit';
-import { useIntl, type MessageDescriptor } from 'react-intl';
+import { useIntl, type IntlShape, type MessageDescriptor, type PrimitiveType } from 'react-intl';
 import { NavLink, Navigate, useNavigate, useMatch, useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 import * as yup from 'yup';
@@ -235,10 +235,55 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && !Array.isArray(value) && value !== null;
 };
 
-const isMessageDescriptor = (value: unknown): value is MessageDescriptor => {
+/**
+ * Validation messages can carry the values needed to interpolate their placeholders, e.g.
+ * `components.Input.error.validation.minLength` ("The value is too short (min: {min}).").
+ */
+type TranslationMessage = MessageDescriptor & { values?: Record<string, PrimitiveType> };
+
+const isMessageDescriptor = (value: unknown): value is TranslationMessage => {
   return (
     isRecord(value) && typeof value.id === 'string' && typeof value.defaultMessage === 'string'
   );
+};
+
+/**
+ * @description Turns a yup validation message into a displayable string. The message can be a
+ * plain string, a descriptor, or a descriptor wrapped in `{ message }` / `{ errors: [] }`.
+ *
+ * `values` is forwarded to `formatMessage`, otherwise react-intl cannot interpolate placeholders
+ * such as the `{min}` of `components.Input.error.validation.minLength` and renders the raw
+ * pattern instead. See strapi/strapi#19030.
+ */
+export const formatValidationMessage = (
+  msg: unknown,
+  formatMessage: IntlShape['formatMessage']
+): string => {
+  const format = ({ values, ...message }: TranslationMessage) => formatMessage(message, values);
+
+  try {
+    if (msg === undefined || msg === null) return '';
+    if (typeof msg === 'string') return msg;
+    // Direct descriptor
+    if (isMessageDescriptor(msg)) return format(msg);
+    // Wrapped descriptor: { message: { id, defaultMessage } }
+    if (isRecord(msg) && isMessageDescriptor(msg.message)) {
+      return format(msg.message);
+    }
+    // errors array: [{ id, defaultMessage }]
+    if (isRecord(msg) && Array.isArray(msg.errors) && msg.errors.length > 0) {
+      const first = msg.errors[0];
+      if (typeof first === 'string') return first;
+      if (isMessageDescriptor(first)) return format(first);
+    }
+    // fallback to defaultMessage if present
+    if (isRecord(msg) && typeof msg.defaultMessage === 'string') {
+      return msg.defaultMessage;
+    }
+    return String(msg);
+  } catch {
+    return String(msg);
+  }
 };
 
 const Register = ({ hasAdmin }: RegisterProps) => {
@@ -431,36 +476,10 @@ const Register = ({ hasAdmin }: RegisterProps) => {
               }
             } catch (err) {
               if (err instanceof ValidationError) {
-                const formatDescriptor = (msg: unknown) => {
-                  try {
-                    if (msg === undefined || msg === null) return '';
-                    if (typeof msg === 'string') return msg;
-                    // Direct descriptor
-                    if (isMessageDescriptor(msg)) return formatMessage(msg);
-                    // Wrapped descriptor: { message: { id, defaultMessage } }
-                    if (isRecord(msg) && isMessageDescriptor(msg.message)) {
-                      return formatMessage(msg.message);
-                    }
-                    // errors array: [{ id, defaultMessage }]
-                    if (isRecord(msg) && Array.isArray(msg.errors) && msg.errors.length > 0) {
-                      const first = msg.errors[0];
-                      if (typeof first === 'string') return first;
-                      if (isMessageDescriptor(first)) return formatMessage(first);
-                    }
-                    // fallback to defaultMessage if present
-                    if (isRecord(msg) && typeof msg.defaultMessage === 'string') {
-                      return msg.defaultMessage;
-                    }
-                    return String(msg);
-                  } catch {
-                    return String(msg);
-                  }
-                };
-
                 const computed = err.inner.reduce<Record<string, string>>(
                   (acc, { message, path }) => {
                     if (!path) return acc;
-                    acc[path] = formatDescriptor(message);
+                    acc[path] = formatValidationMessage(message, formatMessage);
                     return acc;
                   },
                   {}

--- a/packages/core/admin/admin/src/pages/Auth/components/tests/Register.test.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/tests/Register.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@tests/utils';
 
-import { Register } from '../Register';
+import { Register, formatValidationMessage } from '../Register';
+
+import type { IntlShape } from 'react-intl';
 
 const FIELD_LABELS = ['Firstname', 'Lastname', 'Email', 'Password', 'Confirm Password'];
 
@@ -51,6 +53,59 @@ describe('Register', () => {
 
     FIELD_LABELS.forEach((label) => {
       expect(getByLabelText(new RegExp(`^${label}`, 'i'))).toBeEnabled();
+    });
+  });
+
+  describe('formatValidationMessage', () => {
+    /**
+     * `components.Input.error.validation.minLength` is translated as
+     * "The value is too short (min: {min})." — dropping the descriptor's `values` made react-intl
+     * render that raw pattern under the password field. See strapi/strapi#19030.
+     */
+    const MIN_LENGTH_DESCRIPTOR = {
+      id: 'components.Input.error.validation.minLength',
+      defaultMessage: 'Password must be at least 8 characters',
+      values: { min: 8 },
+    };
+
+    const formatMessage = ((
+      { id, defaultMessage }: { id: string; defaultMessage: string },
+      values?: Record<string, unknown>
+    ) => {
+      const pattern =
+        id === MIN_LENGTH_DESCRIPTOR.id ? 'The value is too short (min: {min}).' : defaultMessage;
+
+      return pattern.replace(/\{(\w+)\}/g, (match, key) =>
+        values && key in values ? String(values[key]) : match
+      );
+    }) as IntlShape['formatMessage'];
+
+    it('interpolates the values carried by a descriptor', () => {
+      expect(formatValidationMessage(MIN_LENGTH_DESCRIPTOR, formatMessage)).toBe(
+        'The value is too short (min: 8).'
+      );
+    });
+
+    it('interpolates the values of a wrapped descriptor', () => {
+      expect(formatValidationMessage({ message: MIN_LENGTH_DESCRIPTOR }, formatMessage)).toBe(
+        'The value is too short (min: 8).'
+      );
+    });
+
+    it('interpolates the values of the first descriptor of an errors array', () => {
+      expect(formatValidationMessage({ errors: [MIN_LENGTH_DESCRIPTOR] }, formatMessage)).toBe(
+        'The value is too short (min: 8).'
+      );
+    });
+
+    it('passes plain strings through untouched', () => {
+      expect(formatValidationMessage('Passwords must match', formatMessage)).toBe(
+        'Passwords must match'
+      );
+    });
+
+    it('returns an empty string for a missing message', () => {
+      expect(formatValidationMessage(undefined, formatMessage)).toBe('');
     });
   });
 });

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -93,13 +93,20 @@ export const formatErrorMessages = (
       const defaultMessage = isErrorMessageDescriptor
         ? (value.defaultMessage as string)
         : (value as string);
+      /**
+       * The descriptor carries its own values (e.g. `{ min: 8 }`). They have to be forwarded,
+       * otherwise a locale without the `.withField` variant falls back to a `defaultMessage`
+       * that still contains `{min}` and react-intl renders the raw placeholder.
+       * See strapi/strapi#19030.
+       */
+      const values = isErrorMessageDescriptor ? value.values : undefined;
       messages.push(
         formatMessage(
           {
             id: `${id}.withField`,
             defaultMessage,
           },
-          { field: currentKey }
+          { ...values, field: currentKey }
         )
       );
     } else {

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/tests/formatErrorMessages.test.ts
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/tests/formatErrorMessages.test.ts
@@ -227,4 +227,31 @@ describe('formatErrorMessages', () => {
 
     expect(calls[0].id).toBe('error.required.withField');
   });
+
+  /**
+   * Messages such as `components.Input.error.validation.minLength` interpolate `{min}`. When a
+   * locale has no `.withField` variant react-intl falls back to the defaultMessage, so dropping
+   * the descriptor's own values leaked the raw `{min}` placeholder. See strapi/strapi#19030.
+   */
+  it('forwards the values carried by the descriptor alongside the field', () => {
+    const calls: Array<[ErrorMessageDescriptor, FormatMessageValues]> = [];
+    const spy = ((msg: ErrorMessageDescriptor, values: FormatMessageValues) => {
+      calls.push([msg, values]);
+      return msg.defaultMessage;
+    }) as FormatMessage;
+
+    formatErrorMessages(
+      {
+        name: {
+          id: 'components.Input.error.validation.minLength',
+          defaultMessage: 'The value is too short (min: {min}).',
+          values: { min: 8 },
+        },
+      } as unknown as FormErrors,
+      '',
+      spy
+    );
+
+    expect(calls[0][1]).toEqual({ min: 8, field: 'name' });
+  });
 });

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/tests/types.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/tests/types.test.ts
@@ -1,0 +1,35 @@
+import { ValidationError } from 'yup';
+
+import { attributeTypes } from '../types';
+
+const validateEnum = async (enumValues: string[]) => {
+  try {
+    await attributeTypes.enumeration([], []).validate({
+      name: 'category',
+      type: 'enumeration',
+      enum: enumValues,
+    });
+
+    return undefined;
+  } catch (err) {
+    return (err as ValidationError).message;
+  }
+};
+
+describe('attributeTypes.enumeration', () => {
+  it('accepts a non-empty list of values', async () => {
+    await expect(validateEnum(['one', 'two'])).resolves.toBeUndefined();
+  });
+
+  /**
+   * The generic `components.Input.error.validation.min` message interpolates `{min}`, but CTB
+   * renders field errors as `formatMessage({ id: error })` without any values, so it used to leak
+   * the raw `(min: {min})` placeholder. See strapi/strapi#19030.
+   */
+  it('reports an empty enumeration with a message that needs no interpolation', async () => {
+    const message = await validateEnum([]);
+
+    expect(message).toBe('content-type-builder.error.validation.enum-empty');
+    expect(message).not.toContain('{min}');
+  });
+});

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.ts
@@ -161,7 +161,12 @@ export const attributeTypes = {
       enum: yup
         .array()
         .of(yup.string())
-        .min(1, errorsTrads.min.id)
+        /**
+         * CTB renders field errors as `formatMessage({ id: error })` with no values, so the
+         * message must not interpolate anything — the generic `errorsTrads.min` id would leak
+         * its `{min}` placeholder. See strapi/strapi#19030.
+         */
+        .min(1, getTrad('error.validation.enum-empty'))
         .test({
           name: 'areEnumValuesUnique',
           message: getTrad('error.validation.enum-duplicate'),

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -64,6 +64,7 @@
   "error.contentTypeName.reserved-name": "This name cannot be used in your project as it might break other functionalities",
   "error.category.format": "A category name must start with a letter and only contain letters, numbers, dashes and underscores",
   "error.validation.enum-duplicate": "Duplicate values are not allowed (only alphanumeric characters are taken into account).",
+  "error.validation.enum-empty": "You must add at least one value",
   "error.validation.enum-empty-string": "Empty strings are not allowed",
   "error.validation.enum-regex": "At least one value is invalid. Values should have at least one alphabetical character preceding the first occurence of a number.",
   "error.validation.minSupMax": "Min can't be superior to max",

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromUrlForm.tsx
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromUrlForm.tsx
@@ -8,6 +8,12 @@ import { useTracking } from '../../../hooks/useTracking';
 import { getTrad, urlsToAssets, urlSchema } from '../../../utils';
 
 import type { FileWithRawFile } from './AddAssetStep';
+import type { MessageDescriptor, PrimitiveType } from 'react-intl';
+
+type TranslationMessage = MessageDescriptor & { values?: Record<string, PrimitiveType> };
+
+const isMessageDescriptor = (error: unknown): error is TranslationMessage =>
+  typeof error === 'object' && error !== null && 'id' in error;
 
 interface FromUrlFormProps {
   onClose: () => void;
@@ -20,6 +26,24 @@ export const FromUrlForm = ({ onClose, onAddAsset, trackedLocation }: FromUrlFor
   const [error, setError] = React.useState<Error | undefined>(undefined);
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
+
+  /**
+   * `urlSchema` errors are message descriptors: they carry the values needed to interpolate
+   * placeholders such as `{max}` or `{number}`, even though Formik types the error as a string.
+   */
+  const formatValidationError = (validationError: unknown) => {
+    if (isMessageDescriptor(validationError)) {
+      const { values, ...message } = validationError;
+
+      return formatMessage({ defaultMessage: 'An error occurred', ...message }, values);
+    }
+
+    if (typeof validationError === 'string') {
+      return formatMessage({ id: validationError, defaultMessage: 'An error occurred' });
+    }
+
+    return undefined;
+  };
 
   const handleSubmit = async ({ urls }: { urls: string }) => {
     setLoading(true);
@@ -57,12 +81,7 @@ export const FromUrlForm = ({ onClose, onAddAsset, trackedLocation }: FromUrlFor
                 id: getTrad('input.url.description'),
                 defaultMessage: 'Separate your URL links by a carriage return.',
               })}
-              error={
-                error?.message ||
-                (errors.urls
-                  ? formatMessage({ id: errors.urls, defaultMessage: 'An error occurred' })
-                  : undefined)
-              }
+              error={error?.message || formatValidationError(errors.urls)}
             >
               <Field.Label>
                 {formatMessage({ id: getTrad('input.url.label'), defaultMessage: 'URL' })}

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/tests/FromUrlForm.test.tsx
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/tests/FromUrlForm.test.tsx
@@ -1,0 +1,64 @@
+import { DesignSystemProvider } from '@strapi/design-system';
+import { fireEvent, render as renderTL, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+
+import { FromUrlForm } from '../FromUrlForm';
+
+jest.mock('@strapi/admin/strapi-admin', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin'),
+  getFetchClient: jest.fn().mockReturnValue({
+    get: jest.fn(),
+  }),
+}));
+
+const messages = {
+  'components.Input.error.validation.max': 'The value is too high (max: {max}).',
+  'upload.form.upload-url.error.url.invalids': '{number} URLs are invalids',
+};
+
+const render = () =>
+  renderTL(
+    <IntlProvider locale="en" messages={messages}>
+      <DesignSystemProvider>
+        <FromUrlForm onClose={jest.fn()} onAddAsset={jest.fn()} />
+      </DesignSystemProvider>
+    </IntlProvider>
+  );
+
+const submitUrls = async (user: ReturnType<typeof userEvent.setup>, urls: string) => {
+  await user.click(screen.getByRole('textbox'));
+  await user.paste(urls);
+  // jsdom does not submit the form when the `Modal.Footer` button is clicked, so submit it directly.
+  // eslint-disable-next-line testing-library/no-node-access
+  fireEvent.submit(screen.getByRole('textbox').closest('form')!);
+};
+
+describe('FromUrlForm', () => {
+  /**
+   * Regression tests for strapi/strapi#19030: the validation messages interpolate values,
+   * so a missing `values` payload makes react-intl render the raw ICU placeholder.
+   */
+  it('interpolates the maximum number of urls in the error message', async () => {
+    const user = userEvent.setup();
+    render();
+
+    await submitUrls(
+      user,
+      Array.from({ length: 21 }, (_, i) => `https://strapi.io/${i}.png`).join('\n')
+    );
+
+    expect(await screen.findByText('The value is too high (max: 20).')).toBeInTheDocument();
+    expect(screen.queryByText(/\{max\}/)).not.toBeInTheDocument();
+  });
+
+  it('interpolates the number of invalid urls in the error message', async () => {
+    const user = userEvent.setup();
+    render();
+
+    await submitUrls(user, ['not-a-url', 'me-neither'].join('\n'));
+
+    expect(await screen.findByText('2 URLs are invalids')).toBeInTheDocument();
+    expect(screen.queryByText(/\{number\}/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/tests/UploadAssetDialog.test.tsx
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/tests/UploadAssetDialog.test.tsx
@@ -102,7 +102,9 @@ describe('UploadAssetDialog', () => {
        */
       fireEvent.click(getByRole('button', { name: 'Next' }));
 
-      await screen.findByText('An error occurred');
+      // The trailing `[Enter]` leaves an empty line, which is not a valid URL. The message comes
+      // from the schema's own descriptor rather than a generic fallback.
+      await screen.findByText('One URL is invalid');
     }, 10000);
 
     /**

--- a/packages/core/upload/admin/src/utils/tests/urlYupSchema.test.ts
+++ b/packages/core/upload/admin/src/utils/tests/urlYupSchema.test.ts
@@ -1,0 +1,58 @@
+import { ValidationError } from 'yup';
+
+import { urlSchema } from '../urlYupSchema';
+
+const validateUrls = async (urls: string) => {
+  try {
+    await urlSchema.validate({ urls });
+
+    return undefined;
+  } catch (err) {
+    return (err as ValidationError).message as unknown;
+  }
+};
+
+describe('urlSchema', () => {
+  it('accepts a list of valid urls', async () => {
+    const urls = ['https://strapi.io/a.png', 'https://strapi.io/b.png'].join('\n');
+
+    await expect(validateUrls(urls)).resolves.toBeUndefined();
+  });
+
+  it('returns a message descriptor carrying the max value when there are too many urls', async () => {
+    const urls = Array.from({ length: 21 }, (_, i) => `https://strapi.io/${i}.png`).join('\n');
+
+    const message = await validateUrls(urls);
+
+    /**
+     * The message has to carry `values`, otherwise react-intl cannot interpolate
+     * `components.Input.error.validation.max` ("The value is too high (max: {max}).")
+     * and renders the raw `{max}` placeholder instead. See strapi/strapi#19030.
+     */
+    expect(message).toEqual({
+      id: 'components.Input.error.validation.max',
+      defaultMessage: 'The value is too high (max: {max}).',
+      values: { max: 20 },
+    });
+  });
+
+  it('returns a message descriptor carrying the count of invalid urls', async () => {
+    const message = await validateUrls(['not-a-url', 'me-neither'].join('\n'));
+
+    expect(message).toEqual({
+      id: 'upload.form.upload-url.error.url.invalids',
+      defaultMessage: '{number} URLs are invalids',
+      values: { number: 2 },
+    });
+  });
+
+  it('returns the singular message descriptor for a single invalid url', async () => {
+    const message = await validateUrls('not-a-url');
+
+    expect(message).toEqual({
+      id: 'upload.form.upload-url.error.url.invalid',
+      defaultMessage: 'One URL is invalid',
+      values: { number: 1 },
+    });
+  });
+});

--- a/packages/core/upload/admin/src/utils/urlYupSchema.ts
+++ b/packages/core/upload/admin/src/utils/urlYupSchema.ts
@@ -3,6 +3,8 @@ import * as yup from 'yup';
 
 import { getTrad } from './getTrad';
 
+const MAX_URLS = 20;
+
 export const urlSchema = yup.object().shape({
   urls: yup.string().test({
     name: 'isUrlValid',
@@ -11,17 +13,22 @@ export const urlSchema = yup.object().shape({
     test(values = '') {
       const urls = values.split(/\r?\n/);
 
+      /**
+       * Messages are message descriptors rather than bare ids because these translations
+       * interpolate values (`{min}`, `{max}`, `{number}`). Without `values`, react-intl
+       * fails to format them and renders the raw placeholder. See strapi/strapi#19030.
+       */
       if (urls.length === 0) {
         return this.createError({
           path: this.path,
-          message: errorsTrads.min.id,
+          message: { ...errorsTrads.min, values: { min: 1 } },
         });
       }
 
-      if (urls.length > 20) {
+      if (urls.length > MAX_URLS) {
         return this.createError({
           path: this.path,
-          message: errorsTrads.max.id,
+          message: { ...errorsTrads.max, values: { max: MAX_URLS } },
         });
       }
 
@@ -45,13 +52,19 @@ export const urlSchema = yup.object().shape({
 
       const errorMessage =
         filteredLength > 1
-          ? 'form.upload-url.error.url.invalids'
-          : 'form.upload-url.error.url.invalid';
+          ? {
+              id: 'form.upload-url.error.url.invalids',
+              defaultMessage: '{number} URLs are invalids',
+            }
+          : { id: 'form.upload-url.error.url.invalid', defaultMessage: 'One URL is invalid' };
 
       return this.createError({
         path: this.path,
-        message: getTrad(errorMessage),
-        params: { number: filtered.length },
+        message: {
+          ...errorMessage,
+          id: getTrad(errorMessage.id),
+          values: { number: filteredLength },
+        },
       });
     },
   }),


### PR DESCRIPTION
### What does it do?

Several admin translations carry ICU placeholders — `components.Input.error.validation.min`, `max`, `minLength` and `maxLength` all interpolate `{min}` / `{max}`. A few call sites handed react-intl only the message **id**, or a descriptor stripped of its `values`. react-intl then fails to format the message and returns the unformatted pattern, so the raw `{min}` is rendered to the user.

Four call sites are fixed:

- **`@strapi/admin` — `Register`** (the reported bug). Its `onSubmit` re-validates the schema and formats the yup messages itself, calling `formatMessage(msg)` without `msg.values`. The inline `formatDescriptor` is extracted into an exported `formatValidationMessage` helper that forwards `values` in every branch (direct descriptor, `{ message }`, `{ errors: [] }`).
- **`@strapi/upload` — "Add from URL"**. `urlYupSchema` returned bare message ids (`errorsTrads.min.id` / `errorsTrads.max.id`) and used yup's `params` for the invalid-url count, which never reaches the UI. It now returns full descriptors carrying `values`, and `FromUrlForm` formats both the descriptor and legacy string shapes.
- **`@strapi/content-type-builder` — empty enumeration**. `.min(1, errorsTrads.min.id)` reused the generic message, but CTB renders field errors as `formatMessage({ id: error })` with no values, so the placeholder always leaked. Replaced with a dedicated `error.validation.enum-empty` key that needs no interpolation.
- **`@strapi/content-manager` — bulk publish**. `formatErrorMessages` rebuilds the descriptor as `${id}.withField` and passed only `{ field }`, dropping the descriptor's own values. For locales with no `.withField` variant react-intl falls back to a `defaultMessage` that still contains `{min}`.

### Why is it needed?

Registering the first admin with a short password shows `The value is too short (min: {min}).` instead of the minimum length. Reported in #19030, confirmed by a maintainer, open since December 2023 with no PR. The same class of defect was live on three other screens.

### How to test it?

Environment: `examples/getstarted`, SQLite, `yarn develop`.

1. **The reported case** — open `/admin/auth/register-admin` on a fresh project, enter `Pass1` as the password and submit. Before: `The value is too short (min: {min}).` After: `The value is too short (min: 8).`
2. **Media Library** — *Add new assets* → *From URL* → paste 21 URLs → *Next*. Before: `The value is too high (max: {max}).` After: `The value is too high (max: 20).` Pasting two invalid URLs shows `2 URLs are invalids` rather than `{number} URLs are invalids`.
3. **Content-Type Builder** — add an *Enumeration* field and submit with no values. Before: `The value is too low (min: {min}).` After: `You must add at least one value`.

Automated coverage — each test was confirmed to fail without its fix:

- `packages/core/upload/admin/src/utils/tests/urlYupSchema.test.ts` (new)
- `packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/tests/FromUrlForm.test.tsx` (new, asserts the rendered text)
- `packages/core/content-type-builder/admin/src/components/FormModal/attributes/tests/types.test.ts` (new)
- `packages/core/admin/admin/src/pages/Auth/components/tests/Register.test.tsx` (extended)
- `packages/core/content-manager/.../tests/formatErrorMessages.test.ts` (extended)

One existing assertion changed: `UploadAssetDialog.test.tsx` expected the generic `An error occurred` fallback, which is now the schema's own message.

`yarn test:unit`, `yarn test:front`, `yarn test:ts`, `yarn lint` and `yarn prettier:check` all pass.

### Related issue(s)/PR(s)

Fix #19030