### PR TITLE
fix(admin): dedupe react-query in the admin bundle

### DIFF
--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
@@ -24,6 +24,16 @@ const PNPM_OPTIMIZE_ALIAS_MODULES = ['invariant', 'prismjs', 'lodash'] as const;
 const DND_SINGLETON_MODULES = ['react-dnd', 'react-dnd-html5-backend'] as const;
 
 /**
+ * react-query keeps its QueryClient on a module-scope context. @strapi/admin mounts the only
+ * QueryClientProvider, while @strapi/content-manager, @strapi/content-releases,
+ * @strapi/content-type-builder, @strapi/email, @strapi/upload, @strapi/plugin-i18n and
+ * @strapi/plugin-users-permissions each declare react-query themselves — so it must be deduped
+ * rather than left to npm hoisting, or the Media Library mounts against an empty context
+ * (#23758, #24865).
+ */
+const QUERY_SINGLETON_MODULES = ['react-query'] as const;
+
+/**
  * resolve.dedupe forces resolution from the app root, so only packages the app itself declares
  * may be deduped. These two are @strapi/admin dependencies: under pnpm's strict isolation they
  * have no top-level node_modules entry, so deduping them would turn a working (if duplicated)
@@ -48,6 +58,16 @@ describe('ADMIN_VITE_ALIAS_MODULES contract', () => {
     for (const mod of DND_SINGLETON_MODULES) {
       expect(ADMIN_VITE_DEDUPE_MODULES).toContain(mod);
     }
+  });
+
+  it('dedupes react-query so the admin QueryClientProvider and upload share one context (#23758)', () => {
+    for (const mod of QUERY_SINGLETON_MODULES) {
+      expect(ADMIN_VITE_DEDUPE_MODULES).toContain(mod);
+    }
+  });
+
+  it('pins react-query alongside other @strapi/admin dependency versions', () => {
+    expect(ADMIN_PINNED_ALIAS_MODULES).toContain('react-query');
   });
 });
 

--- a/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
@@ -28,6 +28,17 @@ export const ADMIN_VITE_ALIAS_MODULES = [
   // "Invariant Violation: Expected drag drop context" (#22392, #22792).
   'react-dnd',
   'react-dnd-html5-backend',
+  // react-query holds its QueryClient on a module-scope React context. @strapi/admin mounts the
+  // only QueryClientProvider (admin/src/components/Providers.tsx), while @strapi/upload,
+  // @strapi/content-manager, @strapi/content-releases, @strapi/content-type-builder,
+  // @strapi/email, @strapi/plugin-i18n and @strapi/plugin-users-permissions each declare
+  // react-query@3.39.3 themselves. npm hoisting collapses those onto one copy, so the provider
+  // and every useQuery/useQueryClient call share a context only by accident of the install
+  // layout. Any tree that keeps the copies separate (install-strategy=nested, a plugin declaring
+  // its own react-query, overrides/resolutions splitting the version) gives them different
+  // contexts and the Media Library crashes on mount with "No QueryClient set, use
+  // QueryClientProvider to set one" (#23758, #24865).
+  'react-query',
 ] as const;
 
 export type AdminViteAliasModule = (typeof ADMIN_VITE_ALIAS_MODULES)[number];
@@ -101,4 +112,5 @@ export const ADMIN_PINNED_ALIAS_MODULES = [
   'invariant',
   'react-dnd',
   'react-dnd-html5-backend',
+  'react-query',
 ] as const satisfies readonly AdminViteAliasModule[];


### PR DESCRIPTION
### What does it do?

Adds `react-query` to `ADMIN_VITE_ALIAS_MODULES`, which puts it on both Vite `resolve.dedupe` and `resolve.alias` (resolved from `@strapi/admin`'s closure via `getModulePath`), and keeps it off `optimizeDeps.exclude` through `PINNED_OPTIMIZE_MODULES`.

It is exact-pinned in `@strapi/admin`'s `dependencies` (`3.39.3`), so it is also added to `ADMIN_PINNED_ALIAS_MODULES` and satisfies its version-pinning contract test.

A regression test asserts it stays on `ADMIN_VITE_DEDUPE_MODULES`.

### Why is it needed?

`react-query` holds its `QueryClient` on a React context created at module scope, so the admin bundle must contain exactly one copy of it. Eight admin-side packages each declare it as their own direct dependency at the same exact version (`react-query: "3.39.3"`):

- `@strapi/admin` — mounts the only `<QueryClientProvider>`, in `admin/src/components/Providers.tsx`
- `@strapi/upload` — the heaviest consumer: 15 runtime modules import it, every Media Library hook (`useAssets`, `useFolder`, `useFolders`, `useFolderStructure`, `useUpload`, `useEditAsset`, `useRemoveAsset`, `useBulkMove`, `useBulkRemove`, `useBulkEdit`, `useEditFolder`, `useAIMetadataJob`, `useConfig`, `useSettings`) plus the settings page
- `@strapi/plugin-users-permissions` — 9 modules, the Roles, Providers, Email templates and Advanced settings pages
- `@strapi/email` — `useQuery`/`useMutation` in the settings page
- `@strapi/content-manager`, `@strapi/content-releases`, `@strapi/content-type-builder`, `@strapi/plugin-i18n` — declare it without importing it any more, so they contribute copies to the install tree but no consumers

Under npm's default hoisting those eight dedupe onto one physical copy, so the provider and the consumers share a context. Nothing enforces that — it is a property of the install layout, not of the code. As soon as the tree keeps the copies separate, `useQueryClient` reads a different context than the one `QueryClientProvider` populated, gets `undefined`, and throws:

```
No QueryClient set, use QueryClientProvider to set one
```

Which is why it takes out the Media Library specifically while the rest of the admin keeps working — `@strapi/upload` is the heaviest `react-query` consumer outside the admin package itself.

Anything that prevents deduping triggers it: npm `install-strategy=nested`, a plugin or app declaring its own `react-query`, or `overrides`/`resolutions` splitting the version. That last one needs no unusual install strategy at all — a plugin depending on `react-query: "^3.39.3"` rather than the exact pin gets its own copy under every package manager as soon as it resolves to anything but `3.39.3`.

This is the same failure class the list already guards against elsewhere — `react-redux` is on it because of `could not find react-redux context value` after hoisting changes (#26944, #27014), the CodeMirror entries because of `instanceof` breakage across duplicated copies, and `react-dnd` because of `Expected drag drop context` (#22392, #22792, added in #27217). `react-query` was simply never added, because hoisting normally hides the problem.

### How to test it?

Measured on a Strapi 5.51.1 app, Node 20, npm workspaces — same source tree throughout, the only variable being whether the copies collapse. Counting `react-query`'s own error string in the built admin bundle is a direct count of bundled instances:

| install | physical `react-query` dirs | `"No QueryClient set"` in built bundle |
| --- | --- | --- |
| `install-strategy=nested`, unpatched | 6 | **3** |
| `install-strategy=nested`, with this change | 6 | **1** |
| deduped on disk (single copy) | 1 | **1** |

The middle row is the point: the six copies stay on disk untouched, and Vite still collapses them onto `@strapi/admin`'s copy, so the layout stops mattering.

To reproduce the failure on an app without this patch:

```bash
# in a Strapi 5 app
echo 'install-strategy=nested' >> .npmrc
rm -rf node_modules package-lock.json && npm install
find node_modules -type d -name react-query -not -path "*/react-query/*" | wc -l   # > 1
npm run build
grep -rho "No QueryClient set" dist/build | wc -l   # > 1
```

Then open the admin panel and click **Media Library** — it crashes on mount with the generic error boundary and `No QueryClient set, use QueryClientProvider to set one`. The six copies land under `@strapi/admin`, `@strapi/upload`, `@strapi/content-manager`, `@strapi/email`, `@strapi/plugin-users-permissions` and one third-party plugin that declares `react-query` itself.

Unpatched, the three surviving instances land in three separate chunks (`strapi-*`, `Settings-*` and `object-*`); with the change, only the `strapi-*` chunk carries one.

**What I ran:** rebased on `develop` (`28b63a1`), installed the monorepo and ran the contract tests this change is bound by, plus lint and format on the two touched files:

```bash
yarn test:unit --testPathPattern "node/core/__tests__/(admin-vite|resolve-module)"
# 4 suites, 73 tests passed
```

- `admin-vite-aliases.test.ts` — `react-query` resolves from `@strapi/admin`'s closure (a direct dependency) and is exact-pinned at `3.39.3`, so the alias and pinned-version assertions hold.
- `resolve-module.test.ts` — `it.each(ADMIN_VITE_ALIAS_MODULES)` resolves each entry from `@strapi/admin`; `react-query` is a direct dependency there.
- `admin-vite-optimize-exclude.test.ts` — entries on the list are only ever *skipped* by `PINNED_OPTIMIZE_MODULES`, and no fixture declares `react-query`, so the expected exclude list is unaffected.
- `eslint --max-warnings=0` and `prettier --check` are clean on both files.

**What I did not run:** the full `yarn test:unit` / `test:front` / `test:e2e` suites, and I measured bundled instance counts rather than loading the Media Library in a browser against a running instance. The measurement above was taken by patching the compiled `ADMIN_VITE_ALIAS_MODULES` inside an installed `@strapi/strapi@5.51.1` (which predates #27217) rather than building the monorepo, so it isolates this one array change.

### Related issue(s)/PR(s)

Fixes #23758
Fixes #24865

Both were closed without a diagnosis — #23758 by the upgrade-tooling template, #24865 as `pending reproduction` — and both are the same root cause.

Follows #27217, which added `react-dnd` to the same list for the same reason.

