### PR TITLE
fix(content-type-builder): editing relations removes inverse field conditions

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
@@ -465,6 +465,7 @@ const slice = createUndoRedoSlice(
           previousTarget,
           previousAttribute.targetAttribute ?? ''
         );
+        const previousTargetAttribute = previousTarget.attributes[previousTargetAttributeIndex];
 
         // remove old targetAttribute
         if (previousAttribute.targetAttribute) {
@@ -487,6 +488,9 @@ const slice = createUndoRedoSlice(
             target: type.uid,
             private: previousAttribute.private ?? attributeToSet.private,
             pluginOptions: previousAttribute.pluginOptions ?? attributeToSet.pluginOptions,
+            ...(previousTarget.uid === newTarget.uid && previousTargetAttribute?.conditions
+              ? { conditions: previousTargetAttribute.conditions }
+              : {}),
             status: 'CHANGED',
           } as AnyAttribute;
 

--- a/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
@@ -465,7 +465,10 @@ const slice = createUndoRedoSlice(
           previousTarget,
           previousAttribute.targetAttribute ?? ''
         );
-        const previousTargetAttribute = previousTarget.attributes[previousTargetAttributeIndex];
+        const previousTargetAttribute =
+          previousTargetAttributeIndex !== -1
+            ? previousTarget.attributes[previousTargetAttributeIndex]
+            : undefined;
 
         // remove old targetAttribute
         if (previousAttribute.targetAttribute) {

--- a/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerEditAttributeAction.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerEditAttributeAction.test.ts
@@ -1180,7 +1180,7 @@ describe('CTB | components | DataManagerProvider | reducer | EDIT_ATTRIBUTE', ()
         });
       });
 
-      it('Should preserve the inverse relation conditions when editing a bidirectional oneToMany relation', () => {
+      it('Should preserve the inverse relation conditions when renaming a bidirectional oneToMany inverse field', () => {
         const articleConditions: AttributeConditions = {
           visible: { '==': [{ var: 'status' }, 'published'] },
         };
@@ -1231,7 +1231,7 @@ describe('CTB | components | DataManagerProvider | reducer | EDIT_ATTRIBUTE', ()
             attributeToSet: {
               name: 'categories',
               relation: 'oneToMany',
-              targetAttribute: 'articles',
+              targetAttribute: 'categorizedArticles',
               target: category.uid,
               type: 'relation',
               conditions: updatedArticleConditions,
@@ -1250,10 +1250,113 @@ describe('CTB | components | DataManagerProvider | reducer | EDIT_ATTRIBUTE', ()
         );
         expect(state.current.contentTypes[category.uid].attributes).toContainEqual(
           expect.objectContaining({
-            name: 'articles',
+            name: 'categorizedArticles',
             conditions: categoryConditions,
           })
         );
+      });
+
+      it('Should not transfer inverse relation conditions when changing the target content type', () => {
+        const inverseConditions: AttributeConditions = {
+          visible: { '==': [{ var: 'status' }, 'enabled'] },
+        };
+        const article = initCT('article', {
+          attributes: [
+            {
+              name: 'categories',
+              relation: 'oneToMany',
+              targetAttribute: 'articles',
+              target: 'api::category.category',
+              type: 'relation',
+            },
+          ],
+        });
+        const category = initCT('category', {
+          attributes: [
+            {
+              name: 'articles',
+              relation: 'manyToOne',
+              targetAttribute: 'categories',
+              target: article.uid,
+              type: 'relation',
+              conditions: inverseConditions,
+            },
+          ],
+        });
+        const tag = initCT('tag', { attributes: [] });
+
+        const state = reducer(
+          init({
+            contentTypes: { [article.uid]: article, [category.uid]: category, [tag.uid]: tag },
+          }),
+          actions.editAttribute({
+            attributeToSet: {
+              name: 'categories',
+              relation: 'oneToMany',
+              targetAttribute: 'articles',
+              target: tag.uid,
+              type: 'relation',
+            },
+            forTarget: 'contentType',
+            targetUid: article.uid,
+            name: 'categories',
+          })
+        );
+
+        const newInverse = state.current.contentTypes[tag.uid].attributes.find(
+          (attribute) => attribute.name === 'articles'
+        );
+
+        expect(newInverse).toMatchObject({ name: 'articles', status: 'NEW' });
+        expect(newInverse).not.toHaveProperty('conditions');
+        expect(state.current.contentTypes[category.uid].attributes).toContainEqual(
+          expect.objectContaining({ name: 'articles', status: 'REMOVED' })
+        );
+      });
+
+      it('Should create a bidirectional inverse without conditions when none previously existed', () => {
+        const article = initCT('article', {
+          attributes: [
+            {
+              name: 'category',
+              relation: 'oneToOne',
+              targetAttribute: null,
+              target: 'api::category.category',
+              type: 'relation',
+            },
+          ],
+        });
+        const category = initCT('category', { attributes: [] });
+
+        const state = reducer(
+          init({ contentTypes: { [article.uid]: article, [category.uid]: category } }),
+          actions.editAttribute({
+            attributeToSet: {
+              name: 'category',
+              relation: 'oneToOne',
+              targetAttribute: 'article',
+              target: category.uid,
+              type: 'relation',
+            },
+            forTarget: 'contentType',
+            targetUid: article.uid,
+            name: 'category',
+          })
+        );
+
+        const inverse = state.current.contentTypes[category.uid].attributes.find(
+          (attribute) => attribute.name === 'article'
+        );
+
+        expect(inverse).toMatchObject({
+          name: 'article',
+          relation: 'oneToOne',
+          targetAttribute: 'category',
+          target: article.uid,
+          type: 'relation',
+          status: 'NEW',
+        });
+        expect(inverse).not.toHaveProperty('conditions');
       });
 
       it('Should save pluginOptions if the relation is nested inside a component', () => {

--- a/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerEditAttributeAction.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerEditAttributeAction.test.ts
@@ -2,6 +2,8 @@ import { reducer, actions } from '../reducer';
 
 import { initCT, initCompo, init } from './utils';
 
+import type { AttributeConditions } from '../../../types';
+
 describe('CTB | components | DataManagerProvider | reducer | EDIT_ATTRIBUTE', () => {
   describe('Editing a common attribute (string, integer, json, media, ...)', () => {
     it('Should edit the attribute correctly and preserve the order of the attributes for a content type', () => {
@@ -979,7 +981,7 @@ describe('CTB | components | DataManagerProvider | reducer | EDIT_ATTRIBUTE', ()
       });
     });
 
-    describe('Editing a relation and preserve plugin options', () => {
+    describe('Editing a relation and preserve relation metadata', () => {
       it('Should save pluginOptions if the relation is a one side relation (oneWay, manyWay)', () => {
         const contentTypeUID = 'api::category.category';
         const updatedTargetUID = 'api::address.address';
@@ -1176,6 +1178,82 @@ describe('CTB | components | DataManagerProvider | reducer | EDIT_ATTRIBUTE', ()
             },
           ],
         });
+      });
+
+      it('Should preserve the inverse relation conditions when editing a bidirectional oneToMany relation', () => {
+        const articleConditions: AttributeConditions = {
+          visible: { '==': [{ var: 'status' }, 'published'] },
+        };
+        const updatedArticleConditions: AttributeConditions = {
+          visible: { '==': [{ var: 'status' }, 'draft'] },
+        };
+        const categoryConditions: AttributeConditions = {
+          visible: { '==': [{ var: 'status' }, 'enabled'] },
+        };
+
+        const article = initCT('article', {
+          attributes: [
+            { name: 'status', type: 'enumeration', enum: ['published', 'draft'] },
+            {
+              name: 'categories',
+              relation: 'oneToMany',
+              targetAttribute: 'articles',
+              target: 'api::category.category',
+              type: 'relation',
+              conditions: articleConditions,
+            },
+          ],
+        });
+        const category = initCT('category', {
+          attributes: [
+            { name: 'status', type: 'enumeration', enum: ['enabled', 'disabled'] },
+            {
+              name: 'articles',
+              relation: 'manyToOne',
+              targetAttribute: 'categories',
+              target: article.uid,
+              type: 'relation',
+              conditions: categoryConditions,
+            },
+          ],
+        });
+
+        const initializedState = init({
+          contentTypes: {
+            [article.uid]: article,
+            [category.uid]: category,
+          },
+        });
+
+        const state = reducer(
+          initializedState,
+          actions.editAttribute({
+            attributeToSet: {
+              name: 'categories',
+              relation: 'oneToMany',
+              targetAttribute: 'articles',
+              target: category.uid,
+              type: 'relation',
+              conditions: updatedArticleConditions,
+            },
+            forTarget: 'contentType',
+            targetUid: article.uid,
+            name: 'categories',
+          })
+        );
+
+        expect(state.current.contentTypes[article.uid].attributes).toContainEqual(
+          expect.objectContaining({
+            name: 'categories',
+            conditions: updatedArticleConditions,
+          })
+        );
+        expect(state.current.contentTypes[category.uid].attributes).toContainEqual(
+          expect.objectContaining({
+            name: 'articles',
+            conditions: categoryConditions,
+          })
+        );
       });
 
       it('Should save pluginOptions if the relation is nested inside a component', () => {


### PR DESCRIPTION
### What does it do?
Preserves conditions on an existing inverse relation when editing a bidirectional relation in the Content-Type Builder.

### Why is it needed?
Editing one conditional relation previously recreated its inverse without the inverse field's conditions, making that field unconditionally visible.

### How to test it?
- Manual reproduction / fix validation: Create `Article.categories` and `Category.articles` as bidirectional relations, assign distinct conditional visibility rules, edit only `Article.categories`, and verify both rules remain on their respective fields. 

### Related issue(s)/PR(s)
fixes #25002
