### PR TITLE
test(e2e): wait for relation modal edit mode before close

### DIFF
--- a/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-publish.spec.ts
+++ b/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-publish.spec.ts
@@ -38,6 +38,9 @@ test.describe('Relations on the fly - Create a Relation and Save', () => {
       await expect(name).toHaveValue('Mr. Fred Passo');
       await expect(page.getByRole('status', { name: 'Published' }).first()).toBeVisible();
 
+      // Wait for publish + parent connect to finish (header flips to Edit) before closing.
+      await expect(page.getByRole('banner').getByText('Edit a relation')).toBeVisible();
+
       // Step 5. Close the relation modal to see the updated relation on the root document
       await page.getByRole('button', { name: 'Close modal' }).click();
       await expect(page.getByRole('button', { name: 'Mr. Fred Passo' })).toBeVisible();
@@ -86,6 +89,8 @@ test.describe('Relations on the fly - Create a Relation and Save', () => {
       })
     );
     expect(parentUpdateData.undefined).toBeUndefined();
+
+    await expect(page.getByRole('banner').getByText('Edit a relation')).toBeVisible();
 
     await clickAndWait(page, page.getByRole('button', { name: 'Close modal' }));
     await expect(page.getByRole('button', { name: authorName })).toBeVisible();

--- a/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-save.spec.ts
+++ b/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-save.spec.ts
@@ -36,11 +36,13 @@ test.describe('Relations on the fly - Create a Relation and Save', () => {
     await expect(name).toHaveValue('Mr. Plop');
     await expect(page.getByRole('status', { name: 'Draft' }).first()).toBeVisible();
 
+    // Wait for create + parent connect to finish (header flips to Edit) before closing.
+    await expect(page.getByRole('banner').getByText('Edit a relation')).toBeVisible();
+
     // Step 5. Close the relation modal to see the updated relation on the root document
     await clickAndWait(page, page.getByRole('button', { name: 'Close modal' }));
 
-    // Wait for the modal to be closed
-    await expect(page.getByText('Create a relation')).not.toBeVisible();
+    await expect(page.getByRole('banner').getByText('Edit a relation')).not.toBeVisible();
     await expect(page.getByRole('button', { name: 'Mr. Plop' })).toBeVisible();
   });
 
@@ -86,6 +88,8 @@ test.describe('Relations on the fly - Create a Relation and Save', () => {
       })
     );
     expect(parentUpdateData.undefined).toBeUndefined();
+
+    await expect(page.getByRole('banner').getByText('Edit a relation')).toBeVisible();
 
     await clickAndWait(page, page.getByRole('button', { name: 'Close modal' }));
     await expect(page.getByRole('button', { name: authorName })).toBeVisible();


### PR DESCRIPTION
### What does it do?

Stabilizes the relations-on-the-fly create+save / create+publish e2e specs by waiting for the relation modal header to flip from **Create a relation** to **Edit a relation** before clicking Close.

After Save/Publish, the modal stays in create mode until the related-document create/publish **and** the parent connect PUT finish. Closing earlier can reopen the modal on the newly created relation, so the parent page never shows the relation chip the assertions look for.

### Why is it needed?

Flaky on CI (especially webkit shard 3/4), observed on [PR #26060](https://github.com/strapi/strapi/pull/26060) and on `develop` after [#27081](https://github.com/strapi/strapi/pull/27081):

`Relations on the fly - Create a Relation and Save › I want to create a new relation, save the related document and check if the new relation is added to the parent document`

`expect(getByRole('button', { name: 'Mr. Plop' })).toBeVisible()` times out because the edit modal is still open over the parent document.

The sibling component specs already waited for `Edit a relation` before close; this aligns the top-level save/publish specs with that pattern.

### How to test it?

```bash
yarn playwright test \
  tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-save.spec.ts \
  tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-and-publish.spec.ts \
  --config test-apps/e2e/test-app-0/playwright.config.js \
  --project=chromium
```

Also verify the scoped save case on webkit.

### Related issue(s)/PR(s)

- Flake seen on [#26060](https://github.com/strapi/strapi/pull/26060) (`[EE] e2e webkit shard 3/4`)
- More likely after [#27081](https://github.com/strapi/strapi/pull/27081) (parent connect PUT became more involved)