### PR TITLE
fix(content-manager): uid field does not generate a slug from its target field

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/UID.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/UID.tsx
@@ -42,7 +42,7 @@ import type { Schema } from '@strapi/types';
 const UID_REGEX = /^[A-Za-z0-9-_.~]*$/;
 
 interface UIDInputProps extends Omit<InputProps, 'type'> {
-  attribute?: Pick<Schema.Attribute.UIDProperties, 'regex'>;
+  attribute?: Pick<Schema.Attribute.UIDProperties, 'regex' | 'targetField'>;
   type: Schema.Attribute.TypeOf<Schema.Attribute.UID>;
 }
 
@@ -62,9 +62,66 @@ const UIDInput = React.forwardRef<HTMLInputElement, UIDInputProps>(
     const [{ query }] = useQueryParams();
     const params = React.useMemo(() => buildValidParams(query), [query]);
 
-    const { regex } = attribute;
+    const { regex, targetField } = attribute;
     const validationRegExp = regex ? new RegExp(regex) : UID_REGEX;
     const trimmedDebouncedValue = debouncedValue?.trim() ?? '';
+
+    /**
+     * The server resolves the target field against the root of the submitted data
+     * (see the `uid` service's `generateUIDField`), so we read it the same way.
+     */
+    const targetFieldValue = targetField
+      ? (allFormValues as Record<string, unknown>)[targetField]
+      : undefined;
+    const debouncedTargetFieldValue = useDebounce(targetFieldValue, 300);
+    const hasTargetFieldValue =
+      typeof debouncedTargetFieldValue === 'string' && debouncedTargetFieldValue.trim() !== '';
+
+    /**
+     * Once the user types in the field it is theirs — including when they clear it,
+     * which must not immediately refill from the target field.
+     */
+    const hasUserEditedRef = React.useRef(false);
+
+    /**
+     * The last value we generated ourselves. While the field still holds it (or is
+     * empty) the user hasn't taken ownership of the UID, so we're free to keep it in
+     * sync with the target field.
+     */
+    const generatedValueRef = React.useRef<string | undefined>(undefined);
+    const isUIDUntouched =
+      !hasUserEditedRef.current &&
+      (field.value === undefined ||
+        field.value === '' ||
+        field.value === generatedValueRef.current);
+
+    /**
+     * With a target field we generate as soon as it has a value, whether or not the UID
+     * itself is required — generating before then would only produce the fallback the
+     * server derives from the model name. Without one there is nothing to wait for, so
+     * we keep filling required fields on mount as before.
+     */
+    const shouldGenerateDefaultUID =
+      isUIDUntouched && (targetField ? hasTargetFieldValue : Boolean(required));
+
+    /**
+     * Snapshot of the form values, kept out of the query key on purpose: the request is
+     * keyed on the debounced target field alone, otherwise a keystroke in any field
+     * would change the args and fire another generate request.
+     */
+    const allFormValuesRef = React.useRef(allFormValues);
+    React.useEffect(() => {
+      allFormValuesRef.current = allFormValues;
+    }, [allFormValues]);
+
+    const defaultUIDRequestData = React.useMemo(
+      () => ({
+        id: currentDocumentMeta.documentId ?? '',
+        ...allFormValuesRef.current,
+        ...(targetField ? { [targetField]: debouncedTargetFieldValue } : {}),
+      }),
+      [currentDocumentMeta.documentId, targetField, debouncedTargetFieldValue]
+    );
 
     const {
       data: defaultGeneratedUID,
@@ -74,14 +131,11 @@ const UIDInput = React.forwardRef<HTMLInputElement, UIDInputProps>(
       {
         contentTypeUID: currentDocumentMeta.model,
         field: name,
-        data: {
-          id: currentDocumentMeta.documentId ?? '',
-          ...allFormValues,
-        },
+        data: defaultUIDRequestData,
         params,
       },
       {
-        skip: (field.value !== undefined && field.value !== '') || !required,
+        skip: !shouldGenerateDefaultUID,
       }
     );
 
@@ -99,10 +153,16 @@ const UIDInput = React.forwardRef<HTMLInputElement, UIDInputProps>(
      * but we also want to set it as the initialValue too.
      */
     React.useEffect(() => {
-      if (defaultGeneratedUID && field.value === undefined) {
+      if (defaultGeneratedUID && isUIDUntouched && field.value !== defaultGeneratedUID) {
+        generatedValueRef.current = defaultGeneratedUID;
         field.onChange(name, defaultGeneratedUID);
       }
-    }, [defaultGeneratedUID, field, name]);
+    }, [defaultGeneratedUID, field, isUIDUntouched, name]);
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+      hasUserEditedRef.current = true;
+      field.onChange(event);
+    };
 
     const [generateUID, { isLoading: isGeneratingUID }] = useGenerateUIDMutation();
 
@@ -116,6 +176,7 @@ const UIDInput = React.forwardRef<HTMLInputElement, UIDInputProps>(
         });
 
         if ('data' in res) {
+          generatedValueRef.current = res.data;
           field.onChange(name, res.data);
         } else {
           toggleNotification({
@@ -269,7 +330,7 @@ const UIDInput = React.forwardRef<HTMLInputElement, UIDInputProps>(
               )}
             </Flex>
           }
-          onChange={field.onChange}
+          onChange={handleChange}
           value={field.value ?? ''}
           {...props}
           type="text"

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/UID.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/UID.tsx
@@ -80,6 +80,11 @@ const UIDInput = React.forwardRef<HTMLInputElement, UIDInputProps>(
     /**
      * Once the user types in the field it is theirs — including when they clear it,
      * which must not immediately refill from the target field.
+     *
+     * Note this is a secondary guard rather than the mechanism: `Form` normalises a
+     * cleared input to `null`, and `null` already falls outside the untouched values
+     * below. Ownership therefore survives this input being unmounted and remounted by
+     * a visibility condition on the attribute, which resets the ref.
      */
     const hasUserEditedRef = React.useRef(false);
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/tests/UID.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/tests/UID.test.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { Form, useField } from '@strapi/admin/strapi-admin';
 import { render as renderRTL, waitFor, act, screen, server } from '@tests/utils';
 import { http, HttpResponse } from 'msw';
@@ -31,11 +33,34 @@ const TargetFieldInput = () => {
   );
 };
 
+/**
+ * Stands in for `ConditionAwareInputRenderer`, which returns `null` when a visibility
+ * condition stops matching. The field is unmounted while the form keeps its value, so
+ * anything the input holds in local state is lost on the way back.
+ */
+const VisibilityToggle = ({ children }: { children: React.ReactNode }) => {
+  const [isVisible, setIsVisible] = React.useState(true);
+
+  return (
+    <>
+      <button type="button" onClick={() => setIsVisible((visible) => !visible)}>
+        Toggle visibility
+      </button>
+      {isVisible ? children : null}
+    </>
+  );
+};
+
 const render = ({
   initialValues = { name: 'test' },
   withTargetField = false,
+  withVisibilityToggle = false,
   ...props
-}: Partial<UIDInputProps> & { initialValues?: object; withTargetField?: boolean } = {}) =>
+}: Partial<UIDInputProps> & {
+  initialValues?: object;
+  withTargetField?: boolean;
+  withVisibilityToggle?: boolean;
+} = {}) =>
   renderRTL(<UIDInput label="Label" name="name" type="uid" {...props} />, {
     renderOptions: {
       wrapper: ({ children }) => (
@@ -45,7 +70,7 @@ const render = ({
             element={
               <Form method="POST" onSubmit={jest.fn()} initialValues={initialValues}>
                 {withTargetField ? <TargetFieldInput /> : null}
-                {children}
+                {withVisibilityToggle ? <VisibilityToggle>{children}</VisibilityToggle> : children}
               </Form>
             }
           />
@@ -239,6 +264,49 @@ describe('UIDInput', () => {
 
     await waitFor(() => expect(screen.queryByTestId('loading-wrapper')).not.toBeInTheDocument());
     expect(uidInput).toHaveValue('');
+
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('Does not refill a cleared value after a visibility condition remounts the field', async () => {
+    jest.useFakeTimers({ doNotFake: ['queueMicrotask', 'setImmediate'] });
+    const { user } = render({
+      initialValues: { target: 'My Title' },
+      attribute: { targetField: 'target' },
+      withTargetField: true,
+      withVisibilityToggle: true,
+    });
+    await waitForInput();
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: 'Label' })).toHaveValue('My Title')
+    );
+
+    await user.clear(screen.getByRole('textbox', { name: 'Label' }));
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    await waitFor(() => expect(screen.queryByTestId('loading-wrapper')).not.toBeInTheDocument());
+    expect(screen.getByRole('textbox', { name: 'Label' })).toHaveValue('');
+
+    // Hide the field and bring it back, as a visibility condition flipping would.
+    const toggle = screen.getByRole('button', { name: 'Toggle visibility' });
+    await user.click(toggle);
+    expect(screen.queryByRole('textbox', { name: 'Label' })).not.toBeInTheDocument();
+    await user.click(toggle);
+    await waitForInput();
+
+    // Give a regeneration every chance to land: run the debounce timers and flush the
+    // promise chain a request would resolve through, so the assertion below is not just
+    // winning a race against it.
+    for (let i = 0; i < 3; i += 1) {
+      await act(async () => {
+        jest.advanceTimersByTime(4000);
+      });
+    }
+    await waitFor(() => expect(screen.queryByTestId('loading-wrapper')).not.toBeInTheDocument());
+    expect(screen.getByRole('textbox', { name: 'Label' })).toHaveValue('');
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/tests/UID.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/tests/UID.test.tsx
@@ -1,4 +1,4 @@
-import { Form } from '@strapi/admin/strapi-admin';
+import { Form, useField } from '@strapi/admin/strapi-admin';
 import { render as renderRTL, waitFor, act, screen, server } from '@tests/utils';
 import { http, HttpResponse } from 'msw';
 import { Route, Routes } from 'react-router-dom';
@@ -7,13 +7,35 @@ import { UIDInput, UIDInputProps } from '../UID';
 
 const waitForInput = async () => {
   await waitFor(() => expect(screen.queryByTestId('loading-wrapper')).not.toBeInTheDocument());
-  await screen.findByRole('textbox');
+  await screen.findByRole('textbox', { name: 'Label' });
+};
+
+/**
+ * The UID input reads its target field off the form, so tests that exercise the
+ * generation need a sibling input to drive it. `/content-manager/uid/generate` is
+ * mocked to echo back `data.target`, so whatever is typed here is what the UID
+ * should end up holding.
+ */
+const TargetFieldInput = () => {
+  const field = useField<string>('target');
+
+  return (
+    <label>
+      Target
+      <input
+        type="text"
+        value={field.value ?? ''}
+        onChange={(event) => field.onChange('target', event.target.value)}
+      />
+    </label>
+  );
 };
 
 const render = ({
   initialValues = { name: 'test' },
+  withTargetField = false,
   ...props
-}: Partial<UIDInputProps> & { initialValues?: object } = {}) =>
+}: Partial<UIDInputProps> & { initialValues?: object; withTargetField?: boolean } = {}) =>
   renderRTL(<UIDInput label="Label" name="name" type="uid" {...props} />, {
     renderOptions: {
       wrapper: ({ children }) => (
@@ -22,6 +44,7 @@ const render = ({
             path="/content-manager/:collectionType/:slug/:id"
             element={
               <Form method="POST" onSubmit={jest.fn()} initialValues={initialValues}>
+                {withTargetField ? <TargetFieldInput /> : null}
                 {children}
               </Form>
             }
@@ -117,6 +140,108 @@ describe('UIDInput', () => {
     await waitForInput();
 
     expect(screen.getByRole('textbox', { name: 'Label' })).not.toHaveValue('regenerated');
+  });
+
+  test('Generates the value from the target field even when the field is not required', async () => {
+    render({
+      initialValues: { target: 'My Title' },
+      attribute: { targetField: 'target' },
+      withTargetField: true,
+    });
+    await waitForInput();
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: 'Label' })).toHaveValue('My Title')
+    );
+  });
+
+  test('Does not generate a value before the target field has one', async () => {
+    // Generating here would only produce the server's model-name fallback, which is
+    // what used to land in the field on mount.
+    render({
+      initialValues: {},
+      attribute: { targetField: 'target' },
+      required: true,
+      withTargetField: true,
+    });
+    await waitForInput();
+
+    expect(screen.getByRole('textbox', { name: 'Label' })).toHaveValue('');
+    expect(screen.getByRole('textbox', { name: 'Label' })).not.toHaveValue('regenerated');
+  });
+
+  test('Follows the target field until the user edits the value themselves', async () => {
+    // MSW v2 / undici use microtasks internally between request emission and handler
+    // resolution. Faking `queueMicrotask` / `setImmediate` doesn't block completion but
+    // stalls them long enough that each fetch here takes ~10s instead of ~100ms. Keep
+    // them real so the file runs in single-digit seconds.
+    jest.useFakeTimers({ doNotFake: ['queueMicrotask', 'setImmediate'] });
+    const { user } = render({
+      initialValues: {},
+      attribute: { targetField: 'target' },
+      withTargetField: true,
+    });
+    await waitForInput();
+
+    const uidInput = screen.getByRole('textbox', { name: 'Label' });
+    const targetInput = screen.getByRole('textbox', { name: 'Target' });
+
+    await user.type(targetInput, 'first');
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    await waitFor(() => expect(uidInput).toHaveValue('first'));
+
+    // Still untouched, so it keeps tracking the target field.
+    await user.clear(targetInput);
+    await user.type(targetInput, 'second');
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    await waitFor(() => expect(uidInput).toHaveValue('second'));
+
+    // Once the user owns the value, the target field must not overwrite it.
+    await user.clear(uidInput);
+    await user.type(uidInput, 'mine');
+    await user.clear(targetInput);
+    await user.type(targetInput, 'third');
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    await waitFor(() => expect(screen.queryByTestId('loading-wrapper')).not.toBeInTheDocument());
+    expect(uidInput).toHaveValue('mine');
+
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('Does not refill the value after the user clears it', async () => {
+    // MSW v2 / undici use microtasks internally between request emission and handler
+    // resolution. Faking `queueMicrotask` / `setImmediate` doesn't block completion but
+    // stalls them long enough that each fetch here takes ~10s instead of ~100ms. Keep
+    // them real so the file runs in single-digit seconds.
+    jest.useFakeTimers({ doNotFake: ['queueMicrotask', 'setImmediate'] });
+    const { user } = render({
+      initialValues: { target: 'My Title' },
+      attribute: { targetField: 'target' },
+      withTargetField: true,
+    });
+    await waitForInput();
+
+    const uidInput = screen.getByRole('textbox', { name: 'Label' });
+    await waitFor(() => expect(uidInput).toHaveValue('My Title'));
+
+    await user.clear(uidInput);
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    await waitFor(() => expect(screen.queryByTestId('loading-wrapper')).not.toBeInTheDocument());
+    expect(uidInput).toHaveValue('');
+
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   test('Checks the availability', async () => {


### PR DESCRIPTION
### What does it do?

Makes the Content Manager's UID input actually generate its value from the attribute's `targetField`.

In `UIDInput`:

- Read `attribute.targetField` and watch its value on the form. The default-UID request is now skipped until that field holds a non-empty value, instead of firing on mount.
- Generate whenever there is a `targetField`, regardless of whether the UID itself is `required`. Without a `targetField` the previous behaviour is kept — required fields are still filled on mount, since there is nothing to wait for.
- Key the request on the *debounced* target field rather than the whole form snapshot, so a keystroke in an unrelated field no longer fires a generate request. The rest of the form values are passed through a ref, keeping them out of the query key.
- Keep the UID in sync with the target field until the user takes ownership of it. Once they type in the input (including clearing it), it is theirs and we stop overwriting it.

### Why is it needed?

The default UID was only requested when the field was marked `required`, and the request went out on mount — before the target field had any value:

```ts
skip: (field.value !== undefined && field.value !== '') || !required,
```

So a non-required UID field was never filled at all, and a required one was filled with the fallback the server derives from the model name (`untitled`-style) rather than a slug of the target field. Users had to click "Regenerate" every time to get the slug the field is configured to produce.

### How to test it?

1. In the Content Type Builder, add a UID field to a collection type and set its **Attached field** to a text field (e.g. `title`).
2. In the Content Manager, create a new entry and type into the target field.
3. The UID field should fill itself with the slug of what was typed, and keep following it as it changes — both when the UID is required and when it is not.
4. Type something into the UID field yourself: it should stop following the target field, and clearing it should not refill it.

Automated coverage lives in `packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/tests/UID.test.tsx`, which gains cases for generating without `required`, not generating before the target field has a value, following the target field until the user edits, and not refilling after a manual clear.

```bash
IS_EE=true yarn nx run @strapi/content-manager:test:front -- FormInputs/tests/UID.test.tsx
```

### Related issue(s)/PR(s)

Fix #21472
