### PR TITLE
fix(admin): dedupe react-dnd in the admin bundle

### DIFF
--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
@@ -15,6 +15,13 @@ const adminDeps = require('@strapi/admin/package.json').dependencies as Record<s
 /** CJS/UMD deps on optimizeDeps.include must stay aliased for pnpm (#27014). */
 const PNPM_OPTIMIZE_ALIAS_MODULES = ['invariant', 'prismjs', 'lodash'] as const;
 
+/**
+ * react-dnd keeps its DndContext in module scope and is declared by both @strapi/admin and
+ * @strapi/content-manager, so it must be deduped rather than left to npm hoisting — otherwise
+ * the Content Manager mounts against a second, empty context (#22392, #22792).
+ */
+const DND_SINGLETON_MODULES = ['react-dnd', 'react-dnd-html5-backend'] as const;
+
 describe('ADMIN_VITE_ALIAS_MODULES contract', () => {
   it.each(PNPM_OPTIMIZE_ALIAS_MODULES)(
     'includes %s for pnpm optimizeDeps.include resolution (#27014)',
@@ -25,6 +32,12 @@ describe('ADMIN_VITE_ALIAS_MODULES contract', () => {
 
   it('pins invariant alongside other @strapi/admin dependency versions', () => {
     expect(ADMIN_PINNED_ALIAS_MODULES).toContain('invariant');
+  });
+
+  it('dedupes react-dnd so the admin DndProvider and content-manager share one context (#22392)', () => {
+    for (const mod of DND_SINGLETON_MODULES) {
+      expect(ADMIN_VITE_DEDUPE_MODULES).toContain(mod);
+    }
   });
 });
 

--- a/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
@@ -18,6 +18,16 @@ export const ADMIN_VITE_ALIAS_MODULES = [
   'lodash',
   'invariant',
   'prismjs',
+  // react-dnd holds its DndContext in module scope, and @strapi/admin and
+  // @strapi/content-manager each declare react-dnd@16.0.1 themselves. npm hoisting collapses
+  // those onto one copy, so the DndProvider rendered by @strapi/admin's AuthenticatedLayout and
+  // the useDragLayer call in the content-manager layout share a context only by accident of
+  // hoisting. Any tree that keeps the copies separate (pnpm's strict isolation,
+  // install-strategy=nested, a plugin pinning its own react-dnd) gives them two different
+  // contexts and the Content Manager crashes on mount with
+  // "Invariant Violation: Expected drag drop context" (#22392, #22792).
+  'react-dnd',
+  'react-dnd-html5-backend',
 ] as const;
 
 export type AdminViteAliasModule = (typeof ADMIN_VITE_ALIAS_MODULES)[number];
@@ -42,4 +52,6 @@ export const ADMIN_PINNED_ALIAS_MODULES = [
   '@strapi/design-system',
   'lodash',
   'invariant',
+  'react-dnd',
+  'react-dnd-html5-backend',
 ] as const satisfies readonly AdminViteAliasModule[];


### PR DESCRIPTION
### What does it do?

Adds `react-dnd` and `react-dnd-html5-backend` to `ADMIN_VITE_ALIAS_MODULES`, which puts them on both Vite `resolve.dedupe` and `resolve.alias` (resolved from `@strapi/admin`'s closure via `getModulePath`), and keeps them off `optimizeDeps.exclude` through `PINNED_OPTIMIZE_MODULES`.

Both are exact-pinned in `@strapi/admin`'s `dependencies` (`16.0.1`), so they are also added to `ADMIN_PINNED_ALIAS_MODULES` and satisfy its version-pinning contract test.

A regression test asserts both stay on `ADMIN_VITE_DEDUPE_MODULES`.

### Why is it needed?

`react-dnd` creates its `DndContext` at module scope, so the admin bundle must contain exactly one copy of it. Two packages each declare it as their own direct dependency:

- `@strapi/admin` → `react-dnd: "16.0.1"` — renders the shared `<DndProvider>` in `AuthenticatedLayout`
- `@strapi/content-manager` → `react-dnd: "16.0.1"` — calls `useDragLayer` in its layout

Under npm's default hoisting those two dedupe onto one physical copy, so the provider and the consumer share a context. Nothing enforces that — it is a property of the install layout, not of the code. As soon as the tree keeps the copies separate, `useDragDropManager` reads a different `DndContext` than the one `DndProvider` populated, gets `undefined`, and throws:

```
Invariant Violation: Expected drag drop context
    at useDragDropManager
    at useDragLayer
    at DragLayer
```

Which is why it takes out the Content Manager specifically while the rest of the admin keeps working.

Anything that prevents deduping triggers it: pnpm's strict `node_modules` isolation, npm `install-strategy=nested`, a plugin or app pinning its own `react-dnd`, or `overrides`/`resolutions` splitting the version. #22392 reports `workspaces/false`, so workspaces are not required to reproduce.

This is the same failure class the list already guards against elsewhere — `react-redux` is on it because of `could not find react-redux context value` after hoisting changes (#26944, #27014), and the CodeMirror entries because of `instanceof` breakage across duplicated copies. `react-dnd` was simply never added, because hoisting normally hides the problem.

### How to test it?

Measured on a Strapi 5.51.1 app, Node 20, npm 10.8.2 — same source tree both times, the only variable being whether npm dedupes. Counting `react-dnd`'s own invariant string in the built admin bundle is a direct count of bundled copies:

| install | physical `react-dnd` dirs | `"Expected drag drop context"` in built bundle | Content Manager |
| --- | --- | --- | --- |
| `install-strategy=nested` | 4 | **4** | crashes |
| default (hoisted) | 1 | **1** | works |

To reproduce the failure on an app without this patch:

```bash
# in a Strapi 5 app
echo 'install-strategy=nested' >> .npmrc
rm -rf node_modules package-lock.json && npm install
find node_modules -type d -name react-dnd | wc -l   # > 1
npm run build
grep -rho "Expected drag drop context" dist | wc -l # matches the copy count
```

Then open the admin panel and click **Content Manager** — it crashes on mount. The four copies land under `@strapi/admin`, `@strapi/content-manager`, `@strapi/review-workflows` and `@strapi/upload`, one per admin-side package that declares `react-dnd` itself.

With this patch, Vite collapses them onto `@strapi/admin`'s copy regardless of the `node_modules` layout, so the bundle contains one instance and the Content Manager mounts.

**Suites I could not run locally:** I verified the change against the contract tests by reading them rather than executing them — I did not run `yarn test:unit`, `yarn test:front` or `yarn test:e2e`, since that needs a full monorepo install I did not have set up. The change is additive to a constant array, and I checked each of its three consumers by hand:

- `admin-vite-aliases.test.ts` — both modules resolve from `@strapi/admin`'s closure (direct dependencies) and are exact-pinned, so the alias and pinned-version assertions hold.
- `resolve-module.test.ts` — `it.each(ADMIN_VITE_ALIAS_MODULES)` resolves each entry from `@strapi/admin`; both are direct dependencies there.
- `admin-vite-optimize-exclude.test.ts` — entries on the list are only ever *skipped* by `PINNED_OPTIMIZE_MODULES`, and no fixture declares `react-dnd`, so the expected exclude list is unaffected.

I deliberately left `dnd-core` off the list: it is not a direct dependency of `@strapi/admin`, so `getModulePath` would throw under pnpm's strict isolation. Deduping `react-dnd` is sufficient, since `DndContext` lives there.

### Related issue(s)/PR(s)

Fixes #22392
Fixes #22792

Both were auto-closed by the template bot without a diagnosis; they are the same root cause.


---
Fixes CPR-471