### PR TITLE
feat(graphql): surface componentKey on GraphQL and OpenAPI

### DIFF
--- a/packages/plugins/documentation/server/src/services/helpers/utils/clean-schema-attributes.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/utils/clean-schema-attributes.ts
@@ -108,7 +108,9 @@ const cleanSchemaAttributes = (
         const rawComponentSchema: OpenAPIV3.SchemaObject = {
           type: 'object',
           properties: {
-            ...(isRequest ? {} : { id: { oneOf: [{ type: 'string' }, { type: 'number' }] } }),
+            // Row id (status-local) + durable componentKey for Draft & Publish round-trips
+            id: { oneOf: [{ type: 'string' }, { type: 'number' }] },
+            componentKey: { type: 'string' },
             ...cleanSchemaAttributes(componentAttributes, {
               typeMap,
               isRequest,
@@ -143,7 +145,8 @@ const cleanSchemaAttributes = (
           const rawComponentSchema: OpenAPIV3.SchemaObject = {
             type: 'object',
             properties: {
-              ...(isRequest ? {} : { id: { oneOf: [{ type: 'string' }, { type: 'number' }] } }),
+              id: { oneOf: [{ type: 'string' }, { type: 'number' }] },
+              componentKey: { type: 'string' },
               __component: { type: 'string', enum: [component] },
               ...cleanSchemaAttributes(componentAttributes, {
                 typeMap,

--- a/packages/plugins/graphql/server/src/services/builders/input.ts
+++ b/packages/plugins/graphql/server/src/services/builders/input.ts
@@ -49,6 +49,11 @@ export default ({ strapi }: Context) => {
             t.id('id');
           }
 
+          // Durable identity for Content API round-trips under Draft & Publish
+          if (modelType === 'component' && isFieldEnabled('componentKey')) {
+            t.id('componentKey');
+          }
+
           validAttributes.forEach(([attributeName, attribute]: [string, any]) => {
             // Enums
             if (isEnumeration(attribute)) {

--- a/packages/plugins/graphql/server/src/services/builders/type.ts
+++ b/packages/plugins/graphql/server/src/services/builders/type.ts
@@ -344,6 +344,10 @@ export default (context: Context) => {
             t.nonNull.id('id');
           }
 
+          if (modelType === 'component' && isNotDisabled(contentType)('componentKey')) {
+            t.nonNull.id('componentKey');
+          }
+
           if (modelType !== 'component' && isNotDisabled(contentType)('documentId')) {
             t.nonNull.id('documentId');
           }
@@ -381,6 +385,8 @@ export default (context: Context) => {
             .filter(isNotPrivate(contentType))
             // Ignore disabled fields (from extension service)
             .filter(isNotDisabled(contentType))
+            // componentKey is registered explicitly above (ID scalar); skip the string attribute pass
+            .filter((attributeName) => attributeName !== 'componentKey')
             // Add each attribute to the type definition
             .forEach((attributeName) => {
               const attribute = attributes[attributeName];

--- a/tests/api/plugins/graphql/component-key.test.api.js
+++ b/tests/api/plugins/graphql/component-key.test.api.js
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * GraphQL surfacing of durable componentKey on nested components.
+ * Stacked on feat/component-key (#27077).
+ */
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let graphqlQuery;
+let documentId;
+
+const blockComponent = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  displayName: 'gql-key-block',
+};
+
+const articleModel = {
+  attributes: {
+    title: {
+      type: 'string',
+    },
+    blocks: {
+      type: 'component',
+      component: 'default.gql-key-block',
+      repeatable: true,
+    },
+  },
+  singularName: 'gql-key-article',
+  pluralName: 'gql-key-articles',
+  displayName: 'Gql Key Article',
+  draftAndPublish: false,
+};
+
+describe('GraphQL — componentKey', () => {
+  beforeAll(async () => {
+    await builder.addComponent(blockComponent).addContentTypes([articleModel]).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    graphqlQuery = (body) =>
+      rq({
+        url: '/graphql',
+        method: 'POST',
+        body,
+      });
+
+    const created = await strapi.documents('api::gql-key-article.gql-key-article').create({
+      data: {
+        title: 'hello',
+        blocks: [{ name: 'a' }, { name: 'b' }],
+      },
+      populate: ['blocks'],
+    });
+    documentId = created.documentId;
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('query returns componentKey on nested components', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          gqlKeyArticle(documentId: $documentId) {
+            data {
+              attributes {
+                title
+                blocks {
+                  id
+                  componentKey
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const blocks = res.body.data.gqlKeyArticle.data.attributes.blocks;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].componentKey).toEqual(expect.any(String));
+    expect(blocks[1].componentKey).toEqual(expect.any(String));
+    expect(blocks[0].componentKey).not.toBe(blocks[1].componentKey);
+  });
+
+  test('mutation update accepts componentKey on component input', async () => {
+    const read = await graphqlQuery({
+      query: /* GraphQL */ `
+        query ($documentId: ID!) {
+          gqlKeyArticle(documentId: $documentId) {
+            data {
+              attributes {
+                blocks {
+                  componentKey
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId },
+    });
+
+    const blocks = read.body.data.gqlKeyArticle.data.attributes.blocks;
+    const targetKey = blocks[0].componentKey;
+
+    const updateRes = await graphqlQuery({
+      query: /* GraphQL */ `
+        mutation updateArticle($documentId: ID!, $data: GqlKeyArticleInput!) {
+          updateGqlKeyArticle(documentId: $documentId, data: $data) {
+            data {
+              attributes {
+                blocks {
+                  componentKey
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: {
+        documentId,
+        data: {
+          blocks: [
+            { componentKey: targetKey, name: 'a-updated' },
+            { componentKey: blocks[1].componentKey, name: 'b' },
+          ],
+        },
+      },
+    });
+
+    expect(updateRes.statusCode).toBe(200);
+    expect(updateRes.body.errors).toBeUndefined();
+
+    const updated = updateRes.body.data.updateGqlKeyArticle.data.attributes.blocks;
+    expect(updated.find((b) => b.componentKey === targetKey).name).toBe('a-updated');
+  });
+});


### PR DESCRIPTION
### What does it do?

Surfaces durable `componentKey` on nested component GraphQL types (output + input) and in the documentation plugin OpenAPI component schemas, mirroring how `id` is exposed on components / `documentId` on content types.

**Stacked on:** #27077 (`feat/component-key`)

| Area | Change |
|------|--------|
| GraphQL output | `t.nonNull.id('componentKey')` on component types |
| GraphQL input | `t.id('componentKey')` on component inputs for updates |
| OpenAPI (documentation) | `componentKey: { type: 'string' }` on component + DZ schemas |
| Tests | `tests/api/plugins/graphql/component-key.test.api.js` |

### Why is it needed?

#27077 adds `componentKey` for REST / Document Service round-trips. GraphQL and OpenAPI clients need the same field exposed to use the feature without falling back to status-local numeric `id`s.

### How to test it?

- [x] `yarn test:api -- tests/api/plugins/graphql/component-key.test.api.js` (2/2)
- [ ] Manual: GraphQL query a document with components → confirm `componentKey` present; update mutation with `componentKey` updates the instance
- [ ] Manual: OpenAPI / documentation plugin shows `componentKey` on component schemas

### Related issue(s)/PR(s)

- Stacks on #27077
- RFC: `docs/docs/rfcs/03-component-key.md`