### PR TITLE
fix(admin): address filter entries by position so duplicate filter chips behave

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -32,13 +32,21 @@ interface FilterFormData {
   value?: string;
 }
 
+/**
+ * Carries the position in the `$and` array so we replace that exact entry, not every entry
+ * sharing the same `(name, operator, value)`.
+ */
+interface EditingFilter extends FilterFormData {
+  index: number;
+}
+
 interface FitlersContextValue {
   disabled: boolean;
   onChange: (data: FilterFormData) => void;
   options: Filters.Filter[];
   setOpen: (open: boolean) => void;
-  editingFilter: FilterFormData | null;
-  setEditingFilter: (filter: FilterFormData | null) => void;
+  editingFilter: EditingFilter | null;
+  setEditingFilter: (filter: EditingFilter | null) => void;
 }
 
 const [FiltersProvider, useFilters] = createContext<FitlersContextValue>('Filters');
@@ -70,24 +78,6 @@ const getFilterDetails = (
   return { name, operator, value: (operatorObj as Record<string, unknown>)[operator] };
 };
 
-const isFilterMatch = (
-  filterEntry: Record<string, unknown>,
-  options: Filters.Filter[],
-  target: FilterFormData
-): boolean => {
-  const details = getFilterDetails(filterEntry, options);
-  if (!details || details.name !== target.name || details.operator !== target.filter) {
-    return false;
-  }
-  if (FILTERS_WITH_NO_VALUE.includes(target.filter)) {
-    return true;
-  }
-
-  const decoded =
-    typeof details.value === 'string' ? decodeURIComponent(details.value) : details.value;
-  return decoded === target.value;
-};
-
 interface RootProps
   extends Partial<Pick<FitlersContextValue, 'disabled' | 'onChange' | 'options'>>,
     Popover.Props {
@@ -104,7 +94,7 @@ const Root = ({
   defaultOpen,
   ...restProps
 }: RootProps) => {
-  const [editingFilter, setEditingFilter] = React.useState<FilterFormData | null>(null);
+  const [editingFilter, setEditingFilter] = React.useState<EditingFilter | null>(null);
 
   const handleChange = (data: FilterFormData) => {
     if (onChange) {
@@ -238,8 +228,8 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
     const newFilterQuery = editingFilter
       ? {
           ...query.filters,
-          $and: existingFilters.map((filter) =>
-            isFilterMatch(filter, options, editingFilter) ? newFilterEntry : filter
+          $and: existingFilters.map((filter, i) =>
+            i === editingFilter.index ? newFilterEntry : filter
           ),
         }
       : {
@@ -261,7 +251,7 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
           onSubmit={handleSubmit}
           key={
             editingFilter
-              ? `edit-${editingFilter.name}-${editingFilter.filter}-${editingFilter.value ?? 'empty'}`
+              ? `edit-${editingFilter.index}-${editingFilter.name}-${editingFilter.filter}-${editingFilter.value ?? 'empty'}`
               : 'create'
           }
         >
@@ -399,23 +389,12 @@ const List = () => {
 
   const options = useFilters('List', ({ options }) => options);
 
-  const handleClick = (data: FilterFormData) => {
-    /**
-     * Check the name, operator and value to see if it already exists in the query
-     * if it does, remove it.
-     */
-    const nextFilters = (query?.filters?.$and ?? []).filter((filter) => {
-      const details = getFilterDetails(filter, options);
-      if (!details) {
-        return true;
-      }
-
-      return !(
-        details.name === data.name &&
-        details.operator === data.filter &&
-        details.value === data.value
-      );
-    });
+  /**
+   * Removed by position: identical filters are a legal query, so matching on
+   * `(name, operator, value)` would drop every copy at once.
+   */
+  const handleRemove = (index: number) => {
+    const nextFilters = (query?.filters?.$and ?? []).filter((_, i) => i !== index);
 
     setQuery({ filters: { $and: nextFilters }, page: 1 });
   };
@@ -426,7 +405,7 @@ const List = () => {
 
   return (
     <>
-      {query?.filters?.$and?.map((queryFilter) => {
+      {query?.filters?.$and?.map((queryFilter, index) => {
         const details = getFilterDetails(queryFilter, options);
         if (!details || typeof details.value === 'object') {
           return null;
@@ -436,11 +415,17 @@ const List = () => {
         if (!filter) {
           return null;
         }
+        /**
+         * `index` is the position in the raw `$and` array — entries skipped above still count.
+         * Never cache it: `qs` re-indexes on removal, so dropping entry 0 of [0, 1, 2]
+         * leaves [0, 1] and any held index goes stale.
+         */
         return (
           <AttributeTag
-            key={`${details.name}-${details.operator}-${details.value}`}
+            key={`${index}-${details.name}-${details.operator}-${details.value}`}
             {...filter}
-            onRemove={handleClick}
+            index={index}
+            onRemove={handleRemove}
             operator={details.operator}
             value={String(details.value)}
           />
@@ -451,12 +436,18 @@ const List = () => {
 };
 
 interface AttributeTagProps extends Filters.Filter {
-  onRemove: (data: FilterFormData) => void;
+  /**
+   * Position in the `$and` array. An explicit prop rather than a closure bound at the call
+   * site, so it stays part of the props comparison if this ever gets memoised.
+   */
+  index: number;
+  onRemove: (index: number) => void;
   operator: string;
   value: string;
 }
 
 const AttributeTag = ({
+  index,
   input,
   label,
   mainField,
@@ -475,13 +466,14 @@ const AttributeTag = ({
     setEditingFilter({
       name,
       filter: operator,
+      index,
       value: FILTERS_WITH_NO_VALUE.includes(operator) ? undefined : decodeURIComponent(value),
     });
     setOpen(true);
   };
 
   const handleRemove = () => {
-    onRemove({ name, value, filter: operator });
+    onRemove(index);
   };
 
   const type = mainField?.type ? mainField.type : filter.type;

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -1,6 +1,32 @@
 import { fireEvent, render as renderRTL, screen, waitFor } from '@tests/utils';
+import { useLocation } from 'react-router-dom';
 
 import { Filters } from '../Filters';
+
+/**
+ * Captures the current query string so tests can assert that the rendered chips and the
+ * `$and` array in the URL agree.
+ *
+ * Deliberately renders nothing: putting the query string in the DOM makes text queries
+ * like `findByText(/Jimbob/)` match both the chip and the spy.
+ */
+let currentSearch = '';
+
+const LocationSpy = () => {
+  currentSearch = useLocation().search;
+
+  return null;
+};
+
+const getAppliedFilters = () => {
+  const params = new URLSearchParams(currentSearch);
+
+  return [...params.keys()].filter((key) => key.startsWith('filters[$and]'));
+};
+
+beforeEach(() => {
+  currentSearch = '';
+});
 
 const DEFAULT_FILTERS = [
   {
@@ -32,8 +58,25 @@ describe('Filters', () => {
         <Filters.Trigger />
         <Filters.Popover />
         <Filters.List />
+        <LocationSpy />
       </Filters.Root>
     );
+
+  /**
+   * Adds `Status is <option>` through the popover, the same way a user would.
+   */
+  const addStatusFilter = async (user: ReturnType<typeof render>['user'], option: string) => {
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
+    await user.click(await screen.findByRole('option', { name: 'Status' }));
+    await user.click(await screen.findByRole('combobox', { name: 'Status' }));
+    await user.click(await screen.findByRole('option', { name: option }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Add filter' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Add filter' })).not.toBeInTheDocument();
+    });
+  };
 
   it('should open the popover when the trigger is clicked', async () => {
     const { user } = render();
@@ -144,6 +187,155 @@ describe('Filters', () => {
     });
     expect(screen.queryByText(/Jimbob/)).not.toBeInTheDocument();
     expect(screen.queryAllByText(/Jane/)).toHaveLength(1);
+  });
+
+  /**
+   * EE-75 — duplicate filter chips.
+   *
+   * Filter entries used to be identified by their `(name, operator, value)` tuple rather than
+   * by their position in the `$and` array. Because two identical filters are a legal query,
+   * the tuple did not uniquely identify an entry: one ✕ click removed every copy, and the
+   * duplicate React keys left a phantom chip behind.
+   */
+  describe('duplicate filters (EE-75)', () => {
+    it('should remove only the clicked chip when two identical filters are applied', async () => {
+      const { user } = render();
+
+      await addStatusFilter(user, 'Draft');
+      await addStatusFilter(user, 'Draft');
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Status $eq draft')).toHaveLength(2);
+      });
+      expect(getAppliedFilters()).toHaveLength(2);
+
+      // ✕ the first of the two identical chips
+      fireEvent.click(screen.getAllByRole('button', { name: 'Status $eq draft' })[0]);
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Status $eq draft')).toHaveLength(1);
+      });
+      expect(getAppliedFilters()).toHaveLength(1);
+    });
+
+    it('should keep the chips in sync with the query while removing them one at a time', async () => {
+      const { user } = render();
+
+      // The issue's exact repro: the same filter added twice, with others in between.
+      await addStatusFilter(user, 'Draft');
+      await addStatusFilter(user, 'Modified');
+      await addStatusFilter(user, 'Published');
+      await addStatusFilter(user, 'Draft');
+
+      await waitFor(() => {
+        expect(getAppliedFilters()).toHaveLength(4);
+      });
+
+      // Removing the first `draft` must drop exactly one entry, not both copies.
+      fireEvent.click(screen.getAllByRole('button', { name: 'Status $eq draft' })[0]);
+
+      await waitFor(() => {
+        expect(getAppliedFilters()).toHaveLength(3);
+      });
+      // Chips and query must agree — this is where the phantom chip used to appear.
+      expect(screen.queryAllByText(/^Status \$eq/)).toHaveLength(3);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Status $eq modified' }));
+
+      await waitFor(() => {
+        expect(getAppliedFilters()).toHaveLength(2);
+      });
+      expect(screen.queryAllByText(/^Status \$eq/)).toHaveLength(2);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Status $eq published' }));
+
+      await waitFor(() => {
+        expect(getAppliedFilters()).toHaveLength(1);
+      });
+      expect(screen.queryAllByText(/^Status \$eq/)).toHaveLength(1);
+      expect(screen.getByText('Status $eq draft')).toBeInTheDocument();
+    });
+
+    it('should leave no phantom chip once every filter has been removed', async () => {
+      const { user } = render();
+
+      await addStatusFilter(user, 'Draft');
+      await addStatusFilter(user, 'Draft');
+
+      await waitFor(() => {
+        expect(getAppliedFilters()).toHaveLength(2);
+      });
+
+      fireEvent.click(screen.getAllByRole('button', { name: 'Status $eq draft' })[0]);
+      await waitFor(() => {
+        expect(getAppliedFilters()).toHaveLength(1);
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Status $eq draft' }));
+
+      // Zero filters in the URL *and* zero chips on screen.
+      await waitFor(() => {
+        expect(getAppliedFilters()).toHaveLength(0);
+      });
+      expect(screen.queryByText(/^Status \$eq/)).not.toBeInTheDocument();
+    });
+
+    it('should edit only the clicked chip when two identical filters are applied', async () => {
+      const { user } = render();
+
+      await addStatusFilter(user, 'Draft');
+      await addStatusFilter(user, 'Draft');
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Status $eq draft')).toHaveLength(2);
+      });
+
+      // Click the chip body (not the ✕) to edit the first duplicate.
+      await user.click(screen.getAllByText('Status $eq draft')[0]);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Update filter' })).toBeInTheDocument();
+      });
+
+      await user.click(await screen.findByRole('combobox', { name: 'Status' }));
+      await user.click(await screen.findByRole('option', { name: 'Published' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Update filter' }));
+
+      // One entry changed, the other left alone.
+      await waitFor(() => {
+        expect(screen.getByText('Status $eq published')).toBeInTheDocument();
+      });
+      expect(screen.queryAllByText('Status $eq draft')).toHaveLength(1);
+      expect(getAppliedFilters()).toHaveLength(2);
+    });
+
+    it('should handle a URL that already contains duplicate filters', async () => {
+      // A shared link or bookmark — this path never goes through `handleSubmit`.
+      renderRTL(
+        <Filters.Root options={DEFAULT_FILTERS}>
+          <Filters.Trigger />
+          <Filters.Popover />
+          <Filters.List />
+          <LocationSpy />
+        </Filters.Root>,
+        {
+          initialEntries: [
+            '/?filters[$and][0][status][$eq]=draft&filters[$and][1][status][$eq]=draft',
+          ],
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Status $eq draft')).toHaveLength(2);
+      });
+
+      fireEvent.click(screen.getAllByRole('button', { name: 'Status $eq draft' })[0]);
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Status $eq draft')).toHaveLength(1);
+      });
+      expect(getAppliedFilters()).toHaveLength(1);
+    });
   });
 
   it('should correctly match filter when value is URL-encoded (decoded comparison)', async () => {

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -24,6 +24,18 @@ const getAppliedFilters = () => {
   return [...params.keys()].filter((key) => key.startsWith('filters[$and]'));
 };
 
+/**
+ * The `$and` entries as `key=value` pairs, so a test can assert *which* entry changed
+ * rather than only how many there are.
+ */
+const getAppliedFilterEntries = () => {
+  const params = new URLSearchParams(currentSearch);
+
+  return [...params.entries()]
+    .filter(([key]) => key.startsWith('filters[$and]'))
+    .map(([key, value]) => `${key}=${value}`);
+};
+
 beforeEach(() => {
   currentSearch = '';
 });
@@ -48,6 +60,12 @@ const DEFAULT_FILTERS = [
     name: 'createdAt',
     label: 'Created At',
     type: 'date',
+  },
+  {
+    name: 'author',
+    label: 'Author',
+    mainField: { name: 'name', type: 'string' },
+    type: 'relation',
   },
 ] satisfies Filters.Filter[];
 
@@ -301,12 +319,15 @@ describe('Filters', () => {
       await user.click(await screen.findByRole('option', { name: 'Published' }));
       fireEvent.click(screen.getByRole('button', { name: 'Update filter' }));
 
-      // One entry changed, the other left alone.
+      // The clicked entry changed and the other kept its original value & position.
       await waitFor(() => {
         expect(screen.getByText('Status $eq published')).toBeInTheDocument();
       });
       expect(screen.queryAllByText('Status $eq draft')).toHaveLength(1);
-      expect(getAppliedFilters()).toHaveLength(2);
+      expect(getAppliedFilterEntries()).toEqual([
+        'filters[$and][0][status][$eq]=published',
+        'filters[$and][1][status][$eq]=draft',
+      ]);
     });
 
     it('should handle a URL that already contains duplicate filters', async () => {
@@ -333,6 +354,112 @@ describe('Filters', () => {
 
       await waitFor(() => {
         expect(screen.queryAllByText('Status $eq draft')).toHaveLength(1);
+      });
+      expect(getAppliedFilters()).toHaveLength(1);
+    });
+
+    it('should remove one of two identical relation filters', async () => {
+      // Relation entries nest the operator under `mainField`, so they exercise a different
+      // branch of `getFilterDetails` than scalar filters.
+      renderRTL(
+        <Filters.Root options={DEFAULT_FILTERS}>
+          <Filters.Trigger />
+          <Filters.Popover />
+          <Filters.List />
+          <LocationSpy />
+        </Filters.Root>,
+        {
+          initialEntries: [
+            '/?filters[$and][0][author][name][$eq]=Bob&filters[$and][1][author][name][$eq]=Bob',
+          ],
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Author $eq Bob')).toHaveLength(2);
+      });
+
+      fireEvent.click(screen.getAllByRole('button', { name: 'Author $eq Bob' })[0]);
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Author $eq Bob')).toHaveLength(1);
+      });
+      expect(getAppliedFilterEntries()).toEqual(['filters[$and][0][author][name][$eq]=Bob']);
+    });
+
+    it('should edit one of two identical $null filters without touching the other', async () => {
+      // `$null`/`$notNull` carry no value, so the deleted `isFilterMatch` matched them on
+      // `(name, operator)` alone — duplicates were maximally ambiguous.
+      const { user } = renderRTL(
+        <Filters.Root options={DEFAULT_FILTERS}>
+          <Filters.Trigger />
+          <Filters.Popover />
+          <Filters.List />
+          <LocationSpy />
+        </Filters.Root>,
+        {
+          initialEntries: [
+            '/?filters[$and][0][name][$null]=true&filters[$and][1][name][$null]=true',
+          ],
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Name $null')).toHaveLength(2);
+      });
+
+      // Edit the first of the two, switching it to `is not null`.
+      await user.click(screen.getAllByText('Name $null')[0]);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Update filter' })).toBeInTheDocument();
+      });
+
+      await user.click(await screen.findByRole('combobox', { name: 'Select filter' }));
+      await user.click(await screen.findByRole('option', { name: 'is not null' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Update filter' }));
+
+      await waitFor(() => {
+        expect(getAppliedFilterEntries()).toEqual([
+          'filters[$and][0][name][$notNull]=true',
+          'filters[$and][1][name][$null]=true',
+        ]);
+      });
+    });
+
+    it('should remove one of two identical chips rendered by a custom input', async () => {
+      // Custom inputs resolve the chip label through their own `options`, a separate code path
+      // from the default renderer.
+      const CUSTOM_FILTERS = [
+        {
+          name: 'owner',
+          label: 'Owner',
+          input: () => null,
+          options: [{ label: 'Ada Lovelace', value: 'ada' }],
+          type: 'enumeration',
+        },
+      ] satisfies Filters.Filter[];
+
+      renderRTL(
+        <Filters.Root options={CUSTOM_FILTERS}>
+          <Filters.Trigger />
+          <Filters.Popover />
+          <Filters.List />
+          <LocationSpy />
+        </Filters.Root>,
+        {
+          initialEntries: ['/?filters[$and][0][owner][$eq]=ada&filters[$and][1][owner][$eq]=ada'],
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Owner $eq Ada Lovelace')).toHaveLength(2);
+      });
+
+      fireEvent.click(screen.getAllByRole('button', { name: 'Owner $eq Ada Lovelace' })[0]);
+
+      await waitFor(() => {
+        expect(screen.queryAllByText('Owner $eq Ada Lovelace')).toHaveLength(1);
       });
       expect(getAppliedFilters()).toHaveLength(1);
     });


### PR DESCRIPTION
### What does it do?

Fixes duplicate filter chips in the shared `Filters` component (`packages/core/admin/admin/src/components/Filters.tsx`).

Two identical filters are a legal query (`$and: [action=create, action=create]`), but entries were identified by their `(name, operator, value)` tuple — which does not tell duplicates apart. So removing one chip removed every copy, editing one rewrote every copy, and the non-unique React keys left a phantom chip on screen that restored old filters when clicked.

Entries are now addressed by their index in `$and`, read from the current `query` on each render. `isFilterMatch` had one caller — the line this replaces — and is removed.

The second commit adds coverage for the filter shapes the existing tests missed: relation filters, `$null`/`$notNull` duplicates, and duplicates from a custom `input`. Each fails on `develop`.

### Why is it needed?

`Filters` is re-exported from `admin/src/index.ts` (public plugin API) and consumed by the Content Manager list view, the Admin Users list, and Audit Logs. Audit Logs is the easiest place to trigger the duplicate case, because its `ComboboxFilter` lets you re-pick a value you already chose. (The Media Library has its own implementation and is unaffected.)

The bug makes the UI lie about what is being filtered: chips that match no active filter, and a stale one that resurrects old state when clicked.

### How to test it?

```bash
cd packages/core/admin
yarn test:front --testPathPattern="components/tests/Filters"   # 16 passed
yarn test:ts:front && yarn lint
```

Manually, against `examples/getstarted` with an EE licence — full plan with observed URLs is on [EE-75](https://linear.app/strapi/issue/EE-75):

Settings → Audit Logs → add `Action is Create entry`, `Update entry`, `Delete entry`, then `Create entry` **again**. Remove the chips one at a time with the ✕. The rendered chips and the `$and` query must agree at every step, and the last removal must leave no chip behind.

Before this fix, the first ✕ dropped **both** `entry.create` entries while leaving three chips on screen, and the final leftover chip restored `[update, delete]` when clicked.

Regression: `--testPathPattern="ListView"` in `content-manager` (60 passed) and `--testPathPattern="(Users/tests|AuditLogs)"` in `admin` (12 passed) stay green.

### Related issue(s)/PR(s)

**not fixed here**

- **EE-112** — `decodeURIComponent` crashes when a filter value contains a literal `%`.
- **EE-113** — `qs` `arrayLimit` turns `$and` into an object past 20 entries.