### PR TITLE
chore(permissions): migrate unit tests from jest to vitest

### DIFF
--- a/packages/core/permissions/jest.config.js
+++ b/packages/core/permissions/jest.config.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  testMatch: ['**/__tests__/**/*.test.ts'],
-  displayName: 'Core permissions',
-};

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -38,8 +38,6 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc -p tsconfig.json",
-    "test:unit": "run -T jest",
-    "test:unit:watch": "run -T jest --watch",
     "test:unit:vitest": "vitest run",
     "test:unit:vitest:watch": "vitest --watch",
     "watch": "run -T rollup -c -w"
@@ -52,10 +50,8 @@
     "sift": "16.0.1"
   },
   "devDependencies": {
-    "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.51.2",
-    "jest": "29.6.0",
     "tsconfig": "5.51.2",
     "vitest": "catalog:",
     "vitest-config": "5.51.2"

--- a/packages/core/permissions/src/__tests__/permissions.engine.vitest.test.ts
+++ b/packages/core/permissions/src/__tests__/permissions.engine.vitest.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
 import _ from 'lodash';
 import { subject } from '@casl/ability';
 import { providerFactory } from '@strapi/utils';
@@ -101,13 +103,13 @@ describe('Permissions Engine', () => {
     engineProviders?: { action: any; condition: any };
     abilityOptions?: Record<string, unknown>;
   }) => {
-    const registerFunctions: jest.Mock[] = [];
+    const registerFunctions: Mock[] = [];
     const engine = buildEngineWithHooks({ providers: engineProviders }, engineHooks);
     const engineCrf = engine.createRegisterFunction;
-    const createRegisterFunction = jest
+    const createRegisterFunction = vi
       .spyOn(engine, 'createRegisterFunction')
       .mockImplementation((can, options) => {
-        const registerFunction = jest.fn(engineCrf(can, options));
+        const registerFunction = vi.fn(engineCrf(can, options));
         registerFunctions.push(registerFunction);
         return registerFunction;
       });
@@ -536,10 +538,10 @@ describe('Permissions Engine', () => {
   describe('before-* hooks', () => {
     it('execute in the correct order', async () => {
       let called = '';
-      const beforeEvaluateFn = jest.fn(() => {
+      const beforeEvaluateFn = vi.fn(() => {
         called = 'beforeEvaluate';
       });
-      const beforeRegisterFn = jest.fn(() => {
+      const beforeRegisterFn = vi.fn(() => {
         expect(called).toEqual('beforeEvaluate');
         called = 'beforeRegister';
       });

--- a/packages/core/permissions/tsconfig.json
+++ b/packages/core/permissions/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   },
   "include": ["src", "vitest.config.ts"],
   "exclude": ["**/__tests__/**"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9683,10 +9683,8 @@ __metadata:
   dependencies:
     "@casl/ability": "npm:6.7.5"
     "@strapi/utils": "npm:5.51.2"
-    "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.51.2"
-    jest: "npm:29.6.0"
     lodash: "npm:4.18.1"
     qs: "npm:6.15.3"
     sift: "npm:16.0.1"


### PR DESCRIPTION
### What does it do?

Fully migrates `@strapi/permissions` unit tests from Jest to Vitest:

- Convert remaining `permissions.engine` Jest suite to `*.vitest.test.ts`
- Remove `jest.config.js`, Jest scripts, and Jest-only dependencies
- Keep existing Vitest domain coverage

### Why is it needed?

Incremental Jest → Vitest migration for monorepo unit tests.

### How to test it?

```bash
yarn workspace @strapi/permissions test:unit:vitest
yarn workspace @strapi/permissions lint
```

### Related issue(s)/PR(s)

Fixes CMS-1476

Stacked on #27218 (`chore/vitest-cloud-cli`).