### PR TITLE
chore(generators): migrate unit tests from jest to vitest

### DIFF
--- a/packages/generators/generators/jest.config.js
+++ b/packages/generators/generators/jest.config.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  testMatch: ['**/__tests__/**/*.test.ts'],
-  displayName: 'Generators',
-};

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -44,9 +44,9 @@
     "copy-files": "copyfiles -u 1 -a 'src/templates/**/*' 'src/files/**/*' dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc -p tsconfig.json",
-    "test:unit": "run -T jest",
-    "test:unit:watch": "run -T jest --watch",
-    "watch": "run -T rollup -c -w"
+    "watch": "run -T rollup -c -w",
+    "test:unit:vitest": "vitest run",
+    "test:unit:vitest:watch": "vitest --watch"
   },
   "dependencies": {
     "@sindresorhus/slugify": "1.1.0",
@@ -62,14 +62,14 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/jest": "29.5.2",
     "@types/jscodeshift": "17.3.0",
     "@types/node": "20.19.41",
     "copyfiles": "2.4.1",
     "eslint-config-custom": "5.51.2",
-    "jest": "29.6.0",
     "outdent": "^0.8.0",
-    "tsconfig": "5.51.2"
+    "tsconfig": "5.51.2",
+    "vitest": "catalog:",
+    "vitest-config": "5.51.2"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/generators/generators/src/plops/__tests__/content-type.vitest.test.ts
+++ b/packages/generators/generators/src/plops/__tests__/content-type.vitest.test.ts
@@ -1,18 +1,20 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+
 import path from 'node:path';
 import process from 'node:process';
 import { readFile, remove, stat } from 'fs-extra';
-import * as strapiGenerators from '../../index';
+import * as strapiGenerators from '../../../dist/index.js';
 
 describe('Content Type Generator', () => {
   const outputDirectory = path.join(__dirname, 'output');
 
   beforeAll(() => {
-    const spy = jest.spyOn(process, 'cwd');
+    const spy = vi.spyOn(process, 'cwd');
     spy.mockReturnValue(outputDirectory);
   });
 
   afterAll(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   afterEach(async () => {
@@ -32,7 +34,7 @@ describe('Content Type Generator', () => {
         bootstrapApi: false,
         attributes: [],
       },
-      { dir: outputDirectory, plopFile: 'plopfile.ts' }
+      { dir: outputDirectory }
     );
 
     const generatedSchemaPath = path.join(
@@ -77,7 +79,7 @@ describe('Content Type Generator', () => {
         bootstrapApi: true,
         attributes: [],
       },
-      { dir: outputDirectory, plopFile: 'plopfile.ts' }
+      { dir: outputDirectory }
     );
     const generatedApiPath = path.join(outputDirectory, 'src/api/testContentType');
 
@@ -158,7 +160,7 @@ describe('Content Type Generator', () => {
           },
         ],
       },
-      { dir: outputDirectory, plopFile: 'plopfile.ts' }
+      { dir: outputDirectory }
     );
 
     const generatedSchemaPath = path.join(

--- a/packages/generators/generators/src/plops/utils/__tests__/extend-plugin-index.files.vitest.test.ts
+++ b/packages/generators/generators/src/plops/utils/__tests__/extend-plugin-index.files.vitest.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import outdent from 'outdent';
 
 import { appendToFile } from '../extend-plugin-index-files';

--- a/packages/generators/generators/src/plops/utils/__tests__/get-file-path.vitest.test.ts
+++ b/packages/generators/generators/src/plops/utils/__tests__/get-file-path.vitest.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 import getFilePath from '../get-file-path';
 
 describe('Get-File-Path util', () => {

--- a/packages/generators/generators/src/plops/utils/__tests__/get-generator-language.vitest.test.ts
+++ b/packages/generators/generators/src/plops/utils/__tests__/get-generator-language.vitest.test.ts
@@ -1,10 +1,12 @@
+import { describe, expect, test, vi } from 'vitest';
+
 import path from 'node:path';
 import { isUsingTypeScriptSync } from '@strapi/typescript-utils';
 
 import getGeneratorLanguage from '../get-generator-language';
 
-jest.mock('@strapi/typescript-utils', () => ({
-  isUsingTypeScriptSync: jest.fn(),
+vi.mock('@strapi/typescript-utils', () => ({
+  isUsingTypeScriptSync: vi.fn(),
 }));
 
 describe('getGeneratorLanguage', () => {
@@ -12,7 +14,7 @@ describe('getGeneratorLanguage', () => {
   const appPlop = {
     getDestBasePath: () => path.join(appRoot, 'src'),
   };
-  const isUsingTypeScriptSyncMock = jest.mocked(isUsingTypeScriptSync);
+  const isUsingTypeScriptSyncMock = vi.mocked(isUsingTypeScriptSync);
 
   test('non-plugin generation checks the generate dir', () => {
     isUsingTypeScriptSyncMock.mockReturnValue(true);

--- a/packages/generators/generators/tsconfig.eslint.json
+++ b/packages/generators/generators/tsconfig.eslint.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "exclude": []
 }

--- a/packages/generators/generators/tsconfig.json
+++ b/packages/generators/generators/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src"],
-  "exclude": ["src/templates"],
+  "include": ["src", "vitest.config.ts"],
+  "exclude": ["**/__tests__/**", "src/templates"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   }
 }

--- a/packages/generators/generators/vitest.config.ts
+++ b/packages/generators/generators/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9578,7 +9578,6 @@ __metadata:
     "@strapi/typescript-utils": "npm:5.51.2"
     "@strapi/utils": "npm:5.51.2"
     "@types/fs-extra": "npm:11.0.4"
-    "@types/jest": "npm:29.5.2"
     "@types/jscodeshift": "npm:17.3.0"
     "@types/node": "npm:20.19.41"
     chalk: "npm:4.1.2"
@@ -9586,13 +9585,14 @@ __metadata:
     eslint-config-custom: "npm:5.51.2"
     fs-extra: "npm:11.3.4"
     handlebars: "npm:4.7.9"
-    jest: "npm:29.6.0"
     jscodeshift: "npm:17.3.0"
     lodash: "npm:4.18.1"
     outdent: "npm:^0.8.0"
     plop: "npm:4.0.5"
     pluralize: "npm:8.0.0"
     tsconfig: "npm:5.51.2"
+    vitest: "catalog:"
+    vitest-config: "npm:5.51.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Fully migrates `@strapi/generators` unit tests from Jest to Vitest:

- Replace Jest scripts/deps with Vitest + shared `vitest-config`
- Add `vitest.config.ts` and rename suites to `*.vitest.test.ts`
- Remove `jest.config.js` and Jest type references from `tsconfig.json`
- Content-type generator suite imports the built package entry (CI builds before Vitest)

### Why is it needed?

Incremental Jest → Vitest migration for monorepo unit tests.

### How to test it?

```bash
yarn workspace @strapi/generators build:code
yarn workspace @strapi/generators test:unit:vitest
yarn workspace @strapi/generators lint
```

### Related issue(s)/PR(s)

Fixes CMS-1481

Stacked on #27219 (`chore/vitest-permissions`).