### PR TITLE
fix(content-manager): resolve single type preview in the requested locale

### DIFF
--- a/packages/core/content-manager/server/src/preview/controllers/validation/preview.ts
+++ b/packages/core/content-manager/server/src/preview/controllers/validation/preview.ts
@@ -37,7 +37,7 @@ export const validatePreviewUrl = async (
 
   // Fill the documentId if it's a single type
   if (isSingleType) {
-    const doc = await strapi.documents(uid).findFirst();
+    const doc = await strapi.documents(uid).findFirst({ locale: newParams.locale });
 
     if (!doc) {
       throw new errors.NotFoundError('Document not found');

--- a/tests/api/core/content-manager/preview/preview.test.api.ts
+++ b/tests/api/core/content-manager/preview/preview.test.api.ts
@@ -40,11 +40,31 @@ const singleTypeModel = {
   },
 };
 
+const nonDefaultLocaleSingleTypeUid = 'api::footer.footer';
+const nonDefaultLocaleSingleTypeModel = {
+  singularName: 'footer',
+  pluralName: 'footers',
+  displayName: 'Footer',
+  kind: 'singleType',
+  draftAndPublish: true,
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  attributes: {
+    title: {
+      type: 'string',
+    },
+  },
+};
+
 describe('Preview', () => {
   const builder = createTestBuilder();
   let strapi;
   let rq;
   let singleTypeEntry;
+  let nonDefaultLocaleSingleTypeEntry;
 
   const updateEntry = async ({ uid, documentId, data, locale }) => {
     const type = documentId ? 'collection-types' : 'single-types';
@@ -69,10 +89,22 @@ describe('Preview', () => {
   };
 
   beforeAll(async () => {
-    await builder.addContentTypes([collectionTypeModel, singleTypeModel]).build();
+    await builder
+      .addContentTypes([collectionTypeModel, singleTypeModel, nonDefaultLocaleSingleTypeModel])
+      .build();
 
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
+
+    await rq({
+      method: 'POST',
+      url: '/i18n/locales',
+      body: {
+        code: 'da',
+        name: 'Danish (da)',
+        isDefault: false,
+      },
+    });
 
     // Update the single type to create an initial history version
     singleTypeEntry = await updateEntry({
@@ -81,6 +113,16 @@ describe('Preview', () => {
       locale: 'en',
       data: {
         title: 'Welcome',
+      },
+    });
+
+    // Only fill the non-default locale, leaving the default one empty
+    nonDefaultLocaleSingleTypeEntry = await updateEntry({
+      uid: nonDefaultLocaleSingleTypeUid,
+      documentId: undefined,
+      locale: 'da',
+      data: {
+        title: 'Sidefod',
       },
     });
 
@@ -123,6 +165,20 @@ describe('Preview', () => {
     expect(statusCode).toBe(200);
     expect(body.data.url).toEqual(
       `/preview/${singleTypeUid}/${singleTypeEntry.documentId}?locale=en&status=draft`
+    );
+  });
+
+  test('Get preview URL for single type that only exists in a non-default locale', async () => {
+    const { body, statusCode } = await getPreviewUrl({
+      uid: nonDefaultLocaleSingleTypeUid,
+      documentId: undefined,
+      locale: 'da',
+      status: 'draft',
+    });
+
+    expect(statusCode).toBe(200);
+    expect(body.data.url).toEqual(
+      `/preview/${nonDefaultLocaleSingleTypeUid}/${nonDefaultLocaleSingleTypeEntry.documentId}?locale=da&status=draft`
     );
   });
 });


### PR DESCRIPTION
### What does it do?

`validatePreviewUrl` resolves the `documentId` of a single type with `strapi.documents(uid).findFirst()`, without any params. The document service fills in the default locale when none is given, so the lookup always targets the default locale and ignores the `locale` the admin sends. This passes the requested locale through to `findFirst`.

### Why is it needed?

For a localized single type whose default locale has no content, `GET /content-manager/preview/url/{contentType}?locale=da&status=draft` returns a 404 `Document not found`, and the admin shows "Set up Preview" instead of "Open Preview". Creating the entry in the default locale makes it work again, which is why the bug looks intermittent.

### How to test it?

Create two locales, keep `en` as the default, and fill a localized single type in `da` only. The preview URL endpoint with `locale=da` now returns the URL instead of a 404. Covered by a new case in `tests/api/core/content-manager/preview/preview.test.api.ts`, which fails before the change.

### Related issue(s)/PR(s)

Fixes #27262