### PR TITLE
chore(deps): align app-template react-router-dom with admin 6.30.4

### DIFF
--- a/tests/app-template/package.json
+++ b/tests/app-template/package.json
@@ -16,7 +16,7 @@
     "better-sqlite3": "12.8.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.30.3",
+    "react-router-dom": "6.30.4",
     "styled-components": "6.4.1"
   },
   "engines": {


### PR DESCRIPTION
### What does it do?

Bumps `react-router-dom` in `tests/app-template` from `6.30.3` to `6.30.4` so it matches the admin / example / plugin pins already on develop.

### Why is it needed?

Develop currently fails package-version / syncpack alignment: the e2e app template was left on `6.30.3` while the rest of the monorepo moved to `6.30.4`.

### How to test it?

- Confirm `tests/app-template/package.json` pins `react-router-dom` to `6.30.4`
- Re-run the package version / syncpack check that previously flagged this drift

### Related issue(s)/PR(s)

- Split out from ambient develop noise noticed while shipping #27209