### PR TITLE
fix(content-manager): mark permission checker field param optional

### DIFF
--- a/packages/core/content-manager/server/src/services/permission-checker.ts
+++ b/packages/core/content-manager/server/src/services/permission-checker.ts
@@ -34,9 +34,7 @@ const createPermissionChecker =
       return entity ? permissionsManager.toSubject(entity, model) : model;
     };
 
-    // @ts-expect-error preserve the parameter order
-    // eslint-disable-next-line @typescript-eslint/default-param-last
-    const can = (action: string, entity?: Entity, field: string) => {
+    const can = (action: string, entity?: Entity, field?: string) => {
       const subject = toSubject(entity);
       const aliases = actionProvider.unstable_aliases(action, model) as string[];
 
@@ -48,9 +46,7 @@ const createPermissionChecker =
       );
     };
 
-    // @ts-expect-error preserve the parameter order
-    // eslint-disable-next-line @typescript-eslint/default-param-last
-    const cannot = (action: string, entity?: Entity, field: string) => {
+    const cannot = (action: string, entity?: Entity, field?: string) => {
       const subject = toSubject(entity);
       const aliases = actionProvider.unstable_aliases(action, model) as string[];
 


### PR DESCRIPTION
### What does it do?

Marks the `field` parameter of the content-manager permission checker's `can` and
`cannot` functions as optional (`field?: string`) instead of required.

This clears the two errors that make the `lint_oxlint` CI job go red, and removes
two pairs of now-unnecessary suppressions:

- `// @ts-expect-error preserve the parameter order`
- `// eslint-disable-next-line @typescript-eslint/default-param-last`

No behaviour changes. The parameter order stays the same, and every caller already
passes `field` positionally or omits it.

### Why is it needed?

`field` was typed as required while sitting after the optional `entity` parameter,
which is not valid TypeScript. OxLint reports this as a parse error:

```
packages/core/content-manager/server/src/services/permission-checker.ts:39:51:
  error TS(1016): A required parameter cannot follow an optional parameter.
packages/core/content-manager/server/src/services/permission-checker.ts:53:54:
  error TS(1016): A required parameter cannot follow an optional parameter.
```

OxLint does not read `@ts-expect-error` or `eslint-disable` comments, so the existing
suppressions do not silence it. These two errors were the only thing failing
`yarn lint:oxlint` across the whole monorepo — with them gone the run is clean.

The job (`lint_oxlint (observation)`, added in #26923) is `continue-on-error: true`,
so this was showing up as a red check without blocking merges. Fixing it means the
observation job is green and will actually surface new violations instead of being
permanently red.

The `default-param-last` disable was also misleading — neither parameter has a
default value, so that rule never applied. And the `@ts-expect-error` silenced any
other type error on those lines, so removing it restores real type checking there.

### How to test it?

Automated checks (all pass on this branch):

```bash
yarn lint:oxlint          # from the repo root — clean, exit 0

cd packages/core/content-manager
yarn test:ts:back
yarn lint
```

To see the failure this fixes, run `yarn lint:oxlint` on `develop` — it exits 1 with
the two `TS(1016)` errors above.

Manual test — permission checks still behave as before:

1. Start the sandbox: `cd examples/getstarted && yarn develop`
2. Log in to the admin panel as a super admin.
3. Go to **Settings → Roles → Editor** and pick any collection type.
4. Turn off **Read** for one field only (leave the entry-level Read on), then save.
5. Create a second user with the Editor role and log in as them.
6. Open an entry of that collection type in the Content Manager.
7. The restricted field is not shown, and the rest of the entry loads and saves
   normally.
8. Back as super admin, remove **Read** on the whole collection type for Editor.
   As the Editor user, the collection type no longer appears in the Content Manager.

### Related issue(s)/PR(s)

Follow-up to #26923, which added the non-blocking OxLint setup that surfaced this.
