### PR TITLE
future(upload): cache-bust detail preview after replace/crop

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/PreviewBox.tsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/PreviewBox.tsx
@@ -43,6 +43,26 @@ interface Asset extends Omit<FileDefinition, 'folder'> {
   folder?: FileDefinition['folder'] & { id: number };
 }
 
+/**
+ * Cache-busts a non-signed, non-local asset URL with the asset's `updatedAt`.
+ *
+ * Replace and crop intentionally preserve the file hash, so the URL path stays
+ * stable and the browser would serve the previously cached file — the
+ * `updatedAt` param forces a fresh request. Signed URLs are left untouched (an
+ * extra param invalidates the signature) and local (blob) URLs need no busting.
+ * Mirrors the list view's `ImageAssetCard`.
+ */
+const appendUpdatedAtToUrl = (
+  url: string | undefined,
+  asset: { isLocal?: boolean; isUrlSigned?: boolean; updatedAt?: string }
+) => {
+  if (!url || asset.isLocal || asset.isUrlSigned) {
+    return url;
+  }
+
+  return appendSearchParamsToUrl({ url, params: { updatedAt: asset.updatedAt } });
+};
+
 interface PreviewBoxProps {
   asset: Asset;
   canUpdate: boolean;
@@ -81,20 +101,17 @@ export const PreviewBox = ({
   const previewRef = React.useRef(null);
   const [isCropImageReady, setIsCropImageReady] = React.useState(false);
   const [hasCropIntent, setHasCropIntent] = React.useState<boolean | null>(null);
-  const [assetUrl, setAssetUrl] = React.useState(createAssetUrl(asset, false));
-  const [thumbnailUrl, setThumbnailUrl] = React.useState(createAssetUrl(asset, true));
-
-  // When loading a cross-origin image for cropping, append a cache-busting parameter
-  // so the browser makes a fresh request with CORS headers instead of serving a
-  // previously cached non-CORS response (which would taint the canvas and break
-  // cropping). Signed URLs are excluded because modifying them invalidates the signature.
-  const cropUrl = React.useMemo(() => {
-    if (!asset.isLocal && !asset.isUrlSigned && assetUrl) {
-      return appendSearchParamsToUrl({ url: assetUrl, params: { updatedAt: asset.updatedAt } });
-    }
-
-    return assetUrl;
-  }, [assetUrl, asset.isLocal, asset.isUrlSigned, asset.updatedAt]);
+  // Busted on init so re-opening the detail view after a replace/crop (which
+  // preserve the hash) fetches the new file instead of the cached one. The full
+  // `assetUrl` doubles as the cropping source: its `updatedAt` param also forces
+  // the fresh CORS request cropping needs (a cached non-CORS response would taint
+  // the canvas).
+  const [assetUrl, setAssetUrl] = React.useState(() =>
+    appendUpdatedAtToUrl(createAssetUrl(asset, false), asset)
+  );
+  const [thumbnailUrl, setThumbnailUrl] = React.useState(() =>
+    appendUpdatedAtToUrl(createAssetUrl(asset, true), asset)
+  );
 
   const { formatMessage } = useIntl();
   const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
@@ -161,8 +178,14 @@ export const PreviewBox = ({
       trackUsage('didCropFile', { duplicatedFile: null, location: trackedLocation! });
     } else {
       const updatedAsset = await editAsset(nextAsset, file);
-      optimizedCachingImage = createAssetUrl(updatedAsset, false);
-      optimizedCachingThumbnailImage = createAssetUrl(updatedAsset, true);
+      optimizedCachingImage = appendUpdatedAtToUrl(
+        createAssetUrl(updatedAsset, false),
+        updatedAsset
+      );
+      optimizedCachingThumbnailImage = appendUpdatedAtToUrl(
+        createAssetUrl(updatedAsset, true),
+        updatedAsset
+      );
 
       trackUsage('didCropFile', { duplicatedFile: false, location: trackedLocation! });
     }
@@ -330,7 +353,7 @@ export const PreviewBox = ({
               ref={previewRef}
               mime={asset.mime!}
               name={asset.name}
-              url={hasCropIntent ? cropUrl! : thumbnailUrl!}
+              url={hasCropIntent ? assetUrl! : thumbnailUrl!}
               onLoad={() => {
                 if (asset.isLocal || hasCropIntent) {
                   setIsCropImageReady(true);

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/EditAssetContent.test.tsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/EditAssetContent.test.tsx
@@ -114,7 +114,7 @@ const store = configureStore({
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(adminApi.middleware),
 });
 
-const renderCompo = () =>
+const renderCompo = (customAsset: Asset = asset) =>
   render(
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>
@@ -123,7 +123,7 @@ const renderCompo = () =>
             <NotificationsProvider>
               <EditAssetDialog
                 open
-                asset={asset}
+                asset={customAsset}
                 onClose={jest.fn()}
                 canUpdate
                 canCopyLink
@@ -171,12 +171,45 @@ describe('<EditAssetDialog />', () => {
       await screen.findByText('Link copied into the clipboard');
     });
 
+    it('cache-busts the preview image URL for non-signed assets so a replace/crop is not served stale', () => {
+      renderCompo();
+
+      expect(screen.getByRole('img', { name: 'Screenshot 2.png' })).toHaveAttribute(
+        'src',
+        'http://localhost:1337/uploads/thumbnail_Screenshot_2_5d4a574d61.png?updatedAt=2021-10-04T09%3A42%3A31.670Z'
+      );
+    });
+
+    it('does not append updatedAt to signed URLs (an extra param breaks the signature)', () => {
+      renderCompo({
+        ...asset,
+        isUrlSigned: true,
+        url: 'https://cdn.example.com/Screenshot_2_5d4a574d61.png?token=signed',
+        formats: {
+          ...asset.formats,
+          thumbnail: {
+            ...asset.formats!.thumbnail!,
+            url: 'https://cdn.example.com/thumbnail_Screenshot_2_5d4a574d61.png?token=signed',
+          },
+        },
+      });
+
+      const preview = screen.getByRole('img', { name: 'Screenshot 2.png' });
+      expect(preview).toHaveAttribute(
+        'src',
+        'https://cdn.example.com/thumbnail_Screenshot_2_5d4a574d61.png?token=signed'
+      );
+      expect(preview.getAttribute('src')).not.toContain('updatedAt');
+    });
+
     it('downloads the file when pressing "Download"', () => {
       renderCompo();
 
       fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+      // The URL is cache-busted with updatedAt so a replaced/cropped file
+      // (which keeps the same hash) is fetched fresh rather than from cache.
       expect(downloadFile).toHaveBeenCalledWith(
-        'http://localhost:1337/uploads/Screenshot_2_5d4a574d61.png',
+        'http://localhost:1337/uploads/Screenshot_2_5d4a574d61.png?updatedAt=2021-10-04T09%3A42%3A31.670Z',
         'Screenshot 2.png'
       );
     });

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/EditAssetDialog.test.tsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/EditAssetDialog.test.tsx
@@ -221,8 +221,10 @@ describe('<EditAssetDialog />', () => {
       renderCompo({ canUpdate: false, canCopyLink: false, canDownload: true });
 
       fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+      // Cache-busted with updatedAt so a replaced/cropped file (same hash) is
+      // fetched fresh rather than from browser cache.
       expect(downloadFile).toHaveBeenCalledWith(
-        'http://localhost:1337/uploads/Screenshot_2_5d4a574d61.png',
+        'http://localhost:1337/uploads/Screenshot_2_5d4a574d61.png?updatedAt=2021-10-04T09%3A42%3A31.670Z',
         'Screenshot 2.png'
       );
     });

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetContent.test.tsx.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetContent.test.tsx.snap
@@ -860,7 +860,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                       <img
                         alt="Screenshot 2.png"
                         crossorigin="anonymous"
-                        src="http://localhost:1337/uploads/thumbnail_Screenshot_2_5d4a574d61.png"
+                        src="http://localhost:1337/uploads/thumbnail_Screenshot_2_5d4a574d61.png?updatedAt=2021-10-04T09%3A42%3A31.670Z"
                       />
                     </div>
                   </div>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.tsx.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.tsx.snap
@@ -860,7 +860,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                       <img
                         alt="Screenshot 2.png"
                         crossorigin="anonymous"
-                        src="http://localhost:1337/uploads/thumbnail_Screenshot_2_5d4a574d61.png"
+                        src="http://localhost:1337/uploads/thumbnail_Screenshot_2_5d4a574d61.png?updatedAt=2021-10-04T09%3A42%3A31.670Z"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
### What does it do?

Fixes the media library **detail view** (`EditAssetDialog` / `PreviewBox`) showing a stale cached image after a replace or crop.

- Adds an `appendUpdatedAtToUrl(url, asset)` helper in `PreviewBox` that appends `?updatedAt=<timestamp>` to **non-signed, non-local** asset URLs — mirroring the list view's `ImageAssetCard`.
- Initializes `assetUrl` / `thumbnailUrl` with the cache-buster, and re-applies it after `editAsset()` resolves in the crop flow (so the returned fresh `updatedAt` is used).
- Signed URLs are left untouched (an extra query param invalidates the signature); local blob URLs need no busting.
- Folds the previous `cropUrl` memo into the now-busted `assetUrl` (the `updatedAt` param already forces the fresh CORS request cropping needs), avoiding a duplicate `updatedAt` param.

### Why is it needed?

The list view already appends `?updatedAt=` for cache busting, but `PreviewBox` built its preview/download/copy-link URLs via `createAssetUrl()`, which does not. Because replace/crop intentionally preserve the file hash, the URL path stays stable and the browser kept serving the previously cached image until a manual refresh — so a replaced or cropped asset looked unchanged in the detail view.

### How to test it?

Legacy Media Library at `/admin/plugins/upload` (e.g. `cd examples/getstarted && yarn develop`).

1. **Replace:** upload image A → open its detail view → **Replace media** with a different image B (same name) → save → reopen the detail view. It shows **B immediately**, no manual refresh.
2. **Crop:** open an image in the detail view → crop → save. The preview reflects the cropped version immediately.
3. **List view unchanged:** grid/table thumbnails still update correctly after replace/crop (no regression).
4. **Signed URLs:** with a private provider (S3 signed URLs), the preview still loads and **no** `?updatedAt` is appended.
5. **Copy link / Download:** after replacing A with B, "Copy link" (open in a new tab) and "Download" return B.

Unit tests:

```
IS_EE=true yarn nx run @strapi/upload:test:front -- --testPathPattern "EditAssetDialog"
```

23 pass, including new cases: the preview URL is cache-busted for non-signed assets, and signed URLs are left untouched.

### Related issue(s)/PR(s)

- fix CMS-671

_Generated with AI. Tested, reviewed and edited by @Adzouz_

🚀