### PR TITLE
fix(upload): stream URL imports to disk instead of buffering in memory

### DIFF
--- a/packages/core/upload/server/src/services/__tests__/file.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/file.test.ts
@@ -1,3 +1,7 @@
+import os from 'os';
+import path from 'path';
+import fse from 'fs-extra';
+
 import fileService from '../file';
 
 const folderPath = '/1';
@@ -107,6 +111,233 @@ describe('file', () => {
       expect(result).toHaveProperty('url', 'file-url');
       expect(provider.isPrivate).toHaveBeenCalledTimes(1);
       expect(provider.getSignedUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchUrlToInputFile', () => {
+    const url = 'https://example.com/files/photo.jpg';
+    let tmpWorkingDirectory: string;
+
+    /**
+     * Builds a web ReadableStream from chunks, optionally erroring after all chunks are emitted.
+     */
+    const webStreamFrom = (chunks: Uint8Array[], errorAfterChunks?: Error) =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          chunks.forEach((chunk) => controller.enqueue(chunk));
+          if (errorAfterChunks) {
+            controller.error(errorAfterChunks);
+          } else {
+            controller.close();
+          }
+        },
+      });
+
+    /**
+     * Minimal Response-like object with a streaming body and a spied `arrayBuffer`, so tests can
+     * assert the implementation never buffers the whole file.
+     */
+    const createStreamingResponse = ({
+      chunks,
+      headers = {},
+      errorAfterChunks,
+      body,
+    }: {
+      chunks?: Uint8Array[];
+      headers?: Record<string, string>;
+      errorAfterChunks?: Error;
+      body?: null;
+    }) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      url,
+      headers: new Headers(headers),
+      body: body === null ? null : webStreamFrom(chunks ?? [], errorAfterChunks),
+      arrayBuffer: jest.fn(() => {
+        throw new Error('arrayBuffer() must not be called: the body must be streamed to disk');
+      }),
+    });
+
+    beforeEach(async () => {
+      tmpWorkingDirectory = await fse.mkdtemp(path.join(os.tmpdir(), 'strapi-url-upload-test-'));
+
+      global.strapi = {
+        fetch: jest.fn(),
+      } as any;
+    });
+
+    afterEach(async () => {
+      await fse.remove(tmpWorkingDirectory);
+    });
+
+    const mockFetch = (response: unknown) => {
+      (global.strapi.fetch as jest.Mock).mockResolvedValue(response);
+    };
+
+    test('Streams the body to disk without ever reading it into a single buffer', async () => {
+      const chunks = [Buffer.from('hello '), Buffer.from('streamed '), Buffer.from('world')].map(
+        (chunk) => new Uint8Array(chunk)
+      );
+      const response = createStreamingResponse({ chunks });
+      mockFetch(response);
+
+      const { file } = await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory);
+
+      expect(response.arrayBuffer).not.toHaveBeenCalled();
+      expect(file.filepath).toBe(path.join(tmpWorkingDirectory, 'photo.jpg'));
+      expect(await fse.readFile(file.filepath, 'utf8')).toBe('hello streamed world');
+    });
+
+    test('Derives the size from the file written on disk', async () => {
+      const chunks = [new Uint8Array(Buffer.alloc(500, 1)), new Uint8Array(Buffer.alloc(300, 2))];
+      mockFetch(createStreamingResponse({ chunks }));
+
+      const { file } = await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory);
+
+      const { size } = await fse.stat(file.filepath);
+      expect(file.size).toBe(size);
+      expect(file.size).toBe(800);
+    });
+
+    test('Rejects when the streamed bytes exceed sizeLimit and no Content-Length is sent', async () => {
+      const chunks = Array.from({ length: 5 }, () => new Uint8Array(Buffer.alloc(100, 3)));
+      mockFetch(createStreamingResponse({ chunks }));
+
+      await expect(fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, 250)).rejects.toThrow(
+        'File too large'
+      );
+      await expect(fse.readdir(tmpWorkingDirectory)).resolves.toEqual([]);
+    });
+
+    test('Rejects when Content-Length understates the real body size', async () => {
+      const chunks = Array.from({ length: 5 }, () => new Uint8Array(Buffer.alloc(100, 4)));
+      mockFetch(createStreamingResponse({ chunks, headers: { 'content-length': '50' } }));
+
+      await expect(fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, 250)).rejects.toThrow(
+        'File too large'
+      );
+      await expect(fse.readdir(tmpWorkingDirectory)).resolves.toEqual([]);
+    });
+
+    test('Rejects early when Content-Length exceeds sizeLimit', async () => {
+      const response = createStreamingResponse({
+        chunks: [new Uint8Array(Buffer.alloc(10))],
+        headers: { 'content-length': String(5 * 1024 * 1024) },
+      });
+      mockFetch(response);
+
+      const onProgress = jest.fn();
+      await expect(
+        fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, 1024 * 1024, onProgress)
+      ).rejects.toThrow('File too large: maximum allowed size is 1MB');
+      expect(response.arrayBuffer).not.toHaveBeenCalled();
+      // Rejected on the header fast-path, so no progress is ever announced
+      expect(onProgress).not.toHaveBeenCalled();
+      await expect(fse.readdir(tmpWorkingDirectory)).resolves.toEqual([]);
+    });
+
+    test('Removes the partial temp file when the stream errors mid-transfer', async () => {
+      const chunks = [new Uint8Array(Buffer.alloc(100, 5))];
+      mockFetch(createStreamingResponse({ chunks, errorAfterChunks: new Error('socket hang up') }));
+
+      await expect(fileService.fetchUrlToInputFile(url, tmpWorkingDirectory)).rejects.toThrow(
+        'socket hang up'
+      );
+      await expect(fse.readdir(tmpWorkingDirectory)).resolves.toEqual([]);
+    });
+
+    test('Reports cumulative progress with the parsed Content-Length as totalBytes', async () => {
+      const chunks = [
+        new Uint8Array(Buffer.alloc(100, 6)),
+        new Uint8Array(Buffer.alloc(150, 7)),
+        new Uint8Array(Buffer.alloc(50, 8)),
+      ];
+      mockFetch(createStreamingResponse({ chunks, headers: { 'content-length': '300' } }));
+
+      const onProgress = jest.fn();
+      await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, undefined, onProgress);
+
+      expect(onProgress.mock.calls.map(([progress]) => progress)).toEqual([
+        // Initial announcement, before any bytes are read
+        { bytesWritten: 0, totalBytes: 300 },
+        { bytesWritten: 100, totalBytes: 300 },
+        { bytesWritten: 250, totalBytes: 300 },
+        { bytesWritten: 300, totalBytes: 300 },
+      ]);
+    });
+
+    test('Announces totalBytes with a zero-byte report before the first chunk', async () => {
+      const chunks = [new Uint8Array(Buffer.alloc(400, 1)), new Uint8Array(Buffer.alloc(600, 2))];
+      mockFetch(createStreamingResponse({ chunks, headers: { 'content-length': '1000' } }));
+
+      const onProgress = jest.fn();
+      await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, undefined, onProgress);
+
+      // Ordering matters: consumers size their progress bar from this first report, so it must
+      // land before any chunk-driven call rather than merely happen at some point.
+      expect(onProgress.mock.calls[0][0]).toEqual({ bytesWritten: 0, totalBytes: 1000 });
+      expect(onProgress.mock.calls[1][0]).toEqual({ bytesWritten: 400, totalBytes: 1000 });
+    });
+
+    test('Announces totalBytes as null in the initial report when Content-Length is absent', async () => {
+      mockFetch(createStreamingResponse({ chunks: [new Uint8Array(Buffer.alloc(25, 3))] }));
+
+      const onProgress = jest.fn();
+      await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, undefined, onProgress);
+
+      expect(onProgress.mock.calls[0][0]).toEqual({ bytesWritten: 0, totalBytes: null });
+    });
+
+    test('Reports every chunk without internal throttling', async () => {
+      // 10 chunks emitted back-to-back: a naive time-based throttle inside the service would
+      // collapse these into one or two reports. Throttling is the caller's responsibility.
+      const chunkCount = 10;
+      const chunks = Array.from({ length: chunkCount }, () => new Uint8Array(Buffer.alloc(64, 4)));
+      mockFetch(createStreamingResponse({ chunks }));
+
+      const onProgress = jest.fn();
+      await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, undefined, onProgress);
+
+      // One report per chunk, plus the initial zero-byte announcement
+      expect(onProgress).toHaveBeenCalledTimes(chunkCount + 1);
+      expect(onProgress.mock.calls.map(([progress]) => progress.bytesWritten)).toEqual([
+        0, 64, 128, 192, 256, 320, 384, 448, 512, 576, 640,
+      ]);
+    });
+
+    test('Reports totalBytes as null when Content-Length is absent', async () => {
+      mockFetch(createStreamingResponse({ chunks: [new Uint8Array(Buffer.alloc(10, 9))] }));
+
+      const onProgress = jest.fn();
+      await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, undefined, onProgress);
+
+      expect(onProgress).toHaveBeenCalledWith({ bytesWritten: 10, totalBytes: null });
+    });
+
+    test('Works without a progress callback', async () => {
+      mockFetch(createStreamingResponse({ chunks: [new Uint8Array(Buffer.from('no callback'))] }));
+
+      const { file } = await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory);
+
+      expect(file.size).toBe(11);
+    });
+
+    test('Writes an empty file when the response has no body', async () => {
+      mockFetch(createStreamingResponse({ body: null }));
+
+      const onProgress = jest.fn();
+      const { file } = await fileService.fetchUrlToInputFile(
+        url,
+        tmpWorkingDirectory,
+        undefined,
+        onProgress
+      );
+
+      expect(file.size).toBe(0);
+      await expect(fse.readFile(file.filepath, 'utf8')).resolves.toBe('');
+      // The initial announcement still fires, so the first report is always a size announcement
+      expect(onProgress.mock.calls).toEqual([[{ bytesWritten: 0, totalBytes: null }]]);
     });
   });
 });

--- a/packages/core/upload/server/src/services/__tests__/file.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/file.test.ts
@@ -164,6 +164,7 @@ describe('file', () => {
 
       global.strapi = {
         fetch: jest.fn(),
+        log: { warn: jest.fn() },
       } as any;
     });
 
@@ -230,11 +231,26 @@ describe('file', () => {
       const onProgress = jest.fn();
       await expect(
         fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, 1024 * 1024, onProgress)
-      ).rejects.toThrow('File too large: maximum allowed size is 1MB');
+      ).rejects.toThrow('File too large: maximum allowed size is 1 MB');
       expect(response.arrayBuffer).not.toHaveBeenCalled();
       // Rejected on the header fast-path, so no progress is ever announced
       expect(onProgress).not.toHaveBeenCalled();
       await expect(fse.readdir(tmpWorkingDirectory)).resolves.toEqual([]);
+    });
+
+    test('Reports small size limits in a readable unit rather than rounding them to 0MB', async () => {
+      const sizeLimit = 200 * 1000;
+      mockFetch(
+        createStreamingResponse({
+          chunks: [new Uint8Array(Buffer.alloc(sizeLimit + 1, 1))],
+        })
+      );
+
+      // A 200KB limit is well under 1MB: formatting it in whole megabytes would tell the user the
+      // maximum allowed size is "0MB".
+      await expect(
+        fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, sizeLimit)
+      ).rejects.toThrow('File too large: maximum allowed size is 200 KB');
     });
 
     test('Removes the partial temp file when the stream errors mid-transfer', async () => {
@@ -280,13 +296,18 @@ describe('file', () => {
       expect(onProgress.mock.calls[1][0]).toEqual({ bytesWritten: 400, totalBytes: 1000 });
     });
 
-    test('Announces totalBytes as null in the initial report when Content-Length is absent', async () => {
+    test('Reports totalBytes as null throughout when Content-Length is absent', async () => {
       mockFetch(createStreamingResponse({ chunks: [new Uint8Array(Buffer.alloc(25, 3))] }));
 
       const onProgress = jest.fn();
       await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, undefined, onProgress);
 
-      expect(onProgress.mock.calls[0][0]).toEqual({ bytesWritten: 0, totalBytes: null });
+      // Null in the initial announcement, and still null once bytes flow — a consumer must not see
+      // a total materialise mid-stream
+      expect(onProgress.mock.calls.map(([progress]) => progress)).toEqual([
+        { bytesWritten: 0, totalBytes: null },
+        { bytesWritten: 25, totalBytes: null },
+      ]);
     });
 
     test('Reports every chunk without internal throttling', async () => {
@@ -306,13 +327,56 @@ describe('file', () => {
       ]);
     });
 
-    test('Reports totalBytes as null when Content-Length is absent', async () => {
-      mockFetch(createStreamingResponse({ chunks: [new Uint8Array(Buffer.alloc(10, 9))] }));
+    test('Ignores a throwing progress callback instead of failing the import', async () => {
+      const chunks = [
+        new Uint8Array(Buffer.from('still ')),
+        new Uint8Array(Buffer.from('written')),
+      ];
+      mockFetch(createStreamingResponse({ chunks }));
 
-      const onProgress = jest.fn();
-      await fileService.fetchUrlToInputFile(url, tmpWorkingDirectory, undefined, onProgress);
+      const onProgress = jest.fn(() => {
+        throw new Error('consumer bug');
+      });
 
-      expect(onProgress).toHaveBeenCalledWith({ bytesWritten: 10, totalBytes: null });
+      // Node surfaces a synchronous throw from `_transform` as a stream error, so an unguarded
+      // callback would reject the pipeline and abort a download that was otherwise fine
+      const { file } = await fileService.fetchUrlToInputFile(
+        url,
+        tmpWorkingDirectory,
+        undefined,
+        onProgress
+      );
+
+      expect(await fse.readFile(file.filepath, 'utf8')).toBe('still written');
+      expect(file.size).toBe(13);
+      // Every report still attempted — one failing call does not disable subsequent reporting
+      expect(onProgress).toHaveBeenCalledTimes(chunks.length + 1);
+      expect(global.strapi.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining('progress callback threw')
+      );
+    });
+
+    test('Keeps the original error when removing the partial temp file fails', async () => {
+      const chunks = [new Uint8Array(Buffer.alloc(100, 5))];
+      mockFetch(createStreamingResponse({ chunks, errorAfterChunks: new Error('socket hang up') }));
+
+      // `fse.remove` is overloaded (promise + callback), so mock the implementation rather than
+      // using mockRejectedValue, which resolves against the callback signature
+      const removeSpy = jest.spyOn(fse, 'remove').mockImplementation(async () => {
+        throw new Error('EPERM: operation not permitted');
+      });
+
+      try {
+        // The cleanup failure must not mask the error the caller acts on
+        await expect(fileService.fetchUrlToInputFile(url, tmpWorkingDirectory)).rejects.toThrow(
+          'socket hang up'
+        );
+        expect(global.strapi.log.warn).toHaveBeenCalledWith(
+          expect.stringContaining('Could not remove partial temp file')
+        );
+      } finally {
+        removeSpy.mockRestore();
+      }
     });
 
     test('Works without a progress callback', async () => {

--- a/packages/core/upload/server/src/services/file.ts
+++ b/packages/core/upload/server/src/services/file.ts
@@ -7,7 +7,7 @@ import { pipeline } from 'node:stream/promises';
 import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 import fse from 'fs-extra';
 import { cloneDeep } from 'lodash/fp';
-import { async, errors } from '@strapi/utils';
+import { async, errors, file as fileUtils } from '@strapi/utils';
 
 import { FOLDER_MODEL_UID, FILE_MODEL_UID } from '../constants';
 import { getService } from '../utils';
@@ -15,6 +15,7 @@ import { getService } from '../utils';
 import { Config, type File } from '../types';
 
 const { ApplicationError } = errors;
+const { bytesToHumanReadable } = fileUtils;
 
 const FETCH_TIMEOUT_MS = 60_000; // 60 seconds
 
@@ -108,6 +109,8 @@ const getFilenameFromUrl = (url: string, contentDisposition?: string | null): st
  *   64KB chunks yields ~8000 calls). Throttling here would bake one consumer's frame rate into a
  *   shared service, and a pre-throttled counter cannot be un-throttled by a caller that needs
  *   every byte.
+ * - If it throws, the error is logged and swallowed: reporting is observational, so a buggy
+ *   consumer never fails the import.
  */
 const fetchUrlToInputFile = async (
   url: string,
@@ -159,7 +162,7 @@ const fetchUrlToInputFile = async (
 
   const tooLargeError = () =>
     new ApplicationError(
-      `File too large: maximum allowed size is ${Math.round((sizeLimit ?? 0) / (1024 * 1024))}MB`
+      `File too large: maximum allowed size is ${bytesToHumanReadable(sizeLimit ?? 0)}`
     );
 
   const parsedContentLength = parseInt(response.headers.get('content-length') ?? '', 10);
@@ -170,11 +173,28 @@ const fetchUrlToInputFile = async (
     throw tooLargeError();
   }
 
+  // Progress reporting is a side-channel for UI: a consumer that throws should not fail the import
+  // it is merely observing. Node turns a synchronous throw inside `_transform` into a stream error,
+  // so an unguarded callback would reject the pipeline and abort a download that was fine.
+  const reportProgress = (progress: UrlFetchProgress) => {
+    if (!onProgress) return;
+
+    try {
+      onProgress(progress);
+    } catch (error) {
+      strapi?.log?.warn(
+        `URL fetch progress callback threw, ignoring: ${
+          error instanceof Error ? error.message : error
+        }`
+      );
+    }
+  };
+
   // Announce the total before any bytes are dispatched. Consumers that size a progress bar from
   // `totalBytes` need it up front: a consumer clamping bytes to a not-yet-known size would clamp
   // every early chunk to zero. Fires exactly once, even when `totalBytes` is null or the body is
   // empty, so the first call is always a size announcement.
-  onProgress?.({ bytesWritten: 0, totalBytes });
+  reportProgress({ bytesWritten: 0, totalBytes });
 
   // Get content type and filename
   const contentType =
@@ -203,7 +223,7 @@ const fetchUrlToInputFile = async (
           }
 
           // Raw, one call per chunk, no throttling — see `onProgress` on the signature above
-          onProgress?.({ bytesWritten, totalBytes });
+          reportProgress({ bytesWritten, totalBytes });
           callback(null, chunk);
         },
       });
@@ -216,8 +236,19 @@ const fetchUrlToInputFile = async (
     }
   } catch (error) {
     // Remove the partially written file — the caller only cleans up the temp directory once all
-    // URLs have been processed
-    await fse.remove(tmpFilePath);
+    // URLs have been processed. Cleanup failures must not replace the error the caller cares about
+    // ("File too large", "socket hang up") with an incidental filesystem one, so swallow and log:
+    // the request-level temp-directory cleanup is still the backstop for the leftover file.
+    try {
+      await fse.remove(tmpFilePath);
+    } catch (cleanupError) {
+      strapi?.log?.warn(
+        `Could not remove partial temp file ${tmpFilePath}: ${
+          cleanupError instanceof Error ? cleanupError.message : cleanupError
+        }`
+      );
+    }
+
     throw error;
   }
 

--- a/packages/core/upload/server/src/services/file.ts
+++ b/packages/core/upload/server/src/services/file.ts
@@ -1,6 +1,10 @@
 import path from 'path';
 import dns from 'dns/promises';
 import net from 'net';
+import { createWriteStream } from 'node:fs';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 import fse from 'fs-extra';
 import { cloneDeep } from 'lodash/fp';
 import { async, errors } from '@strapi/utils';
@@ -41,6 +45,17 @@ interface FetchUrlResult {
 }
 
 /**
+ * Progress of a URL fetch.
+ *
+ * `bytesWritten` is cumulative and non-decreasing (the first report is always 0).
+ * `totalBytes` is the parsed Content-Length when the header is present and valid, `null` otherwise.
+ */
+interface UrlFetchProgress {
+  bytesWritten: number;
+  totalBytes: number | null;
+}
+
+/**
  * Extracts filename from a URL path or Content-Disposition header
  */
 const getFilenameFromUrl = (url: string, contentDisposition?: string | null): string => {
@@ -77,13 +92,28 @@ const getFilenameFromUrl = (url: string, contentDisposition?: string | null): st
 };
 
 /**
- * Fetches a URL and saves it as a temporary file
+ * Fetches a URL and streams it to a temporary file
  * Returns an InputFile-compatible object for use with the upload pipeline
+ *
+ * The response body is never buffered in memory: it is piped straight to disk, so heap usage
+ * stays bounded regardless of the remote file size. `sizeLimit` is enforced on the bytes actually
+ * received, not only on the Content-Length header (which may be absent or wrong).
+ *
+ * `onProgress` (optional) reports raw progress:
+ * - It fires **once immediately** with `{ bytesWritten: 0, totalBytes }` after the response headers
+ *   are validated, before any bytes are read, so callers can size a progress bar up front.
+ * - It then fires **once per streamed chunk** with cumulative `bytesWritten`.
+ * - It is deliberately **not throttled**. Throttling is the caller's responsibility: a consumer
+ *   that turns these into SSE frames should coalesce them to its own frame budget (a 512MB file at
+ *   64KB chunks yields ~8000 calls). Throttling here would bake one consumer's frame rate into a
+ *   shared service, and a pre-throttled counter cannot be un-throttled by a caller that needs
+ *   every byte.
  */
 const fetchUrlToInputFile = async (
   url: string,
   tmpWorkingDirectory: string,
-  sizeLimit?: number
+  sizeLimit?: number,
+  onProgress?: (progress: UrlFetchProgress) => void
 ): Promise<FetchUrlResult> => {
   // Validate URL protocol
   let parsedUrl: URL;
@@ -127,15 +157,24 @@ const fetchUrlToInputFile = async (
     );
   }
 
+  const tooLargeError = () =>
+    new ApplicationError(
+      `File too large: maximum allowed size is ${Math.round((sizeLimit ?? 0) / (1024 * 1024))}MB`
+    );
+
+  const parsedContentLength = parseInt(response.headers.get('content-length') ?? '', 10);
+  const totalBytes = Number.isFinite(parsedContentLength) ? parsedContentLength : null;
+
   // Check Content-Length header for early rejection of large files
-  if (sizeLimit) {
-    const contentLength = response.headers.get('content-length');
-    if (contentLength && parseInt(contentLength, 10) > sizeLimit) {
-      throw new ApplicationError(
-        `File too large: maximum allowed size is ${Math.round(sizeLimit / (1024 * 1024))}MB`
-      );
-    }
+  if (sizeLimit && totalBytes !== null && totalBytes > sizeLimit) {
+    throw tooLargeError();
   }
+
+  // Announce the total before any bytes are dispatched. Consumers that size a progress bar from
+  // `totalBytes` need it up front: a consumer clamping bytes to a not-yet-known size would clamp
+  // every early chunk to zero. Fires exactly once, even when `totalBytes` is null or the body is
+  // empty, so the first call is always a size announcement.
+  onProgress?.({ bytesWritten: 0, totalBytes });
 
   // Get content type and filename
   const contentType =
@@ -143,20 +182,54 @@ const fetchUrlToInputFile = async (
   const contentDisposition = response.headers.get('content-disposition');
   const filename = getFilenameFromUrl(response.url, contentDisposition);
 
-  // Read response body
-  const arrayBuffer = await response.arrayBuffer();
-  const buffer = Buffer.from(arrayBuffer);
-
-  // Write to temp file
   const tmpFilePath = path.join(tmpWorkingDirectory, filename);
-  await fse.writeFile(tmpFilePath, buffer);
+
+  // Stream the response body to the temp file, counting bytes as they go so the size limit is
+  // enforced even when Content-Length is missing or lying.
+  let bytesWritten = 0;
+
+  try {
+    if (response.body === null) {
+      // An empty body is valid per the fetch spec — write an empty file
+      await fse.writeFile(tmpFilePath, '');
+    } else {
+      const counter = new Transform({
+        transform(chunk, _encoding, callback) {
+          bytesWritten += chunk.length;
+
+          if (sizeLimit && bytesWritten > sizeLimit) {
+            callback(tooLargeError());
+            return;
+          }
+
+          // Raw, one call per chunk, no throttling — see `onProgress` on the signature above
+          onProgress?.({ bytesWritten, totalBytes });
+          callback(null, chunk);
+        },
+      });
+
+      await pipeline(
+        Readable.fromWeb(response.body as WebReadableStream),
+        counter,
+        createWriteStream(tmpFilePath)
+      );
+    }
+  } catch (error) {
+    // Remove the partially written file — the caller only cleans up the temp directory once all
+    // URLs have been processed
+    await fse.remove(tmpFilePath);
+    throw error;
+  }
+
+  // Derive the size from the file on disk rather than from a buffer we never hold
+  const { size } = await fse.stat(tmpFilePath);
 
   // Create file object compatible with upload pipeline
   const fetchedFile: UrlFetchedFile = {
     filepath: tmpFilePath,
     originalFilename: filename,
     mimetype: contentType,
-    size: buffer.length,
+    size,
     tmpWorkingDirectory,
   };
 
@@ -209,5 +282,5 @@ const signFileUrls = async (file: File) => {
   return signedFile;
 };
 
-export type { UrlFetchedFile, FetchUrlResult };
+export type { UrlFetchedFile, FetchUrlResult, UrlFetchProgress };
 export default { getFolderPath, deleteByIds, signFileUrls, fetchUrlToInputFile };

--- a/tests/api/core/upload/admin/upload-unstable.test.api.js
+++ b/tests/api/core/upload/admin/upload-unstable.test.api.js
@@ -497,6 +497,62 @@ describe('Upload SSE Streaming', () => {
           }
         );
       });
+
+      test('Rejects files exceeding sizeLimit when no Content-Length header is sent', async () => {
+        if (!authToken) {
+          return;
+        }
+
+        // Set a very small size limit (100 bytes)
+        strapi.config.set('plugin::upload.sizeLimit', 100);
+
+        // Streamed body of 1000 bytes with no Content-Length header: the limit can only be
+        // enforced on the bytes actually received.
+        const streamedUrl = 'https://example.com/streamed/no-content-length.bin';
+        await withMockedFetch(
+          (url) => {
+            if (url !== streamedUrl) {
+              return undefined;
+            }
+
+            const body = new ReadableStream({
+              start(controller) {
+                for (let i = 0; i < 10; i += 1) {
+                  controller.enqueue(new Uint8Array(100));
+                }
+                controller.close();
+              },
+            });
+
+            return new Response(body, {
+              status: 200,
+              headers: { 'Content-Type': 'application/octet-stream' },
+            });
+          },
+          async () => {
+            const res = await makeRawRequest(strapi, {
+              method: 'POST',
+              path: '/upload/unstable/stream-from-urls',
+              headers: {
+                Authorization: `Bearer ${authToken}`,
+                'Content-Type': 'application/json',
+              },
+              body: { urls: [streamedUrl] },
+            });
+
+            expect(res.statusCode).toBe(200);
+
+            const errorEvent = res.events.find((e) => e.event === 'file:error');
+            expect(errorEvent).toBeDefined();
+            // The fetch stage must be the one rejecting it (while streaming), not the downstream
+            // checkFileSize validation, which reports "<name> exceeds size limit of ...".
+            expect(errorEvent.data.message).toMatch(/^File too large: maximum allowed size is/);
+
+            // No file was created
+            expect(res.events.find((e) => e.event === 'file:complete')).toBeUndefined();
+          }
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
### What does it do?

`fetchUrlToInputFile` now streams the remote response straight to its temp file instead of reading it fully into memory first.

- Replaces `response.arrayBuffer()` + `fse.writeFile` with a `pipeline` of `Readable.fromWeb(response.body)` → counting `Transform` → `createWriteStream`. Heap usage no longer grows with the remote file size.
- Enforces `sizeLimit` on the bytes actually received, not only on the `Content-Length` header. A response with a missing or understated `Content-Length` is now aborted mid-stream instead of being written in full. The early header-based rejection is kept as a fast path, and the error message is unchanged.
- Reads the resulting `size` back from disk with `fse.stat` rather than from a buffer.
- Removes the partially written temp file on any pipeline failure (size abort, network error, disk error). Previously a failed URL left its partial file until the request-level temp directory cleanup, which only runs after every URL in the batch has been processed.
- Handles `response.body === null` (valid per the fetch spec) by writing an empty file.

Also adds an optional `onProgress` callback to the same function. It is **intentionally unconsumed by the controller** — it is groundwork for the upcoming URL upload progress work, so that lands as a purely additive change. Its contract is documented on the function and pinned by tests: one initial `{ bytesWritten: 0, totalBytes }` report before any bytes are read, then one cumulative report per chunk, deliberately unthrottled (throttling belongs to the caller, which knows its own frame budget).

No controller changes. SSE events, sequential processing, the 20-URL cap, SSRF validation and the temp-directory cleanup are all untouched.

### Why is it needed?

The server-side URL import buffered the entire remote file in the V8 heap before writing it to disk, so a single large import could spike memory by the full file size — and concurrent imports multiply that on the shared server heap. Before URL import moved server-side, this buffering happened in the user's browser tab, not in the server process.

The size limit had a related hole: it was only checked against the `Content-Length` header. A remote server that omits the header, or reports a smaller size than it actually sends, could push an arbitrarily large file past the limit and into memory.

### How to test it?

**Manual (memory behaviour) — the main thing to verify by hand:**

1. Enable the `unstableMediaLibrary` future flag in `examples/getstarted` (`config/features.js`).
2. Start the app with a small heap so buffering would fail loudly: `NODE_OPTIONS="--max-old-space-size=256" yarn develop`.
3. In the Media Library, use "Add asset" → "From URL" and import a large remote file (~500MB).
4. The import completes and the asset appears. Watch RSS while it runs — it stays flat instead of climbing with the download. On `develop` the same import OOMs or spikes by the file size.

**Automated:**

```bash
yarn nx test:unit @strapi/upload
yarn test:api tests/api/core/upload/admin/upload-unstable.test.api.js   # regenerate the app first: yarn test:generate-app
```

The size-limit behaviour is covered end-to-end by tests rather than by hand — reproducing it manually needs a server that deliberately omits or understates `Content-Length`, which is exactly what these mock:

- Unit: streamed bytes over the limit with no `Content-Length`, and with an understated `Content-Length` — both assert the rejection and that no partial temp file is left behind.
- API: the real SSE endpoint receives an oversize chunked body with no `Content-Length` and emits `file:error` with no `file:complete`.

Remaining unit coverage: the body is never read through `arrayBuffer`, size derived from disk, temp-file cleanup on mid-stream errors, empty body, and the progress callback contract (initial zero-byte announcement, `totalBytes` nullability, no internal throttling, works when omitted).

### Related issue(s)/PR(s)

fix CMS-1345
