### PR TITLE
chore(tooling): report missing locale translation gaps with context

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "verify:translations": "tsx scripts/front/verify-translations/index.ts",
     "verify:translations:fix": "tsx scripts/front/verify-translations/index.ts --fix",
     "verify:translations:write-en": "tsx scripts/front/verify-translations/index.ts --write-en",
+    "verify:translations:report-gaps": "tsx scripts/front/verify-translations/index.ts --report-gaps",
     "verify:translations:test": "tsx --test scripts/front/verify-translations/__tests__/*.test.ts",
     "postinstall": "husky",
     "prepack": "pinst --disable",

--- a/scripts/front/verify-translations/README.md
+++ b/scripts/front/verify-translations/README.md
@@ -8,6 +8,12 @@ Validates Strapi admin `react-intl` message descriptors against `en.json` and lo
 # Full validation (exit 1 on errors)
 yarn verify:translations
 
+# Deterministic gap report: keys in en.json missing from some locales,
+# with sibling-locale values + code call sites (JSON to stdout or --out=)
+yarn verify:translations --report-gaps
+yarn verify:translations --report-gaps --locale=fr,de --out=gaps.json
+yarn verify:translations --report-gaps --bundle=core/upload
+
 # Sync en.json gaps from defaultMessage, then align call-site defaults to en.json
 # (existing catalog English is preserved; use --sync-existing to overwrite from code)
 yarn verify:translations --write-en
@@ -25,6 +31,18 @@ yarn verify:translations --bundle=core/content-manager
 `--fix` always closes `en.json` gaps **before** pruning locales. A key used in code with a
 `defaultMessage` but missing from `en.json` is added first; only then are locale keys absent
 from that catalog removed. That keeps translator work for live message ids.
+
+## Gap report (`--report-gaps`)
+
+Purely deterministic — no model calls. For each `en.json` key missing from one or more locale
+files, the JSON includes:
+
+- `en` — English catalog value
+- `missingLocales` — locale codes that lack the key (`--locale=` filters this list)
+- `presentLocales` — existing translations in other locales (context for fill/review)
+- `usages` — static call sites (`file`, `line`, `defaultMessage`) when extractable
+
+Use this as the input contract for later AI fill / AI review of community translation PRs.
 
 ## What it checks
 
@@ -50,7 +68,7 @@ Admin message namespaces (`global.`, `Settings.`, …) are derived from `core/ad
 ## Legacy scripts
 
 - `reorder-admin-translation-files.js` — replaced by `yarn verify:translations --fix`
-- `add-missing-keys-to-other-language.js` — kept for explicit translator workflows
+- `add-missing-keys-to-other-language.js` — kept for explicit translator workflows (copies English; prefer `--report-gaps` + AI fill later)
 
 ## Notes
 

--- a/scripts/front/verify-translations/__tests__/verify-translations.test.ts
+++ b/scripts/front/verify-translations/__tests__/verify-translations.test.ts
@@ -16,6 +16,7 @@ import {
 import { fixLocaleFiles, validateBundle } from '../validate';
 import { backfillMissingEnKeys } from '../backfill-en';
 import { writeEnJsonForBundle } from '../write-en';
+import { buildGapReport } from '../report-gaps';
 import type { TranslationBundle } from '../types';
 
 describe('pluginPrefixFromPackageName', () => {
@@ -607,5 +608,93 @@ describe('validateBundle cross-package admin refs', () => {
 
     assert.equal(missing.length, 1);
     assert.match(missing[0].message, /global\.not-in-admin/);
+  });
+});
+
+describe('buildGapReport', () => {
+  it('reports keys missing from some locales with sibling values and call sites', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'strapi-trad-gaps-'));
+    const srcDir = path.join(dir, 'admin', 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'en.json'),
+      `${JSON.stringify(
+        { 'plugin.name': 'Upload', 'modal.save': 'Save', 'only.en': 'English only' },
+        null,
+        2
+      )}\n`
+    );
+    fs.writeFileSync(
+      path.join(dir, 'fr.json'),
+      `${JSON.stringify({ 'plugin.name': 'Téléversement', 'modal.save': 'Enregistrer' }, null, 2)}\n`
+    );
+    fs.writeFileSync(
+      path.join(dir, 'de.json'),
+      `${JSON.stringify({ 'plugin.name': 'Upload-de' }, null, 2)}\n`
+    );
+    fs.writeFileSync(
+      path.join(srcDir, 'Widget.tsx'),
+      `
+        formatMessage({ id: getTrad('modal.save'), defaultMessage: 'Save' });
+        formatMessage({ id: getTrad('only.en'), defaultMessage: 'English only' });
+      `
+    );
+
+    const bundle: TranslationBundle = {
+      packagePath: dir,
+      packageName: 'core/upload',
+      enJsonPath: path.join(dir, 'en.json'),
+      translationsDir: dir,
+      pluginPrefix: 'upload',
+      sourceDirs: [srcDir],
+    };
+
+    const report = buildGapReport([bundle], new Set());
+    const gaps = report.bundles[0]!.gaps;
+    const byKey = Object.fromEntries(gaps.map((gap) => [gap.key, gap]));
+
+    assert.equal(byKey['plugin.name'], undefined);
+    assert.deepEqual(byKey['modal.save']!.missingLocales, ['de']);
+    assert.equal(byKey['modal.save']!.presentLocales.fr, 'Enregistrer');
+    assert.equal(byKey['modal.save']!.en, 'Save');
+    assert.equal(byKey['modal.save']!.usages.length, 1);
+    assert.match(byKey['modal.save']!.usages[0]!.file, /Widget\.tsx$/);
+
+    assert.deepEqual(byKey['only.en']!.missingLocales.sort(), ['de', 'fr']);
+    assert.deepEqual(byKey['only.en']!.presentLocales, {});
+    assert.equal(report.summary.keysWithGaps, 2);
+    assert.equal(report.summary.missingOccurrences, 3);
+  });
+
+  it('limits missingLocales when --locale filter is set but still includes sibling presentLocales', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'strapi-trad-gaps-locale-'));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'en.json'),
+      `${JSON.stringify({ 'modal.save': 'Save' }, null, 2)}\n`
+    );
+    fs.writeFileSync(
+      path.join(dir, 'fr.json'),
+      `${JSON.stringify({ 'modal.save': 'Enregistrer' }, null, 2)}\n`
+    );
+    fs.writeFileSync(path.join(dir, 'de.json'), `${JSON.stringify({}, null, 2)}\n`);
+    fs.writeFileSync(path.join(dir, 'ja.json'), `${JSON.stringify({}, null, 2)}\n`);
+
+    const bundle: TranslationBundle = {
+      packagePath: dir,
+      packageName: 'core/upload',
+      enJsonPath: path.join(dir, 'en.json'),
+      translationsDir: dir,
+      pluginPrefix: 'upload',
+      sourceDirs: [],
+    };
+
+    const report = buildGapReport([bundle], new Set(), { locales: ['de'] });
+    const gap = report.bundles[0]!.gaps[0]!;
+
+    assert.equal(gap.key, 'modal.save');
+    assert.deepEqual(gap.missingLocales, ['de']);
+    assert.equal(gap.presentLocales.fr, 'Enregistrer');
+    assert.equal('ja' in gap.presentLocales, false);
   });
 });

--- a/scripts/front/verify-translations/index.ts
+++ b/scripts/front/verify-translations/index.ts
@@ -1,18 +1,31 @@
 #!/usr/bin/env tsx
+import fs from 'node:fs';
+
 import { discoverBundles, readJsonRecord, repoRoot } from './bundles';
 import type { VerifyOptions, ValidationIssue } from './types';
 import { fixLocaleFiles, validateBundle } from './validate';
 import { backfillMissingEnKeys } from './backfill-en';
 import { writeEnJsonForBundle } from './write-en';
 import { alignDefaultMessages } from './align-defaults';
+import { buildGapReport } from './report-gaps';
 
 const parseArgs = (): VerifyOptions => {
   const args = process.argv.slice(2);
+  const localesArg = args.find((arg) => arg.startsWith('--locale='))?.split('=')[1];
+  const outArg = args.find((arg) => arg.startsWith('--out='))?.split('=')[1];
 
   return {
     fix: args.includes('--fix'),
     writeEn: args.includes('--write-en'),
     syncExisting: args.includes('--sync-existing'),
+    reportGaps: args.includes('--report-gaps'),
+    reportGapsOut: outArg,
+    locales: localesArg
+      ? localesArg
+          .split(',')
+          .map((locale) => locale.trim())
+          .filter(Boolean)
+      : undefined,
     bundleFilter: args.find((arg) => arg.startsWith('--bundle='))?.split('=')[1],
   };
 };
@@ -36,6 +49,28 @@ const main = () => {
   }
 
   let adminEnJson = readJsonRecord(adminBundle.enJsonPath);
+
+  if (options.reportGaps) {
+    const report = buildGapReport(bundles, new Set(Object.keys(adminEnJson)), {
+      locales: options.locales,
+    });
+    const json = `${JSON.stringify(report, null, 2)}\n`;
+
+    if (options.reportGapsOut) {
+      fs.writeFileSync(options.reportGapsOut, json);
+      console.error(
+        `report-gaps: wrote ${options.reportGapsOut} (${report.summary.keysWithGaps} keys with gaps, ${report.summary.missingOccurrences} missing key×locale)`
+      );
+    } else {
+      process.stdout.write(json);
+      console.error(
+        `report-gaps: ${report.summary.keysWithGaps} keys with gaps, ${report.summary.missingOccurrences} missing key×locale across ${report.summary.bundleCount} bundle(s)`
+      );
+    }
+
+    process.exit(0);
+  }
+
   const allIssues: ValidationIssue[] = [];
   let fixedLocales = 0;
   let writtenEn = 0;

--- a/scripts/front/verify-translations/report-gaps.ts
+++ b/scripts/front/verify-translations/report-gaps.ts
@@ -1,0 +1,175 @@
+import path from 'node:path';
+
+import { extractMessages } from './extract';
+import { listLocaleFiles, readJsonRecord, repoRoot } from './bundles';
+import type { MessageExtraction, TranslationBundle } from './types';
+
+export interface GapUsage {
+  file: string;
+  line: number;
+  defaultMessage: string | null;
+}
+
+export interface GapKeyReport {
+  /** Key as stored in this bundle's en.json. */
+  key: string;
+  en: string;
+  /** Locale codes (without .json) missing this key. */
+  missingLocales: string[];
+  /** Translations that already exist for this key in other locales. */
+  presentLocales: Record<string, string>;
+  /** Call sites that reference this key (best-effort from static extraction). */
+  usages: GapUsage[];
+}
+
+export interface BundleGapReport {
+  bundle: string;
+  gaps: GapKeyReport[];
+  summary: {
+    enKeyCount: number;
+    localeCount: number;
+    keysWithGaps: number;
+    missingOccurrences: number;
+  };
+}
+
+export interface GapReport {
+  generatedAt: string;
+  bundles: BundleGapReport[];
+  summary: {
+    bundleCount: number;
+    keysWithGaps: number;
+    missingOccurrences: number;
+  };
+}
+
+export interface ReportGapsOptions {
+  /** Restrict which target locales appear in `missingLocales` (still includes others in presentLocales). */
+  locales?: string[];
+}
+
+const localeCodeFromPath = (localePath: string) => path.basename(localePath, '.json');
+
+const toRepoRelative = (filePath: string) => {
+  const relative = path.relative(repoRoot, filePath);
+  return relative.startsWith('..') ? filePath : relative.split(path.sep).join('/');
+};
+
+const usagesForKey = (key: string, extractions: MessageExtraction[]): GapUsage[] => {
+  const usages: GapUsage[] = [];
+  const seen = new Set<string>();
+
+  for (const extraction of extractions) {
+    const matches =
+      extraction.jsonKey === key ||
+      (extraction.expandedJsonKeys?.includes(key) ?? false) ||
+      (extraction.messageId != null &&
+        extraction.messageId.split('|').some((branch) => branch === key));
+
+    if (!matches) {
+      continue;
+    }
+
+    const file = toRepoRelative(extraction.file);
+    const dedupe = `${file}:${extraction.line}`;
+    if (seen.has(dedupe)) {
+      continue;
+    }
+    seen.add(dedupe);
+
+    usages.push({
+      file,
+      line: extraction.line,
+      defaultMessage: extraction.defaultMessage,
+    });
+  }
+
+  return usages;
+};
+
+/**
+ * Deterministic gap report: keys present in en.json but missing from one or more locale files,
+ * with sibling-locale values and code call-site context for downstream AI fill/review.
+ */
+export const buildGapReport = (
+  bundles: TranslationBundle[],
+  adminEnKeys: Set<string>,
+  options: ReportGapsOptions = {}
+): GapReport => {
+  const localeFilter =
+    options.locales && options.locales.length > 0 ? new Set(options.locales) : null;
+
+  const bundleReports: BundleGapReport[] = [];
+  let totalKeysWithGaps = 0;
+  let totalMissingOccurrences = 0;
+
+  for (const bundle of bundles) {
+    const enJson = readJsonRecord(bundle.enJsonPath);
+    const enKeys = Object.keys(enJson);
+    const localePaths = listLocaleFiles(bundle);
+    const locales = localePaths.map((localePath) => ({
+      code: localeCodeFromPath(localePath),
+      values: readJsonRecord(localePath),
+    }));
+
+    const extractions = extractMessages(bundle, adminEnKeys);
+    const gaps: GapKeyReport[] = [];
+
+    for (const key of enKeys) {
+      const missingLocales: string[] = [];
+      const presentLocales: Record<string, string> = {};
+
+      for (const locale of locales) {
+        if (key in locale.values) {
+          presentLocales[locale.code] = locale.values[key]!;
+          continue;
+        }
+
+        if (localeFilter && !localeFilter.has(locale.code)) {
+          continue;
+        }
+
+        missingLocales.push(locale.code);
+      }
+
+      if (missingLocales.length === 0) {
+        continue;
+      }
+
+      missingLocales.sort((a, b) => a.localeCompare(b));
+
+      gaps.push({
+        key,
+        en: enJson[key]!,
+        missingLocales,
+        presentLocales,
+        usages: usagesForKey(key, extractions),
+      });
+    }
+
+    const missingOccurrences = gaps.reduce((sum, gap) => sum + gap.missingLocales.length, 0);
+    totalKeysWithGaps += gaps.length;
+    totalMissingOccurrences += missingOccurrences;
+
+    bundleReports.push({
+      bundle: bundle.packageName,
+      gaps,
+      summary: {
+        enKeyCount: enKeys.length,
+        localeCount: locales.length,
+        keysWithGaps: gaps.length,
+        missingOccurrences,
+      },
+    });
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    bundles: bundleReports,
+    summary: {
+      bundleCount: bundleReports.length,
+      keysWithGaps: totalKeysWithGaps,
+      missingOccurrences: totalMissingOccurrences,
+    },
+  };
+};

--- a/scripts/front/verify-translations/types.ts
+++ b/scripts/front/verify-translations/types.ts
@@ -43,5 +43,11 @@ export interface VerifyOptions {
   writeEn: boolean;
   /** With --write-en: overwrite existing en.json values from defaultMessage (code → catalog). */
   syncExisting: boolean;
+  /** Emit a deterministic missing-locale gap report (JSON) with sibling-locale + call-site context. */
+  reportGaps: boolean;
+  /** Optional path for --report-gaps JSON output (default: stdout). */
+  reportGapsOut?: string;
+  /** Optional comma-separated locale codes to include as gap targets (e.g. fr,de). */
+  locales?: string[];
   bundleFilter?: string;
 }


### PR DESCRIPTION
### What does it do?

Stacked on #27181 / #27179 / #26960 (stack #27180). Adds a **deterministic** gap report for missing locale strings — the shared input contract for later AI fill and AI review of community translation PRs.

- `yarn verify:translations --report-gaps` emits JSON of `en.json` keys missing from one or more locale files
- Each gap includes: English value, `missingLocales`, `presentLocales` (sibling translations), and static `usages` (`file` / `line` / `defaultMessage`)
- `--locale=fr,de` limits which locales count as “missing” (siblings still included for context)
- `--out=gaps.json` writes the report to a file (default: stdout)
- `--bundle=` scopes like the rest of the verifier
- No model calls; does not modify catalogs; exits 0 after reporting

```bash
yarn verify:translations --report-gaps
yarn verify:translations --report-gaps --locale=fr --out=gaps-fr.json
yarn verify:translations --report-gaps --bundle=core/email
```

### Example output

Command (scoped so the report is small enough to read):

```bash
yarn verify:translations --report-gaps --bundle=core/email --locale=fr
```

Stderr summary:

```text
report-gaps: 43 keys with gaps, 43 missing key×locale across 1 bundle(s)
```

Stdout is full JSON. Excerpt (2 of 43 gaps), showing English, missing `fr`, sibling locales that already have the string, and the call site:

```json
{
  "generatedAt": "2026-07-31T13:55:27.055Z",
  "summary": {
    "bundleCount": 1,
    "keysWithGaps": 43,
    "missingOccurrences": 43
  },
  "bundles": [
    {
      "bundle": "core/email",
      "summary": {
        "enKeyCount": 43,
        "localeCount": 23,
        "keysWithGaps": 43,
        "missingOccurrences": 43
      },
      "gaps": [
        {
          "key": "link",
          "en": "Link",
          "missingLocales": ["fr"],
          "presentLocales": {
            "cs": "Odkaz",
            "de": "Link",
            "es": "Enlace",
            "ja": "リンク",
            "ko": "링크",
            "nl": "Link",
            "pl": "Link",
            "pt": "Link",
            "ru": "Ссылка",
            "sk": "Odkaz",
            "tr": "Bağlantı",
            "uk": "Посилання",
            "zh-Hans": "链接",
            "zh": "連結"
          },
          "usages": [
            {
              "file": "packages/core/email/admin/src/pages/Settings.tsx",
              "line": 402,
              "defaultMessage": "Link"
            }
          ]
        },
        {
          "key": "Settings.email.plugin.button.test-email",
          "en": "Send test email",
          "missingLocales": ["fr"],
          "presentLocales": {
            "cs": "Odeslat testovací e-mail",
            "da": "Send test e-mail",
            "de": "Test-E-Mail senden",
            "es": "Enviar email de prueba",
            "ja": "メール送信のテスト",
            "ko": "테스트 발송",
            "nl": "Testmail verzenden",
            "pl": "Wyślij testowy email",
            "pt": "Enviar e-mail de teste",
            "ru": "Отправить тестовое письмо",
            "sk": "Odoslať testovací email",
            "tr": "Deneme e-postası gönder",
            "uk": "Надіслати тестовий лист",
            "zh-Hans": "发送测试邮件",
            "zh": "寄送測試電子郵件"
          },
          "usages": [
            {
              "file": "packages/core/email/admin/src/pages/Settings.tsx",
              "line": 640,
              "defaultMessage": "Send test email"
            }
          ]
        }
      ]
    }
  ]
}
```

So for AI fill/review, the model gets: the English string, how other languages already translated it, and where it appears in the admin UI code.

### Why is it needed?

AI fill and unsupervised translation-PR review both need the same grounded context pack. This layer produces it without coupling to any LLM provider.

### How to test it?

- [x] `yarn verify:translations:test` (15/15)
- [x] `yarn verify:translations` → 0/0 (unchanged CI gate)
- [x] `yarn verify:translations --report-gaps --bundle=core/email --locale=fr` returns gaps with sibling locales + usages

### Related issue(s)/PR(s)

- Stack #27180 — #26960 → #27179 → #27181 → this PR (#27189)