### PR TITLE
ci: backend test jobs skipped when the jest unit preset changes

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -6,7 +6,7 @@ backend:
   - 'packages/{utils,generators,cli,providers}/**'
   - 'packages/core/*/{lib,bin,ee,src}/**'
   - 'packages/core/database/**'
-  - 'jest-preset.back.js'
+  - 'jest-preset.unit.js'
 frontend:
   - 'packages/**/admin/src/**'
   - 'packages/**/admin/ee/admin/**'

--- a/jest-preset.front.js
+++ b/jest-preset.front.js
@@ -1,7 +1,9 @@
+// @ts-check
 'use strict';
 
 const path = require('path');
 
+/** @type {import('jest').Config['moduleNameMapper']} */
 const moduleNameMapper = {
   '.*\\.(css|less|styl|scss|sass)$': '@strapi/admin-test-utils/file-mock',
   '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|ico)$':
@@ -17,10 +19,8 @@ const moduleNameMapper = {
   '^styled-components$': path.join(__dirname, 'node_modules/styled-components'),
 };
 
-/**
- * @type {import('jest').Config}
- */
-module.exports = {
+/** @type {import('jest').Config} */
+const config = {
   rootDir: __dirname,
   moduleNameMapper,
   /* Tells jest to ignore duplicated manual mock files, such as index.js */
@@ -91,8 +91,6 @@ module.exports = {
     // the package's `default` export so `msw/node` resolves correctly under Jest+jsdom.
     customExportConditions: [''],
   },
-  // Use `jest-watch-typeahead` version 0.6.5. Newest version 1.0.0 does not support jest@26
-  // Reference: https://github.com/jest-community/jest-watch-typeahead/releases/tag/v1.0.0
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
 
   // NOTE: this doesn't work with projects due to a jest bug, so we also set it
@@ -131,3 +129,5 @@ module.exports = {
     '<rootDir>/static/',
   ],
 };
+
+module.exports = config;

--- a/jest-preset.unit.js
+++ b/jest-preset.unit.js
@@ -1,6 +1,8 @@
+// @ts-check
 'use strict';
 
-module.exports = {
+/** @type {import('jest').Config} */
+const config = {
   setupFilesAfterEnv: [__dirname + '/tests/setup/unit.setup.js'],
   modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]', '[/\\\\]dist[/\\\\]'],
   testPathIgnorePatterns: [
@@ -15,10 +17,8 @@ module.exports = {
   prettierPath: require.resolve('prettier-2'),
   testMatch: ['**/__tests__/**/*.{js,ts,jsx,tsx}'],
   transform: {
-    '^.+\\.(t|j)sx?$': ['@swc/jest'],
+    '^.+\\.(t|j)sx?$': ['@swc/jest', {}],
   },
-  // Use `jest-watch-typeahead` version 0.6.5. Newest version 1.0.0 does not support jest@26
-  // Reference: https://github.com/jest-community/jest-watch-typeahead/releases/tag/v1.0.0
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
   // Coverage configuration for SonarQube
   collectCoverage: false, // Will be enabled via CLI flag
@@ -49,3 +49,5 @@ module.exports = {
     '<rootDir>/coverage/',
   ],
 };
+
+module.exports = config;

--- a/jest.config.api.js
+++ b/jest.config.api.js
@@ -1,6 +1,8 @@
+// @ts-check
 'use strict';
 
-module.exports = {
+/** @type {import('jest').Config} */
+const config = {
   displayName: 'API integration tests',
   testMatch: ['**/?(*.)+(spec|test).api.(js|ts)'],
   testEnvironment: 'node',
@@ -33,7 +35,9 @@ module.exports = {
     '<rootDir>/coverage/',
   ],
   transform: {
-    '^.+\\.ts$': ['@swc/jest'],
+    '^.+\\.ts$': ['@swc/jest', {}],
   },
   modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]', '[/\\\\]dist[/\\\\]'],
 };
+
+module.exports = config;

--- a/jest.config.cli.js
+++ b/jest.config.cli.js
@@ -1,6 +1,8 @@
+// @ts-check
 'use strict';
 
-module.exports = {
+/** @type {import('jest').Config} */
+const config = {
   displayName: 'CLI tests',
   testMatch: ['**/?(*.)+(spec|test).cli.(js|ts)'],
   testEnvironment: 'node',
@@ -12,7 +14,9 @@ module.exports = {
     '<rootDir>/test/',
   ],
   transform: {
-    '^.+\\.ts$': ['@swc/jest'],
+    '^.+\\.ts$': ['@swc/jest', {}],
   },
   modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]', '[/\\\\]dist[/\\\\]'],
 };
+
+module.exports = config;


### PR DESCRIPTION
### What does it do?

Two things:

1. Updates the `backend` entry in `.github/filters.yaml` to reference `jest-preset.unit.js` instead of `jest-preset.back.js`.
2. Tidies the root jest config files that entry now guards (`jest-preset.unit.js`, `jest-preset.front.js`, `jest.config.api.js`, `jest.config.cli.js`):
   - adds `// @ts-check` and `@type {import('jest').Config}` annotations so the configs are type-checked in the editor;
   - passes an explicit empty options object to the `@swc/jest` transform, which the tuple form of the jest `transform` type requires (`['@swc/jest']` fails the check with `Source has 1 element(s) but target requires 2`);
   - removes stale comments referencing jest@26.

   No jest behaviour changes from (2) — the transform tuple is equivalent and the annotations are types only.

### Why is it needed?

`.github/workflows/tests.yml` uses `dorny/paths-filter` with `.github/filters.yaml` to decide which test jobs to run. The `backend` filter lists `jest-preset.back.js`, but no file with that name has ever existed in the repository — the backend/unit jest preset is `jest-preset.unit.js` (added in #15957, before the filter entry was introduced in #22161).

As a result, a PR that only touches the backend jest preset does not set `needs.conditions.outputs.backend`, and the unit test jobs are skipped — the exact change most likely to break them goes untested. The equivalent frontend entry (`jest-preset.front.js`) is correct, so only the backend side is affected.

### How to test it?

- `ls jest-preset.*` — only `jest-preset.front.js` and `jest-preset.unit.js` exist.
- `git log --all -- jest-preset.back.js` — no history, the path never existed.
- Open a PR touching only `jest-preset.unit.js`: before this change the `Unit tests` jobs are skipped, after it they run.
- Unit tests still resolve and pass against the tidied preset — e.g. `cd packages/core/utils && npx jest` (33 suites).

### Related issue(s)/PR(s)

- Filter entry introduced in #22161
- `jest-preset.unit.js` added in #15957

🤖 Generated with [Claude Code](https://claude.com/claude-code)
