### PR TITLE
future(upload): refresh list after replace (CMS-1237, CMS-1558)

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -616,7 +616,7 @@ export const AssetsPage = () => {
 
                 <Layouts.Content>
                   {/* Renders nothing — keeps every loaded page's query subscribed
-                      so a rename/delete refreshes the whole list (CMS-1558). */}
+                      so a rename/delete refreshes the whole list. */}
                   {assetPageSubscribers}
                   <DropZoneWithOverlay>
                     <DropFilesMessage uploadDropZoneRef={uploadDropZoneRef} folderName={title} />

--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -350,6 +350,7 @@ export const AssetsPage = () => {
 
   const {
     assets,
+    subscribers: assetPageSubscribers,
     pagination,
     isLoading: isLoadingAssets,
     isFetchingMore,
@@ -614,6 +615,9 @@ export const AssetsPage = () => {
                 </HeaderWrapper>
 
                 <Layouts.Content>
+                  {/* Renders nothing — keeps every loaded page's query subscribed
+                      so a rename/delete refreshes the whole list (CMS-1558). */}
+                  {assetPageSubscribers}
                   <DropZoneWithOverlay>
                     <DropFilesMessage uploadDropZoneRef={uploadDropZoneRef} folderName={title} />
                     <AssetsView

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
@@ -275,11 +275,24 @@ interface AssetPreviewProps {
 }
 
 const AssetPreview = ({ asset }: AssetPreviewProps) => {
-  const { alternativeText, ext, formats, mime, url, isLocal, isUrlSigned } = asset;
+  const { alternativeText, ext, formats, mime, url, updatedAt, isLocal, isUrlSigned } = asset;
 
   if (mime?.includes(ASSET_TYPES.Image)) {
-    const mediaURL =
+    // Replace keeps the same hash/URL, so without a cache-buster the browser
+    // serves the stale thumbnail after a Replace Media (CMS-1237). `updatedAt`
+    // changes on replace, so it re-fetches exactly once per replacement.
+    // Skipped for signed URLs — an extra query param invalidates the signature.
+    const cacheKey = updatedAt && !isUrlSigned ? new Date(updatedAt).getTime() : undefined;
+    const appendCacheBuster = (raw: string) => {
+      if (cacheKey === undefined) {
+        return raw;
+      }
+      return raw.includes('?') ? `${raw}&v=${cacheKey}` : `${raw}?v=${cacheKey}`;
+    };
+
+    const rawMediaURL =
       prefixFileUrlWithBackendUrl(formats?.thumbnail?.url) ?? prefixFileUrlWithBackendUrl(url);
+    const mediaURL = rawMediaURL ? appendCacheBuster(rawMediaURL) : rawMediaURL;
 
     if (mediaURL) {
       return (

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
@@ -279,7 +279,7 @@ const AssetPreview = ({ asset }: AssetPreviewProps) => {
 
   if (mime?.includes(ASSET_TYPES.Image)) {
     // Replace keeps the same hash/URL, so without a cache-buster the browser
-    // serves the stale thumbnail after a Replace Media (CMS-1237). `updatedAt`
+    // serves the stale thumbnail after a Replace Media. `updatedAt`
     // changes on replace, so it re-fetches exactly once per replacement.
     // Skipped for signed URLs — an extra query param invalidates the signature.
     const cacheKey = updatedAt && !isUrlSigned ? new Date(updatedAt).getTime() : undefined;

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.eviction.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.eviction.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react';
+
+import { uploadApi } from '../../../../services/api';
+import { useInfiniteAssets } from '../useInfiniteAssets';
+
+/**
+ * A leaving-the-folder regression guard: RTK Query 1.9.7 can leave a query's
+ * store subscription in place when its last subscriber unmounts mid-refetch, so
+ * `useInfiniteAssets` evicts the left folder's `getAssets` cache entries on a
+ * folder change. Without it a later `{Asset, LIST}` invalidation refetches the
+ * previous folder's pages (one bogus `/upload/files` request per loaded page).
+ */
+
+const emptyPage = {
+  results: [],
+  pagination: { page: 1, pageSize: 20, pageCount: 1, total: 0 },
+};
+const queryResult = {
+  data: emptyPage,
+  currentData: emptyPage,
+  isLoading: false,
+  isFetching: false,
+  error: undefined,
+};
+
+const mockUseGetAssetsQuery = jest.fn(() => queryResult);
+jest.mock('../../../../services/assets', () => ({
+  useGetAssetsQuery: (...args: unknown[]) => mockUseGetAssetsQuery(...args),
+}));
+
+const mockDispatch = jest.fn();
+let mockState: unknown = {};
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+  useStore: () => ({ getState: () => mockState }),
+}));
+
+const key = (folder: number, page: number) =>
+  `getAssets({"filters":[],"folder":${folder},"page":${page},"pageSize":20,"sort":"updatedAt:DESC"})`;
+
+const evictedKeys = () =>
+  mockDispatch.mock.calls
+    .map(([action]) => (action as { payload?: { queryCacheKey?: string } })?.payload?.queryCacheKey)
+    .filter((k): k is string => Boolean(k));
+
+describe('useInfiniteAssets — cache eviction on folder change', () => {
+  beforeEach(() => {
+    mockDispatch.mockClear();
+    mockState = {
+      [uploadApi.reducerPath]: {
+        queries: {
+          [key(1, 1)]: {},
+          [key(1, 2)]: {},
+          [key(2, 1)]: {},
+          'getFolders({"parentId":1})': {},
+        },
+      },
+    };
+  });
+
+  it('evicts only the previous folder getAssets entries when the folder changes', () => {
+    const { rerender } = renderHook(({ folder }) => useInfiniteAssets({ folder }), {
+      initialProps: { folder: 1 as number | null },
+    });
+
+    mockDispatch.mockClear(); // ignore the initial mount
+
+    rerender({ folder: 2 });
+
+    const evicted = evictedKeys();
+    expect(evicted).toEqual(expect.arrayContaining([key(1, 1), key(1, 2)]));
+    // Never the folder we navigated into, never non-asset queries.
+    expect(evicted).not.toContain(key(2, 1));
+    expect(evicted).not.toContain('getFolders({"parentId":1})');
+  });
+
+  it('does not evict anything when the folder is unchanged', () => {
+    const { rerender } = renderHook(({ folder }) => useInfiniteAssets({ folder }), {
+      initialProps: { folder: 1 as number | null },
+    });
+
+    mockDispatch.mockClear();
+    rerender({ folder: 1 });
+
+    expect(evictedKeys()).toHaveLength(0);
+  });
+});

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
@@ -577,7 +577,7 @@ describe('useInfiniteAssets', () => {
     expect(result.current.assets[PAGE_SIZE].name).toMatch(/^refetched-/);
   });
 
-  it('refreshes an earlier page after a mutation refetch so a rename reaches the list (CMS-1558)', async () => {
+  it('refreshes an earlier page after a mutation refetch so a rename reaches the list', async () => {
     // Page 1 is accumulated, then page 2 becomes the current page — so page 1 is
     // no longer the subscribed query. A rename on a page-1 asset invalidates
     // `{Asset, LIST}`; only the rendered `subscribers` keep page 1 subscribed so

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
@@ -577,6 +577,60 @@ describe('useInfiniteAssets', () => {
     expect(result.current.assets[PAGE_SIZE].name).toMatch(/^refetched-/);
   });
 
+  it('refreshes an earlier page after a mutation refetch so a rename reaches the list (CMS-1558)', async () => {
+    // Page 1 is accumulated, then page 2 becomes the current page — so page 1 is
+    // no longer the subscribed query. A rename on a page-1 asset invalidates
+    // `{Asset, LIST}`; only the rendered `subscribers` keep page 1 subscribed so
+    // that refetch actually reaches the accumulated list.
+    const page1 = createMockPage(1, 2, 40);
+    const page2 = createMockPage(2, 2, 40);
+    const page1Refetched = asRefetch(page1);
+
+    let hasRenamed = false;
+
+    mockUseGetAssetsQuery.mockImplementation(({ page: p }: { page: number }) => {
+      if (p === 1) {
+        return hasRenamed ? page1Refetched : page1;
+      }
+
+      return page2;
+    });
+
+    let hookResult: ReturnType<typeof useInfiniteAssets>;
+    let bumpTick: () => void;
+
+    const SubscribedWrapper = () => {
+      const [, setTick] = useState(0);
+      hookResult = useInfiniteAssets();
+      bumpTick = () => setTick((tick) => tick + 1);
+
+      // Rendering the subscribers node is what keeps every loaded page
+      // subscribed — the fix under test.
+      return hookResult.subscribers;
+    };
+
+    render(createElement(SubscribedWrapper));
+
+    act(() => {
+      hookResult!.fetchNextPage();
+    });
+
+    expect(hookResult!.assets).toHaveLength(PAGE_SIZE * 2);
+    expect(hookResult!.assets[0].name).not.toMatch(/^refetched-/);
+
+    // The invalidation refetches the subscribed page-1 query with renamed data.
+    hasRenamed = true;
+    await act(async () => {
+      bumpTick();
+    });
+
+    await waitFor(() => {
+      expect(hookResult!.assets[0].name).toMatch(/^refetched-/);
+    });
+    // Page 2 (the current page) is untouched by the page-1 refresh.
+    expect(hookResult!.assets[PAGE_SIZE].name).not.toMatch(/^refetched-/);
+  });
+
   it('does not duplicate a short final page', () => {
     // 20 + 6: the accumulated length never reaches `page * PAGE_SIZE`, which is
     // what used to let a re-read append the final page a second time.

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { createElement, Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useGetAssetsQuery } from '../../../services/assets';
 
@@ -14,6 +14,13 @@ interface UseInfiniteAssetsOptions {
   filters?: Record<string, unknown>[];
   /** Structural switch: an `is [folder]`-only type badge means no file can match. */
   enabled?: boolean;
+}
+
+interface QueryArgs {
+  folder: number | null;
+  sort?: string;
+  search?: string;
+  filters?: Record<string, unknown>[];
 }
 
 /**
@@ -33,6 +40,8 @@ interface PageState {
   queryKey: string;
   page: number;
 }
+
+type PageRefreshedHandler = (page: number, results: File[]) => void;
 
 /**
  * Concatenates the pages in ascending order, one entry per asset id.
@@ -56,15 +65,46 @@ const flattenPages = (pages: Record<number, File[]>): File[] => {
 };
 
 /**
+ * Keeps one earlier page's `getAssets` query subscribed and reports its results
+ * back up whenever they change.
+ *
+ * The hook itself only subscribes the current (latest) page. Without these, a
+ * mutation invalidating `{Asset, LIST}` refetches that page alone and earlier
+ * pages stay frozen — a rename or delete on an earlier page never reaches the
+ * list until a folder/sort/search change (CMS-1558). One subscriber per earlier
+ * page keeps them all subscribed so the invalidation refetches the whole list.
+ * Renders nothing; it exists only for the subscription + `onRefreshed` report.
+ */
+const PageSubscriber = ({
+  queryArgs,
+  page,
+  onRefreshed,
+}: {
+  queryArgs: QueryArgs;
+  page: number;
+  onRefreshed: PageRefreshedHandler;
+}) => {
+  const { currentData } = useGetAssetsQuery({ ...queryArgs, page, pageSize: PAGE_SIZE });
+  const results = currentData?.results;
+
+  useEffect(() => {
+    if (results) {
+      onRefreshed(page, results);
+    }
+    // `results` is a stable reference per cache entry, so this only re-reports
+    // when a refetch actually replaces the page's data. Reporting the same
+    // reference the accumulator already holds is a no-op (see `onRefreshed`).
+  }, [results, page, onRefreshed]);
+
+  return null;
+};
+
+/**
  * Infinite scroll over `/upload/files`, keeping one accumulated slot per page.
  *
- * Known limitation: only the current page is subscribed, so a mutation
- * invalidating `{Asset, LIST}` refetches that page alone. Earlier pages are
- * detached copies and can go stale — a deleted asset lingers, a new upload
- * never appears, rows shift across the page boundary. The id dedupe above
- * keeps that from producing duplicate React keys or confusing
- * `useAssetSelection`, but the list only becomes consistent again on the next
- * folder/sort/search/filter change.
+ * The caller MUST render the returned `subscribers` node — that is what keeps
+ * every loaded page subscribed, so `{Asset, LIST}` invalidations keep the whole
+ * list consistent rather than only the current page (CMS-1558).
  */
 const useInfiniteAssets = ({
   folder = null,
@@ -75,7 +115,7 @@ const useInfiniteAssets = ({
 }: UseInfiniteAssetsOptions = {}) => {
   // Derived from the request args themselves, so a new filter can't reach the
   // API without also invalidating what was accumulated under the old one.
-  const queryArgs = { folder, sort, search, filters };
+  const queryArgs: QueryArgs = { folder, sort, search, filters };
   const queryKey = JSON.stringify(queryArgs);
   // Identifies the list being viewed, ignoring the search term. Folder, sort
   // and filter changes are single committed actions, so one clean reset per
@@ -128,6 +168,39 @@ const useInfiniteAssets = ({
     );
   }
 
+  // Merges a refetched earlier page back into the accumulator. Ignores reports
+  // for a superseded query, and no-ops when the reference is unchanged so a
+  // subscriber re-reporting its already-stored page can't loop.
+  const handlePageRefreshed = useCallback<PageRefreshedHandler>(
+    (refreshedPage, results) => {
+      setAccumulated((prev) => {
+        if (prev.queryKey !== queryKey || prev.pages[refreshedPage] === results) {
+          return prev;
+        }
+
+        return { ...prev, pages: { ...prev.pages, [refreshedPage]: results } };
+      });
+    },
+    [queryKey]
+  );
+
+  // One subscriber per earlier page (the current page is already subscribed by
+  // the query above). Keyed by queryKey so a folder/sort/search change remounts
+  // them against the new args instead of reusing a stale cache entry.
+  // `createElement` rather than JSX so this stays a plain `.ts` hook file.
+  const subscribers = createElement(
+    Fragment,
+    null,
+    Array.from({ length: Math.max(0, page - 1) }, (_, index) => index + 1).map((earlierPage) =>
+      createElement(PageSubscriber, {
+        key: `${queryKey}:${earlierPage}`,
+        queryArgs,
+        page: earlierPage,
+        onRefreshed: handlePageRefreshed,
+      })
+    )
+  );
+
   // Until the new list's first page lands the accumulator still holds the
   // previous folder. Reported as loading so the page shows a spinner instead
   // of the outgoing folder's assets under the incoming folder's header.
@@ -153,6 +226,8 @@ const useInfiniteAssets = ({
   if (!enabled) {
     return {
       assets: [] as File[],
+      // No list to keep fresh while disabled, so nothing to subscribe.
+      subscribers: null,
       pagination: undefined,
       isLoading: false,
       isFetchingMore: false,
@@ -164,6 +239,7 @@ const useInfiniteAssets = ({
 
   return {
     assets,
+    subscribers,
     // Falls back to the accumulated total so a consumer showing the count
     // doesn't flash zero mid-transition, matching the possibly stale `assets`.
     pagination: currentData?.pagination ?? accumulated.pagination,

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
@@ -71,7 +71,7 @@ const flattenPages = (pages: Record<number, File[]>): File[] => {
  * The hook itself only subscribes the current (latest) page. Without these, a
  * mutation invalidating `{Asset, LIST}` refetches that page alone and earlier
  * pages stay frozen — a rename or delete on an earlier page never reaches the
- * list until a folder/sort/search change (CMS-1558). One subscriber per earlier
+ * list until a folder/sort/search change. One subscriber per earlier
  * page keeps them all subscribed so the invalidation refetches the whole list.
  * Renders nothing; it exists only for the subscription + `onRefreshed` report.
  */
@@ -104,7 +104,7 @@ const PageSubscriber = ({
  *
  * The caller MUST render the returned `subscribers` node — that is what keeps
  * every loaded page subscribed, so `{Asset, LIST}` invalidations keep the whole
- * list consistent rather than only the current page (CMS-1558).
+ * list consistent rather than only the current page.
  */
 const useInfiniteAssets = ({
   folder = null,

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
@@ -1,5 +1,8 @@
-import { createElement, Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { createElement, Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { useDispatch, useStore } from 'react-redux';
+
+import { uploadApi } from '../../../services/api';
 import { useGetAssetsQuery } from '../../../services/assets';
 
 import type { File, Pagination } from '../../../../../../shared/contracts/files';
@@ -200,6 +203,54 @@ const useInfiniteAssets = ({
       })
     )
   );
+
+  // Drop the left folder's cached `getAssets` pages when the folder changes.
+  //
+  // RTK Query 1.9.7 leaves a query's store subscription in place when its last
+  // subscriber unmounts while a refetch is still in flight — e.g. a delete
+  // invalidates `{Asset, LIST}`, every loaded page starts refetching, and the
+  // user navigates away before those settle. Those stale subscriptions make the
+  // next `{Asset, LIST}` invalidation (an upload in the new folder) refetch the
+  // *previous* folder's pages: one bogus `/upload/files` request per loaded
+  // page. There is no public per-entry unsubscribe, so evict the left folder's
+  // entries outright — returning reloads from page 1, which the accumulator
+  // already does on a list change.
+  const dispatch = useDispatch();
+  const store = useStore();
+  const prevFolderRef = useRef(folder);
+  useEffect(() => {
+    const prevFolder = prevFolderRef.current;
+    prevFolderRef.current = folder;
+    if (prevFolder === folder) {
+      return;
+    }
+
+    const apiState = (store.getState() as Record<string, { queries?: Record<string, unknown> }>)[
+      uploadApi.reducerPath
+    ];
+    const removeQueryResult = (
+      uploadApi as unknown as {
+        internalActions: {
+          removeQueryResult: (payload: { queryCacheKey: string }) => { type: string };
+        };
+      }
+    ).internalActions.removeQueryResult;
+
+    Object.keys(apiState?.queries ?? {}).forEach((cacheKey) => {
+      if (!cacheKey.startsWith('getAssets(')) {
+        return;
+      }
+      let args: { folder?: number | null };
+      try {
+        args = JSON.parse(cacheKey.slice('getAssets('.length, -1));
+      } catch {
+        return;
+      }
+      if (args.folder === prevFolder) {
+        dispatch(removeQueryResult({ queryCacheKey: cacheKey }));
+      }
+    });
+  }, [folder, dispatch, store]);
 
   // Until the new list's first page lands the accumulator still holds the
   // previous folder. Reported as loading so the page shows a spinner instead

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
@@ -199,6 +199,26 @@ describe('AssetsGrid', () => {
         expect(screen.getByRole('img')).toBeInTheDocument();
       });
 
+      it('cache-busts the thumbnail with updatedAt so a replaced image refetches (CMS-1237)', () => {
+        const asset = createMockAsset(1, 'test.jpg', 'image/jpeg', '.jpg');
+        asset.updatedAt = '2024-05-06T00:00:00.000Z';
+        setup({ assets: [asset] });
+
+        const src = screen.getByRole('img').getAttribute('src') ?? '';
+        expect(src).toContain(`v=${new Date(asset.updatedAt).getTime()}`);
+      });
+
+      it('omits the cache-buster on signed URLs (an extra param breaks the signature)', () => {
+        const asset = {
+          ...createMockAsset(1, 'test.jpg', 'image/jpeg', '.jpg'),
+          isUrlSigned: true,
+          updatedAt: '2024-05-06T00:00:00.000Z',
+        };
+        setup({ assets: [asset] });
+
+        expect(screen.getByRole('img').getAttribute('src') ?? '').not.toContain('v=');
+      });
+
       it('loads signed remote thumbnails with crossOrigin="anonymous" (#26581)', () => {
         const asset = {
           ...createMockAsset(1, 'test.jpg', 'image/jpeg', '.jpg'),

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, server, waitFor } from '@tests/utils';
 import { http, HttpResponse } from 'msw';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { useDeleteAssetMutation } from '../../../services/assets';
 import { AssetsPage } from '../AssetsPage';
 
 import type { File } from '../../../../../../shared/contracts/files';
@@ -386,6 +387,74 @@ describe('AssetsPage search', () => {
       expect(await screen.findByText('page-two.png')).toBeInTheDocument();
       expect(screen.getByText('page-one-0.png')).toBeInTheDocument();
       expect(screen.getAllByText(/^page-one-/)).toHaveLength(20);
+    });
+
+    it('refetches an earlier page after a mutation invalidation (the subscribers node is rendered)', async () => {
+      // Page-level guard for the "caller must render `subscribers`" contract: if
+      // AssetsPage drops that node, page 1 stops being subscribed, so the rename
+      // below never reaches the list and this test fails.
+      let hasRenamed = false;
+
+      server.use(
+        http.get('*/upload/files', ({ request }) => {
+          const isPageTwo = new URL(request.url).searchParams.get('page') === '2';
+
+          if (isPageTwo) {
+            return HttpResponse.json({
+              results: [createAsset(100, 'page-two.png')],
+              pagination: { page: 2, pageSize: 20, pageCount: 2, total: 21 },
+            });
+          }
+
+          const firstRow = hasRenamed
+            ? createAsset(1, 'renamed-0.png')
+            : createAsset(1, 'page-one-0.png');
+          const rest = Array.from({ length: 19 }, (_, index) =>
+            createAsset(index + 2, `page-one-${index + 1}.png`)
+          );
+
+          return HttpResponse.json({
+            results: [firstRow, ...rest],
+            pagination: { page: 1, pageSize: 20, pageCount: 2, total: 21 },
+          });
+        }),
+        http.delete('*/upload/files/:id', () => {
+          // Stand in for the server-side change; page 1's next fetch is renamed.
+          hasRenamed = true;
+          return HttpResponse.json({ data: {} });
+        })
+      );
+
+      // Triggers a `{ Asset, LIST }` invalidation from outside the list, the way
+      // a real delete/rename does, without wiring the drawer or bulk bar.
+      const DeleteProbe = () => {
+        const [deleteAsset] = useDeleteAssetMutation();
+        return (
+          <button type="button" onClick={() => deleteAsset(100)}>
+            delete-probe
+          </button>
+        );
+      };
+
+      const { user } = render(
+        <>
+          <AssetsPage />
+          <DeleteProbe />
+        </>,
+        { initialEntries: ['/?folder=1'] }
+      );
+
+      expect(await screen.findByText('page-one-0.png')).toBeInTheDocument();
+
+      await scrollToLoadMore();
+      expect(await screen.findByText('page-two.png')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'delete-probe' }));
+
+      // Page 1 was refetched through its subscriber, so the rename shows without
+      // a reload. Fails if AssetsPage stops rendering the subscribers node.
+      expect(await screen.findByText('renamed-0.png')).toBeInTheDocument();
+      expect(screen.queryByText('page-one-0.png')).not.toBeInTheDocument();
     });
 
     it('keeps the folder assets rendered while a search started inside a folder is in flight', async () => {


### PR DESCRIPTION
### What does it do?

Two list-freshness bug fixes in the future media library (`admin/src/future`), one per commit:

- **CMS-1237 — grid thumbnail stale after Replace Media.** Replace keeps the same file URL/hash, so the grid served the browser-cached thumbnail. Append `?v=<updatedAt>` to the grid preview `src` (guarded by `!isUrlSigned`, since an extra query param breaks a signed URL), mirroring the drawer preview. The replace mutation already invalidates `{Asset, LIST}`, so the current page refetches with a fresh `updatedAt`.
- **CMS-1558 — rename/delete on an earlier page not reflected in the list.** Infinite scroll only subscribed the *current* page, so a `{Asset, LIST}` invalidation refetched that page alone; earlier pages stayed frozen until a folder/sort/search change. RTK is 1.9.7 (no `infiniteQuery` API), so the current-page path is left unchanged and a hidden `PageSubscriber` is rendered per earlier page — it keeps that page's query subscribed and merges its refetched data back into the accumulator. `AssetsPage` renders the returned `subscribers` node (renders nothing).

### Why is it needed?

Renaming an asset or replacing an image left the media library list showing stale data (old name / old image) until a full navigation change, which reads as a broken update.

### How to test it?

Enable the future media library: `UNSTABLE_MEDIA_LIBRARY=true yarn develop`, open `/admin/plugins/unstable-upload`.

**CMS-1237 (replace):**
1. Grid view, open an image asset's details drawer, Replace Media with a different image (same name).
2. The grid tile shows the new image immediately (previously stale until refresh).

**CMS-1558 (rename on earlier page):**
1. Have >20 assets so the list paginates; scroll to load page 2+.
2. Rename an asset that lives on page 1 (visible after scroll-up), save.
3. The renamed row updates in place without a folder/sort/search change (previously stale until navigating away).

Unit: `IS_EE=true yarn nx run @strapi/upload:test:front -- --testPathPattern "future/pages/Assets"` — 457 pass (incl. the CMS-1558 earlier-page-refresh test and the CMS-1237 cache-buster tests).

### Related issue(s)/PR(s)

- fix CMS-1237
- fix CMS-1558
- Stacked on #27171 (`future/CMS-1535-pagination-fix`) — CMS-1558 relies on its `flattenPages` id-dedupe (an earlier-page refetch can shift ids across the page boundary). **Must merge after #27171**; rebase onto `develop` once it lands.

_Generated by AI, reviewed and edited by @Adzouz_

🚀