### PR TITLE
fix(upload): guard cache-buster on signed URLs in new-ML AssetCropEditor

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
@@ -288,21 +288,24 @@ export const AssetCropEditor = ({
   // Focal point as a percentage of the crop area (matches the {x,y} contract).
   const [focal, setFocal] = React.useState<FocalPoint>(asset.focalPoint ?? { x: 50, y: 50 });
 
-  // Append `updatedAt` as a cache-buster: a replaced asset is served at the same
-  // URL, so without this, reopening the editor shows the browser-cached old image
-  // (mirrors AssetPreview).
-  // Skipped for signed URLs: the asset URL is a presigned S3 URL and any extra
-  // query param invalidates the signature (403 SignatureDoesNotMatch). Dropping
-  // the buster makes this URL byte-identical to AssetPreview's; for a signed
-  // remote asset AssetPreview also loads with crossOrigin="anonymous" (see the
-  // img below), so the two share one CORS-consistent cache entry rather than
-  // colliding (see #26581).
+  // The crop editor reads pixels from a canvas (useCropImg -> toBlob), so its
+  // <img> must be CORS-clean and always sets crossOrigin="anonymous" (see the
+  // img below) — even for unsigned URLs, which AssetPreview leaves unset because
+  // it only displays. That difference is why the crop URL is kept DISTINCT from
+  // the thumbnail's: identical URL + different crossOrigin collide in the HTTP
+  // cache (#26581), and the crop's anonymous request could otherwise reuse the
+  // thumbnail's non-CORS cached response and taint the canvas. So the buster
+  // uses `updatedAt` where AssetPreview uses `v`, giving each its own entry
+  // (mirrors the legacy PreviewBox fix).
+  // Signed URLs get no param at all — a presigned S3 URL breaks if you add one,
+  // and on the signed side AssetPreview also loads anonymous, so the identical
+  // URL there shares one CORS-consistent entry, which is fine.
   const rawImageUrl = prefixFileUrlWithBackendUrl(asset.url) as string;
   const cacheKey =
     asset.updatedAt && !asset.isUrlSigned ? new Date(asset.updatedAt).getTime() : undefined;
   const imageUrl =
     cacheKey !== undefined
-      ? `${rawImageUrl}${rawImageUrl.includes('?') ? '&' : '?'}v=${cacheKey}`
+      ? `${rawImageUrl}${rawImageUrl.includes('?') ? '&' : '?'}updatedAt=${cacheKey}`
       : rawImageUrl;
 
   const handleImageLoad = () => {

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
@@ -293,9 +293,10 @@ export const AssetCropEditor = ({
   // (mirrors AssetPreview).
   // Skipped for signed URLs: the asset URL is a presigned S3 URL and any extra
   // query param invalidates the signature (403 SignatureDoesNotMatch). Dropping
-  // the buster also makes this URL byte-identical to AssetPreview's, so both
-  // loads — each with crossOrigin="anonymous" below — share one CORS-consistent
-  // cache entry (see #26581). CMS-1548.
+  // the buster makes this URL byte-identical to AssetPreview's; for a signed
+  // remote asset AssetPreview also loads with crossOrigin="anonymous" (see the
+  // img below), so the two share one CORS-consistent cache entry rather than
+  // colliding (see #26581).
   const rawImageUrl = prefixFileUrlWithBackendUrl(asset.url) as string;
   const cacheKey =
     asset.updatedAt && !asset.isUrlSigned ? new Date(asset.updatedAt).getTime() : undefined;
@@ -510,6 +511,10 @@ export const AssetCropEditor = ({
                 ref={imgRef}
                 src={imageUrl}
                 alt={asset.name}
+                // Always anonymous, unlike AssetPreview/AssetsGrid which gate it:
+                // the editor reads pixels via canvas (useCropImg -> toBlob), which
+                // taints on a cross-origin image loaded without CORS, so every
+                // remote image must be fetched CORS-clean.
                 crossOrigin="anonymous"
                 onLoad={handleImageLoad}
                 draggable={false}

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
@@ -291,8 +291,14 @@ export const AssetCropEditor = ({
   // Append `updatedAt` as a cache-buster: a replaced asset is served at the same
   // URL, so without this, reopening the editor shows the browser-cached old image
   // (mirrors AssetPreview).
+  // Skipped for signed URLs: the asset URL is a presigned S3 URL and any extra
+  // query param invalidates the signature (403 SignatureDoesNotMatch). Dropping
+  // the buster also makes this URL byte-identical to AssetPreview's, so both
+  // loads — each with crossOrigin="anonymous" below — share one CORS-consistent
+  // cache entry (see #26581). CMS-1548.
   const rawImageUrl = prefixFileUrlWithBackendUrl(asset.url) as string;
-  const cacheKey = asset.updatedAt ? new Date(asset.updatedAt).getTime() : undefined;
+  const cacheKey =
+    asset.updatedAt && !asset.isUrlSigned ? new Date(asset.updatedAt).getTime() : undefined;
   const imageUrl =
     cacheKey !== undefined
       ? `${rawImageUrl}${rawImageUrl.includes('?') ? '&' : '?'}v=${cacheKey}`

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
@@ -227,11 +227,11 @@ describe('AssetCropEditor cache-buster on signed URLs', () => {
     expect(src).not.toContain('v=');
   });
 
-  it('appends ?v=<updatedAt> on an unsigned URL (cache busting still works after replace)', async () => {
+  it('busts an unsigned URL with a distinct `updatedAt` param (still refreshes after replace)', async () => {
     await renderEditor({ asset: unsignedAsset });
 
     const src = document.querySelector('img')?.getAttribute('src') ?? '';
-    expect(src).toContain(`v=${new Date(unsignedAsset.updatedAt as string).getTime()}`);
+    expect(src).toContain(`updatedAt=${new Date(unsignedAsset.updatedAt as string).getTime()}`);
   });
 
   it('produces the same URL and crossOrigin as AssetPreview for a signed asset (one CORS-consistent cache entry)', async () => {
@@ -252,6 +252,30 @@ describe('AssetCropEditor cache-buster on signed URLs', () => {
     expect(cropImg).toHaveAttribute('src', previewSrc as string);
     expect(cropImg).toHaveAttribute('crossorigin', previewCrossOrigin as string);
     expect(previewCrossOrigin).toBe('anonymous');
+  });
+
+  it('gives the crop image its own cache entry for an unsigned asset (distinct URL + anonymous)', async () => {
+    // The editor reads canvas pixels (useCropImg -> toBlob), so it must load
+    // CORS-clean (crossOrigin="anonymous"); AssetPreview only displays and leaves
+    // it unset. Same URL + different crossOrigin collide (#26581) — the anonymous
+    // crop request could reuse the thumbnail's non-CORS response and taint the
+    // canvas. So the crop URL must differ: it busts with `updatedAt`, the
+    // thumbnail with `v`.
+    const preview = render(<AssetPreview asset={unsignedAsset} />);
+    const previewImg = preview.getByAltText(String(unsignedAsset.alternativeText));
+    const previewSrc = previewImg.getAttribute('src') ?? '';
+    expect(previewImg).not.toHaveAttribute('crossorigin');
+    preview.unmount();
+
+    await renderEditor({ asset: unsignedAsset });
+    const cropImg = screen.getByAltText(unsignedAsset.name) as HTMLImageElement;
+    const cropSrc = cropImg.getAttribute('src') ?? '';
+
+    // Distinct cache entry: different URL, and the crop opts into CORS.
+    expect(cropSrc).not.toBe(previewSrc);
+    expect(cropSrc).toContain('updatedAt=');
+    expect(previewSrc).toContain('v=');
+    expect(cropImg).toHaveAttribute('crossorigin', 'anonymous');
   });
 });
 

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@tests/utils';
 
 import { AssetCropEditor } from '../AssetCropEditor';
+import { AssetPreview } from '../AssetPreview';
 
 import type { AssetWithPopulatedCreatedBy } from '../../../../../../../../shared/contracts/files';
 
@@ -40,6 +41,18 @@ let restoreRect: () => void;
 let restoreNatural: () => void;
 
 beforeAll(() => {
+  // AssetPreview (rendered by the parity test below) observes its image with a
+  // ResizeObserver, which jsdom doesn't implement.
+  if (!('ResizeObserver' in globalThis)) {
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe() {}
+
+      unobserve() {}
+
+      disconnect() {}
+    };
+  }
+
   const originalRect = Element.prototype.getBoundingClientRect;
   Element.prototype.getBoundingClientRect = () =>
     ({
@@ -88,10 +101,13 @@ afterAll(() => {
   restoreNatural();
 });
 
-const renderEditor = async ({ canSaveAsCopy = true }: { canSaveAsCopy?: boolean } = {}) => {
+const renderEditor = async ({
+  canSaveAsCopy = true,
+  asset: assetProp = asset,
+}: { canSaveAsCopy?: boolean; asset?: AssetWithPopulatedCreatedBy } = {}) => {
   const utils = render(
     <AssetCropEditor
-      asset={asset}
+      asset={assetProp}
       onClose={jest.fn()}
       onApply={jest.fn()}
       onSaveAsCopy={jest.fn()}
@@ -184,6 +200,58 @@ describe('AssetCropEditor save-as-copy gating', () => {
 
     expect(screen.queryByRole('button', { name: 'Save as copy' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+  });
+});
+
+describe('AssetCropEditor cache-buster on signed URLs (CMS-1548)', () => {
+  const signedAsset = {
+    ...asset,
+    isUrlSigned: true,
+    // A presigned S3 URL already carries its signature as query params; a
+    // `&v=` cache-buster would invalidate it (403 SignatureDoesNotMatch).
+    url: 'https://cdn.example.com/photo.png?X-Amz-Signature=sig',
+  } as unknown as AssetWithPopulatedCreatedBy;
+
+  const unsignedAsset = {
+    ...asset,
+    isUrlSigned: false,
+    url: '/uploads/photo.png',
+    updatedAt: '2026-05-06T00:00:00.000Z',
+  } as unknown as AssetWithPopulatedCreatedBy;
+
+  it('does not append the cache-buster on a signed URL (preserves the signature)', async () => {
+    await renderEditor({ asset: signedAsset });
+
+    const src = document.querySelector('img')?.getAttribute('src') ?? '';
+    expect(src).toBe(signedAsset.url);
+    expect(src).not.toContain('v=');
+  });
+
+  it('appends ?v=<updatedAt> on an unsigned URL (cache busting still works after replace)', async () => {
+    await renderEditor({ asset: unsignedAsset });
+
+    const src = document.querySelector('img')?.getAttribute('src') ?? '';
+    expect(src).toContain(`v=${new Date(unsignedAsset.updatedAt as string).getTime()}`);
+  });
+
+  it('produces the same URL and crossOrigin as AssetPreview for a signed asset (one CORS-consistent cache entry)', async () => {
+    // AssetPreview is the sibling render site; for a signed asset both must drop
+    // the buster and opt into CORS, or the two loads would fight over the cache
+    // (the #26581 collision).
+    const preview = render(<AssetPreview asset={signedAsset} />);
+    // Select by alt (the real image), not the first <img> — AssetPreview also
+    // renders a loading-spinner SVG <img> until the media load fires.
+    const previewImg = preview.getByAltText(String(signedAsset.alternativeText));
+    const previewSrc = previewImg.getAttribute('src');
+    const previewCrossOrigin = previewImg.getAttribute('crossorigin');
+    preview.unmount();
+
+    await renderEditor({ asset: signedAsset });
+    const cropImg = screen.getByAltText(signedAsset.name) as HTMLImageElement;
+
+    expect(cropImg).toHaveAttribute('src', previewSrc as string);
+    expect(cropImg).toHaveAttribute('crossorigin', previewCrossOrigin as string);
+    expect(previewCrossOrigin).toBe('anonymous');
   });
 });
 

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
@@ -203,7 +203,7 @@ describe('AssetCropEditor save-as-copy gating', () => {
   });
 });
 
-describe('AssetCropEditor cache-buster on signed URLs (CMS-1548)', () => {
+describe('AssetCropEditor cache-buster on signed URLs', () => {
   const signedAsset = {
     ...asset,
     isUrlSigned: true,


### PR DESCRIPTION
### What does it do?

Guards the image cache-buster in the new Media Library's `AssetCropEditor` so it is **not** appended to signed URLs.

* `AssetCropEditor.tsx` — the `?v=<updatedAt>` cache-buster is now gated on `!asset.isUrlSigned`, mirroring the existing guard in the sibling `AssetPreview.tsx`. Signed URLs keep the buster (and the replace-cache-bust behaviour) for local/public providers, and skip it for presigned ones.
* Dropping the buster for signed URLs also makes the crop-editor image URL byte-identical to `AssetPreview`'s. Both render with `crossOrigin="anonymous"`, so the two loads share one CORS-consistent cache entry (the strapi/strapi#26581 collision scenario, resolved by both sides agreeing).

### Why is it needed?

On a private-ACL S3 provider the asset URL is a **presigned** URL. Any extra query parameter invalidates the signature, so the unconditional `?v=` made the crop editor load a `403 SignatureDoesNotMatch` instead of the image. The file (added by strapi/strapi#26686) predated the sweep in strapi/strapi#26901 that added this guard to every other render site, so it was the one surviving unguarded spot.

Not user-visible today — behind `unstableMediaLibrary`; ships with the new Media Library.

### How to test it?

Requires a private-ACL S3 provider + `UNSTABLE_MEDIA_LIBRARY=true`.

1. Open the new Media Library, select an image asset, open the crop panel in the detail drawer.
2. **Before:** the crop image fails with `403 SignatureDoesNotMatch`. **After:** it loads.
3. With a **local** provider (or public ACL): replace an image, reopen the crop editor — the new image shows (buster still appended → `?v=<updatedAt>` present).

Automated: `IS_EE=true yarn nx run @strapi/upload:test:front -- --testPathPattern "AssetCropEditor"` — 10 pass, incl. the new [CMS-1548](https://linear.app/strapi/issue/CMS-1548/guard-cache-buster-on-signed-urls-in-new-ml-assetcropeditor) cases (signed → no `v`; unsigned+`updatedAt` → `v` present; crop URL + `crossOrigin` match `AssetPreview` for a signed asset).

### Related issue(s)/PR(s)

* fix [CMS-1548](https://linear.app/strapi/issue/CMS-1548/guard-cache-buster-on-signed-urls-in-new-ml-assetcropeditor)
* Related: strapi/strapi#26581 / strapi/strapi#26901 (added the equivalent guard to `AssetPreview`), strapi/strapi#26686 (introduced this file), [CMS-1549](https://linear.app/strapi/issue/CMS-1549/centralise-asset-cache-busting-behind-a-signed-url-aware-helper) (follow-up: centralise this cache-busting behind one signed-URL-aware helper — this is the 3rd copy of the pattern).

*Generated by AI, reviewed and edited by* @Adzouz

🚀