### PR TITLE
chore(typescript-utils): migrate unit tests from jest to vitest

### DIFF
--- a/packages/utils/typescript/jest.config.js
+++ b/packages/utils/typescript/jest.config.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  displayName: 'Typescript utils',
-};

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -43,8 +43,8 @@
     "clean": "run -T rimraf dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts": "run -T tsc --noEmit",
-    "test:unit": "run -T jest",
-    "test:unit:watch": "run -T jest --watch",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest --watch",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
@@ -57,12 +57,12 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/jest": "29.5.2",
     "@types/lodash": "^4.14.191",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.51.1",
-    "jest": "29.6.0",
-    "tsconfig": "5.51.1"
+    "tsconfig": "5.51.1",
+    "vitest": "catalog:",
+    "vitest-config": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/utils/typescript/src/__tests__/generators/schemas/attributes.test.ts
+++ b/packages/utils/typescript/src/__tests__/generators/schemas/attributes.test.ts
@@ -1,3 +1,4 @@
+import { vi, describe, afterEach, expect, test } from 'vitest';
 import * as ts from 'typescript';
 
 import {
@@ -7,14 +8,14 @@ import {
 } from '../../../generators/common/models/attributes';
 import { addImport } from '../../../generators/common/imports';
 
-jest.mock('../../../generators/common/imports', () => ({ addImport: jest.fn() }));
+vi.mock(import('../../../generators/common/imports'), () => ({ addImport: vi.fn() }));
 
-const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
+const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 // TODO: emit definition (to a string) & also check snapshots based on that. It would allow checking both the structure & the output.
 describe('Attributes', () => {
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('Attribute to Property Signature', () => {
@@ -887,7 +888,7 @@ describe('Attributes', () => {
         });
 
         test('Default: <function>', () => {
-          const anyFunction = jest.fn();
+          const anyFunction = vi.fn();
           const attribute = { default: anyFunction };
 
           const modifiers = getAttributeModifiers(attribute);

--- a/packages/utils/typescript/src/__tests__/generators/schemas/imports.test.ts
+++ b/packages/utils/typescript/src/__tests__/generators/schemas/imports.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'vitest';
 import * as ts from 'typescript';
 
 import {

--- a/packages/utils/typescript/src/__tests__/generators/schemas/utils.test.ts
+++ b/packages/utils/typescript/src/__tests__/generators/schemas/utils.test.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect } from 'vitest';
 import * as ts from 'typescript';
 import { factory } from 'typescript';
 

--- a/packages/utils/typescript/src/__tests__/generators/utils.test.ts
+++ b/packages/utils/typescript/src/__tests__/generators/utils.test.ts
@@ -1,8 +1,13 @@
+import { describe, test, expect } from 'vitest';
+import * as ts from 'typescript';
 import { generateSharedExtensionDefinition, emitDefinitions } from '../../generators/utils';
 
-const makeDefinition = (uid, name) => ({
+const makeDefinition = (
+  uid: string,
+  name: string
+): { uid: string; definition: ts.InterfaceDeclaration } => ({
   uid,
-  definition: { name: { escapedText: name } },
+  definition: { name: { escapedText: name } } as ts.InterfaceDeclaration,
 });
 
 describe('generateSharedExtensionDefinition', () => {

--- a/packages/utils/typescript/tsconfig.eslint.json
+++ b/packages/utils/typescript/tsconfig.eslint.json
@@ -1,8 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": []
 }

--- a/packages/utils/typescript/tsconfig.json
+++ b/packages/utils/typescript/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/**"]
+  "include": ["src", "vitest.config.ts"],
+  "exclude": ["**/__tests__/**"]
 }

--- a/packages/utils/typescript/vitest.config.ts
+++ b/packages/utils/typescript/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      name: 'Typescript utils',
+      root: __dirname,
+      include: ['**/*.test.ts'],
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10182,18 +10182,18 @@ __metadata:
   resolution: "@strapi/typescript-utils@workspace:packages/utils/typescript"
   dependencies:
     "@types/fs-extra": "npm:11.0.4"
-    "@types/jest": "npm:29.5.2"
     "@types/lodash": "npm:^4.14.191"
     "@types/node": "npm:20.19.41"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
     eslint-config-custom: "npm:5.51.1"
     fs-extra: "npm:11.3.4"
-    jest: "npm:29.6.0"
     lodash: "npm:4.18.1"
     prettier: "npm:3.3.3"
     tsconfig: "npm:5.51.1"
     typescript: "npm:5.9.3"
+    vitest: "catalog:"
+    vitest-config: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -31384,7 +31384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest-config@npm:5.51.1, vitest-config@workspace:packages/utils/vitest-config":
+"vitest-config@npm:5.51.1, vitest-config@workspace:*, vitest-config@workspace:packages/utils/vitest-config":
   version: 0.0.0-use.local
   resolution: "vitest-config@workspace:packages/utils/vitest-config"
   dependencies:


### PR DESCRIPTION
### What does it do?

Migrates `@strapi/typescript-utils` (`packages/utils/typescript`) from Jest to Vitest, following the in-progress repo-wide jest-to-vitest migration.

- Swap `jest` for `vitest` in `test:unit` scripts and devDependencies (drop `jest`, `@types/jest`)
- Add `vitest.config.ts` built on the shared `vitest-config` unit preset
- Convert the generator test suites (`attributes`, `imports`, `utils`, `generators/utils`) from `jest.*` to `vi.*`
- Remove `jest.config.js`
- Point the ESLint TSConfig at `vitest.config.ts` so the config file is type-aware

All 102 tests pass under Vitest; `test:ts` and `lint` are green.

### Why is it needed?

Part of the ongoing effort to standardise unit testing on Vitest across the monorepo. `packages/utils/typescript` was still on Jest.

### How to test it?

```bash
yarn workspace @strapi/typescript-utils test:unit
yarn workspace @strapi/typescript-utils test:ts
yarn workspace @strapi/typescript-utils lint
```

### Related issue(s)/PR(s)

Part of the jest → vitest migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)