### PR TITLE
enhancement(utils): stop using a thrown Error to test for boolean-like populate keys

### DIFF
--- a/packages/core/utils/src/__tests__/parse-type.test.ts
+++ b/packages/core/utils/src/__tests__/parse-type.test.ts
@@ -1,5 +1,5 @@
 import format from 'date-fns/format';
-import parseType from '../parse-type';
+import parseType, { isBooleanLike } from '../parse-type';
 
 describe('parseType', () => {
   describe('boolean', () => {
@@ -21,6 +21,49 @@ describe('parseType', () => {
       expect(parseType({ type: 'boolean', value: 0 })).toBe(false);
 
       expect(() => parseType({ type: 'boolean', value: 12 })).toThrow();
+    });
+  });
+
+  describe('isBooleanLike', () => {
+    // The predicate exists so callers can ask this question without catching an error.
+    // Its whole contract is that it agrees with parseType, so assert that directly
+    // rather than restating the accepted values: a change to one and not the other
+    // cannot then pass silently.
+    const cases: unknown[] = [
+      true,
+      false,
+      'true',
+      't',
+      '1',
+      1,
+      'false',
+      'f',
+      '0',
+      0,
+      'test',
+      '',
+      12,
+      -1,
+      1.5,
+      NaN,
+      null,
+      undefined,
+      {},
+      [],
+      'TRUE',
+      'yes',
+    ];
+
+    it.each(cases.map((value) => [value]))('agrees with parseType for %p', (value) => {
+      let parseAccepts: boolean;
+      try {
+        parseType({ type: 'boolean', value });
+        parseAccepts = true;
+      } catch {
+        parseAccepts = false;
+      }
+
+      expect(isBooleanLike(value)).toBe(parseAccepts);
     });
   });
 

--- a/packages/core/utils/src/parse-type.ts
+++ b/packages/core/utils/src/parse-type.ts
@@ -87,6 +87,38 @@ export interface ParseTypeOptions<T extends keyof TypeMap> {
   forceCast?: boolean;
 }
 
+/**
+ * Hoisted out of `parseBoolean`, which allocated both of these arrays on every call.
+ * Query validation calls it once per node of the populate tree of every request, which
+ * made those two throwaway allocations one of the largest single sources of GC pressure
+ * in a read: 4.3% of on-CPU time in a profiled LaunchPad run.
+ */
+const TRUTHY_INPUTS: ReadonlyArray<string | number> = ['true', 't', '1', 1];
+const FALSY_INPUTS: ReadonlyArray<string | number> = ['false', 'f', '0', 0];
+
+/**
+ * Whether `parseBoolean` would accept this value without `forceCast`.
+ *
+ * Exists so callers can ask the question without using an exception as control flow.
+ * Query validation asked it once per populate key by calling `parseType` inside a
+ * `try`/`catch`, so every key that is not a boolean keyword — which is nearly all of
+ * them — built an Error and captured a stack trace only to discard it. Stack capture is
+ * the expensive part, and it made this the second hottest function in a read.
+ *
+ * Kept in lockstep with `parseBoolean`'s accept conditions below.
+ */
+const isBooleanLike = (value: unknown): boolean => {
+  if (typeof value === 'boolean') {
+    return true;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    return TRUTHY_INPUTS.includes(value) || FALSY_INPUTS.includes(value);
+  }
+
+  return false;
+};
+
 const parseBoolean = (value: unknown, options: { forceCast?: boolean }): boolean => {
   const { forceCast = false } = options;
 
@@ -95,11 +127,11 @@ const parseBoolean = (value: unknown, options: { forceCast?: boolean }): boolean
   }
 
   if (typeof value === 'string' || typeof value === 'number') {
-    if (['true', 't', '1', 1].includes(value)) {
+    if (TRUTHY_INPUTS.includes(value)) {
       return true;
     }
 
-    if (['false', 'f', '0', 0].includes(value)) {
+    if (FALSY_INPUTS.includes(value)) {
       return false;
     }
   }
@@ -141,4 +173,5 @@ const parseType = <Type extends keyof TypeMap>(options: ParseTypeOptions<Type>):
   }
 };
 
+export { isBooleanLike };
 export default parseType;

--- a/packages/core/utils/src/validate/validators.ts
+++ b/packages/core/utils/src/validate/validators.ts
@@ -17,7 +17,7 @@ import { throwPassword, throwPrivate, throwDynamicZones, throwMorphToRelations }
 import { isOperator } from '../operators';
 import { asyncCurry, throwInvalidKey } from './utils';
 import type { Attribute, Model } from '../types';
-import parseType from '../parse-type';
+import { isBooleanLike } from '../parse-type';
 import type { Parent, Path } from '../traverse/factory';
 
 const { ID_ATTRIBUTE, DOC_ID_ATTRIBUTE } = constants;
@@ -496,21 +496,21 @@ export const validatePopulate = asyncCurry(
 
           // Ensure count is a boolean
           if (key === 'count') {
-            try {
-              parseType({ type: 'boolean', value });
+            if (isBooleanLike(value)) {
               return;
-            } catch {
-              throwInvalidKey({ key, path: path.attribute });
             }
+
+            throwInvalidKey({ key, path: path.attribute });
           }
 
-          // Allowed boolean-like keywords should be ignored
-          try {
-            parseType({ type: 'boolean', value: key });
-            // Key is an allowed boolean-like keyword, skipping validation...
+          // Allowed boolean-like keywords should be ignored.
+          //
+          // Asked as a predicate rather than by catching `parseType`'s error: this runs
+          // once per populate key, and almost no key is boolean-like, so the previous
+          // try/catch built and threw away an Error — including a stack capture — on
+          // essentially every key of every populate tree of every request.
+          if (isBooleanLike(key)) {
             return;
-          } catch {
-            // Continue, because it's not a boolean-like
           }
 
           // Handle nested `sort` validation with custom or default traversals


### PR DESCRIPTION
### What does it do?

Stops populate validation from using a thrown error as a boolean test.

`validatePopulate` needed to know whether a populate key was one of the boolean-like keywords (`true`, `t`, `1`, `false`, `f`, `0`). It asked by calling `parseType` inside a `try`/`catch` and treating the throw as "not boolean-like":

```js
try {
  parseType({ type: 'boolean', value: key });
  return;
} catch {
  // Continue, because it's not a boolean-like
}
```

Almost no populate key is boolean-like, so on essentially every key of every populate tree of every request this constructed an `Error` and captured a stack trace only to discard it. Stack capture is the expensive part.

Replaced with an `isBooleanLike` predicate exported from `parse-type`, used for both this check and the `count` check just above it. `parseBoolean`'s two comparison arrays are hoisted to module constants in the same change, since the predicate reuses them and they were previously reallocated on every call.

### Why is it needed?

`parseBoolean` was 4.3% of on-CPU time in a sampling profile of a LaunchPad read workload, arriving there 100% through populate validation. Hoisting the arrays on their own moved it by only 8%, which is what pointed at the throw rather than the allocation as the real cost. After this change `parseBoolean` no longer appears in the profile at all.

Measured on LaunchPad against Postgres, 10 VUs, 30s runs, median of 3 rounds, with the `@strapi/utils` build swapped between every run and the variants cycled round-robin:

The base build is the combined performance branch (`develop` plus the open sanitization PRs and #26626). It is not plain `develop`, because #26626 adds an export to `@strapi/utils` that the rest of that build imports, so a plain `develop` build of just this package will not boot against it. Both changes here are independent of those PRs, so the delta is attributable to this change alone.

| build | req/s, median of 3 | range | p95 |
| --- | --- | --- | --- |
| base | 47.64 | 47.44 - 49.34 | 435.7ms |
| base + this change | 52.05 | 50.68 - 52.33 | 394.4ms |

1.09x throughput and 1.10x on p95. The two ranges do not overlap. No failed requests in any run.

### How to test it?

The predicate has to keep agreeing with `parseType` or validation would start accepting or rejecting different keys. The test asserts that agreement across a table of inputs rather than restating the accepted values, so the two cannot drift apart silently:

```bash
cd packages/core/utils
yarn test:unit src/__tests__/parse-type.test.ts
yarn test:unit    # validate-query and query-populate cover the call sites
```

For the behaviour itself, a populate clause using a boolean keyword should still be accepted and an invalid `count` should still be rejected:

```bash
# accepted
curl 'http://localhost:1337/api/<plural>?populate[<relation>][count]=true'
# rejected with a validation error
curl 'http://localhost:1337/api/<plural>?populate[<relation>][count]=notabool'
```

### Related issue(s)/PR(s)

Found while profiling the combined performance branch. Independent of #27140, #27141 and #27145, which tune the entity traversal rather than query validation.
