### PR TITLE
fix(strapi): allowlist Vite optimizeDeps.exclude for plugin UI kits

### DIFF
--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
@@ -1,8 +1,11 @@
 import {
+  ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST,
   collectAdminOptimizeDepsExclude,
   getPluginPackageName,
   hasReactPeerDependency,
+  isEligibleForOptimizeDepsExclude,
   isEsmPackage,
+  packageOptsIntoOptimizeDepsExclude,
   shipsPreBuiltDist,
   shouldExcludeFromOptimizeDeps,
 } from '../admin-vite-optimize-exclude';
@@ -30,7 +33,7 @@ const PINNED_OPTIMIZE_MODULES = [
   '@strapi/strapi',
 ] as const;
 
-const preBuiltReactPeerPackage = (name: string) => ({
+const preBuiltReactPeerPackage = (name: string, extras: Record<string, unknown> = {}) => ({
   name,
   type: 'module',
   module: './dist/index.js',
@@ -39,6 +42,7 @@ const preBuiltReactPeerPackage = (name: string) => ({
     react: '^18.0.0',
     'react-dom': '^18.0.0',
   },
+  ...extras,
 });
 
 const strapiDesignExtendedLike = {
@@ -57,6 +61,15 @@ const strapiDesignExtendedLike = {
     '@strapi/design-system': '^2.2.0',
   },
 };
+
+/** CKEditor-class: matches the UI-kit shape but must not auto-exclude (#27136). */
+const ckeditorPluginLike = preBuiltReactPeerPackage('@_sh/strapi-plugin-ckeditor', {
+  dependencies: {
+    ckeditor5: '^43.0.0',
+    yup: '^0.32.0',
+    fuzzysort: '^3.0.0',
+  },
+});
 
 describe('admin vite optimize exclude heuristics', () => {
   it('matches pre-built ESM libraries with React peers', () => {
@@ -130,7 +143,55 @@ describe('admin vite optimize exclude heuristics', () => {
     expect(shipsPreBuiltDist({ files: ['dist'] })).toBe(true);
     expect(shipsPreBuiltDist({ module: './lib/index.js' })).toBe(false);
   });
+
+  it('allowlists only known thin UI kits', () => {
+    expect(ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has('strapi-design-extended')).toBe(true);
+    expect(ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has('@_sh/strapi-plugin-ckeditor')).toBe(
+      false
+    );
+  });
+
+  it('reads package.json opt-in for optimizeDeps.exclude', () => {
+    expect(
+      packageOptsIntoOptimizeDepsExclude({
+        strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+      } as PackageJsonLike)
+    ).toBe(true);
+    expect(packageOptsIntoOptimizeDepsExclude(strapiDesignExtendedLike as PackageJsonLike)).toBe(
+      false
+    );
+  });
+
+  it('requires allowlist or opt-in on top of the UI-kit shape (#27136)', () => {
+    expect(isEligibleForOptimizeDepsExclude('strapi-design-extended', strapiDesignExtendedLike)).toBe(
+      true
+    );
+    expect(isEligibleForOptimizeDepsExclude('@_sh/strapi-plugin-ckeditor', ckeditorPluginLike)).toBe(
+      false
+    );
+    expect(
+      isEligibleForOptimizeDepsExclude(
+        'my-thin-ui-kit',
+        preBuiltReactPeerPackage('my-thin-ui-kit', {
+          strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+        })
+      )
+    ).toBe(true);
+    expect(
+      isEligibleForOptimizeDepsExclude(
+        'opted-in-but-cjs',
+        {
+          name: 'opted-in-but-cjs',
+          main: 'index.js',
+          peerDependencies: { react: '^18.0.0' },
+          strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+        } as PackageJsonLike
+      )
+    ).toBe(false);
+  });
 });
+
+type PackageJsonLike = Parameters<typeof packageOptsIntoOptimizeDepsExclude>[0];
 
 describe('collectAdminOptimizeDepsExclude', () => {
   const getModuleMock = getModule as jest.Mock;
@@ -140,7 +201,7 @@ describe('collectAdminOptimizeDepsExclude', () => {
     readPkgUp.mockResolvedValue(undefined);
   });
 
-  it('excludes pre-built React peer libraries from plugin dependencies', async () => {
+  it('excludes allowlisted pre-built React peer libraries from plugin dependencies', async () => {
     const plugins: PluginMeta[] = [
       {
         name: 'my-plugin',
@@ -171,7 +232,69 @@ describe('collectAdminOptimizeDepsExclude', () => {
     ]);
   });
 
-  it('never excludes @strapi/strapi from app root but still excludes matching UI kits', async () => {
+  it('does not auto-exclude CKEditor-class plugins that only match the UI-kit shape (#27136)', async () => {
+    const plugins: PluginMeta[] = [
+      {
+        name: 'ckeditor',
+        importName: 'ckeditor',
+        type: 'module',
+        modulePath: '@_sh/strapi-plugin-ckeditor/strapi-admin',
+      },
+    ];
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === '@_sh/strapi-plugin-ckeditor') {
+        return ckeditorPluginLike;
+      }
+
+      return null;
+    });
+
+    readPkgUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          '@_sh/strapi-plugin-ckeditor': '^1.0.0',
+        },
+      },
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', plugins)).resolves.toEqual([]);
+  });
+
+  it('excludes packages that opt in via strapi.admin.vite.optimizeDepsExclude', async () => {
+    const plugins: PluginMeta[] = [
+      {
+        name: 'my-plugin',
+        importName: 'myPlugin',
+        type: 'module',
+        modulePath: '@org/my-plugin/strapi-admin',
+      },
+    ];
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === '@org/my-plugin') {
+        return {
+          dependencies: {
+            'my-thin-ui-kit': '^1.0.0',
+          },
+        };
+      }
+
+      if (name === 'my-thin-ui-kit') {
+        return preBuiltReactPeerPackage('my-thin-ui-kit', {
+          strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+        });
+      }
+
+      return null;
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', plugins)).resolves.toEqual([
+      'my-thin-ui-kit',
+    ]);
+  });
+
+  it('never excludes @strapi/strapi from app root but still excludes allowlisted UI kits', async () => {
     readPkgUp.mockResolvedValue({
       packageJson: {
         dependencies: {

--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
@@ -163,12 +163,12 @@ describe('admin vite optimize exclude heuristics', () => {
   });
 
   it('requires allowlist or opt-in on top of the UI-kit shape (#27136)', () => {
-    expect(isEligibleForOptimizeDepsExclude('strapi-design-extended', strapiDesignExtendedLike)).toBe(
-      true
-    );
-    expect(isEligibleForOptimizeDepsExclude('@_sh/strapi-plugin-ckeditor', ckeditorPluginLike)).toBe(
-      false
-    );
+    expect(
+      isEligibleForOptimizeDepsExclude('strapi-design-extended', strapiDesignExtendedLike)
+    ).toBe(true);
+    expect(
+      isEligibleForOptimizeDepsExclude('@_sh/strapi-plugin-ckeditor', ckeditorPluginLike)
+    ).toBe(false);
     expect(
       isEligibleForOptimizeDepsExclude(
         'my-thin-ui-kit',
@@ -178,15 +178,12 @@ describe('admin vite optimize exclude heuristics', () => {
       )
     ).toBe(true);
     expect(
-      isEligibleForOptimizeDepsExclude(
-        'opted-in-but-cjs',
-        {
-          name: 'opted-in-but-cjs',
-          main: 'index.js',
-          peerDependencies: { react: '^18.0.0' },
-          strapi: { admin: { vite: { optimizeDepsExclude: true } } },
-        } as PackageJsonLike
-      )
+      isEligibleForOptimizeDepsExclude('opted-in-but-cjs', {
+        name: 'opted-in-but-cjs',
+        main: 'index.js',
+        peerDependencies: { react: '^18.0.0' },
+        strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+      } as PackageJsonLike)
     ).toBe(false);
   });
 });

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -155,7 +155,9 @@ export const isEligibleForOptimizeDepsExclude = (name: string, pkg: PackageJson)
     return false;
   }
 
-  return ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has(name) || packageOptsIntoOptimizeDepsExclude(pkg);
+  return (
+    ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has(name) || packageOptsIntoOptimizeDepsExclude(pkg)
+  );
 };
 
 /**

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -22,7 +22,18 @@ const PINNED_OPTIMIZE_MODULES = new Set<string>([
   ...ADMIN_VITE_ALIAS_MODULES,
   ...ADMIN_VITE_SINGLETON_MODULES,
   '@strapi/strapi',
-  'react-colorful',
+]);
+
+/**
+ * Thin shared plugin UI kits that are known to break when Vite re-optimizes their pre-built
+ * dist (original #26944 victims). Only these names — plus packages that opt in via package.json —
+ * may be auto-excluded. Broad heuristic matching alone was too aggressive for large plugins
+ * (e.g. CKEditor) and orphaned their transitive CJS/UMD deps (#27136).
+ *
+ * @internal exported for tests
+ */
+export const ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST = new Set<string>([
+  'strapi-design-extended',
 ]);
 
 const isOfficialStrapiPackage = (name: string): boolean => name.startsWith('@strapi/');
@@ -102,10 +113,50 @@ export const shipsPreBuiltDist = (pkg: PackageJson): boolean => {
 };
 
 /**
+ * Shape check for packages that *could* be excluded (pre-built ESM + React peer + dist).
+ * Matching alone is not enough to exclude — see {@link isEligibleForOptimizeDepsExclude}.
+ *
  * @internal exported for tests
  */
 export const shouldExcludeFromOptimizeDeps = (pkg: PackageJson): boolean =>
   hasReactPeerDependency(pkg) && isEsmPackage(pkg) && shipsPreBuiltDist(pkg);
+
+type StrapiAdminViteMeta = {
+  optimizeDepsExclude?: unknown;
+};
+
+type StrapiPackageMeta = {
+  admin?: {
+    vite?: StrapiAdminViteMeta;
+  };
+};
+
+/**
+ * Packages may opt into optimizeDeps.exclude via package.json:
+ * `{ "strapi": { "admin": { "vite": { "optimizeDepsExclude": true } } } }`
+ *
+ * @internal exported for tests
+ */
+export const packageOptsIntoOptimizeDepsExclude = (pkg: PackageJson): boolean => {
+  const strapi = (pkg as PackageJson & { strapi?: StrapiPackageMeta }).strapi;
+
+  return strapi?.admin?.vite?.optimizeDepsExclude === true;
+};
+
+/**
+ * A candidate is excluded only when it matches the UI-kit shape AND is either on the
+ * known-safe allowlist or explicitly opts in. This keeps #26944 working for thin kits
+ * without auto-excluding large editor/chart plugins (#27136).
+ *
+ * @internal exported for tests
+ */
+export const isEligibleForOptimizeDepsExclude = (name: string, pkg: PackageJson): boolean => {
+  if (!shouldExcludeFromOptimizeDeps(pkg)) {
+    return false;
+  }
+
+  return ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has(name) || packageOptsIntoOptimizeDepsExclude(pkg);
+};
 
 /**
  * @internal exported for tests
@@ -162,9 +213,12 @@ const loadAppPackageJson = async (cwd: string): Promise<PackageJson | null> => {
  * Strapi's React/design-system pre-bundling. Skip dep optimization so they resolve through
  * the admin resolve aliases instead of being re-bundled by Vite.
  *
- * Scans app and plugin dependency trees (#26944). Official @strapi/* packages and pinned
+ * Scans app and plugin dependency trees (#26944). Only allowlisted or opt-in packages that
+ * also match the UI-kit shape are excluded (#27136). Official @strapi/* packages and pinned
  * singletons are never auto-excluded — @strapi/strapi matches the heuristic but must stay on
  * the optimizeDeps.include path (#26944, #27014).
+ *
+ * Apps can still exclude additional packages via `src/admin/vite.config` optimizeDeps.exclude.
  *
  * @internal
  */
@@ -200,7 +254,7 @@ export const collectAdminOptimizeDepsExclude = async (
 
     const pkg = await getModule(name, cwd);
 
-    if (pkg && shouldExcludeFromOptimizeDeps(pkg)) {
+    if (pkg && isEligibleForOptimizeDepsExclude(name, pkg)) {
       exclude.push(name);
     }
   }

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -53,7 +53,7 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
       // - The admin entry host (@strapi/strapi) MUST NOT be in optimizeDeps.exclude.
       // When design-system is linked (portal:, file:, yarn link), exclude from pre-bundling
       // so changes are reflected without clearing node_modules/.strapi/vite cache.
-      // Also skip pre-built ESM plugin UI libraries with React peers (see collectAdminOptimizeDepsExclude).
+      // Also skip allowlisted / opt-in pre-built ESM plugin UI kits (see collectAdminOptimizeDepsExclude).
       ...(optimizeDepsExclude.length > 0 && { exclude: optimizeDepsExclude }),
       include: [
         // pre-bundle React dependencies to avoid React duplicates,


### PR DESCRIPTION
### What does it do?

Changes admin Vite `optimizeDeps.exclude` collection so packages are no longer excluded solely because they match the pre-built ESM + React peer + `dist/` shape.

A package is auto-excluded only when it still matches that shape **and**:

1. it is on a small known-safe allowlist (`strapi-design-extended`), or
2. it opts in via `package.json`:

```json
{
  "strapi": {
    "admin": {
      "vite": {
        "optimizeDepsExclude": true
      }
    }
  }
}
```

Official `@strapi/*` packages and pinned singleton modules remain never auto-excluded. Apps can still exclude additional packages through `src/admin/vite.config`.

### Why is it needed?

`#26944` auto-excluded any matching UI-kit-shaped package. That also matched large plugins such as `@_sh/strapi-plugin-ckeditor`. Excluding those roots stops Vite from discovering their transitive CJS/UMD leaves (`property-expr`, `fuzzysort`, …), which produces the named-export / default interop failures reported in strapi/strapi#27136 (still present on 5.51.2 after strapi/strapi#27203).

Keeping React / design-system / redux / known CJS prebundling unchanged, while only excluding known thin kits (or explicit opt-ins), preserves the original `#26944` goal without the CKEditor-class cascade.

### Why this approach (and not the alternatives)

The failure is the **exclude**, not missing leaf pins. Once a fat plugin root is in `optimizeDeps.exclude`, Vite never walks that tree — so the fix is to stop auto-excluding packages that only *look* like thin UI kits. Exclude stays a privilege for known kits / explicit opt-in; default stays “let Vite discover and prebundle.”

Alternatives that are worse for this bug class:

* **Per-leaf** `optimizeDeps.include` **pins** ([#27123](<https://github.com/strapi/strapi/issues/27123>), strapi/strapi#27203, …) — whack-a-mole. Every editor/chart plugin brings a new set of CJS/UMD leaves; we can’t maintain that list.
* **Crawl excluded packages and force-include their CJS deps** — mops up after blinding the scanner. Incomplete for subpaths / peers / dynamic imports, and keeps paying for a bad exclude.
* **Expand transitive exclude** (strapi/strapi#26977) — wrong polarity; excluding more of the graph creates more orphaned leaves.
* **Full revert of** `#26944` — fixes CKEditor-class apps but regresses thin kits like `strapi-design-extended` that still need exclude. This PR keeps that path via allowlist / opt-in without guessing from shape alone.

### How to test it?

* Unit: `yarn nx run @strapi/strapi:test:unit --testPathPattern=admin-vite-optimize-exclude`
* Manual: app with `@_sh/strapi-plugin-ckeditor` — `strapi develop`, exercise emoji / color / markdown paths without a custom `optimizeDeps.include` workaround; admin should not throw CJS named-export errors for those leaves
* Manual: app depending on `strapi-design-extended` — still excluded (allowlist); develop should behave as after strapi/strapi#26944
* Optional: thin UI kit with `strapi.admin.vite.optimizeDepsExclude: true` appears in exclude

### Related issue(s)/PR(s)

* Fixes strapi/strapi#27136
* Fixes strapi/strapi#27062
* Fixes strapi/strapi#27062
* Relates to strapi/strapi#27136
* Follow-up to strapi/strapi#26944 / strapi/strapi#27014; alternative to expanding transitive exclude (strapi/strapi#26977) or per-leaf pins ([#27123](<https://github.com/strapi/strapi/issues/27123>), strapi/strapi#27203)