### PR TITLE
fix(upload): refresh folder header count on upload & delete (CMS-1563)

### DIFF
--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -553,7 +553,7 @@ const uploadApi = adminApi
           });
         },
         // `Folder, LIST` refreshes the folder header count, which changes when
-        // files are added to it (CMS-1563).
+        // files are added to it.
         invalidatesTags: [
           { type: 'Asset', id: 'LIST' },
           { type: 'Folder', id: 'LIST' },
@@ -591,7 +591,7 @@ const uploadApi = adminApi
           }
         },
         // `Folder, LIST` refreshes the folder header count, which changes when
-        // files are added to it (CMS-1563).
+        // files are added to it.
         invalidatesTags: [
           { type: 'Asset', id: 'LIST' },
           { type: 'Folder', id: 'LIST' },
@@ -641,7 +641,7 @@ const uploadApi = adminApi
           });
         },
         // `Folder, LIST` refreshes the folder header count, which changes when
-        // files are added to it (CMS-1563).
+        // files are added to it.
         invalidatesTags: [
           { type: 'Asset', id: 'LIST' },
           { type: 'Folder', id: 'LIST' },
@@ -743,7 +743,7 @@ const uploadApi = adminApi
           }
         },
         // `Folder, LIST` refreshes the folder header count, which changes when
-        // files are added to it (CMS-1563).
+        // files are added to it.
         invalidatesTags: [
           { type: 'Asset', id: 'LIST' },
           { type: 'Folder', id: 'LIST' },

--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -552,7 +552,12 @@ const uploadApi = adminApi
             generateAiMetadata,
           });
         },
-        invalidatesTags: [{ type: 'Asset', id: 'LIST' }],
+        // `Folder, LIST` refreshes the folder header count, which changes when
+        // files are added to it (CMS-1563).
+        invalidatesTags: [
+          { type: 'Asset', id: 'LIST' },
+          { type: 'Folder', id: 'LIST' },
+        ],
       }),
 
       /**
@@ -585,7 +590,12 @@ const uploadApi = adminApi
             return { error: { name: 'UnknownError', message } };
           }
         },
-        invalidatesTags: [{ type: 'Asset', id: 'LIST' }],
+        // `Folder, LIST` refreshes the folder header count, which changes when
+        // files are added to it (CMS-1563).
+        invalidatesTags: [
+          { type: 'Asset', id: 'LIST' },
+          { type: 'Folder', id: 'LIST' },
+        ],
       }),
 
       /**
@@ -630,7 +640,12 @@ const uploadApi = adminApi
             generateAiMetadata: batch.generateAiMetadata,
           });
         },
-        invalidatesTags: [{ type: 'Asset', id: 'LIST' }],
+        // `Folder, LIST` refreshes the folder header count, which changes when
+        // files are added to it (CMS-1563).
+        invalidatesTags: [
+          { type: 'Asset', id: 'LIST' },
+          { type: 'Folder', id: 'LIST' },
+        ],
       }),
 
       /**
@@ -727,7 +742,12 @@ const uploadApi = adminApi
             };
           }
         },
-        invalidatesTags: [{ type: 'Asset', id: 'LIST' }],
+        // `Folder, LIST` refreshes the folder header count, which changes when
+        // files are added to it (CMS-1563).
+        invalidatesTags: [
+          { type: 'Asset', id: 'LIST' },
+          { type: 'Folder', id: 'LIST' },
+        ],
       }),
 
       /**

--- a/packages/core/upload/admin/src/future/services/assets.ts
+++ b/packages/core/upload/admin/src/future/services/assets.ts
@@ -148,6 +148,8 @@ const assetsApi = uploadApi.injectEndpoints({
       invalidatesTags: (_result, _error, id) => [
         { type: 'Asset' as const, id },
         { type: 'Asset' as const, id: 'LIST' },
+        // Refresh the folder header count — deleting an asset changes it (CMS-1563).
+        { type: 'Folder' as const, id: 'LIST' },
       ],
     }),
     /**

--- a/packages/core/upload/admin/src/future/services/assets.ts
+++ b/packages/core/upload/admin/src/future/services/assets.ts
@@ -108,6 +108,9 @@ const assetsApi = uploadApi.injectEndpoints({
       invalidatesTags: (_result, _error, { id }) => [
         { type: 'Asset' as const, id },
         { type: 'Asset' as const, id: 'LIST' },
+        // The Location select routes a folder move through this mutation, which
+        // changes both folders' counts — refresh the folder header count.
+        { type: 'Folder' as const, id: 'LIST' },
       ],
     }),
     /**
@@ -148,7 +151,7 @@ const assetsApi = uploadApi.injectEndpoints({
       invalidatesTags: (_result, _error, id) => [
         { type: 'Asset' as const, id },
         { type: 'Asset' as const, id: 'LIST' },
-        // Refresh the folder header count — deleting an asset changes it (CMS-1563).
+        // Refresh the folder header count — deleting an asset changes it.
         { type: 'Folder' as const, id: 'LIST' },
       ],
     }),

--- a/packages/core/upload/admin/src/future/services/folders.ts
+++ b/packages/core/upload/admin/src/future/services/folders.ts
@@ -172,7 +172,7 @@ const foldersApi = uploadApi.injectEndpoints({
       // count (upload / delete into it) can refresh the header count by
       // invalidating `{ Folder, LIST }`, without needing the folder id at the
       // mutation site (it's buried in the upload FormData / not passed to the
-      // delete). See CMS-1563.
+      // delete).
       providesTags: (_result, _error, { id }) => [
         { type: 'Folder', id },
         { type: 'Folder', id: 'LIST' },

--- a/packages/core/upload/admin/src/future/services/folders.ts
+++ b/packages/core/upload/admin/src/future/services/folders.ts
@@ -168,7 +168,15 @@ const foldersApi = uploadApi.injectEndpoints({
       }),
       transformResponse: (response: GetFolder.Response) =>
         response.data as unknown as FolderWithCounts,
-      providesTags: (_result, _error, { id }) => [{ type: 'Folder', id }],
+      // Also carries the LIST tag so a mutation that changes a folder's file
+      // count (upload / delete into it) can refresh the header count by
+      // invalidating `{ Folder, LIST }`, without needing the folder id at the
+      // mutation site (it's buried in the upload FormData / not passed to the
+      // delete). See CMS-1563.
+      providesTags: (_result, _error, { id }) => [
+        { type: 'Folder', id },
+        { type: 'Folder', id: 'LIST' },
+      ],
     }),
     bulkMove: builder.mutation<BulkMoveFolders.Response['data'], BulkMoveParams>({
       query: ({ fileIds = [], folderIds = [], destinationFolderId }) => ({

--- a/packages/core/upload/admin/src/future/services/tests/folders.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/folders.test.ts
@@ -1,8 +1,9 @@
-import { renderHook, server, waitFor } from '@tests/utils';
+import { act, renderHook, server, waitFor } from '@tests/utils';
 import { http, HttpResponse } from 'msw';
 import * as qs from 'qs';
 
-import { useGetFoldersQuery } from '../folders';
+import { useDeleteAssetMutation } from '../assets';
+import { useGetFoldersQuery, useGetFolderQuery } from '../folders';
 
 describe('future folders service - getFolders filter shape', () => {
   let lastRequestParams:
@@ -113,5 +114,43 @@ describe('future folders service - getFolders filter shape', () => {
       });
       expect(lastRequestParams).not.toHaveProperty('_q');
     });
+  });
+});
+
+describe('future folder header count invalidation (CMS-1563)', () => {
+  it('refetches the folder so the header count updates when an asset is deleted from it', async () => {
+    let folderRequests = 0;
+    let fileCount = 3;
+
+    server.use(
+      http.get('*/upload/folders/:id', () => {
+        folderRequests += 1;
+        return HttpResponse.json({
+          data: { id: 1, name: 'My folder', files: { count: fileCount }, children: { count: 0 } },
+        });
+      }),
+      http.delete('*/upload/files/:id', () => {
+        // The delete changed the folder's file count on the server.
+        fileCount = 2;
+        return HttpResponse.json({ data: {} });
+      })
+    );
+
+    const { result } = renderHook(() => ({
+      folder: useGetFolderQuery({ id: 1 }),
+      deleteAsset: useDeleteAssetMutation(),
+    }));
+
+    await waitFor(() => expect(result.current.folder.data?.files?.count).toBe(3));
+    expect(folderRequests).toBe(1);
+
+    await act(async () => {
+      await result.current.deleteAsset[0](99).unwrap();
+    });
+
+    // deleteAsset invalidates `{ Folder, LIST }`; getFolder now carries that tag,
+    // so the header count refetches to the new value without a page reload.
+    await waitFor(() => expect(result.current.folder.data?.files?.count).toBe(2));
+    expect(folderRequests).toBeGreaterThan(1);
   });
 });

--- a/packages/core/upload/admin/src/future/services/tests/folders.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/folders.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook, server, waitFor } from '@tests/utils';
 import { http, HttpResponse } from 'msw';
 import * as qs from 'qs';
 
-import { useDeleteAssetMutation } from '../assets';
+import { useDeleteAssetMutation, useUpdateAssetMutation } from '../assets';
 import { useGetFoldersQuery, useGetFolderQuery } from '../folders';
 
 describe('future folders service - getFolders filter shape', () => {
@@ -117,7 +117,7 @@ describe('future folders service - getFolders filter shape', () => {
   });
 });
 
-describe('future folder header count invalidation (CMS-1563)', () => {
+describe('future folder header count invalidation', () => {
   it('refetches the folder so the header count updates when an asset is deleted from it', async () => {
     let folderRequests = 0;
     let fileCount = 3;
@@ -150,6 +150,44 @@ describe('future folder header count invalidation (CMS-1563)', () => {
 
     // deleteAsset invalidates `{ Folder, LIST }`; getFolder now carries that tag,
     // so the header count refetches to the new value without a page reload.
+    await waitFor(() => expect(result.current.folder.data?.files?.count).toBe(2));
+    expect(folderRequests).toBeGreaterThan(1);
+  });
+
+  it('refetches the folder header count when an asset is moved out of it via updateAsset', async () => {
+    // The Location select in the asset drawer submits a folder move through
+    // updateAsset — the folder's count must refresh, same as upload/delete.
+    let folderRequests = 0;
+    let fileCount = 3;
+
+    server.use(
+      http.get('*/upload/folders/:id', () => {
+        folderRequests += 1;
+        return HttpResponse.json({
+          data: { id: 1, name: 'My folder', files: { count: fileCount }, children: { count: 0 } },
+        });
+      }),
+      http.post('*/upload', () => {
+        // The move dropped this folder's count on the server.
+        fileCount = 2;
+        return HttpResponse.json({ data: { id: 99 } });
+      })
+    );
+
+    const { result } = renderHook(() => ({
+      folder: useGetFolderQuery({ id: 1 }),
+      updateAsset: useUpdateAssetMutation(),
+    }));
+
+    await waitFor(() => expect(result.current.folder.data?.files?.count).toBe(3));
+    expect(folderRequests).toBe(1);
+
+    await act(async () => {
+      await result.current.updateAsset[0]({ id: 99, fileInfo: { folder: 2 } }).unwrap();
+    });
+
+    // updateAsset now invalidates `{ Folder, LIST }`, so the header count
+    // refetches after a move without a page reload.
     await waitFor(() => expect(result.current.folder.data?.files?.count).toBe(2));
     expect(folderRequests).toBeGreaterThan(1);
   });


### PR DESCRIPTION
### What does it do?

Makes the new Media Library's folder **header item count** refresh as soon as an upload or a single delete changes it.

- `services/folders.ts` — `getFolder` (which feeds the header count via `files.count`) now also carries the `{ Folder, LIST }` tag, not just `{ Folder, id }`.
- `services/api.ts` — the four upload endpoints (`uploadFiles`, `uploadFileSilently`, `retryCancelledFiles`, `uploadFromUrls`) now invalidate `{ Folder, LIST }` alongside `{ Asset, LIST }`. `generateAiMetadata` is left untouched (it never changes a folder's count).
- `services/assets.ts` — single `deleteAsset` now invalidates `{ Folder, LIST }` too.

Carrying the LIST tag on `getFolder` is what lets the mutations refresh it without knowing the folder id at the mutation site (it's buried in the upload FormData, and the delete only receives the asset id).

### Why is it needed?

The folder header count is served by `getFolder`, tagged only `{ Folder, id }`. Uploads and single-asset deletes only invalidated `{ Asset, LIST }`, so the folder query never refetched — the count stayed stale (`My folder (3 items)` after adding files) until a full page reload. Navigating out and back in didn't help. Home was unaffected (its count is the asset-list `pagination.total`). This covers both directions — add and remove — and makes bulk delete's existing `{ Folder, LIST }` invalidation reach the header too, so all three are now consistent (CMS-1563).

### How to test it?

`UNSTABLE_MEDIA_LIBRARY=true yarn develop` in a sandbox, open the new Media Library.

1. Navigate into a folder; note the header count, e.g. `My folder (3 items)`.
2. Upload one or more files into it → the count updates immediately (was stuck at `3`).
3. Delete a single asset from inside the folder → the count decrements immediately.
4. Confirm Home's count still behaves, and bulk delete still updates the count.

Automated: `IS_EE=true yarn nx run @strapi/upload:test:front -- --testPathPattern "future/services/tests/folders"` — new case renders `useGetFolderQuery` + `useDeleteAssetMutation` in one store and asserts the folder refetches (count `3 → 2`) after a delete, no reload.

### Related issue(s)/PR(s)

- fix CMS-1563

_Generated by AI. Reviewed, tested and edited by @Adzouz_

🚀