### PR TITLE
chore(upload-aws-s3): migrate unit tests from jest to vitest

### DIFF
--- a/packages/providers/upload-aws-s3/jest.config.js
+++ b/packages/providers/upload-aws-s3/jest.config.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  displayName: 'S3 upload provider',
-};

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -44,9 +44,9 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc -p tsconfig.json",
-    "test:unit": "run -T jest",
-    "test:unit:watch": "run -T jest --watch",
-    "watch": "run -T rollup -c -w"
+    "watch": "run -T rollup -c -w",
+    "test:unit:vitest": "vitest run",
+    "test:unit:vitest:watch": "vitest --watch"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.1023.0",
@@ -56,11 +56,11 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.51.2",
-    "jest": "29.6.0",
-    "tsconfig": "5.51.2"
+    "tsconfig": "5.51.2",
+    "vitest": "catalog:",
+    "vitest-config": "5.51.2"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/providers/upload-aws-s3/src/__tests__/is-url-from-bucket.vitest.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/is-url-from-bucket.vitest.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 import { isUrlFromBucket } from '../utils';
 
 describe('Test for URLs', () => {

--- a/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.vitest.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.vitest.test.ts
@@ -1,37 +1,51 @@
 import { Upload } from '@aws-sdk/lib-storage';
+import { afterEach, beforeEach, describe, expect, test, vi, type Mock } from 'vitest';
 
 import awsProvider, { File, ProviderConfig } from '../index';
 
-jest.mock('../utils', () => ({
-  ...jest.requireActual('../utils'),
-  extractCredentials: jest.fn().mockReturnValue({
-    accessKeyId: 'test',
-    secretAccessKey: 'test',
-  }),
-}));
+const { extractCredentialsMock, uploadMock, mockSend, UploadMock, S3ClientMock } = vi.hoisted(
+  () => {
+    const uploadMock = {
+      done: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          Location: 'https://validurl.test/tmp/test.json',
+          ETag: '"abc123def456"',
+          $metadata: {},
+        })
+      ),
+    };
+    const mockSend = vi.fn();
+    const UploadMock = vi.fn(function Upload() {
+      return uploadMock;
+    });
+    const S3ClientMock = vi.fn(function S3Client() {
+      return { send: mockSend };
+    });
+    const extractCredentialsMock = vi.fn().mockReturnValue({
+      accessKeyId: 'test',
+      secretAccessKey: 'test',
+    });
+    return { extractCredentialsMock, uploadMock, mockSend, UploadMock, S3ClientMock };
+  }
+);
 
-const uploadMock = {
-  done: jest.fn().mockImplementation(() =>
-    Promise.resolve({
-      Location: 'https://validurl.test/tmp/test.json',
-      ETag: '"abc123def456"',
-      $metadata: {},
-    })
-  ),
-};
-
-jest.mock('@aws-sdk/lib-storage', () => ({
-  Upload: jest.fn().mockImplementation(() => uploadMock),
-}));
-
-const mockSend = jest.fn();
-jest.mock('@aws-sdk/client-s3', () => {
-  const actual = jest.requireActual('@aws-sdk/client-s3');
+vi.mock('../utils', async () => {
+  const actual = await vi.importActual<typeof import('../utils')>('../utils');
   return {
     ...actual,
-    S3Client: jest.fn().mockImplementation(() => ({
-      send: mockSend,
-    })),
+    extractCredentials: extractCredentialsMock,
+  };
+});
+
+vi.mock('@aws-sdk/lib-storage', () => ({
+  Upload: UploadMock,
+}));
+
+vi.mock('@aws-sdk/client-s3', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-s3')>('@aws-sdk/client-s3');
+  return {
+    ...actual,
+    S3Client: S3ClientMock,
   };
 });
 
@@ -50,7 +64,7 @@ const createTestFile = (overrides: Partial<File> = {}): File => ({
 
 describe('AWS-S3 provider', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     mockSend.mockReset();
     uploadMock.done.mockImplementation(() =>
       Promise.resolve({
@@ -322,7 +336,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.ChecksumAlgorithm).toBe('CRC32');
     });
 
@@ -341,7 +355,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.ChecksumAlgorithm).toBe('SHA256');
     });
 
@@ -360,7 +374,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.ChecksumAlgorithm).toBe('CRC64NVME');
     });
 
@@ -376,7 +390,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.ChecksumAlgorithm).toBeUndefined();
     });
   });
@@ -397,7 +411,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.IfNoneMatch).toBe('*');
     });
 
@@ -416,7 +430,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.IfNoneMatch).toBeUndefined();
     });
   });
@@ -437,7 +451,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.StorageClass).toBe('STANDARD');
     });
 
@@ -456,7 +470,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.StorageClass).toBe('INTELLIGENT_TIERING');
     });
 
@@ -475,7 +489,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.StorageClass).toBe('GLACIER');
     });
 
@@ -494,7 +508,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.StorageClass).toBe('DEEP_ARCHIVE');
     });
   });
@@ -517,7 +531,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.ServerSideEncryption).toBe('AES256');
       expect(uploadCall.params.SSEKMSKeyId).toBeUndefined();
     });
@@ -540,7 +554,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.ServerSideEncryption).toBe('aws:kms');
       expect(uploadCall.params.SSEKMSKeyId).toBe(
         'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012'
@@ -565,7 +579,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.ServerSideEncryption).toBe('aws:kms:dsse');
       expect(uploadCall.params.SSEKMSKeyId).toBe('test-key-id');
     });
@@ -589,7 +603,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Tagging).toBe('project=test-project');
     });
 
@@ -612,7 +626,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Tagging).toContain('project=test-project');
       expect(uploadCall.params.Tagging).toContain('environment=production');
       expect(uploadCall.params.Tagging).toContain('team=backend');
@@ -635,7 +649,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Tagging).toBe('key%20with%20spaces=value%20with%20spaces');
     });
 
@@ -654,7 +668,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Tagging).toBeUndefined();
     });
   });
@@ -677,7 +691,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.partSize).toBe(10 * 1024 * 1024);
     });
 
@@ -698,7 +712,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.queueSize).toBe(8);
     });
 
@@ -719,7 +733,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.leavePartsOnError).toBe(true);
     });
 
@@ -742,7 +756,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.partSize).toBe(5 * 1024 * 1024);
       expect(uploadCall.queueSize).toBe(4);
       expect(uploadCall.leavePartsOnError).toBe(false);
@@ -762,7 +776,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.uploadIfMatch(file, 'expected-etag-123');
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.IfMatch).toBe('expected-etag-123');
     });
 
@@ -959,7 +973,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
 
       expect(uploadCall.params.Bucket).toBe('test-bucket');
       expect(uploadCall.params.ACL).toBe('private');
@@ -989,7 +1003,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile({ path: '../../../etc/passwd' });
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Key).not.toContain('..');
       expect(uploadCall.params.Key).toBe('etc/passwd/test.json');
     });
@@ -1006,7 +1020,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile({ path: '', hash: '../../../malicious' });
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Key).not.toContain('..');
       expect(uploadCall.params.Key).toBe('malicious.json');
     });
@@ -1023,7 +1037,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile({ ext: '.json;rm -rf /' });
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Key).toBe('tmp/test.jsonrmrf');
     });
 
@@ -1039,7 +1053,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile({ path: 'foo///bar//baz' });
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Key).toBe('foo/bar/baz/test.json');
     });
   });
@@ -1057,7 +1071,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file, { Bucket: 'malicious-bucket' } as any);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Bucket).toBe('secure-bucket');
     });
 
@@ -1073,7 +1087,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file, { Key: 'malicious-key' } as any);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Key).toBe('tmp/test.json');
     });
 
@@ -1090,7 +1104,7 @@ describe('AWS-S3 provider', () => {
       const maliciousBody = Buffer.from('malicious content');
       await providerInstance.upload(file, { Body: maliciousBody } as any);
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.Body).toEqual(Buffer.from('test content'));
     });
 
@@ -1106,7 +1120,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file, { ContentDisposition: 'attachment' });
 
-      const uploadCall = (Upload as jest.Mock).mock.calls[0][0];
+      const uploadCall = (Upload as Mock).mock.calls[0][0];
       expect(uploadCall.params.ContentDisposition).toBe('attachment');
     });
   });
@@ -1299,10 +1313,10 @@ describe('AWS-S3 provider', () => {
   });
 
   describe('configuration validation', () => {
-    let warningSpy: jest.SpyInstance;
+    let warningSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
-      warningSpy = jest.spyOn(process, 'emitWarning').mockImplementation(() => {});
+      warningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
     });
 
     afterEach(() => {

--- a/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.vitest.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.vitest.test.ts
@@ -1,5 +1,4 @@
-import { Upload } from '@aws-sdk/lib-storage';
-import { afterEach, beforeEach, describe, expect, test, vi, type Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import awsProvider, { File, ProviderConfig } from '../index';
 
@@ -336,7 +335,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.ChecksumAlgorithm).toBe('CRC32');
     });
 
@@ -355,7 +354,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.ChecksumAlgorithm).toBe('SHA256');
     });
 
@@ -374,7 +373,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.ChecksumAlgorithm).toBe('CRC64NVME');
     });
 
@@ -390,7 +389,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.ChecksumAlgorithm).toBeUndefined();
     });
   });
@@ -411,7 +410,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.IfNoneMatch).toBe('*');
     });
 
@@ -430,7 +429,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.IfNoneMatch).toBeUndefined();
     });
   });
@@ -451,7 +450,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.StorageClass).toBe('STANDARD');
     });
 
@@ -470,7 +469,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.StorageClass).toBe('INTELLIGENT_TIERING');
     });
 
@@ -489,7 +488,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.StorageClass).toBe('GLACIER');
     });
 
@@ -508,7 +507,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.StorageClass).toBe('DEEP_ARCHIVE');
     });
   });
@@ -531,7 +530,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.ServerSideEncryption).toBe('AES256');
       expect(uploadCall.params.SSEKMSKeyId).toBeUndefined();
     });
@@ -554,7 +553,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.ServerSideEncryption).toBe('aws:kms');
       expect(uploadCall.params.SSEKMSKeyId).toBe(
         'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012'
@@ -579,7 +578,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.ServerSideEncryption).toBe('aws:kms:dsse');
       expect(uploadCall.params.SSEKMSKeyId).toBe('test-key-id');
     });
@@ -603,7 +602,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Tagging).toBe('project=test-project');
     });
 
@@ -626,7 +625,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Tagging).toContain('project=test-project');
       expect(uploadCall.params.Tagging).toContain('environment=production');
       expect(uploadCall.params.Tagging).toContain('team=backend');
@@ -649,7 +648,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Tagging).toBe('key%20with%20spaces=value%20with%20spaces');
     });
 
@@ -668,7 +667,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Tagging).toBeUndefined();
     });
   });
@@ -691,7 +690,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.partSize).toBe(10 * 1024 * 1024);
     });
 
@@ -712,7 +711,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.queueSize).toBe(8);
     });
 
@@ -733,7 +732,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.leavePartsOnError).toBe(true);
     });
 
@@ -756,7 +755,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.partSize).toBe(5 * 1024 * 1024);
       expect(uploadCall.queueSize).toBe(4);
       expect(uploadCall.leavePartsOnError).toBe(false);
@@ -776,7 +775,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.uploadIfMatch(file, 'expected-etag-123');
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.IfMatch).toBe('expected-etag-123');
     });
 
@@ -973,7 +972,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
 
       expect(uploadCall.params.Bucket).toBe('test-bucket');
       expect(uploadCall.params.ACL).toBe('private');
@@ -1003,7 +1002,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile({ path: '../../../etc/passwd' });
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Key).not.toContain('..');
       expect(uploadCall.params.Key).toBe('etc/passwd/test.json');
     });
@@ -1020,7 +1019,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile({ path: '', hash: '../../../malicious' });
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Key).not.toContain('..');
       expect(uploadCall.params.Key).toBe('malicious.json');
     });
@@ -1037,7 +1036,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile({ ext: '.json;rm -rf /' });
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Key).toBe('tmp/test.jsonrmrf');
     });
 
@@ -1053,7 +1052,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile({ path: 'foo///bar//baz' });
       await providerInstance.upload(file);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Key).toBe('foo/bar/baz/test.json');
     });
   });
@@ -1071,7 +1070,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file, { Bucket: 'malicious-bucket' } as any);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Bucket).toBe('secure-bucket');
     });
 
@@ -1087,7 +1086,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file, { Key: 'malicious-key' } as any);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Key).toBe('tmp/test.json');
     });
 
@@ -1104,7 +1103,7 @@ describe('AWS-S3 provider', () => {
       const maliciousBody = Buffer.from('malicious content');
       await providerInstance.upload(file, { Body: maliciousBody } as any);
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.Body).toEqual(Buffer.from('test content'));
     });
 
@@ -1120,7 +1119,7 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file, { ContentDisposition: 'attachment' });
 
-      const uploadCall = (Upload as Mock).mock.calls[0][0];
+      const uploadCall = UploadMock.mock.calls[0][0];
       expect(uploadCall.params.ContentDisposition).toBe('attachment');
     });
   });

--- a/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.vitest.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.vitest.test.ts
@@ -28,8 +28,8 @@ const { extractCredentialsMock, uploadMock, mockSend, UploadMock, S3ClientMock }
   }
 );
 
-vi.mock('../utils', async () => {
-  const actual = await vi.importActual<typeof import('../utils')>('../utils');
+vi.mock(import('../utils'), async (importOriginal) => {
+  const actual = await importOriginal();
   return {
     ...actual,
     extractCredentials: extractCredentialsMock,
@@ -40,8 +40,8 @@ vi.mock('@aws-sdk/lib-storage', () => ({
   Upload: UploadMock,
 }));
 
-vi.mock('@aws-sdk/client-s3', async () => {
-  const actual = await vi.importActual<typeof import('@aws-sdk/client-s3')>('@aws-sdk/client-s3');
+vi.mock(import('@aws-sdk/client-s3'), async (importOriginal) => {
+  const actual = await importOriginal();
   return {
     ...actual,
     S3Client: S3ClientMock,

--- a/packages/providers/upload-aws-s3/src/__tests__/utils.vitest.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/utils.vitest.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test, vi } from 'vitest';
+
 import { ObjectCannedACL } from '@aws-sdk/client-s3';
 import type { InitOptions } from '..';
 import { extractCredentials } from '../utils';
@@ -85,7 +87,7 @@ describe('Utils', () => {
     });
 
     test('Extracts root-level accessKeyId/secretAccessKey from s3Options', () => {
-      const warningSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const warningSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const options: InitOptions = {
         s3Options: {

--- a/packages/providers/upload-aws-s3/tsconfig.json
+++ b/packages/providers/upload-aws-s3/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src"],
-  "exclude": ["**/__tests__/**"],
+  "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   }
 }

--- a/packages/providers/upload-aws-s3/tsconfig.json
+++ b/packages/providers/upload-aws-s3/tsconfig.json
@@ -3,5 +3,6 @@
   "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
     "types": ["node"]
-  }
+  },
+  "exclude": ["**/__tests__/**"]
 }

--- a/packages/providers/upload-aws-s3/vitest.config.ts
+++ b/packages/providers/upload-aws-s3/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9997,12 +9997,12 @@ __metadata:
     "@aws-sdk/lib-storage": "npm:3.1023.0"
     "@aws-sdk/s3-request-presigner": "npm:3.1023.0"
     "@aws-sdk/types": "npm:3.973.6"
-    "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.51.2"
-    jest: "npm:29.6.0"
     lodash: "npm:4.18.1"
     tsconfig: "npm:5.51.2"
+    vitest: "catalog:"
+    vitest-config: "npm:5.51.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Fully migrates `@strapi/provider-upload-aws-s3` unit tests from Jest to Vitest:

- Replace Jest scripts/deps with Vitest + shared `vitest-config`
- Add `vitest.config.ts` and rename suites to `*.vitest.test.ts`
- Remove `jest.config.js` and Jest type references from `tsconfig.json`
- Adjust AWS SDK / utils mocks for Vitest (`vi.hoisted`, constructable mocks, `vi.importActual`)

### Why is it needed?

Incremental Jest → Vitest migration for monorepo unit tests. This is the last leaf upload/email provider still on Jest.

### How to test it?

```bash
yarn workspace @strapi/provider-upload-aws-s3 test:unit:vitest
yarn workspace @strapi/provider-upload-aws-s3 lint
```

### Related issue(s)/PR(s)

Fixes CMS-1488

Stacked on #27252 (`chore/vitest-sentry`).