### PR TITLE
fix: properly encode URL query parameters with special characters

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -84,7 +84,7 @@ const isFilterMatch = (
   }
 
   const decoded =
-    typeof details.value === 'string' ? decodeURIComponent(details.value) : details.value;
+    details.value;
   return decoded === target.value;
 };
 
@@ -195,7 +195,7 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
   const handleSubmit = (data: FilterFormData) => {
     const value = FILTERS_WITH_NO_VALUE.includes(data.filter)
       ? 'true'
-      : encodeURIComponent(data.value ?? '');
+      : (data.value ?? '');
 
     if (!value) {
       return;
@@ -475,7 +475,7 @@ const AttributeTag = ({
     setEditingFilter({
       name,
       filter: operator,
-      value: FILTERS_WITH_NO_VALUE.includes(operator) ? undefined : decodeURIComponent(value),
+      value: FILTERS_WITH_NO_VALUE.includes(operator) ? undefined : value,
     });
     setOpen(true);
   };

--- a/packages/core/admin/admin/src/components/SearchInput.tsx
+++ b/packages/core/admin/admin/src/components/SearchInput.tsx
@@ -56,7 +56,7 @@ const SearchInput = ({
       if (trackedEvent) {
         trackUsage(trackedEvent, trackedEventDetails);
       }
-      setQuery({ _q: encodeURIComponent(value), page: 1 });
+      setQuery({ _q: value, page: 1 });
     } else {
       handleToggle();
       setQuery({ _q: '' }, 'remove');

--- a/packages/core/admin/admin/src/hooks/useQueryParams.ts
+++ b/packages/core/admin/admin/src/hooks/useQueryParams.ts
@@ -39,7 +39,7 @@ const useQueryParams = <TQuery extends object = QueryParams>(initialParams?: TQu
         nextQuery = { ...query, ...nextParams };
       }
 
-      navigate({ search: stringify(nextQuery, { encode: false }) }, { replace });
+      navigate({ search: stringify(nextQuery, { encode: true }) }, { replace });
     },
     [navigate, query]
   );


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where filter values containing `&` (e.g. "Safe & Sustainable Operations") get truncated when the URL query string is rewritten after adding another filter, sorting, or changing page.

## Actual behavior

1. Add a filter with value containing `&` — works on first submit
2. Change anything else (sort, add filter, change page) — URL is rewritten without encoding the `&`, filter value gets truncated at `&`, list returns "0 entries found"

## Expected behavior

The filter value survives any number of subsequent query-param changes and keeps matching the entry.

## Root cause

The `useQueryParams` hook used `stringify(nextQuery, { encode: false })` which did not URL-encode special characters in query values. The previous fix (PR #21406) added `encodeURIComponent()` in the Filters component's `handleSubmit`, but this only protected the value on the initial submit. When the URL was rewritten (e.g. sorting, adding another filter), `qs.parse` decoded the encoded value, and `stringify` with `encode: false` did not re-encode it — causing `&` to become a URL parameter separator.

## Fix

1. **useQueryParams.ts**: Changed `stringify(nextQuery, { encode: false })` to `stringify(nextQuery, { encode: true })` — the `qs` library now properly encodes all special characters in query values.
2. **Filters.tsx**: Removed manual `encodeURIComponent()` / `decodeURIComponent()` calls since the `qs` library now handles encoding/decoding.
3. **SearchInput.tsx**: Removed manual `encodeURIComponent()` call for the same reason.

## How to test

1. Create a collection type with a text field
2. Create an entry with value `Safe & Sustainable Operations`
3. In the Content Manager list view, add a filter: `field is Safe & Sustainable Operations`
4. The entry should be returned correctly
5. Add another filter, or sort by a column, or change page
6. The filter value should survive and the entry should still be returned

## Related issue

Closes #27220