### PR TITLE
fix(upload): media library MVP fixes

### DIFF
--- a/packages/core/upload/admin/src/future/components/Drawer.tsx
+++ b/packages/core/upload/admin/src/future/components/Drawer.tsx
@@ -82,7 +82,9 @@ const DrawerContainer = styled(Flex)<DrawerContainerProps>`
   z-index: 200;
   overflow: hidden;
   width: ${({ width }) => width ?? '400px'};
-  max-height: ${({ maxHeight }) => maxHeight ?? '100vh'};
+  /* dvh, not vh: anchored to the bottom, a 100vh cap on mobile (visual
+     viewport < 100vh under the URL bar) would push the drawer top off-screen. */
+  max-height: ${({ maxHeight }) => maxHeight ?? '100dvh'};
 
   &:focus {
     outline: none;

--- a/packages/core/upload/admin/src/future/hooks/useMediaLibraryPermissions.ts
+++ b/packages/core/upload/admin/src/future/hooks/useMediaLibraryPermissions.ts
@@ -1,0 +1,34 @@
+import { useRBAC } from '@strapi/admin/strapi-admin';
+
+import { PERMISSIONS } from '../../constants';
+
+// Hoisted to module scope (matching the legacy hook): a fresh object each render
+// would hand `useRBAC` a new identity every time, re-running its memos for no
+// gain (it guards refetch with a deep `isEqual`, so this is wasted work, not a loop).
+const { main: _main, ...RBAC_PERMISSIONS } = PERMISSIONS;
+
+/**
+ * RBAC gate for the future Media Library UI. Mirrors the legacy hook of the
+ * same name: the server already enforces every action route-side (assets and
+ * folder operations share the asset permissions — folder create requires
+ * `assets.create`, folder rename/move/delete require `assets.update`); this
+ * hook is what keeps the UI honest so users don't discover a missing
+ * permission through a 403.
+ *
+ * - `canCreate` — upload (files, from URL) and New folder
+ * - `canUpdate` — edit details, replace, crop, move (dnd + bulk), delete
+ *   (single + bulk), AI metadata — the `assets.update` action covers
+ *   "Update (crop, details, replace) + delete" by definition
+ * - `canDownload` / `canCopyLink` — the matching drawer actions
+ */
+export const useMediaLibraryPermissions = () => {
+  const { allowedActions, isLoading } = useRBAC(RBAC_PERMISSIONS);
+
+  return {
+    isLoading,
+    canCreate: Boolean(allowedActions.canCreate),
+    canUpdate: Boolean(allowedActions.canUpdate),
+    canDownload: Boolean(allowedActions.canDownload),
+    canCopyLink: Boolean(allowedActions.canCopyLink),
+  };
+};

--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -23,6 +23,7 @@ import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
 
 import { useAIAvailability } from '../../../hooks/useAiAvailability';
+import { useMediaLibraryPermissions } from '../../hooks/useMediaLibraryPermissions';
 import { useUploadFromUrlsMutation, useUploadFilesMutation } from '../../services/api';
 import { useGetFolderQuery, useGetFoldersQuery } from '../../services/folders';
 import { getTranslationKey } from '../../utils/translations';
@@ -116,6 +117,7 @@ interface AssetsViewProps {
   onClearFilters: () => void;
   onAssetItemClick: (assetId: number) => void;
   onAddAssets: () => void;
+  canAddAssets: boolean;
   onClearSearch: () => void;
 }
 
@@ -136,6 +138,7 @@ const AssetsView = ({
   onClearFilters,
   onAssetItemClick,
   onAddAssets,
+  canAddAssets,
   onClearSearch,
 }: AssetsViewProps) => {
   const { formatMessage } = useIntl();
@@ -195,6 +198,7 @@ const AssetsView = ({
     ) : (
       <EmptyState
         onAddAssets={onAddAssets}
+        canAddAssets={canAddAssets}
         searchQuery={searchQuery}
         onClearSearch={onClearSearch}
       />
@@ -320,6 +324,7 @@ const HeaderWrapper = styled(Box)`
 export const AssetsPage = () => {
   const { formatMessage } = useIntl();
   const { openDetails } = useAssetDetailsParam();
+  const { canCreate, canUpdate } = useMediaLibraryPermissions();
 
   const { currentFolderId, navigateToFolderId, navigateToRoot } = useFolderNavigation();
   // Deleted or missing folders (404) need a fetch — handled here, not in
@@ -469,6 +474,9 @@ export const AssetsPage = () => {
   };
 
   const handleDrop = async (files: globalThis.File[]) => {
+    // Defence in depth: the provider is `disabled` without `assets.create`
+    // (so onDrop won't fire), but guard here too in case it's ever wired live.
+    if (!canCreate) return;
     await uploadFilesToFolder(files, currentFolderId);
   };
 
@@ -496,8 +504,8 @@ export const AssetsPage = () => {
 
   return (
     <>
-      <UploadDropZoneProvider onDrop={handleDrop}>
-        <AssetSelectionProvider>
+      <UploadDropZoneProvider onDrop={handleDrop} disabled={!canCreate}>
+        <AssetSelectionProvider disabled={!canUpdate}>
           <AssetsDndProvider>
             <ClearSelectionOnChange listQueryKey={listQueryKey} />
             <Box ref={uploadDropZoneRef}>
@@ -520,37 +528,39 @@ export const AssetsPage = () => {
                   <Layouts.Header
                     title={pageHeaderTitle}
                     primaryAction={
-                      <SimpleMenu
-                        popoverPlacement="bottom-end"
-                        variant="default"
-                        endIcon={<ChevronDown />}
-                        label={formatMessage({
-                          id: getTranslationKey('new'),
-                          defaultMessage: 'New',
-                        })}
-                      >
-                        <MenuItem
-                          onSelect={() => setIsCreateFolderDialogOpen(true)}
-                          startIcon={<FolderIcon />}
+                      canCreate && (
+                        <SimpleMenu
+                          popoverPlacement="bottom-end"
+                          variant="default"
+                          endIcon={<ChevronDown />}
+                          label={formatMessage({
+                            id: getTranslationKey('new'),
+                            defaultMessage: 'New',
+                          })}
                         >
-                          {formatMessage({
-                            id: getTranslationKey('folder.create.title'),
-                            defaultMessage: 'New folder',
-                          })}
-                        </MenuItem>
-                        <MenuItem onSelect={handleFileSelect} startIcon={<Files />}>
-                          {formatMessage({
-                            id: getTranslationKey('import-files'),
-                            defaultMessage: 'Import files',
-                          })}
-                        </MenuItem>
-                        <MenuItem onSelect={() => setIsUrlDialogOpen(true)} startIcon={<Link />}>
-                          {formatMessage({
-                            id: getTranslationKey('import-from-url'),
-                            defaultMessage: 'Import from URL',
-                          })}
-                        </MenuItem>
-                      </SimpleMenu>
+                          <MenuItem
+                            onSelect={() => setIsCreateFolderDialogOpen(true)}
+                            startIcon={<FolderIcon />}
+                          >
+                            {formatMessage({
+                              id: getTranslationKey('folder.create.title'),
+                              defaultMessage: 'New folder',
+                            })}
+                          </MenuItem>
+                          <MenuItem onSelect={handleFileSelect} startIcon={<Files />}>
+                            {formatMessage({
+                              id: getTranslationKey('import-files'),
+                              defaultMessage: 'Import files',
+                            })}
+                          </MenuItem>
+                          <MenuItem onSelect={() => setIsUrlDialogOpen(true)} startIcon={<Link />}>
+                            {formatMessage({
+                              id: getTranslationKey('import-from-url'),
+                              defaultMessage: 'Import from URL',
+                            })}
+                          </MenuItem>
+                        </SimpleMenu>
+                      )
                     }
                     subtitle={
                       <>
@@ -634,6 +644,7 @@ export const AssetsPage = () => {
                       onClearFilters={listFilters.clearFilters}
                       onAssetItemClick={openDetails}
                       onAddAssets={handleFileSelect}
+                      canAddAssets={canCreate}
                       onClearSearch={clearSearch}
                     />
                   </DropZoneWithOverlay>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
@@ -45,6 +45,8 @@ const Overlay = styled(Flex)`
   border-radius: ${({ theme }) => theme.borderRadius};
   border: 1px solid ${({ theme }) => theme.colors.neutral150};
   background: ${({ theme }) => theme.colors.neutral0};
+  /* Focused programmatically on open (tabIndex -1) — no visible ring needed. */
+  outline: none;
 `;
 
 const HeaderBar = styled(Flex)`
@@ -56,6 +58,9 @@ const HeaderBar = styled(Flex)`
 `;
 
 // Fills the remaining space between header/footer; checkerboard pattern.
+// The horizontal padding keeps the image off the viewport edges — the corner
+// handles overhang the image by half their size, and on narrow (mobile)
+// screens an edge-to-edge image leaves nothing to grab.
 const Body = styled(Box)`
   width: 100%;
   position: relative;
@@ -65,6 +70,7 @@ const Body = styled(Box)`
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  padding: 0 ${({ theme }) => theme.spaces[4]};
   background: repeating-conic-gradient(
       ${({ theme }) => theme.colors.neutral100} 0% 25%,
       ${({ theme }) => theme.colors.neutral0} 0% 50%
@@ -97,6 +103,9 @@ const CropOverlay = styled.div`
   border: 1px dashed ${({ theme }) => theme.colors.primary600};
   box-shadow: 0 0 0 9999px rgba(33, 33, 52, 0.5);
   cursor: move;
+  /* Without this, touch browsers claim the gesture for scrolling and fire
+     pointercancel mid-drag — the crop drag dies while the finger is down. */
+  touch-action: none;
 `;
 
 const ResizeHandle = styled.button<{ $cursor: string }>`
@@ -109,6 +118,7 @@ const ResizeHandle = styled.button<{ $cursor: string }>`
   border-radius: 2px;
   background: ${({ theme }) => theme.colors.neutral0};
   cursor: ${({ $cursor }) => $cursor};
+  touch-action: none;
 `;
 
 const FocalPointHandle = styled.button`
@@ -121,6 +131,7 @@ const FocalPointHandle = styled.button`
   background: transparent;
   cursor: grab;
   padding: 0;
+  touch-action: none;
 
   &::before {
     content: '';
@@ -221,6 +232,12 @@ interface AssetCropEditorProps {
   onClose: () => void;
   onApply: (file: globalThis.File, focalPoint: FocalPoint) => void;
   onSaveAsCopy: (file: globalThis.File, focalPoint: FocalPoint) => void;
+  /**
+   * "Save as copy" creates a new asset (`assets.create`), a different permission
+   * from cropping in place (`assets.update`). Hidden when the user lacks it, so
+   * an update-only role can't trigger a 403.
+   */
+  canSaveAsCopy: boolean;
 }
 
 type Corner = 'tl' | 'tr' | 'bl' | 'br';
@@ -231,6 +248,7 @@ export const AssetCropEditor = ({
   onClose,
   onApply,
   onSaveAsCopy,
+  canSaveAsCopy,
 }: AssetCropEditorProps) => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
@@ -243,6 +261,15 @@ export const AssetCropEditor = ({
   const infoMutedColor = isDark ? 'neutral600' : 'neutral200';
   const imgRef = React.useRef<HTMLImageElement>(null);
   const cropAreaRef = React.useRef<HTMLDivElement>(null);
+  const overlayRef = React.useRef<HTMLDivElement>(null);
+
+  // FocusTrap's auto-focus lands on the first focusable element — the crop
+  // width NumberInput — which pops the keyboard on mobile the moment the
+  // editor opens. Focus the (tabIndex -1) overlay instead: keyboard users are
+  // one Tab away from the first control, Escape still reaches the trap.
+  React.useEffect(() => {
+    overlayRef.current?.focus();
+  }, []);
 
   const {
     init,
@@ -289,39 +316,77 @@ export const AssetCropEditor = ({
     };
   };
 
-  // Drag the entire crop rectangle.
-  const handleMovePointerDown = (event: React.PointerEvent) => {
+  // Teardown for the drag currently in flight, so it can be run both on pointer
+  // release AND on unmount. Without the unmount path, closing the editor mid-drag
+  // (Escape, drawer close, a re-render dropping the overlay) would never fire a
+  // pointer event, leaking the window listeners and letting a stale `onMove`
+  // call `setCropPosition` on an unmounted component.
+  const activeDragCleanupRef = React.useRef<(() => void) | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      activeDragCleanupRef.current?.();
+    };
+  }, []);
+
+  // Track a pointer drag until the pointer is released or the browser cancels
+  // it. The pointer is captured so the drag follows the finger even once it
+  // leaves the (12px) handle it started on, and pointercancel is treated as
+  // release so an interrupted touch never leaves stale window listeners.
+  const trackPointerDrag = (event: React.PointerEvent, onMove: (e: PointerEvent) => void) => {
     event.preventDefault();
     event.stopPropagation();
+    const { pointerId } = event;
+    try {
+      event.currentTarget.setPointerCapture(pointerId);
+    } catch {
+      // Unsupported environment (jsdom) — window listeners still track the drag.
+    }
+    const move = (e: PointerEvent) => {
+      if (e.pointerId !== pointerId) return;
+      onMove(e);
+    };
+    const cleanup = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', end);
+      window.removeEventListener('pointercancel', end);
+      activeDragCleanupRef.current = null;
+    };
+    const end = (e: PointerEvent) => {
+      if (e.pointerId !== pointerId) return;
+      cleanup();
+    };
+    // Only one drag is ever live at a time; tear down any previous one first.
+    activeDragCleanupRef.current?.();
+    activeDragCleanupRef.current = cleanup;
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', end);
+    window.addEventListener('pointercancel', end);
+  };
+
+  // Drag the entire crop rectangle.
+  const handleMovePointerDown = (event: React.PointerEvent) => {
     const start = pointerToNatural(event);
     if (!start) return;
     const startCrop = { ...crop };
-    const move = (e: PointerEvent) => {
+    trackPointerDrag(event, (e) => {
       const next = pointerToNatural(e);
       if (!next) return;
       setCropPosition({
         x: startCrop.x + (next.x - start.x),
         y: startCrop.y + (next.y - start.y),
       });
-    };
-    const up = () => {
-      window.removeEventListener('pointermove', move);
-      window.removeEventListener('pointerup', up);
-    };
-    window.addEventListener('pointermove', move);
-    window.addEventListener('pointerup', up);
+    });
   };
 
   // Resize from a corner; the opposite corner stays anchored.
   const handleResizePointerDown = (corner: Corner) => (event: React.PointerEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
     const startCrop = { ...crop };
     const anchorX =
       corner === 'tl' || corner === 'bl' ? startCrop.x + startCrop.width : startCrop.x;
     const anchorY =
       corner === 'tl' || corner === 'tr' ? startCrop.y + startCrop.height : startCrop.y;
-    const move = (e: PointerEvent) => {
+    trackPointerDrag(event, (e) => {
       const point = pointerToNatural(e);
       if (!point) return;
       const {
@@ -337,13 +402,7 @@ export const AssetCropEditor = ({
       });
       setCropPosition({ x, y });
       setCropSize({ width: w, height: h });
-    };
-    const up = () => {
-      window.removeEventListener('pointermove', move);
-      window.removeEventListener('pointerup', up);
-    };
-    window.addEventListener('pointermove', move);
-    window.addEventListener('pointerup', up);
+    });
   };
 
   const toggleAspectLock = () => {
@@ -356,9 +415,7 @@ export const AssetCropEditor = ({
 
   // Drag the focal handle within the crop rectangle, clamped 0–100.
   const handleFocalPointerDown = (event: React.PointerEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const move = (e: PointerEvent) => {
+    trackPointerDrag(event, (e) => {
       const point = pointerToNatural(e);
       if (!point) return;
       // Convert pointer to a percentage of the current crop area.
@@ -368,13 +425,7 @@ export const AssetCropEditor = ({
         x: Math.round(Math.min(100, Math.max(0, px))),
         y: Math.round(Math.min(100, Math.max(0, py))),
       });
-    };
-    const up = () => {
-      window.removeEventListener('pointermove', move);
-      window.removeEventListener('pointerup', up);
-    };
-    window.addEventListener('pointermove', move);
-    window.addEventListener('pointerup', up);
+    });
   };
 
   const focalPxX = Math.round((focal.x / 100) * width);
@@ -428,8 +479,8 @@ export const AssetCropEditor = ({
 
   return (
     <Portal>
-      <FocusTrap onEscape={onClose}>
-        <Overlay>
+      <FocusTrap onEscape={onClose} skipAutoFocus>
+        <Overlay ref={overlayRef} tabIndex={-1}>
           <HeaderBar alignItems="center">
             <Crop aria-hidden />
             <Typography variant="omega" fontWeight="bold">
@@ -640,17 +691,19 @@ export const AssetCropEditor = ({
               {formatMessage({ id: 'app.components.Button.cancel', defaultMessage: 'Cancel' })}
             </Button>
             <Flex gap={2}>
-              <Button
-                variant="secondary"
-                onClick={() => handleAction('copy')}
-                loading={isBusy}
-                disabled={!isReady}
-              >
-                {formatMessage({
-                  id: getTranslationKey('asset-details.crop.save-as-copy'),
-                  defaultMessage: 'Save as copy',
-                })}
-              </Button>
+              {canSaveAsCopy && (
+                <Button
+                  variant="secondary"
+                  onClick={() => handleAction('copy')}
+                  loading={isBusy}
+                  disabled={!isReady}
+                >
+                  {formatMessage({
+                    id: getTranslationKey('asset-details.crop.save-as-copy'),
+                    defaultMessage: 'Save as copy',
+                  })}
+                </Button>
+              )}
               <Button
                 variant="default"
                 onClick={() => handleAction('apply')}

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -41,6 +41,7 @@ import { styled } from 'styled-components';
 
 import { ASSET_TYPES } from '../../../../../enums';
 import { Drawer } from '../../../../components/Drawer';
+import { useMediaLibraryPermissions } from '../../../../hooks/useMediaLibraryPermissions';
 import { useUploadFileSilentlyMutation } from '../../../../services/api';
 import {
   useDeleteAssetMutation,
@@ -303,9 +304,10 @@ interface DetailFieldProps {
   name: string;
   label: string;
   required?: boolean;
+  disabled?: boolean;
 }
 
-const DetailField = ({ name, label, required }: DetailFieldProps) => {
+const DetailField = ({ name, label, required, disabled }: DetailFieldProps) => {
   const { formatMessage } = useIntl();
   const field = useField<string>(name);
   const isSubmitting = useForm('DetailField', (state) => state.isSubmitting);
@@ -349,7 +351,7 @@ const DetailField = ({ name, label, required }: DetailFieldProps) => {
           ) : undefined
         }
         type="text"
-        disabled={isSubmitting}
+        disabled={isSubmitting || disabled}
       />
     </Field.Root>
   );
@@ -363,9 +365,10 @@ interface LocationFieldProps {
   label: string;
   rootLabel: string;
   folders: Array<{ id: number; name: string }>;
+  disabled?: boolean;
 }
 
-const LocationField = ({ label, rootLabel, folders }: LocationFieldProps) => {
+const LocationField = ({ label, rootLabel, folders, disabled }: LocationFieldProps) => {
   const field = useField<number | null>('folder');
   const isSubmitting = useForm('LocationField', (state) => state.isSubmitting);
 
@@ -382,7 +385,7 @@ const LocationField = ({ label, rootLabel, folders }: LocationFieldProps) => {
           const next = value === '' ? null : Number(value);
           field.onChange('folder', next);
         }}
-        disabled={isSubmitting}
+        disabled={isSubmitting || disabled}
       >
         <SingleSelectOption value="">{rootLabel}</SingleSelectOption>
         {folders.map((folder) => (
@@ -703,6 +706,7 @@ interface AssetFormState {
 
 export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
   const { formatMessage, formatDate } = useIntl();
+  const { canUpdate, canDownload, canCopyLink } = useMediaLibraryPermissions();
   const { data: folders = [] } = useGetAllFoldersQuery();
   const { toggleNotification } = useNotification();
   const [updateAsset] = useUpdateAssetMutation();
@@ -944,7 +948,9 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
                     <AssetPreview
                       asset={asset}
                       actions={
-                        isImage ? <AssetImageActions onCrop={() => setIsCropOpen(true)} /> : null
+                        isImage && canUpdate ? (
+                          <AssetImageActions onCrop={() => setIsCropOpen(true)} />
+                        ) : null
                       }
                     />
                     <Flex
@@ -1058,6 +1064,7 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
                           defaultMessage: 'File name',
                         })}
                         required
+                        disabled={!canUpdate}
                       />
                       <LocationField
                         label={formatMessage({
@@ -1069,6 +1076,7 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
                           defaultMessage: 'Home',
                         })}
                         folders={folders}
+                        disabled={!canUpdate}
                       />
                       {isImage && (
                         <>
@@ -1078,6 +1086,7 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
                               id: getTranslationKey('asset-details.caption'),
                               defaultMessage: 'Caption',
                             })}
+                            disabled={!canUpdate}
                           />
                           <DetailField
                             name="alternativeText"
@@ -1085,39 +1094,46 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
                               id: getTranslationKey('asset-details.alternativeText'),
                               defaultMessage: 'Alternative text',
                             })}
+                            disabled={!canUpdate}
                           />
                         </>
                       )}
                     </Flex>
                   </Drawer.ScrollableContent>
-                  <Flex
-                    justifyContent="space-between"
-                    alignItems="center"
-                    gap={2}
-                    padding={3}
-                    borderColor="neutral150"
-                    borderStyle="solid"
-                    borderWidth="1px 0 0 0"
-                    background="neutral0"
-                  >
-                    <Flex gap={2}>
-                      <DeleteAssetButton />
-                      <CopyLinkButton asset={asset} />
-                      <DownloadAssetButton asset={asset} />
-                    </Flex>
-                    <Button
-                      type="submit"
-                      variant="default"
-                      loading={isSubmitting}
-                      // File name is required; block submit when it's empty or whitespace so the API can't 400 on a blank value.
-                      disabled={!modified || isSubmitting || nameIsEmpty}
+                  {/* Every footer action is permission-gated — when none survive,
+                      drop the whole bar instead of showing an empty strip. */}
+                  {(canUpdate || canCopyLink || canDownload) && (
+                    <Flex
+                      justifyContent="space-between"
+                      alignItems="center"
+                      gap={2}
+                      padding={3}
+                      borderColor="neutral150"
+                      borderStyle="solid"
+                      borderWidth="1px 0 0 0"
+                      background="neutral0"
                     >
-                      {formatMessage({
-                        id: getTranslationKey('asset-details.save'),
-                        defaultMessage: 'Save changes',
-                      })}
-                    </Button>
-                  </Flex>
+                      <Flex gap={2}>
+                        {canUpdate && <DeleteAssetButton />}
+                        {canCopyLink && <CopyLinkButton asset={asset} />}
+                        {canDownload && <DownloadAssetButton asset={asset} />}
+                      </Flex>
+                      {canUpdate && (
+                        <Button
+                          type="submit"
+                          variant="default"
+                          loading={isSubmitting}
+                          // File name is required; block submit when it's empty or whitespace so the API can't 400 on a blank value.
+                          disabled={!modified || isSubmitting || nameIsEmpty}
+                        >
+                          {formatMessage({
+                            id: getTranslationKey('asset-details.save'),
+                            defaultMessage: 'Save changes',
+                          })}
+                        </Button>
+                      )}
+                    </Flex>
+                  )}
                 </>
               );
             }}

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -309,7 +309,21 @@ const DetailField = ({ name, label, required }: DetailFieldProps) => {
   const { formatMessage } = useIntl();
   const field = useField<string>(name);
   const isSubmitting = useForm('DetailField', (state) => state.isSubmitting);
-  const value = field.value ?? '';
+
+  // The form context (use-context-selector) echoes changes back
+  // asynchronously — driving the input straight from `field.value` makes
+  // React rewrite the DOM value after the keystroke, which throws the cursor
+  // to the end of the field. The input is therefore controlled by local state
+  // (synchronous, cursor-safe) and the form follows; the effect below only
+  // matters for EXTERNAL value changes (discard/reset), where a cursor jump
+  // is fine because the user isn't typing.
+  const fieldValue = field.value ?? '';
+  const [value, setValue] = React.useState(fieldValue);
+
+  React.useEffect(() => {
+    setValue(fieldValue);
+  }, [fieldValue]);
+
   const emptyTooltipLabel = formatMessage(
     {
       id: getTranslationKey('asset-details.field.empty'),
@@ -323,9 +337,10 @@ const DetailField = ({ name, label, required }: DetailFieldProps) => {
       <Field.Label>{label}</Field.Label>
       <TextInput
         value={value}
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-          field.onChange(name, event.target.value)
-        }
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          setValue(event.target.value);
+          field.onChange(name, event.target.value);
+        }}
         endAction={
           !value ? (
             <Tooltip label={emptyTooltipLabel}>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -706,7 +706,7 @@ interface AssetFormState {
 
 export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
   const { formatMessage, formatDate } = useIntl();
-  const { canUpdate, canDownload, canCopyLink } = useMediaLibraryPermissions();
+  const { canCreate, canUpdate, canDownload, canCopyLink } = useMediaLibraryPermissions();
   const { data: folders = [] } = useGetAllFoldersQuery();
   const { toggleNotification } = useNotification();
   const [updateAsset] = useUpdateAssetMutation();
@@ -926,6 +926,7 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
                       onClose={() => setIsCropOpen(false)}
                       onApply={handleCropApply}
                       onSaveAsCopy={handleCropSaveAsCopy}
+                      canSaveAsCopy={canCreate}
                     />
                   ) : null}
                   {busyMessage ? (
@@ -1271,7 +1272,11 @@ export const AssetDetailsDrawer = () => {
       <Drawer.Body
         animationDirection="left"
         width="41.6rem"
-        height="100vh"
+        // dvh, not vh: the drawer is anchored to the bottom, so with 100vh on
+        // mobile (where the URL bar shrinks the visual viewport below 100vh)
+        // the top of the drawer — header, title, close button — is pushed
+        // off-screen. dvh tracks the actual visible height.
+        height="100dvh"
         onAnimationEnd={onCloseAnimationEnd}
       >
         <DrawerContent assetId={assetId} closeDetails={closeDetails} />

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
@@ -1,0 +1,211 @@
+import { fireEvent, render, screen } from '@tests/utils';
+
+import { AssetCropEditor } from '../AssetCropEditor';
+
+import type { AssetWithPopulatedCreatedBy } from '../../../../../../../../shared/contracts/files';
+
+const asset = {
+  id: 1,
+  name: 'photo.png',
+  alternativeText: 'A photo',
+  caption: null,
+  ext: '.png',
+  mime: 'image/png',
+  size: 1024,
+  width: 800,
+  height: 600,
+  hash: 'photo',
+  url: '/uploads/photo.png',
+  folder: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  formats: {},
+  createdBy: null,
+} as unknown as AssetWithPopulatedCreatedBy;
+
+/**
+ * jsdom (v20) has no PointerEvent constructor, `naturalWidth`/`naturalHeight`
+ * are always 0, and layout boxes are empty — everything the crop editor's
+ * pointer-to-natural mapping relies on is stubbed here.
+ */
+const pointerEvent = (type: string, props: Record<string, unknown>) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, props);
+  return event;
+};
+
+const NATURAL = { width: 800, height: 600 };
+
+let restoreRect: () => void;
+let restoreNatural: () => void;
+
+beforeAll(() => {
+  const originalRect = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: NATURAL.width,
+      bottom: NATURAL.height,
+      width: NATURAL.width,
+      height: NATURAL.height,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  restoreRect = () => {
+    Element.prototype.getBoundingClientRect = originalRect;
+  };
+
+  const widthDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLImageElement.prototype,
+    'naturalWidth'
+  );
+  const heightDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLImageElement.prototype,
+    'naturalHeight'
+  );
+  Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', {
+    configurable: true,
+    get: () => NATURAL.width,
+  });
+  Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', {
+    configurable: true,
+    get: () => NATURAL.height,
+  });
+  restoreNatural = () => {
+    if (widthDescriptor) {
+      Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', widthDescriptor);
+    }
+    if (heightDescriptor) {
+      Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', heightDescriptor);
+    }
+  };
+});
+
+afterAll(() => {
+  restoreRect();
+  restoreNatural();
+});
+
+const renderEditor = async ({ canSaveAsCopy = true }: { canSaveAsCopy?: boolean } = {}) => {
+  const utils = render(
+    <AssetCropEditor
+      asset={asset}
+      onClose={jest.fn()}
+      onApply={jest.fn()}
+      onSaveAsCopy={jest.fn()}
+      canSaveAsCopy={canSaveAsCopy}
+    />
+  );
+
+  // Seed the crop state: the editor only initialises once the image loads.
+  const image = document.querySelector('img') as HTMLImageElement;
+  fireEvent.load(image);
+
+  const focalHandle = await screen.findByRole('button', { name: 'Focal point' });
+
+  return { ...utils, focalHandle };
+};
+
+// `touch-action: none` on the drag surfaces is the other half of this fix
+// (stops mobile browsers from claiming the gesture for scrolling, which fires
+// pointercancel mid-drag) — jsdom's CSSOM drops the property, so it can't be
+// asserted here.
+describe('AssetCropEditor focus on open', () => {
+  it('focuses the overlay container instead of the first field (keyboard would pop on mobile)', async () => {
+    await renderEditor();
+
+    const active = document.activeElement as HTMLElement;
+    expect(active.tagName).not.toBe('INPUT');
+    expect(active).toHaveAttribute('tabindex', '-1');
+  });
+});
+
+describe('AssetCropEditor pointer drags', () => {
+  it('follows the pointer for the whole focal-point drag', async () => {
+    const { focalHandle } = await renderEditor();
+
+    fireEvent(
+      focalHandle,
+      pointerEvent('pointerdown', { pointerId: 1, clientX: 400, clientY: 300 })
+    );
+    fireEvent(window, pointerEvent('pointermove', { pointerId: 1, clientX: 600, clientY: 450 }));
+
+    // 600/800 and 450/600 of the full-image crop → 75% on both axes.
+    expect(focalHandle).toHaveStyle({ left: '75%', top: '75%' });
+
+    fireEvent(window, pointerEvent('pointerup', { pointerId: 1, clientX: 600, clientY: 450 }));
+  });
+
+  it('stops the drag on pointercancel and ignores later moves', async () => {
+    const { focalHandle } = await renderEditor();
+
+    fireEvent(
+      focalHandle,
+      pointerEvent('pointerdown', { pointerId: 1, clientX: 400, clientY: 300 })
+    );
+    fireEvent(window, pointerEvent('pointermove', { pointerId: 1, clientX: 600, clientY: 450 }));
+    fireEvent(window, pointerEvent('pointercancel', { pointerId: 1 }));
+
+    // The gesture ended — a move from a later touch must not drag the handle.
+    fireEvent(window, pointerEvent('pointermove', { pointerId: 1, clientX: 80, clientY: 60 }));
+
+    expect(focalHandle).toHaveStyle({ left: '75%', top: '75%' });
+  });
+
+  it('ignores moves from other concurrent pointers', async () => {
+    const { focalHandle } = await renderEditor();
+
+    fireEvent(
+      focalHandle,
+      pointerEvent('pointerdown', { pointerId: 1, clientX: 400, clientY: 300 })
+    );
+    // A second finger lands elsewhere — its moves must not steal the drag.
+    fireEvent(window, pointerEvent('pointermove', { pointerId: 2, clientX: 80, clientY: 60 }));
+
+    expect(focalHandle).toHaveStyle({ left: '50%', top: '50%' });
+
+    fireEvent(window, pointerEvent('pointerup', { pointerId: 1, clientX: 400, clientY: 300 }));
+  });
+});
+
+describe('AssetCropEditor save-as-copy gating', () => {
+  it('shows "Save as copy" when the user can create assets', async () => {
+    await renderEditor({ canSaveAsCopy: true });
+
+    expect(screen.getByRole('button', { name: 'Save as copy' })).toBeInTheDocument();
+    // Apply (crop in place = assets.update) is always present.
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+  });
+
+  it('hides "Save as copy" without create permission, keeping Apply', async () => {
+    await renderEditor({ canSaveAsCopy: false });
+
+    expect(screen.queryByRole('button', { name: 'Save as copy' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+  });
+});
+
+describe('AssetCropEditor drag cleanup on unmount', () => {
+  it('removes window drag listeners when unmounted mid-drag', async () => {
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+    const { focalHandle, unmount } = await renderEditor();
+
+    // Start a drag but never release it.
+    fireEvent(
+      focalHandle,
+      pointerEvent('pointerdown', { pointerId: 1, clientX: 400, clientY: 300 })
+    );
+
+    unmount();
+
+    // The unmount cleanup must tear down all three window listeners so a stale
+    // onMove can't fire on the unmounted component.
+    for (const type of ['pointermove', 'pointerup', 'pointercancel']) {
+      expect(removeSpy).toHaveBeenCalledWith(type, expect.any(Function));
+    }
+
+    removeSpy.mockRestore();
+  });
+});

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -95,7 +95,7 @@ describe('AssetDetails (asset details drawer body)', () => {
 
     expect(screen.queryByRole('button', { name: 'Apply' })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Crop' }));
+    await user.click(await screen.findByRole('button', { name: 'Crop' }));
 
     expect(await screen.findByRole('button', { name: 'Apply' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save as copy' })).toBeInTheDocument();
@@ -113,6 +113,8 @@ describe('AssetDetails (asset details drawer body)', () => {
     const { user } = render(<AssetDetails asset={baseAsset} closeDetails={jest.fn()} />);
 
     const nameInput = await screen.findByDisplayValue('photo.png');
+    // The field starts disabled until the RBAC check resolves.
+    await waitFor(() => expect(nameInput).toBeEnabled());
     await user.clear(nameInput);
     await user.type(nameInput, 'updated.png');
 
@@ -198,7 +200,7 @@ describe('AssetDetails (asset details drawer body)', () => {
     // Wait for folders query so the toast can resolve the folder name.
     await screen.findByRole('combobox');
 
-    const trashButton = screen.getByRole('button', { name: 'Delete this file' });
+    const trashButton = await screen.findByRole('button', { name: 'Delete this file' });
     await user.click(trashButton);
 
     // Dialog opens via Radix AlertDialog — match by the body copy.
@@ -220,7 +222,7 @@ describe('AssetDetails (asset details drawer body)', () => {
     const { user } = render(<AssetDetails asset={baseAsset} closeDetails={closeDetails} />);
 
     await screen.findByRole('combobox');
-    await user.click(screen.getByRole('button', { name: 'Delete this file' }));
+    await user.click(await screen.findByRole('button', { name: 'Delete this file' }));
     await screen.findByText(/This file cannot be recovered/i);
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
@@ -254,7 +256,7 @@ describe('AssetDetails (asset details drawer body)', () => {
     // Confirm dialog must NOT be visible before the trigger is clicked.
     expect(screen.queryByText(/Replace this media file\?/i)).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Replace this file' }));
+    await user.click(await screen.findByRole('button', { name: 'Replace this file' }));
 
     await screen.findByText(/Replace this media file\?/i);
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
@@ -283,8 +285,92 @@ describe('AssetDetails (asset details drawer body)', () => {
     const { user } = render(<AssetDetails asset={baseAsset} closeDetails={jest.fn()} />);
     await screen.findByRole('combobox');
 
-    await user.click(screen.getByRole('button', { name: 'Replace this file' }));
+    await user.click(await screen.findByRole('button', { name: 'Replace this file' }));
 
     await screen.findByText(/AI will generate new metadata after upload/i);
+  });
+});
+
+describe('AssetDetails RBAC gating', () => {
+  beforeEach(() => {
+    server.use(buildFoldersHandler(), buildSettingsHandler());
+  });
+
+  const withoutAction = (action: string) => ({
+    providerOptions: {
+      permissions: (defaults: Array<{ action: string }>) =>
+        defaults.filter((permission) => permission.action !== action),
+    },
+  });
+
+  it('hides every mutating action and disables the fields without assets.update', async () => {
+    render(
+      <AssetDetails asset={baseAsset} closeDetails={jest.fn()} />,
+      withoutAction('plugin::upload.assets.update')
+    );
+
+    const nameInput = await screen.findByDisplayValue('photo.png');
+    await waitFor(() => expect(nameInput).toBeDisabled());
+    expect(screen.getByDisplayValue('A caption')).toBeDisabled();
+    expect(screen.getByDisplayValue('A photo')).toBeDisabled();
+
+    expect(screen.queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete this file' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Crop' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Replace this file' })).not.toBeInTheDocument();
+
+    // Read-scoped actions survive.
+    expect(screen.getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+  });
+
+  it('drops the footer bar entirely when no footer action is permitted', async () => {
+    render(<AssetDetails asset={baseAsset} closeDetails={jest.fn()} />, {
+      providerOptions: {
+        permissions: (defaults: Array<{ action: string }>) =>
+          defaults.filter(
+            (permission) =>
+              ![
+                'plugin::upload.assets.update',
+                'plugin::upload.assets.download',
+                'plugin::upload.assets.copy-link',
+              ].includes(permission.action)
+          ),
+      },
+    });
+
+    const nameInput = await screen.findByDisplayValue('photo.png');
+    await waitFor(() => expect(nameInput).toBeDisabled());
+
+    for (const name of ['Save changes', 'Delete this file', 'Copy link', 'Download']) {
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument();
+    }
+  });
+
+  it('hides the download action without assets.download', async () => {
+    render(
+      <AssetDetails asset={baseAsset} closeDetails={jest.fn()} />,
+      withoutAction('plugin::upload.assets.download')
+    );
+
+    await screen.findByDisplayValue('photo.png');
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument()
+    );
+    expect(screen.getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete this file' })).toBeInTheDocument();
+  });
+
+  it('hides the copy link action without assets.copy-link', async () => {
+    render(
+      <AssetDetails asset={baseAsset} closeDetails={jest.fn()} />,
+      withoutAction('plugin::upload.assets.copy-link')
+    );
+
+    await screen.findByDisplayValue('photo.png');
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Copy link' })).not.toBeInTheDocument()
+    );
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
   });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
@@ -14,6 +14,7 @@ import { useIntl } from 'react-intl';
 import { styled, css } from 'styled-components';
 
 import { ASSET_TYPES } from '../../../../enums';
+import { useMediaLibraryPermissions } from '../../../hooks/useMediaLibraryPermissions';
 import { prefixFileUrlWithBackendUrl } from '../../../utils/files';
 import { getAssetIcon } from '../../../utils/getAssetIcon';
 import { getTranslationKey } from '../../../utils/translations';
@@ -139,6 +140,7 @@ const FolderCard = ({ folder, orderedItemKeys }: FolderCardProps) => {
   const { navigateToFolder } = useFolderNavigation();
   const { isMovePending } = useAssetsDndOptional() ?? { isMovePending: false };
   const { isSelected, toggle, selectRange } = useAssetSelection();
+  const { canUpdate } = useMediaLibraryPermissions();
   const {
     draggable: { attributes, listeners, setNodeRef: setDragRef, isDragging },
     droppable: { setNodeRef: setDropRef },
@@ -201,19 +203,21 @@ const FolderCard = ({ folder, orderedItemKeys }: FolderCardProps) => {
       role="listitem"
       tabIndex={0}
     >
-      <Flex onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}>
-        <Checkbox
-          checked={isSelected(key)}
-          onClick={handleCheckboxClick}
-          aria-label={formatMessage(
-            {
-              id: getTranslationKey('list.table.row.select'),
-              defaultMessage: 'Select {name}',
-            },
-            { name: folder.name }
-          )}
-        />
-      </Flex>
+      {canUpdate && (
+        <Flex onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}>
+          <Checkbox
+            checked={isSelected(key)}
+            onClick={handleCheckboxClick}
+            aria-label={formatMessage(
+              {
+                id: getTranslationKey('list.table.row.select'),
+                defaultMessage: 'Select {name}',
+              },
+              { name: folder.name }
+            )}
+          />
+        </Flex>
+      )}
       <FolderIconContainer>
         <FolderIcon width={20} height={20} />
       </FolderIconContainer>
@@ -368,6 +372,7 @@ const AssetCard = ({ asset, orderedItemKeys, onAssetItemClick }: AssetCardProps)
   const { isMovePending } = useAssetsDndOptional() ?? { isMovePending: false };
   const { attributes, listeners, setNodeRef, isDragging } = useFileDraggable(asset);
   const { isSelected, toggle, selectRange } = useAssetSelection();
+  const { canUpdate } = useMediaLibraryPermissions();
 
   const key = assetKey(asset.id);
   const selected = isSelected(key);
@@ -427,19 +432,21 @@ const AssetCard = ({ asset, orderedItemKeys, onAssetItemClick }: AssetCardProps)
       onKeyDown={handleKeyDown}
     >
       <StyledCardHeader>
-        <CheckboxOverlay onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}>
-          <Checkbox
-            checked={selected}
-            onClick={handleCheckboxClick}
-            aria-label={formatMessage(
-              {
-                id: getTranslationKey('list.table.row.select'),
-                defaultMessage: 'Select {name}',
-              },
-              { name: asset.name }
-            )}
-          />
-        </CheckboxOverlay>
+        {canUpdate && (
+          <CheckboxOverlay onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}>
+            <Checkbox
+              checked={selected}
+              onClick={handleCheckboxClick}
+              aria-label={formatMessage(
+                {
+                  id: getTranslationKey('list.table.row.select'),
+                  defaultMessage: 'Select {name}',
+                },
+                { name: asset.name }
+              )}
+            />
+          </CheckboxOverlay>
+        )}
         <AssetPreview asset={asset} />
       </StyledCardHeader>
       <CardBody>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
@@ -16,6 +16,7 @@ import { Folder as FolderIcon, More } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { styled, css } from 'styled-components';
 
+import { useMediaLibraryPermissions } from '../../../hooks/useMediaLibraryPermissions';
 import { formatBytes } from '../../../utils/files';
 import { getAssetIcon } from '../../../utils/getAssetIcon';
 import { getTranslationKey } from '../../../utils/translations';
@@ -177,6 +178,7 @@ const AssetRow = ({ asset, orderedItemKeys, onAssetItemClick }: AssetRowProps) =
   const { isMovePending } = useAssetsDndOptional() ?? { isMovePending: false };
   const { attributes, listeners, setNodeRef, isDragging } = useFileDraggable(asset);
   const { isSelected, toggle, selectRange } = useAssetSelection();
+  const { canUpdate } = useMediaLibraryPermissions();
 
   const key = assetKey(asset.id);
   const selected = isSelected(key);
@@ -233,8 +235,9 @@ const AssetRow = ({ asset, orderedItemKeys, onAssetItemClick }: AssetRowProps) =
       onClick={handleRowClick}
       onKeyDown={handleKeyDown}
     >
-      {/* TODO:? no checkbox column on mobile — multi-select on mobile is deferred. */}
-      {!isMobile && (
+      {/* No checkbox column on mobile (multi-select deferred) or without the
+          update permission (nothing selectable can be acted on). */}
+      {!isMobile && canUpdate && (
         <CheckboxTd onClick={stopRowEvent} onKeyDown={stopRowEvent}>
           <Flex>
             <Checkbox
@@ -321,6 +324,7 @@ const FolderRow = ({ folder, orderedItemKeys }: FolderRowProps) => {
   const { formatDate, formatMessage } = useIntl();
   const { navigateToFolder } = useFolderNavigation();
   const { isSelected, toggle, selectRange } = useAssetSelection();
+  const { canUpdate } = useMediaLibraryPermissions();
   const { isMovePending } = useAssetsDndOptional() ?? { isMovePending: false };
   const {
     draggable: { attributes, listeners, setNodeRef: setDragRef, isDragging },
@@ -382,7 +386,7 @@ const FolderRow = ({ folder, orderedItemKeys }: FolderRowProps) => {
       onClick={handleRowClick}
       onKeyDown={handleKeyDown}
     >
-      {!isMobile && (
+      {!isMobile && canUpdate && (
         <CheckboxTd onClick={stopRowEvent} onKeyDown={stopRowEvent}>
           <Flex>
             <Checkbox
@@ -476,14 +480,17 @@ export const AssetsTable = ({
   const isMobile = useIsMobile();
   const { formatMessage } = useIntl();
   const { selectedKeys, selectAll, clear } = useAssetSelection();
+  const { canUpdate } = useMediaLibraryPermissions();
 
   const visibleHeaders = isMobile
     ? TABLE_HEADERS.filter((h) => h.name === 'name' || h.name === 'actions')
     : TABLE_HEADERS;
 
   // The checkbox column is a dedicated structural column (not part of
-  // TABLE_HEADERS) and is hidden on mobile.
-  const showCheckboxColumn = !isMobile;
+  // TABLE_HEADERS). Hidden on mobile (multi-select deferred) and without the
+  // update permission — every bulk action needs `assets.update`, so a
+  // read-only user has nothing to select for.
+  const showCheckboxColumn = !isMobile && canUpdate;
   const colCount = visibleHeaders.length + (showCheckboxColumn ? 1 : 0);
 
   const totalRows = folders.length + assets.length;

--- a/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
@@ -11,6 +11,7 @@ import {
   isAIMetadataSupportedMime,
 } from '../../../../../../shared/constants';
 import { useAIAvailability } from '../../../../hooks/useAiAvailability';
+import { useMediaLibraryPermissions } from '../../../hooks/useMediaLibraryPermissions';
 import {
   useBulkDeleteItemsMutation,
   useGenerateAiMetadataMutation,
@@ -70,6 +71,9 @@ export const BulkActionsBar = ({ assets = [] }: BulkActionsBarProps) => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
   const { isEnabled: isAiMetadataEnabled } = useAIAvailability();
+  // Every bulk action (move, delete, metadata) is an `assets.update` mutation
+  // server-side — one flag gates the whole cluster.
+  const { canUpdate } = useMediaLibraryPermissions();
   const { selectedIds, selectedFolderIds, clear } = useAssetSelection();
   const [bulkDeleteItems, { isLoading: isDeleting }] = useBulkDeleteItemsMutation();
   const [generateAiMetadata, { isLoading: isGeneratingMetadata }] = useGenerateAiMetadataMutation();
@@ -245,7 +249,11 @@ export const BulkActionsBar = ({ assets = [] }: BulkActionsBarProps) => {
     clear();
   };
 
-  if (count === 0) {
+  // Every bulk action is behind `assets.update`; with nothing selected, or
+  // without the permission, the bar has nothing to offer — drop it entirely
+  // rather than show a count + "Clear selection" over no actions (mirrors the
+  // drawer footer, which hides when no permitted action survives).
+  if (count === 0 || !canUpdate) {
     return null;
   }
 
@@ -268,6 +276,8 @@ export const BulkActionsBar = ({ assets = [] }: BulkActionsBarProps) => {
         )}
       </Typography>
 
+      {/* Past the early return the user always has `assets.update`, so the
+          individual actions no longer re-check it. */}
       <ActionCluster>
         {isAiMetadataEnabled && (
           <Tooltip label={metadataDisabledReason}>
@@ -363,7 +373,10 @@ export const BulkActionsBar = ({ assets = [] }: BulkActionsBarProps) => {
             <Dialog.Footer>
               <Dialog.Cancel>
                 <Button variant="tertiary" disabled={isDeleting} fullWidth>
-                  {formatMessage({ id: 'app.components.Button.cancel', defaultMessage: 'Cancel' })}
+                  {formatMessage({
+                    id: 'app.components.Button.cancel',
+                    defaultMessage: 'Cancel',
+                  })}
                 </Button>
               </Dialog.Cancel>
               <Dialog.Action>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/Dnd/AssetsDndProvider.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/Dnd/AssetsDndProvider.tsx
@@ -22,6 +22,7 @@ import { useNotification } from '@strapi/admin/strapi-admin';
 import { Box, VisuallyHidden } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
+import { useMediaLibraryPermissions } from '../../../../hooks/useMediaLibraryPermissions';
 import { useBulkMoveMutation, useGetFolderStructureQuery } from '../../../../services/folders';
 import { buildBulkMovePayload } from '../../../../utils/buildBulkMovePayload';
 import { canDropItemOnFolder } from '../../../../utils/canDropItemOnFolder';
@@ -100,6 +101,11 @@ const resolveDestination = (
   return null;
 };
 
+// Activation distance no real pointer gesture will ever reach — used to keep a
+// constant-length sensor array while disabling drag for users without the move
+// permission (see the note in the provider).
+const DRAG_DISABLED_DISTANCE = Number.MAX_SAFE_INTEGER;
+
 export const AssetsDndProvider = ({ children }: AssetsDndProviderProps) => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
@@ -121,9 +127,21 @@ export const AssetsDndProvider = ({ children }: AssetsDndProviderProps) => {
     requestAnimationFrame(() => setLiveAnnouncement(message));
   }, []);
 
+  // Moving is a mutation (bulk-move → `assets.update`); without the permission
+  // pointer drag must never activate. Keyboard moves go through BulkMoveDialog,
+  // which is itself gated.
+  //
+  // The gate has to keep BOTH the `useSensor`/`useSensors` calls AND the sensor
+  // array's length constant across renders: `canUpdate` starts false and flips
+  // true once the RBAC check resolves, and dnd-kit keys internal memos/effects
+  // on the sensor list, erroring if its size changes ("argument changed size
+  // between renders"). So adding/removing a sensor is out — instead keep one
+  // PointerSensor always and push its activation distance out of reach when the
+  // user can't move, which no real drag gesture will ever satisfy.
+  const { canUpdate } = useMediaLibraryPermissions();
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      activationConstraint: { distance: 8 },
+      activationConstraint: { distance: canUpdate ? 8 : DRAG_DISABLED_DISTANCE },
     })
   );
 

--- a/packages/core/upload/admin/src/future/pages/Assets/components/DropZone/UploadDropZoneContext.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/DropZone/UploadDropZoneContext.tsx
@@ -46,9 +46,20 @@ const DropZoneWrapper = styled(Box)`
 interface UploadDropZoneProps {
   children: ReactNode;
   onDrop?: DropHandler;
+  /**
+   * When true, the zone never enters the dragging state and never fires
+   * `onDrop` — no overlay, no "drop here" invitation. Used to hide the whole
+   * upload affordance from users without `assets.create`, so they don't drag a
+   * file onto an inviting target that then silently discards it.
+   */
+  disabled?: boolean;
 }
 
-export const UploadDropZoneProvider = ({ children, onDrop }: UploadDropZoneProps) => {
+export const UploadDropZoneProvider = ({
+  children,
+  onDrop,
+  disabled = false,
+}: UploadDropZoneProps) => {
   const [isDragging, setIsDragging] = useState(false);
   const dragCounterRef = useRef(0);
 
@@ -80,19 +91,27 @@ export const UploadDropZoneProvider = ({ children, onDrop }: UploadDropZoneProps
     };
   }, []);
 
-  const handleDragEnter = useCallback((e: DragEvent<HTMLElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const handleDragEnter = useCallback(
+    (e: DragEvent<HTMLElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
 
-    // Bidirectional guard with AssetsDndProvider — internal item drags must not
-    // activate the upload overlay. See AssetsDndProvider.tsx.
-    if (!e.dataTransfer.types.includes('Files')) {
-      return;
-    }
+      // No upload permission → never light up the drop target.
+      if (disabled) {
+        return;
+      }
 
-    dragCounterRef.current += 1;
-    setIsDragging(true);
-  }, []);
+      // Bidirectional guard with AssetsDndProvider — internal item drags must not
+      // activate the upload overlay. See AssetsDndProvider.tsx.
+      if (!e.dataTransfer.types.includes('Files')) {
+        return;
+      }
+
+      dragCounterRef.current += 1;
+      setIsDragging(true);
+    },
+    [disabled]
+  );
 
   const handleDragLeave = useCallback((e: DragEvent<HTMLElement>) => {
     e.preventDefault();
@@ -121,12 +140,16 @@ export const UploadDropZoneProvider = ({ children, onDrop }: UploadDropZoneProps
       setIsDragging(false);
       dragCounterRef.current = 0;
 
+      if (disabled) {
+        return;
+      }
+
       const { files } = e.dataTransfer;
       if (files?.length && onDrop) {
         onDrop(Array.from(files));
       }
     },
-    [onDrop]
+    [onDrop, disabled]
   );
 
   return (

--- a/packages/core/upload/admin/src/future/pages/Assets/components/EmptyState.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/EmptyState.tsx
@@ -7,6 +7,12 @@ import { getTranslationKey } from '../../../utils/translations';
 
 interface EmptyStateProps {
   onAddAssets: () => void;
+  /**
+   * RBAC gate — without `assets.create` the "Add assets" CTA is hidden.
+   * Required (not defaulted) so a permission gate can't silently regress to
+   * permissive when a future call site forgets to pass it.
+   */
+  canAddAssets: boolean;
   searchQuery?: string;
   onClearSearch?: () => void;
 }
@@ -17,7 +23,12 @@ interface EmptyStateProps {
  * as New > File upload; drag-and-drop upload keeps working since the page-wide
  * drop zone wraps this component.
  */
-export const EmptyState = ({ onAddAssets, searchQuery, onClearSearch }: EmptyStateProps) => {
+export const EmptyState = ({
+  onAddAssets,
+  canAddAssets,
+  searchQuery,
+  onClearSearch,
+}: EmptyStateProps) => {
   const { formatMessage } = useIntl();
   const isSearchEmptyState = Boolean(searchQuery);
 
@@ -60,12 +71,14 @@ export const EmptyState = ({ onAddAssets, searchQuery, onClearSearch }: EmptySta
           })}
         </Button>
       ) : (
-        <Button onClick={onAddAssets}>
-          {formatMessage({
-            id: getTranslationKey('list.empty.add-assets'),
-            defaultMessage: 'Add assets',
-          })}
-        </Button>
+        canAddAssets && (
+          <Button onClick={onAddAssets}>
+            {formatMessage({
+              id: getTranslationKey('list.empty.add-assets'),
+              defaultMessage: 'Add assets',
+            })}
+          </Button>
+        )
       )}
     </Flex>
   );

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useAssetSelection.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useAssetSelection.ts
@@ -54,27 +54,48 @@ const AssetSelectionContext = createContext<AssetSelection | null>(null);
 
 interface AssetSelectionProviderProps {
   children: ReactNode;
+  /**
+   * When true, selection is inert: every mutator is a no-op and nothing ever
+   * reads as selected. Every bulk action is gated on `assets.update`, so a user
+   * without it has nothing to select for — the views also hide the checkboxes,
+   * and this makes the remaining paths (click-to-select, Space key) do nothing.
+   */
+  disabled?: boolean;
 }
 
-export const AssetSelectionProvider = ({ children }: AssetSelectionProviderProps) => {
+export const AssetSelectionProvider = ({
+  children,
+  disabled = false,
+}: AssetSelectionProviderProps) => {
   const [state, setState] = useState<SelectionState>(createEmptySelection);
 
   const isSelected = useCallback(
-    (key: ItemKey) => state.selectedKeys.has(key),
-    [state.selectedKeys]
+    (key: ItemKey) => !disabled && state.selectedKeys.has(key),
+    [disabled, state.selectedKeys]
   );
 
-  const toggle = useCallback((key: ItemKey) => setState((prev) => toggleSelection(prev, key)), []);
+  const toggle = useCallback(
+    (key: ItemKey) => {
+      if (disabled) return;
+      setState((prev) => toggleSelection(prev, key));
+    },
+    [disabled]
+  );
 
   const selectRange = useCallback(
-    (orderedKeys: ItemKey[], targetKey: ItemKey) =>
-      setState((prev) => selectRangeState(prev, orderedKeys, targetKey)),
-    []
+    (orderedKeys: ItemKey[], targetKey: ItemKey) => {
+      if (disabled) return;
+      setState((prev) => selectRangeState(prev, orderedKeys, targetKey));
+    },
+    [disabled]
   );
 
   const selectAll = useCallback(
-    (orderedKeys: ItemKey[]) => setState(selectAllState(orderedKeys)),
-    []
+    (orderedKeys: ItemKey[]) => {
+      if (disabled) return;
+      setState(selectAllState(orderedKeys));
+    },
+    [disabled]
   );
 
   const clear = useCallback(() => setState(clearSelection()), []);

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
@@ -1,5 +1,5 @@
 import { userEvent } from '@testing-library/user-event';
-import { render, screen } from '@tests/utils';
+import { render, screen, waitFor } from '@tests/utils';
 
 import { AssetsGrid } from '../components/AssetsGrid';
 import { BulkActionsBar } from '../components/BulkActionsBar';
@@ -344,6 +344,31 @@ describe('AssetsGrid', () => {
   });
 
   describe('Selection', () => {
+    it('hides all card checkboxes without assets.update', async () => {
+      render(
+        <>
+          <AssetsGrid
+            assets={mockAssets}
+            folders={[createMockFolder(1, 'Photos')]}
+            onAssetItemClick={mockOnAssetItemClick}
+          />
+          <BulkActionsBar />
+        </>,
+        {
+          renderOptions: { wrapper: AssetSelectionProvider },
+          providerOptions: {
+            permissions: (defaults: Array<{ action: string }>) =>
+              defaults.filter((permission) => permission.action !== 'plugin::upload.assets.update'),
+          },
+        }
+      );
+
+      expect(await screen.findByText('image1.png')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+      });
+    });
+
     it('opens the asset details on plain card click (no selection)', async () => {
       const { user } = setup();
       const cards = screen.getAllByRole('listitem');
@@ -371,7 +396,7 @@ describe('AssetsGrid', () => {
       const { user } = setup();
       const cards = screen.getAllByRole('listitem');
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
       await user.keyboard('{Shift>}');
       await user.click(cards[2]);
       await user.keyboard('{/Shift}');
@@ -383,12 +408,12 @@ describe('AssetsGrid', () => {
       const folders = [createMockFolder(1, 'Photos')];
       const { user } = setup({ folders, assets: mockAssets });
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select Photos' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select Photos' }));
 
       expect(screen.getByText('1 item selected')).toBeInTheDocument();
       expect(mockNavigateToFolder).not.toHaveBeenCalled();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select Photos' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select Photos' }));
       expect(screen.queryByRole('region', { name: 'Bulk actions' })).not.toBeInTheDocument();
     });
 
@@ -404,20 +429,20 @@ describe('AssetsGrid', () => {
     it('toggles selection additively via the corner checkbox', async () => {
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
 
       // Checkbox is additive (unlike plain card click, which replaces).
       expect(screen.getByText('2 items selected')).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
     });
 
     it('extends the selection range with Shift+click on the corner checkbox', async () => {
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
       await user.keyboard('{Shift>}');
-      await user.click(screen.getByRole('checkbox', { name: 'Select image3.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image3.png' }));
       await user.keyboard('{/Shift}');
 
       expect(screen.getByText('3 items selected')).toBeInTheDocument();
@@ -454,9 +479,9 @@ describe('AssetsGrid', () => {
 
       expect(mockNavigateToFolder).not.toHaveBeenCalled();
       expect(screen.getByText('3 items selected')).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
-      expect(screen.getByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
-      expect(screen.getByRole('checkbox', { name: 'Select image3.png' })).not.toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image3.png' })).not.toBeChecked();
     });
   });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
@@ -441,3 +441,42 @@ describe('AssetsPage search', () => {
     });
   });
 });
+
+describe('AssetsPage RBAC gating', () => {
+  const withoutCreate = {
+    providerOptions: {
+      permissions: (defaults: Array<{ action: string }>) =>
+        defaults.filter((permission) => permission.action !== 'plugin::upload.assets.create'),
+    },
+  };
+
+  it('shows the New menu with the default permissions', async () => {
+    respondWithAssets([createAsset(1, 'image.png')]);
+
+    renderPage();
+    await findHeading();
+
+    expect(await screen.findByRole('button', { name: 'New' })).toBeInTheDocument();
+  });
+
+  it('hides the New menu without assets.create', async () => {
+    respondWithAssets([createAsset(1, 'image.png')]);
+
+    render(<AssetsPage />, { initialEntries: ['/'], ...withoutCreate });
+    await findHeading();
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
+    );
+  });
+
+  it('hides the empty-state Add assets action without assets.create', async () => {
+    respondWithAssets([]);
+    respondWithFolders([]);
+
+    render(<AssetsPage />, { initialEntries: ['/'], ...withoutCreate });
+
+    expect(await screen.findByText('No assets yet')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add assets' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
@@ -260,18 +260,51 @@ describe('AssetsTable', () => {
   });
 
   describe('Selection', () => {
-    it('renders a selection checkbox on each asset row', () => {
+    it('hides all selection checkboxes and the select-all header without assets.update', async () => {
+      render(
+        <>
+          <AssetsTable
+            assets={mockAssets}
+            folders={[createMockFolder(1, 'Photos')]}
+            onAssetItemClick={mockOnAssetItemClick}
+          />
+          <BulkActionsBar />
+        </>,
+        {
+          renderOptions: { wrapper: AssetSelectionProvider },
+          providerOptions: {
+            permissions: (defaults: Array<{ action: string }>) =>
+              defaults.filter((permission) => permission.action !== 'plugin::upload.assets.update'),
+          },
+        }
+      );
+
+      // Rows still render; only the selection affordance is gone.
+      expect(await screen.findByText('image1.png')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+      });
+      expect(screen.queryByRole('checkbox', { name: 'Select all' })).not.toBeInTheDocument();
+    });
+
+    it('renders a selection checkbox on each asset row', async () => {
       setup();
 
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Select image2.png' })).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Select image3.png' })).toBeInTheDocument();
+      expect(
+        await screen.findByRole('checkbox', { name: 'Select image1.png' })
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('checkbox', { name: 'Select image2.png' })
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('checkbox', { name: 'Select image3.png' })
+      ).toBeInTheDocument();
     });
 
     it('toggles folder selection via the folder checkbox and counts it in the bar', async () => {
       const { user } = setup({ folders: [createMockFolder(1, 'Photos')], assets: mockAssets });
 
-      const folderCheckbox = screen.getByRole('checkbox', { name: 'Select Photos' });
+      const folderCheckbox = await screen.findByRole('checkbox', { name: 'Select Photos' });
       expect(folderCheckbox).toBeEnabled();
 
       await user.click(folderCheckbox);
@@ -291,7 +324,7 @@ describe('AssetsTable', () => {
       await user.click(firstAssetRow);
 
       expect(mockOnAssetItemClick).toHaveBeenCalledWith(1);
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).not.toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).not.toBeChecked();
     });
 
     it('opens details (and does not select) when the filename is clicked', async () => {
@@ -300,36 +333,36 @@ describe('AssetsTable', () => {
       await user.click(screen.getByText('image1.png'));
 
       expect(mockOnAssetItemClick).toHaveBeenCalledWith(1);
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).not.toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).not.toBeChecked();
     });
 
     it('toggles selection via the row checkbox without opening details', async () => {
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
 
-      expect(screen.getByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
       expect(mockOnAssetItemClick).not.toHaveBeenCalled();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
-      expect(screen.getByRole('checkbox', { name: 'Select image2.png' })).not.toBeChecked();
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
+      expect(await screen.findByRole('checkbox', { name: 'Select image2.png' })).not.toBeChecked();
     });
 
     it('selects folders and assets via the header checkbox and shows indeterminate when partial', async () => {
       const { user } = setup({ folders: [createMockFolder(1, 'Photos')], assets: mockAssets });
 
-      const selectAll = screen.getByRole('checkbox', { name: 'Select all' });
+      const selectAll = await screen.findByRole('checkbox', { name: 'Select all' });
 
       await user.click(selectAll);
 
-      expect(screen.getByRole('checkbox', { name: 'Select Photos' })).toBeChecked();
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
-      expect(screen.getByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
-      expect(screen.getByRole('checkbox', { name: 'Select image3.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select Photos' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image3.png' })).toBeChecked();
       expect(screen.getByText('4 items selected')).toBeInTheDocument();
 
       // Unchecking one item leaves the header checkbox in the indeterminate state.
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
       expect(selectAll).toHaveAttribute('data-state', 'indeterminate');
     });
 
@@ -337,11 +370,11 @@ describe('AssetsTable', () => {
       const { user } = setup({ folders: [createMockFolder(1, 'Photos')], assets: mockAssets });
 
       // Selecting every asset but not the folder must not report "all selected".
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image3.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image3.png' }));
 
-      expect(screen.getByRole('checkbox', { name: 'Select all' })).toHaveAttribute(
+      expect(await screen.findByRole('checkbox', { name: 'Select all' })).toHaveAttribute(
         'data-state',
         'indeterminate'
       );
@@ -350,14 +383,14 @@ describe('AssetsTable', () => {
     it('clears the selection from the header checkbox when all are selected', async () => {
       const { user } = setup({ folders: [createMockFolder(1, 'Photos')], assets: mockAssets });
 
-      const selectAll = screen.getByRole('checkbox', { name: 'Select all' });
+      const selectAll = await screen.findByRole('checkbox', { name: 'Select all' });
 
       await user.click(selectAll);
       expect(screen.getByText('4 items selected')).toBeInTheDocument();
 
       await user.click(selectAll);
       expect(screen.queryByText(/items? selected/)).not.toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Select Photos' })).not.toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select Photos' })).not.toBeChecked();
     });
 
     it('selects a contiguous range across folders and assets with Shift+click', async () => {
@@ -365,15 +398,15 @@ describe('AssetsTable', () => {
 
       // Anchor on the folder, then Shift+click the second asset: the folder and
       // the first two assets end up selected.
-      await user.click(screen.getByRole('checkbox', { name: 'Select Photos' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select Photos' }));
       await user.keyboard('{Shift>}');
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
       await user.keyboard('{/Shift}');
 
-      expect(screen.getByRole('checkbox', { name: 'Select Photos' })).toBeChecked();
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
-      expect(screen.getByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
-      expect(screen.getByRole('checkbox', { name: 'Select image3.png' })).not.toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select Photos' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image3.png' })).not.toBeChecked();
       expect(screen.getByText('3 items selected')).toBeInTheDocument();
     });
   });
@@ -388,7 +421,7 @@ describe('AssetsTable', () => {
     it('shows the singular count and clears the selection on close', async () => {
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
 
       const bar = screen.getByRole('region', { name: 'Bulk actions' });
       expect(bar).toBeInTheDocument();
@@ -397,13 +430,13 @@ describe('AssetsTable', () => {
       await user.click(screen.getByRole('button', { name: 'Clear selection' }));
 
       expect(screen.queryByRole('region', { name: 'Bulk actions' })).not.toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).not.toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).not.toBeChecked();
     });
 
     it('renders the bulk action buttons when assets are selected', async () => {
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
 
       expect(screen.getByRole('button', { name: 'Create metadata' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Move' })).toBeInTheDocument();
@@ -431,8 +464,8 @@ describe('AssetsTable', () => {
 
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
       await user.click(screen.getByRole('button', { name: 'Create metadata' }));
 
       await waitFor(() =>
@@ -464,9 +497,9 @@ describe('AssetsTable', () => {
 
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image3.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image3.png' }));
       await user.click(screen.getByRole('button', { name: 'Create metadata' }));
 
       await waitFor(() =>
@@ -483,7 +516,7 @@ describe('AssetsTable', () => {
         assets: [createMockAsset(1, 'doc.pdf', 'application/pdf', '.pdf')],
       });
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select doc.pdf' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select doc.pdf' }));
 
       // The server would only ever report this back as fully skipped, so the
       // request is never worth sending.
@@ -498,8 +531,8 @@ describe('AssetsTable', () => {
         ],
       });
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select doc.pdf' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select doc.pdf' }));
 
       expect(screen.getByRole('button', { name: 'Create metadata' })).toBeEnabled();
     });
@@ -515,8 +548,8 @@ describe('AssetsTable', () => {
 
       const { user } = setup({ folders: [createMockFolder(1, 'Photos')], assets: mockAssets });
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select Photos' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select Photos' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
       await user.click(screen.getByRole('button', { name: 'Create metadata' }));
 
       // Everything sent succeeded, but the folder was never eligible — warn
@@ -544,7 +577,7 @@ describe('AssetsTable', () => {
 
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
       await user.click(screen.getByRole('button', { name: 'Create metadata' }));
 
       await waitFor(() =>
@@ -553,7 +586,7 @@ describe('AssetsTable', () => {
           message: 'An error occurred while generating metadata.',
         })
       );
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
       expect(screen.getByRole('region', { name: 'Bulk actions' })).toBeInTheDocument();
     });
 
@@ -574,8 +607,8 @@ describe('AssetsTable', () => {
 
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
       await user.click(screen.getByRole('button', { name: 'Create metadata' }));
 
       await waitFor(() =>
@@ -585,14 +618,14 @@ describe('AssetsTable', () => {
         })
       );
       // A 200 where nothing was written must not clear the selection.
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
       expect(screen.getByRole('region', { name: 'Bulk actions' })).toBeInTheDocument();
     });
 
     it('opens the move dialog when Move is clicked and cancels without moving', async () => {
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
       await user.click(screen.getByRole('button', { name: 'Move' }));
 
       expect(await screen.findByText('Move elements to')).toBeInTheDocument();
@@ -602,7 +635,7 @@ describe('AssetsTable', () => {
 
       expect(screen.queryByText('Move elements to')).not.toBeInTheDocument();
       // Selection untouched, nothing sent.
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
       expect(mockToggleNotification).not.toHaveBeenCalled();
     });
 
@@ -632,8 +665,8 @@ describe('AssetsTable', () => {
 
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
       await user.click(screen.getByRole('button', { name: 'Move' }));
 
       // Pick the destination folder in the Location select (defaults to the root).
@@ -671,7 +704,7 @@ describe('AssetsTable', () => {
 
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
       await user.click(screen.getByRole('button', { name: 'Move' }));
 
       // Move to the root (default destination) — the request itself fails. The
@@ -694,13 +727,13 @@ describe('AssetsTable', () => {
 
       // Selection kept for retry.
       expect(screen.getByRole('region', { name: 'Bulk actions' })).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
     });
 
     it('opens a confirm dialog when Delete is clicked and cancels without deleting', async () => {
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
       await user.click(screen.getByRole('button', { name: 'Delete' }));
 
       expect(await screen.findByText('Delete 1 item?')).toBeInTheDocument();
@@ -709,7 +742,7 @@ describe('AssetsTable', () => {
 
       expect(screen.queryByText('Delete 1 item?')).not.toBeInTheDocument();
       // Selection untouched, nothing sent.
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
       expect(mockToggleNotification).not.toHaveBeenCalled();
     });
 
@@ -728,8 +761,8 @@ describe('AssetsTable', () => {
 
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
-      await user.click(screen.getByRole('checkbox', { name: 'Select image2.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
       await user.click(screen.getByRole('button', { name: 'Delete' }));
       await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
@@ -755,7 +788,7 @@ describe('AssetsTable', () => {
 
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
       await user.click(screen.getByRole('button', { name: 'Delete' }));
       await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
@@ -774,7 +807,7 @@ describe('AssetsTable', () => {
 
       // Selection kept for retry.
       expect(screen.getByRole('region', { name: 'Bulk actions' })).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
     });
 
     it('hides Create metadata when AI metadata is unavailable', async () => {
@@ -782,7 +815,7 @@ describe('AssetsTable', () => {
 
       const { user } = setup();
 
-      await user.click(screen.getByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
 
       expect(screen.queryByRole('button', { name: 'Create metadata' })).not.toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Move' })).toBeInTheDocument();

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/EmptyState.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/EmptyState.test.tsx
@@ -4,7 +4,7 @@ import { EmptyState } from '../components/EmptyState';
 
 describe('EmptyState', () => {
   it('renders the title, description and Add assets action', () => {
-    render(<EmptyState onAddAssets={jest.fn()} />);
+    render(<EmptyState onAddAssets={jest.fn()} canAddAssets />);
 
     expect(screen.getByText('No assets yet')).toBeInTheDocument();
     expect(
@@ -15,16 +15,30 @@ describe('EmptyState', () => {
 
   it('calls onAddAssets when the button is clicked', async () => {
     const onAddAssets = jest.fn();
-    const { user } = render(<EmptyState onAddAssets={onAddAssets} />);
+    const { user } = render(<EmptyState onAddAssets={onAddAssets} canAddAssets />);
 
     await user.click(screen.getByRole('button', { name: 'Add assets' }));
 
     expect(onAddAssets).toHaveBeenCalledTimes(1);
   });
 
+  it('hides the Add assets action when canAddAssets is false', () => {
+    render(<EmptyState onAddAssets={jest.fn()} canAddAssets={false} />);
+
+    expect(screen.getByText('No assets yet')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add assets' })).not.toBeInTheDocument();
+  });
+
   describe('when searching', () => {
     it('renders no-results copy including the query', () => {
-      render(<EmptyState onAddAssets={jest.fn()} searchQuery="kitten" onClearSearch={jest.fn()} />);
+      render(
+        <EmptyState
+          onAddAssets={jest.fn()}
+          canAddAssets
+          searchQuery="kitten"
+          onClearSearch={jest.fn()}
+        />
+      );
 
       expect(screen.getByText('No results found')).toBeInTheDocument();
       expect(
@@ -33,7 +47,14 @@ describe('EmptyState', () => {
     });
 
     it('replaces "Add assets" with "Clear search"', () => {
-      render(<EmptyState onAddAssets={jest.fn()} searchQuery="kitten" onClearSearch={jest.fn()} />);
+      render(
+        <EmptyState
+          onAddAssets={jest.fn()}
+          canAddAssets
+          searchQuery="kitten"
+          onClearSearch={jest.fn()}
+        />
+      );
 
       expect(screen.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Add assets' })).not.toBeInTheDocument();
@@ -42,7 +63,12 @@ describe('EmptyState', () => {
     it('calls onClearSearch when the button is clicked', async () => {
       const onClearSearch = jest.fn();
       const { user } = render(
-        <EmptyState onAddAssets={jest.fn()} searchQuery="kitten" onClearSearch={onClearSearch} />
+        <EmptyState
+          onAddAssets={jest.fn()}
+          canAddAssets
+          searchQuery="kitten"
+          onClearSearch={onClearSearch}
+        />
       );
 
       await user.click(screen.getByRole('button', { name: 'Clear search' }));
@@ -51,7 +77,9 @@ describe('EmptyState', () => {
     });
 
     it('falls back to the no-assets state when the query is empty', () => {
-      render(<EmptyState onAddAssets={jest.fn()} searchQuery="" onClearSearch={jest.fn()} />);
+      render(
+        <EmptyState onAddAssets={jest.fn()} canAddAssets searchQuery="" onClearSearch={jest.fn()} />
+      );
 
       expect(screen.getByText('No assets yet')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Add assets' })).toBeInTheDocument();


### PR DESCRIPTION
### What does it do?

Four MVP fixes for the new Media Library, one commit per ticket:

- **CMS-1536 — cursor jumps in asset details fields**: the admin `Form` context (use-context-selector) echoes field changes back asynchronously, so React rewrote the input DOM value after each keystroke and threw the cursor to the end. The fields are now controlled by local state (synchronous, cursor-safe) with the form as follower; external resets (discard) still sync back.

https://github.com/user-attachments/assets/6eb199b3-07e9-4954-8d3f-ba5d08c7922b


- **CMS-434 — asset permissions applied to the UI**: the future Media Library rendered every action regardless of the user's role. New `useMediaLibraryPermissions` hook (wraps `useRBAC` over the plugin's asset permissions), gating: "New" menu + page-wide drop-zone + empty-state CTA (`assets.create`), bulk move/delete/metadata bar, drag-and-drop moves, drawer delete/crop/replace/save + editable fields (`assets.update`), copy link (`assets.copy-link`) and download (`assets.download`). The drawer footer bar disappears entirely when no action survives. The server already enforced all of this route-side — this stops users discovering missing permissions through 403s.
- **CMS-1538 — crop drag dies on touch devices**: the drag surfaces had no `touch-action: none`, so mobile browsers claimed the gesture for scrolling and fired `pointercancel` mid-drag; the cancel event also was never cleaned up. Now: `touch-action: none` on the crop overlay/resize handles/focal point, a shared `trackPointerDrag` helper with pointer capture, `pointercancel` treated as release, and moves filtered by `pointerId` (multi-touch safe). Also: horizontal padding in the editor body so edge handles stay grabbable, and no auto-focus on the first field when the editor opens (the focus trap focused the crop-width input, popping the mobile keyboard) — focus goes to the overlay container instead.
- **CMS-1539 — drawer header hidden on mobile**: the drawer is anchored to the bottom with `height: 100vh`; on mobile the visual viewport is smaller than `100vh` (URL bar), so the top of the panel — title and close button — was pushed off-screen. Switched to `100dvh` (and the container's default max-height), which tracks the real visible height. Desktop unchanged.

### Why is it needed?

All four are part of the Media Library revamp MVP stabilization (milestone "Ensure stability and performance" / "Improve UI/UX"): typing in the rename field was unusable, role permissions were not reflected in the UI at all (already taken care of on the backend side though), and the crop tool and details drawer were broken on mobile.

### How to test it?

`UNSTABLE_MEDIA_LIBRARY=true yarn develop` then navigate to `/admin/plugins/unstable-upload`

1. **Cursor**: open an asset's details, place the cursor mid-word in File name / Caption / Alt text, type or delete — the cursor stays put.
2. **Permissions**: Settings → Roles → duplicate a role, disable *Update (crop, details, replace) + delete* on Media Library, log in as a user of that role: no New menu, no bulk actions, no delete/crop/replace/save in the drawer, fields disabled, drag-and-drop move inert, drop-zone upload refused. Toggle the other actions (create / download / copy link) to see each control appear/disappear. With everything off, the drawer footer bar is gone entirely.
3. **Mobile crop** (real device or devtools device mode + touch): open an image, Crop — no keyboard pops on open; drag the corner handles, the crop rectangle and the focal point: they follow the finger for the whole gesture; the image no longer touches the screen edges.
4. **Mobile drawer**: open asset details on a phone — header with title and close button visible; the close button works.

### Related issue(s)/PR(s)

fix CMS-1536
fix CMS-434
fix CMS-1538
fix CMS-1539

_Generated with AI, edited by @Adzouz_

🚀