### PR TITLE
fix(upload): target current asset in drawer actions

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -777,32 +777,35 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
   );
 
   // Owns the replace upload so isReplacing can drive the busy overlay.
-  const handleReplace = async (file: globalThis.File) => {
-    const res = await replaceMutation({ id: asset.id, file });
-    if ('error' in res) {
-      const error = res.error as { data?: { error?: { message?: string }; message?: string } };
-      const message =
-        error?.data?.error?.message ??
-        error?.data?.message ??
-        formatMessage({
-          id: getTranslationKey('asset-details.replace.error'),
-          defaultMessage: 'Failed to replace the file.',
-        });
-      notify({ type: 'danger', message });
-      return;
-    }
-    notify({
-      type: 'success',
-      message: formatMessage({
-        id: getTranslationKey('asset-details.replace.success'),
-        defaultMessage: 'File replaced.',
-      }),
-    });
-  };
+  const handleReplace = React.useCallback(
+    async (file: globalThis.File) => {
+      const res = await replaceMutation({ id: asset.id, file });
+      if ('error' in res) {
+        const error = res.error as { data?: { error?: { message?: string }; message?: string } };
+        const message =
+          error?.data?.error?.message ??
+          error?.data?.message ??
+          formatMessage({
+            id: getTranslationKey('asset-details.replace.error'),
+            defaultMessage: 'Failed to replace the file.',
+          });
+        notify({ type: 'danger', message });
+        return;
+      }
+      notify({
+        type: 'success',
+        message: formatMessage({
+          id: getTranslationKey('asset-details.replace.success'),
+          defaultMessage: 'File replaced.',
+        }),
+      });
+    },
+    [asset.id, formatMessage, notify, replaceMutation]
+  );
 
   // Owns the delete: on error notify in-drawer (drawer stays), on success fire
   // a persistent global notification then close the drawer.
-  const handleDelete = async () => {
+  const handleDelete = React.useCallback(async () => {
     const res = await deleteMutation(asset.id);
     if ('error' in res) {
       const error = res.error as { data?: { error?: { message?: string }; message?: string } };
@@ -827,7 +830,15 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
       ),
     });
     closeDetails();
-  };
+  }, [
+    asset.id,
+    closeDetails,
+    deleteMutation,
+    folderName,
+    formatMessage,
+    notify,
+    toggleNotification,
+  ]);
 
   const notifyCropError = () => {
     notify({
@@ -897,10 +908,7 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
       isReplacing,
       isDeleting,
     }),
-    // handleReplace / handleDelete close over asset+mutations and don't need a
-    // stable identity here; the consumers re-render with the new context value.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isReplacing, isDeleting]
+    [handleReplace, handleDelete, isReplacing, isDeleting]
   );
 
   return (

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -211,6 +211,35 @@ describe('AssetDetails (asset details drawer body)', () => {
     await waitFor(() => expect(closeDetails).toHaveBeenCalledTimes(1));
   });
 
+  it('deletes the asset currently shown after the drawer switches assets', async () => {
+    const firstAsset = { ...baseAsset, id: 1, name: 'first.png' };
+    const secondAsset = { ...baseAsset, id: 2, name: 'second.png' };
+    let deleteId: string | null = null;
+
+    server.use(
+      http.delete('/upload/files/:id', ({ params }) => {
+        deleteId = String(params.id);
+        return HttpResponse.json({ id: Number(params.id) });
+      })
+    );
+
+    const closeDetails = jest.fn();
+    const { user, rerender } = render(
+      <AssetDetails asset={firstAsset} closeDetails={closeDetails} />
+    );
+    await screen.findByRole('combobox');
+
+    rerender(<AssetDetails asset={secondAsset} closeDetails={closeDetails} />);
+    expect(await screen.findByDisplayValue('second.png')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Delete this file' }));
+    await screen.findByText(/This file cannot be recovered/i);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => expect(deleteId).not.toBeNull());
+    expect(deleteId).toBe('2');
+  });
+
   it('keeps the drawer open and surfaces the error message when the delete request fails', async () => {
     const closeDetails = jest.fn();
     server.use(
@@ -277,6 +306,40 @@ describe('AssetDetails (asset details drawer body)', () => {
     // Success toast renders inside the drawer, above the preview, not in the
     // global notifications region.
     await screen.findByText(/File replaced\./i);
+  });
+
+  it('replaces the asset currently shown after the drawer switches assets', async () => {
+    const firstAsset = { ...baseAsset, id: 1, name: 'first.png' };
+    const secondAsset = { ...baseAsset, id: 2, name: 'second.png' };
+    let replaceId: string | null = null;
+
+    server.use(
+      http.post('/upload', async ({ request }) => {
+        const url = new URL(request.url, 'http://localhost:1337');
+        replaceId = url.searchParams.get('id');
+        return HttpResponse.json({ ...secondAsset, name: 'replacement.png' });
+      })
+    );
+
+    const closeDetails = jest.fn();
+    const { user, rerender } = render(
+      <AssetDetails asset={firstAsset} closeDetails={closeDetails} />
+    );
+    await screen.findByRole('combobox');
+
+    rerender(<AssetDetails asset={secondAsset} closeDetails={closeDetails} />);
+    expect(await screen.findByDisplayValue('second.png')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Replace this file' }));
+    await screen.findByText(/Replace this media file\?/i);
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['hello'], 'replacement.png', { type: 'image/png' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => expect(replaceId).not.toBeNull());
+    expect(replaceId).toBe('2');
   });
 
   it('shows the AI variant of the replace description when AI metadata is enabled in settings', async () => {


### PR DESCRIPTION
### What does it do?

In the new Media Library asset details drawer, `handleReplace` and `handleDelete` were plain functions passed through a `useMemo`-built context whose dependency array only listed `isReplacing` and `isDeleting`, with an `eslint-disable react-hooks/exhaustive-deps` suppressing the warning. The memo therefore kept the handlers created on the first render, and those handlers closed over the first `asset` prop.

`AssetDetails` is not keyed by asset id, so it stays mounted when the drawer switches to a different asset (the drawer is driven by the `assetId` URL param). Once that happened, the context still held the original handlers and the actions ran against the previously shown asset.

- Wrap `handleReplace` and `handleDelete` in `React.useCallback` with their real dependencies.
- List both handlers in the context `useMemo` deps and remove the `exhaustive-deps` suppression, so the context value updates when the asset changes.
- Add two regression tests that rerender the drawer with a second asset and assert the request targets the asset on screen.

No behaviour change when the drawer shows a single asset for its whole lifetime.

### Why is it needed?

With the drawer open, switching to a different asset and then using **Replace this file** or **Delete this file** acted on the asset that was shown when the drawer first opened. Deleting removed the wrong file and replacing overwrote the wrong file — both destructive and silent, since the drawer reported success for the asset the user was looking at.

### How to test it?

Environment: `examples/getstarted`, new Media Library enabled.

```bash
yarn build
cd examples/getstarted && yarn develop
```

Manual test plan:

1. Go to **Media Library** and upload at least two distinct images, e.g. `first.png` and `second.png`.
2. Click `first.png` to open the details drawer. Note the URL now has `?assetId=<first-id>`.
3. With the drawer still open, change `assetId` in the URL to the id of `second.png` (or open `second.png` directly while the drawer is open). Confirm the drawer body now shows `second.png`.
4. Click **Delete this file**, then **Confirm**.
5. Expected: `second.png` is deleted and `first.png` is untouched. Before this fix, `first.png` was deleted instead.
6. Repeat steps 1–3, then click **Replace this file** → **Continue** and pick a new image.
7. Expected: the file replaced is `second.png`. Before this fix, `first.png` was overwritten.

Automated tests (in addition to the manual steps):

```bash
npx jest --config packages/core/upload/jest.config.front.js AssetDetailsDrawer
```

The two new tests fail against the previous code (the request carries id `1` instead of `2`) and pass with the fix.

### Related issue(s)/PR(s)

fix CMS-1566
