### PR TITLE
fix(content-manager): merge query populate paths to preserve nested populate

### DIFF
--- a/packages/core/content-manager/server/src/services/utils/__tests__/query-populate.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/__tests__/query-populate.test.ts
@@ -135,6 +135,23 @@ describe('Populate', () => {
       });
     });
 
+    test('nested populate is not dropped by a shallower sibling condition', async () => {
+      const query = {
+        filters: {
+          $or: [
+            { relation: { component: { field: { $eq: 'value' } } } },
+            { $and: [{ $or: [{ relation: { field: 'value' } }] }] },
+          ],
+        },
+      };
+
+      const result = await getQueryPopulate(uid, query);
+
+      expect(result).toEqual({
+        relation: { populate: { component: {} } },
+      });
+    });
+
     test('populate multiple fields at once', async () => {
       const query = getFilterQuery([
         { relation: { component: { field: { $eq: 'value' } } } },

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -426,8 +426,7 @@ const getQueryPopulate = async (uid: UID.Schema, query: object): Promise<Populat
       // Populate all relations, components and media
       if (isRelation(attribute) || isMedia(attribute) || isComponent(attribute)) {
         const populatePath = path.attribute.replace(/\./g, '.populate.');
-        // @ts-expect-error - lodash doesn't resolve the Populate type correctly
-        populateQuery = set(populatePath, {}, populateQuery);
+        populateQuery = merge(populateQuery, set(populatePath, {}, {}));
       }
     },
     { schema: strapi.getModel(uid), getModel: strapi.getModel.bind(strapi) },


### PR DESCRIPTION
### What does it do?

`getQueryPopulate` accumulates each populate path with `set(populatePath, {}, populateQuery)`. Since `set` from lodash/fp replaces the whole subtree at that path, a shallow write for one filter branch (`relation`) wipes out a deeper populate a sibling branch already wrote (`relation.populate.component`). Which write lands last comes down to the order the filter traversal branches resolve in, so the nested populate can get dropped. This merges each new path into the accumulator instead, so shallow and deep paths combine rather than race.

### Why is it needed?

When a filter needs a nested relation populated and a sibling condition touches the same relation at a shallower level, the nested populate can be silently discarded. The relation then isn't populated for the filter, so filtering returns the wrong records instead of raising an error. Whether it happens depends on how deeply the sibling condition is wrapped in `$and` / `$or`, which is what makes it look intermittent.

### How to test it?

Run `cd packages/core/content-manager && yarn test:unit query-populate`. The added test sets up a filter where one branch needs `relation.populate.component` while a sibling wraps a shallower `relation` condition in `$and`/`$or`. It fails on the current code (returns `relation: {}`) and passes with the fix.

### Related issue(s)/PR(s)

Fix #27235
