### PR TITLE
fix: enable fr locale in admin app template so it's selectable (#27191)

### DIFF
--- a/packages/cli/create-strapi-app/templates/example/src/admin/app.example.tsx
+++ b/packages/cli/create-strapi-app/templates/example/src/admin/app.example.tsx
@@ -1,10 +1,9 @@
 import type { StrapiApp } from '@strapi/strapi/admin';
-
 export default {
   config: {
     locales: [
       // 'ar',
-      // 'fr',
+       'fr',
       // 'cs',
       // 'de',
       // 'da',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Uncomments the `fr` locale in the admin app template
(`packages/cli/create-strapi-app/templates/example/src/admin/app.example.tsx`),
making French selectable as an admin interface language for
newly created Strapi projects.

### Why is it needed?

The `fr` locale (and other non-English locales) were present in
the template but commented out, so new projects had no way to
select French as the admin UI language — the language picker
only ever showed English, and setting `preferredLanguage` to
"fr" had no effect since the locale was never registered.

### How to test it?

1. Run `create-strapi-app` to scaffold a new project using this
   updated template (or manually add `locales: ['fr']` to
   `src/admin/app.tsx` in an existing project).
2. Run `strapi build && strapi start`.
3. Open the admin panel — "Français" now appears in the language
   picker, and selecting it correctly translates the interface.

### Related issue(s)/PR(s)

Fix #27191

---
Fixes CPR-468