### PR TITLE
fix(content-type-builder): clear stale validation errors when the form data is replaced

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/reducer.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/reducer.ts
@@ -367,9 +367,15 @@ const slice = createSlice({
       const { data } = action.payload;
       state.modifiedData = data;
       state.initialData = data;
+      state.formErrors = {};
     },
     setAttributeDataSchema: (state, action: PayloadAction<SetAttributeDataSchemaPayload>) => {
       const { isEditing } = action.payload;
+
+      // The errors describe the data being replaced below, so they no longer apply. Leaving
+      // them behind surfaces the previous attempt's errors on a freshly picked, blank type.
+      // See https://github.com/strapi/strapi/issues/20947
+      state.formErrors = {};
 
       if (isEditing === true) {
         const { modifiedDataToSetForEditing } = action.payload;
@@ -433,6 +439,8 @@ const slice = createSlice({
     setCustomFieldDataSchema: (state, action: PayloadAction<SetCustomFieldDataSchemaPayload>) => {
       const { payload } = action;
 
+      state.formErrors = {};
+
       if (payload.isEditing === true) {
         const { modifiedDataToSetForEditing } = action.payload;
         state.modifiedData = modifiedDataToSetForEditing;
@@ -462,6 +470,7 @@ const slice = createSlice({
       const { attributeToEdit } = action.payload;
       state.modifiedData = attributeToEdit;
       state.initialData = attributeToEdit;
+      state.formErrors = {};
     },
     setErrors: (state, action: PayloadAction<SetErrorsPayload>) => {
       state.formErrors = action.payload.errors;

--- a/packages/core/content-type-builder/admin/src/components/FormModal/tests/reducer.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/tests/reducer.test.ts
@@ -726,6 +726,71 @@ describe('CTB | components | FormModal | reducer | actions', () => {
     });
   });
 
+  // Errors describe the data they were produced from. Every action that replaces that data
+  // must drop them, otherwise the previous attempt's errors show up on a blank form.
+  // https://github.com/strapi/strapi/issues/20947
+  describe('Clearing stale form errors', () => {
+    const stateWithErrors: State = {
+      ...initialState,
+      modifiedData: { name: '', type: 'string' },
+      formErrors: {
+        name: {
+          id: 'component.Input.error.validation.required',
+          defaultMessage: 'this is required',
+        },
+      },
+    };
+
+    it('clears the errors when a new attribute type is picked', () => {
+      const action = actions.setAttributeDataSchema({
+        attributeType: 'text',
+        nameToSetForRelation: 'address',
+        targetUid: 'api::address.address',
+        isEditing: false,
+        modifiedDataToSetForEditing: {},
+        step: null,
+        uid: 'api::address.address',
+      });
+
+      expect(reducer(stateWithErrors, action).formErrors).toEqual({});
+    });
+
+    it('clears the errors when an existing attribute is opened for editing', () => {
+      const action = actions.setAttributeDataSchema({
+        isEditing: true,
+        modifiedDataToSetForEditing: { name: 'address', type: 'string' },
+        uid: 'api::address.address',
+      });
+
+      expect(reducer(stateWithErrors, action).formErrors).toEqual({});
+    });
+
+    it('clears the errors when a custom field is picked', () => {
+      const action = actions.setCustomFieldDataSchema({
+        isEditing: false,
+        modifiedDataToSetForEditing: {},
+        uid: 'api::address.address',
+        customField: { type: 'string' },
+      });
+
+      expect(reducer(stateWithErrors, action).formErrors).toEqual({});
+    });
+
+    it('clears the errors when a dynamic zone schema is set', () => {
+      const action = actions.setDynamicZoneDataSchema({
+        attributeToEdit: { name: 'dz', type: 'dynamiczone', components: [] },
+      });
+
+      expect(reducer(stateWithErrors, action).formErrors).toEqual({});
+    });
+
+    it('clears the errors when the data to edit is replaced', () => {
+      const action = actions.setDataToEdit({ data: { displayName: 'Address' } });
+
+      expect(reducer(stateWithErrors, action).formErrors).toEqual({});
+    });
+  });
+
   describe('Default', () => {
     it('Should return the initialState', () => {
       const action = { type: 'DUMMY' };


### PR DESCRIPTION
## What does it do?

Fixes #20947 — after a validation error, going back to the type picker and choosing a different type shows the previous attempt's errors on the new, blank form.

In `components/FormModal/reducer.ts`, `formErrors` had exactly one writer — `setErrors` — and was only cleared on submit (`FormModal.tsx`, in `submitForm`). The actions that swap the form's contents replaced `modifiedData` and `initialData` but left `formErrors` untouched:

- `setAttributeDataSchema`
- `setCustomFieldDataSchema`
- `setDynamicZoneDataSchema`
- `setDataToEdit`

So errors produced for the discarded data outlived it. Reproduced against the reducer directly before writing the fix:

```
after setErrors:              {"name":{"id":"required","defaultMessage":"required"}}
after setAttributeDataSchema: {"name":{"id":"required","defaultMessage":"required"}}   ← stale
modifiedData reset to:        {"type":"string"}                                        ← blank form
```

Those four actions now clear `formErrors`. This matches `resetPropsAndSetTheFormForAddingACompoToADz`, which already returns `{ ...initialState, modifiedData }` and so has always dropped the errors for the same reason — the fix brings the rest of the data-replacing actions in line with it rather than introducing a new convention.

`setDataToEdit` is included because it replaces both `modifiedData` and `initialData` on the same principle; it is what runs when the CT/component edit form is opened.

## Why is it needed?

The stale error blocks the form: it renders against a field that is now empty and belongs to a type the user is no longer editing, so the modal reads as invalid with nothing to correct.

## How to test it

```bash
npx jest --config packages/core/content-type-builder/jest.config.front.js --rootDir packages/core/content-type-builder admin/src/components/FormModal
```

The five cases under `Clearing stale form errors` in `tests/reducer.test.ts` fail on `develop` and pass with this change.

Manually:

1. Content-Type Builder → add a new field, pick **Text**.
2. Submit with the name empty to trigger the validation error.
3. Go back and pick a different type, e.g. **Number**.
4. The form is blank with no error; before this change the "required" error from step 2 was still shown.

Full `@strapi/content-type-builder` suites pass — 301 front tests and 99 server tests — along with `tsc --noEmit` and lint.

## Related issue(s)

Fixes #20947