### PR TITLE
fix(upload): keep infinite scroll loading when the sentinel stays visible (CMS-1562)

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -1,7 +1,7 @@
-import { useRef, useCallback, useMemo, useState, useEffect, type ChangeEvent } from 'react';
+import { useRef, useMemo, useState, useEffect, type ChangeEvent } from 'react';
 
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
-import { Layouts, useElementOnScreen, usePersistentState } from '@strapi/admin/strapi-admin';
+import { Layouts, usePersistentState } from '@strapi/admin/strapi-admin';
 import {
   Box,
   Flex,
@@ -54,6 +54,7 @@ import { AssetSelectionProvider, useAssetSelection } from './hooks/useAssetSelec
 import { useFolderInfo } from './hooks/useFolderInfo';
 import { useFolderNavigation } from './hooks/useFolderNavigation';
 import { useInfiniteAssets } from './hooks/useInfiniteAssets';
+import { useInfiniteScrollSentinel } from './hooks/useInfiniteScrollSentinel';
 import { useListFilters } from './hooks/useListFilters';
 import { useListSort, type FoldersPosition } from './hooks/useListSort';
 import { buildAssetFilters } from './utils/buildAssetFilters';
@@ -161,17 +162,12 @@ const AssetsView = ({
     [foldersPosition, isGridView, folders, assets, assetsSort, hasNextPage]
   );
 
-  const loadMoreRef = useElementOnScreen<HTMLDivElement>(
-    useCallback(
-      (isVisible) => {
-        if (isVisible && hasNextPage && !isFetchingMore) {
-          fetchNextPage();
-        }
-      },
-      [hasNextPage, isFetchingMore, fetchNextPage]
-    ),
-    INTERSECTION_OPTIONS
-  );
+  const loadMoreRef = useInfiniteScrollSentinel({
+    hasNextPage,
+    isFetchingMore,
+    onLoadMore: fetchNextPage,
+    options: INTERSECTION_OPTIONS,
+  });
 
   if (isLoading) {
     return (

--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -64,7 +64,15 @@ import { mergeMixedList } from './utils/mergeMixedList';
 import type { File, UploadFileInfo } from '../../../../../shared/contracts/files';
 import type { Folder } from '../../../../../shared/contracts/folders';
 
-const INTERSECTION_OPTIONS: IntersectionObserverInit = { threshold: 0.1 };
+// The negative bottom margin shrinks the trigger area by a pixel so the 1px
+// sentinel sitting exactly at the fold (when a page's rows happen to fill the
+// viewport) reads as "not visible" and doesn't pull an extra page. It still
+// triggers as soon as the sentinel scrolls a hair into view. Tune the bottom
+// value if the list over- or under-fetches near the fold.
+const INTERSECTION_OPTIONS: IntersectionObserverInit = {
+  threshold: 0,
+  rootMargin: '0px 0px -1px 0px',
+};
 
 const ITEM_COUNT_MESSAGE = {
   id: getTranslationKey('header.content.item-count'),

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteScrollSentinel.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteScrollSentinel.test.ts
@@ -4,7 +4,11 @@ import { useInfiniteScrollSentinel } from '../useInfiniteScrollSentinel';
 
 /**
  * jsdom has no IntersectionObserver. This controllable stub lets a test drive
- * the sentinel's visibility by hand and records observe/disconnect calls.
+ * the sentinel's visibility by hand.
+ *
+ * `observe()` re-emits the last known intersection, mirroring the browser's
+ * initial notification for a freshly observed target — which is what the hook
+ * relies on when it re-observes after a page settles.
  */
 class MockIntersectionObserver {
   static instances: MockIntersectionObserver[] = [];
@@ -15,13 +19,27 @@ class MockIntersectionObserver {
 
   disconnected = false;
 
+  lastIsIntersecting = false;
+
   constructor(callback: IntersectionObserverCallback) {
     this.callback = callback;
     MockIntersectionObserver.instances.push(this);
   }
 
+  private fire(isIntersecting: boolean) {
+    act(() => {
+      this.callback(
+        [{ isIntersecting } as IntersectionObserverEntry],
+        this as unknown as IntersectionObserver
+      );
+    });
+  }
+
   observe(el: Element) {
     this.observed.push(el);
+    // A freshly observed target gets an initial notification with its current
+    // intersection — this is how re-observing on settle produces a fresh read.
+    this.fire(this.lastIsIntersecting);
   }
 
   disconnect() {
@@ -36,12 +54,8 @@ class MockIntersectionObserver {
 
   /** Simulate the observed element entering/leaving the viewport. */
   emit(isIntersecting: boolean) {
-    act(() => {
-      this.callback(
-        [{ isIntersecting } as IntersectionObserverEntry],
-        this as unknown as IntersectionObserver
-      );
-    });
+    this.lastIsIntersecting = isIntersecting;
+    this.fire(isIntersecting);
   }
 }
 
@@ -76,10 +90,10 @@ describe('useInfiniteScrollSentinel', () => {
     expect(onLoadMore).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps requesting pages while the sentinel stays visible after each fetch settles', () => {
-    // The core bug: the observer never re-fires because the sentinel never
-    // transitions off screen. Fetching must instead resume when isFetchingMore
-    // settles back to false.
+  it('keeps requesting pages while the sentinel is still visible after each fetch settles', () => {
+    // The observer never re-fires on its own because the sentinel never
+    // transitions off screen. Re-observing on settle re-reads it and keeps
+    // loading a viewport a single page didn't fill.
     const onLoadMore = jest.fn();
     const { result, rerender } = renderHook(
       ({ isFetchingMore }: { isFetchingMore: boolean }) =>
@@ -95,9 +109,31 @@ describe('useInfiniteScrollSentinel', () => {
     rerender({ isFetchingMore: true });
     expect(onLoadMore).toHaveBeenCalledTimes(1);
 
-    // Page settled, sentinel STILL visible (no transition emitted) → next page.
+    // Page settled, a fresh read still reports visible → next page.
     rerender({ isFetchingMore: false });
     expect(onLoadMore).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fetch an extra page when a settle finds the sentinel no longer visible', () => {
+    // The double-fetch: once a page fills the viewport the sentinel is no longer
+    // visible, so a settle must NOT pull another page. Loading is gated on the
+    // fresh read at settle time, never a stale one.
+    const onLoadMore = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ isFetchingMore }: { isFetchingMore: boolean }) =>
+        useInfiniteScrollSentinel({ hasNextPage: true, isFetchingMore, onLoadMore }),
+      { initialProps: { isFetchingMore: false } }
+    );
+
+    attach(result);
+    latestObserver().emit(true); // visible → first fetch
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    rerender({ isFetchingMore: true });
+    latestObserver().emit(false); // the loaded page filled the viewport
+
+    rerender({ isFetchingMore: false }); // settle → re-observe → fresh read is "not visible"
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
   });
 
   it('stops requesting once there is no next page', () => {
@@ -113,7 +149,7 @@ describe('useInfiniteScrollSentinel', () => {
     expect(onLoadMore).toHaveBeenCalledTimes(1);
 
     rerender({ hasNextPage: false });
-    // A settle after the last page must not fetch again.
+    latestObserver().emit(true); // still visible, but nothing more to load
     expect(onLoadMore).toHaveBeenCalledTimes(1);
   });
 
@@ -155,8 +191,8 @@ describe('useInfiniteScrollSentinel', () => {
     const spy = jest.fn();
     const { result, rerender } = renderHook(() =>
       // A fresh arrow every render — onLoadMore's identity changes each time.
-      // The hook holds it in a ref and keeps it out of the load effect's deps,
-      // so this can't become a fetch-per-render loop.
+      // The hook holds it in a ref, and loading only fires from observer reads,
+      // so an inert rerender can't become a fetch.
       useInfiniteScrollSentinel({
         hasNextPage: true,
         isFetchingMore: false,
@@ -168,7 +204,6 @@ describe('useInfiniteScrollSentinel', () => {
     latestObserver().emit(true); // visible → exactly one fetch
     expect(spy).toHaveBeenCalledTimes(1);
 
-    // Inert rerenders (nothing changes but onLoadMore's identity) must not fetch.
     rerender();
     rerender();
     expect(spy).toHaveBeenCalledTimes(1);

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteScrollSentinel.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteScrollSentinel.test.ts
@@ -1,0 +1,153 @@
+import { act, renderHook } from '@tests/utils';
+
+import { useInfiniteScrollSentinel } from '../useInfiniteScrollSentinel';
+
+/**
+ * jsdom has no IntersectionObserver. This controllable stub lets a test drive
+ * the sentinel's visibility by hand and records observe/disconnect calls.
+ */
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  callback: IntersectionObserverCallback;
+
+  observed: Element[] = [];
+
+  disconnected = false;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+
+  disconnect() {
+    this.disconnected = true;
+  }
+
+  unobserve() {}
+
+  takeRecords() {
+    return [];
+  }
+
+  /** Simulate the observed element entering/leaving the viewport. */
+  emit(isIntersecting: boolean) {
+    act(() => {
+      this.callback(
+        [{ isIntersecting } as IntersectionObserverEntry],
+        this as unknown as IntersectionObserver
+      );
+    });
+  }
+}
+
+const latestObserver = () =>
+  MockIntersectionObserver.instances[MockIntersectionObserver.instances.length - 1];
+
+beforeEach(() => {
+  MockIntersectionObserver.instances = [];
+  (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+    MockIntersectionObserver;
+});
+
+describe('useInfiniteScrollSentinel', () => {
+  const attach = (result: { current: (node: HTMLElement | null) => void }) => {
+    // Mounting the sentinel — the callback ref binds the observer.
+    act(() => {
+      result.current(document.createElement('div'));
+    });
+  };
+
+  it('requests the next page when the sentinel becomes visible', () => {
+    const onLoadMore = jest.fn();
+    const { result } = renderHook(() =>
+      useInfiniteScrollSentinel({ hasNextPage: true, isFetchingMore: false, onLoadMore })
+    );
+
+    attach(result);
+    expect(onLoadMore).not.toHaveBeenCalled();
+
+    latestObserver().emit(true);
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps requesting pages while the sentinel stays visible after each fetch settles (CMS-1562)', () => {
+    // The core bug: the observer never re-fires because the sentinel never
+    // transitions off screen. Fetching must instead resume when isFetchingMore
+    // settles back to false.
+    const onLoadMore = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ isFetchingMore }: { isFetchingMore: boolean }) =>
+        useInfiniteScrollSentinel({ hasNextPage: true, isFetchingMore, onLoadMore }),
+      { initialProps: { isFetchingMore: false } }
+    );
+
+    attach(result);
+    latestObserver().emit(true); // sentinel visible → first fetch
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    // Page in flight — no duplicate request while fetching.
+    rerender({ isFetchingMore: true });
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    // Page settled, sentinel STILL visible (no transition emitted) → next page.
+    rerender({ isFetchingMore: false });
+    expect(onLoadMore).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops requesting once there is no next page', () => {
+    const onLoadMore = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ hasNextPage }: { hasNextPage: boolean }) =>
+        useInfiniteScrollSentinel({ hasNextPage, isFetchingMore: false, onLoadMore }),
+      { initialProps: { hasNextPage: true } }
+    );
+
+    attach(result);
+    latestObserver().emit(true);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    rerender({ hasNextPage: false });
+    // A settle after the last page must not fetch again.
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch while the sentinel is off screen', () => {
+    const onLoadMore = jest.fn();
+    const { result } = renderHook(() =>
+      useInfiniteScrollSentinel({ hasNextPage: true, isFetchingMore: false, onLoadMore })
+    );
+
+    attach(result);
+    latestObserver().emit(false);
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('rebinds the observer when the sentinel remounts and drops it on unmount', () => {
+    const onLoadMore = jest.fn();
+    const { result } = renderHook(() =>
+      useInfiniteScrollSentinel({ hasNextPage: true, isFetchingMore: false, onLoadMore })
+    );
+
+    attach(result);
+    const first = latestObserver();
+    expect(first.observed).toHaveLength(1);
+
+    // Sentinel unmounts (e.g. the list drops back to a loader on folder change).
+    act(() => {
+      result.current(null);
+    });
+    expect(first.disconnected).toBe(true);
+
+    // Remounts → a fresh observer binds to the new node.
+    attach(result);
+    expect(latestObserver()).not.toBe(first);
+    expect(latestObserver().observed).toHaveLength(1);
+  });
+});

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteScrollSentinel.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteScrollSentinel.test.ts
@@ -76,7 +76,7 @@ describe('useInfiniteScrollSentinel', () => {
     expect(onLoadMore).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps requesting pages while the sentinel stays visible after each fetch settles (CMS-1562)', () => {
+  it('keeps requesting pages while the sentinel stays visible after each fetch settles', () => {
     // The core bug: the observer never re-fires because the sentinel never
     // transitions off screen. Fetching must instead resume when isFetchingMore
     // settles back to false.
@@ -149,5 +149,28 @@ describe('useInfiniteScrollSentinel', () => {
     attach(result);
     expect(latestObserver()).not.toBe(first);
     expect(latestObserver().observed).toHaveLength(1);
+  });
+
+  it('an unstable onLoadMore does not turn inert rerenders into extra fetches', () => {
+    const spy = jest.fn();
+    const { result, rerender } = renderHook(() =>
+      // A fresh arrow every render — onLoadMore's identity changes each time.
+      // The hook holds it in a ref and keeps it out of the load effect's deps,
+      // so this can't become a fetch-per-render loop.
+      useInfiniteScrollSentinel({
+        hasNextPage: true,
+        isFetchingMore: false,
+        onLoadMore: () => spy(),
+      })
+    );
+
+    attach(result);
+    latestObserver().emit(true); // visible → exactly one fetch
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Inert rerenders (nothing changes but onLoadMore's identity) must not fetch.
+    rerender();
+    rerender();
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteScrollSentinel.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteScrollSentinel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 interface UseInfiniteScrollSentinelArgs {
   /** Whether there is a further page to request. */
@@ -20,18 +20,22 @@ interface UseInfiniteScrollSentinelArgs {
  * Infinite-scroll trigger for the media library list.
  *
  * Returns a callback ref to place on a sentinel element rendered after the last
- * row. Two deliberate choices fix the "page 2 never loads" bug:
+ * row. Three deliberate choices:
  *
- * 1. **Fetching is driven by state, not by the observer's events.** An
- *    `IntersectionObserver` only fires on a *transition*. Once the sentinel is
- *    visible and stays visible (a page that doesn't push it off screen — tall
- *    viewport, a short final page, grid view fitting the whole page), it never
- *    fires again, so a callback-per-event approach loads one page and stalls.
- *    Here the observer only maintains `isVisible`; an effect reacts to
- *    `isFetchingMore` settling and keeps pulling pages while the sentinel is
- *    still on screen — until the viewport fills or `hasNextPage` is false.
+ * 1. **Loading is driven only by fresh observer readings.** A fetch fires from
+ *    the `IntersectionObserver` callback — never from a state/prop change — so
+ *    it can't react to a stale `isIntersecting` from before newly loaded rows
+ *    rendered (which fetched an extra page on every trigger).
  *
- * 2. **A callback ref, not a stable object ref.** The sentinel only mounts once
+ * 2. **Each settled page re-observes the sentinel.** An `IntersectionObserver`
+ *    only fires on a *transition*. When the sentinel stays on screen (a page
+ *    that doesn't fill the viewport — tall viewport, short page, grid fitting
+ *    the whole page) it would never fire again and loading would stall. So when
+ *    `isFetchingMore` settles back to false we re-observe, forcing a fresh
+ *    reading against the new layout: still on screen → load the next page;
+ *    viewport now filled → stop.
+ *
+ * 3. **A callback ref, not a stable object ref.** The sentinel only mounts once
  *    the first page has rendered (the list shows a loader before that). A
  *    callback ref (re)binds the observer exactly when the node mounts/unmounts,
  *    so the observer can't miss a sentinel that appears after the hook first ran.
@@ -42,28 +46,33 @@ export const useInfiniteScrollSentinel = ({
   onLoadMore,
   options,
 }: UseInfiniteScrollSentinelArgs) => {
-  const [isVisible, setIsVisible] = useState(false);
   const observerRef = useRef<IntersectionObserver | null>(null);
+  const nodeRef = useRef<HTMLElement | null>(null);
 
-  // Both read through refs so the callback ref and the load effect stay stable:
-  // `options` is read once at attach time (see its JSDoc), and `onLoadMore` need
-  // not be stable — an inline arrow from the caller can't turn the effect into a
-  // fetch-per-render loop.
+  // Read through refs so the callback ref stays stable and the observer callback
+  // always sees the latest values. `options` is read once at attach time (see
+  // its JSDoc); `onLoadMore` need not be stable.
   const optionsRef = useRef(options);
   optionsRef.current = options;
   const onLoadMoreRef = useRef(onLoadMore);
   onLoadMoreRef.current = onLoadMore;
+  const hasNextPageRef = useRef(hasNextPage);
+  hasNextPageRef.current = hasNextPage;
+  const isFetchingMoreRef = useRef(isFetchingMore);
+  isFetchingMoreRef.current = isFetchingMore;
 
   const sentinelRef = useCallback((node: HTMLElement | null) => {
     observerRef.current?.disconnect();
+    nodeRef.current = node;
 
     if (!node) {
-      setIsVisible(false);
       return;
     }
 
     const observer = new IntersectionObserver(([entry]) => {
-      setIsVisible(entry.isIntersecting);
+      if (entry.isIntersecting && hasNextPageRef.current && !isFetchingMoreRef.current) {
+        onLoadMoreRef.current();
+      }
     }, optionsRef.current);
 
     observer.observe(node);
@@ -72,11 +81,19 @@ export const useInfiniteScrollSentinel = ({
 
   useEffect(() => () => observerRef.current?.disconnect(), []);
 
+  // Once a page settles, re-observe so a *fresh* reading against the new layout
+  // decides whether to keep loading — rather than a stale `isIntersecting` from
+  // before the rows rendered. Re-observing re-emits the current intersection
+  // even without a transition, which is what keeps loading a viewport that a
+  // single page didn't fill.
   useEffect(() => {
-    if (isVisible && hasNextPage && !isFetchingMore) {
-      onLoadMoreRef.current();
+    if (isFetchingMore || !observerRef.current || !nodeRef.current) {
+      return;
     }
-  }, [isVisible, hasNextPage, isFetchingMore]);
+
+    observerRef.current.unobserve(nodeRef.current);
+    observerRef.current.observe(nodeRef.current);
+  }, [isFetchingMore]);
 
   return sentinelRef;
 };

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteScrollSentinel.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteScrollSentinel.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseInfiniteScrollSentinelArgs {
+  /** Whether there is a further page to request. */
+  hasNextPage: boolean;
+  /** Whether a subsequent page is already in flight. */
+  isFetchingMore: boolean;
+  /** Called to request the next page. Must be stable across renders. */
+  onLoadMore: () => void;
+  options?: IntersectionObserverInit;
+}
+
+/**
+ * Infinite-scroll trigger for the media library list.
+ *
+ * Returns a callback ref to place on a sentinel element rendered after the last
+ * row. Two deliberate choices fix the "page 2 never loads" bug (CMS-1562):
+ *
+ * 1. **Fetching is driven by state, not by the observer's events.** An
+ *    `IntersectionObserver` only fires on a *transition*. Once the sentinel is
+ *    visible and stays visible (a page that doesn't push it off screen — tall
+ *    viewport, a short final page, grid view fitting the whole page), it never
+ *    fires again, so a callback-per-event approach loads one page and stalls.
+ *    Here the observer only maintains `isVisible`; an effect reacts to
+ *    `isFetchingMore` settling and keeps pulling pages while the sentinel is
+ *    still on screen — until the viewport fills or `hasNextPage` is false.
+ *
+ * 2. **A callback ref, not a stable object ref.** The sentinel only mounts once
+ *    the first page has rendered (the list shows a loader before that). A
+ *    callback ref (re)binds the observer exactly when the node mounts/unmounts,
+ *    so the observer can't miss a sentinel that appears after the hook first ran.
+ */
+export const useInfiniteScrollSentinel = ({
+  hasNextPage,
+  isFetchingMore,
+  onLoadMore,
+  options,
+}: UseInfiniteScrollSentinelArgs) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  // Read the latest options at attach time without making the ref callback
+  // depend on them (the caller passes a stable module-level object anyway).
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const sentinelRef = useCallback((node: HTMLElement | null) => {
+    observerRef.current?.disconnect();
+
+    if (!node) {
+      setIsVisible(false);
+      return;
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsVisible(entry.isIntersecting);
+    }, optionsRef.current);
+
+    observer.observe(node);
+    observerRef.current = observer;
+  }, []);
+
+  useEffect(() => () => observerRef.current?.disconnect(), []);
+
+  useEffect(() => {
+    if (isVisible && hasNextPage && !isFetchingMore) {
+      onLoadMore();
+    }
+  }, [isVisible, hasNextPage, isFetchingMore, onLoadMore]);
+
+  return sentinelRef;
+};

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteScrollSentinel.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteScrollSentinel.ts
@@ -5,8 +5,14 @@ interface UseInfiniteScrollSentinelArgs {
   hasNextPage: boolean;
   /** Whether a subsequent page is already in flight. */
   isFetchingMore: boolean;
-  /** Called to request the next page. Must be stable across renders. */
+  /** Called to request the next page. Held in a ref, so it need not be stable. */
   onLoadMore: () => void;
+  /**
+   * Passed to the `IntersectionObserver`. Read once, when the sentinel node
+   * attaches — changing it afterwards does NOT rebuild the observer, so a
+   * later `threshold`/`rootMargin` is silently ignored. Pass a stable, ideally
+   * module-level, object.
+   */
   options?: IntersectionObserverInit;
 }
 
@@ -14,7 +20,7 @@ interface UseInfiniteScrollSentinelArgs {
  * Infinite-scroll trigger for the media library list.
  *
  * Returns a callback ref to place on a sentinel element rendered after the last
- * row. Two deliberate choices fix the "page 2 never loads" bug (CMS-1562):
+ * row. Two deliberate choices fix the "page 2 never loads" bug:
  *
  * 1. **Fetching is driven by state, not by the observer's events.** An
  *    `IntersectionObserver` only fires on a *transition*. Once the sentinel is
@@ -39,10 +45,14 @@ export const useInfiniteScrollSentinel = ({
   const [isVisible, setIsVisible] = useState(false);
   const observerRef = useRef<IntersectionObserver | null>(null);
 
-  // Read the latest options at attach time without making the ref callback
-  // depend on them (the caller passes a stable module-level object anyway).
+  // Both read through refs so the callback ref and the load effect stay stable:
+  // `options` is read once at attach time (see its JSDoc), and `onLoadMore` need
+  // not be stable — an inline arrow from the caller can't turn the effect into a
+  // fetch-per-render loop.
   const optionsRef = useRef(options);
   optionsRef.current = options;
+  const onLoadMoreRef = useRef(onLoadMore);
+  onLoadMoreRef.current = onLoadMore;
 
   const sentinelRef = useCallback((node: HTMLElement | null) => {
     observerRef.current?.disconnect();
@@ -64,9 +74,9 @@ export const useInfiniteScrollSentinel = ({
 
   useEffect(() => {
     if (isVisible && hasNextPage && !isFetchingMore) {
-      onLoadMore();
+      onLoadMoreRef.current();
     }
-  }, [isVisible, hasNextPage, isFetchingMore, onLoadMore]);
+  }, [isVisible, hasNextPage, isFetchingMore]);
 
   return sentinelRef;
 };

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
@@ -10,18 +10,17 @@ import type { File } from '../../../../../../shared/contracts/files';
 /**
  * Infinite scroll is driven by an IntersectionObserver, which the shared test
  * setup stubs out with a no-op — the sentinel never reports itself visible.
- * Swapping the hook for a manual trigger is what lets a test reach page 2.
+ * Mocking the sentinel hook to expose its `onLoadMore` is what lets a test
+ * reach page 2.
  */
 let mockShowLoadMoreSentinel: () => void = () => {};
 
-jest.mock('@strapi/admin/strapi-admin', () => {
-  const actual = jest.requireActual('@strapi/admin/strapi-admin');
+jest.mock('../hooks/useInfiniteScrollSentinel', () => {
   const { useRef } = jest.requireActual('react');
 
   return {
-    ...actual,
-    useElementOnScreen: (onVisibilityChange: (isVisible: boolean) => void) => {
-      mockShowLoadMoreSentinel = () => onVisibilityChange(true);
+    useInfiniteScrollSentinel: ({ onLoadMore }: { onLoadMore: () => void }) => {
+      mockShowLoadMoreSentinel = () => onLoadMore();
 
       return useRef(null);
     },


### PR DESCRIPTION
### What does it do?

Fixes the new Media Library's infinite scroll stalling at the first page.

- Adds `useInfiniteScrollSentinel` (`future/pages/Assets/hooks/`) and uses it in `AssetsView` in place of `useElementOnScreen` for the load-more trigger (grid **and** table share this view, so both are covered).
- The observer now only maintains an `isVisible` state; an effect reacts to `isFetchingMore` settling and keeps requesting pages **while the sentinel is on screen**, until the viewport fills or there is no next page.
- Attaches the observer via a **callback ref**, so it reliably binds to the sentinel — which only renders after the first page has loaded.

### Why is it needed?

The load-more sentinel was driven by an `IntersectionObserver` callback, which only fires on a **transition**. When an appended page didn't push the 1px sentinel off screen — a tall viewport / maximised window, a final page with fewer than 20 rows, or grid view fitting all 20 items — the observer never re-fired, so page 2 was never requested. The list stayed stuck at 20 items until the user resized the window or otherwise forced a scroll event. Affected both grid and table view (CMS-1562).

### How to test it?

`UNSTABLE_MEDIA_LIBRARY=true yarn develop` in a sandbox, open the new Media Library.

1. On a tall screen / maximised window, open a folder with **more than 20 assets** (grid view reproduces most reliably).
2. **Before:** only 20 assets render, no further fetch. **After:** the next page loads automatically until the viewport is filled or all assets are loaded — no resize needed.
3. Also verify normal scrolling still pages through a long list, and that a folder/sort/search change resets cleanly.

Automated: `IS_EE=true yarn nx run @strapi/upload:test:front -- --testPathPattern "useInfiniteScrollSentinel"` (5 cases: fires when visible; keeps fetching while the sentinel stays visible after each settle; stops at no-next-page; no fetch off screen; rebinds on remount / disconnects on unmount). `AssetsPage` suite updated to trigger the new hook.

> Note: jsdom has no real `IntersectionObserver`, so the loop is proven with a controllable stub; the true end-to-end proof is a tall-viewport manual check per the steps above.

### Related issue(s)/PR(s)

- fix CMS-1562

_Generated with AI. Reviewed, tested and edited by @Adzouz_

🚀