### PR TITLE
future(upload): final admin endpoint names for the new media library

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -51,11 +51,10 @@ const captureUpdateRequest = (responseAsset: AssetWithPopulatedCreatedBy = baseA
   });
 
   server.use(
-    http.post('/upload', async ({ request }) => {
+    http.put('/upload/files/:id', async ({ request, params }) => {
       try {
-        const url = new URL(request.url, 'http://localhost:1337');
         resolveRequest({
-          id: url.searchParams.get('id'),
+          id: String(params.id),
           body: await request.formData(),
         });
       } catch (error) {
@@ -276,11 +275,10 @@ describe('AssetDetails (asset details drawer body)', () => {
       file: null,
     };
     server.use(
-      http.post('/upload', async ({ request }) => {
-        const url = new URL(request.url, 'http://localhost:1337');
+      http.post('/upload/files/:id/replace', async ({ request, params }) => {
         const body = await request.formData();
         captured = {
-          id: url.searchParams.get('id'),
+          id: String(params.id),
           file: body.get('files'),
         };
         return HttpResponse.json({ ...baseAsset, name: 'replacement.png' });
@@ -322,9 +320,8 @@ describe('AssetDetails (asset details drawer body)', () => {
     let replaceId: string | null = null;
 
     server.use(
-      http.post('/upload', async ({ request }) => {
-        const url = new URL(request.url, 'http://localhost:1337');
-        replaceId = url.searchParams.get('id');
+      http.post('/upload/files/:id/replace', async ({ params }) => {
+        replaceId = params.id as string;
         return HttpResponse.json({ ...secondAsset, name: 'replacement.png' });
       })
     );
@@ -378,7 +375,7 @@ describe('AssetDetails (asset details drawer body)', () => {
     };
 
     it('covers the form while a replace is in flight and clears it once settled', async () => {
-      const release = gateRequest('post', '/upload');
+      const release = gateRequest('post', '/upload/files/:id/replace');
 
       const { user } = render(<AssetDetails asset={baseAsset} closeDetails={jest.fn()} />);
       await screen.findByRole('combobox');

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/AssetActionsMenu.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/AssetActionsMenu.test.tsx
@@ -229,10 +229,10 @@ describe('AssetActionsMenu', () => {
       let uploadedId: string | null = null;
       server.use(
         http.post(
-          '*/upload',
-          ({ request }) => {
-            uploadedId = new URL(request.url).searchParams.get('id');
-            return HttpResponse.json([{ id: 5, name: 'new.png' }]);
+          '*/upload/files/:id/replace',
+          ({ params }) => {
+            uploadedId = params.id as string;
+            return HttpResponse.json({ id: 5, name: 'new.png' });
           },
           { once: true }
         )
@@ -266,12 +266,12 @@ describe('AssetActionsMenu', () => {
       let releaseUpload: (() => void) | undefined;
       server.use(
         http.post(
-          '*/upload',
+          '*/upload/files/:id/replace',
           async () => {
             await new Promise<void>((resolve) => {
               releaseUpload = resolve;
             });
-            return HttpResponse.json([{ id: 5, name: 'new.png' }]);
+            return HttpResponse.json({ id: 5, name: 'new.png' });
           },
           { once: true }
         )
@@ -300,7 +300,7 @@ describe('AssetActionsMenu', () => {
     it('releases the busy flag when the replace fails', async () => {
       server.use(
         http.post(
-          '*/upload',
+          '*/upload/files/:id/replace',
           () => HttpResponse.json({ error: { message: 'Nope.' } }, { status: 500 }),
           {
             once: true,
@@ -390,7 +390,7 @@ describe('AssetActionsMenu', () => {
 
     it('surfaces the server message when the replace fails', async () => {
       server.use(
-        http.post('*/upload', () =>
+        http.post('*/upload/files/:id/replace', () =>
           HttpResponse.json({ error: { message: 'File too large' } }, { status: 413 })
         )
       );

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
@@ -621,7 +621,7 @@ describe('AssetsTable', () => {
       let requestBody: unknown;
       server.use(
         http.post(
-          '*/upload/actions/generate-ai-metadata-for-files',
+          '*/upload/actions/generate-ai-metadata',
           async ({ request }) => {
             requestBody = await request.json();
             return HttpResponse.json({
@@ -655,7 +655,7 @@ describe('AssetsTable', () => {
     it('summarises a partial metadata result in a warning toast', async () => {
       server.use(
         http.post(
-          '*/upload/actions/generate-ai-metadata-for-files',
+          '*/upload/actions/generate-ai-metadata',
           () =>
             HttpResponse.json({
               data: [
@@ -713,7 +713,7 @@ describe('AssetsTable', () => {
     it('reports folders in the selection as ignored rather than silently dropping them', async () => {
       server.use(
         http.post(
-          '*/upload/actions/generate-ai-metadata-for-files',
+          '*/upload/actions/generate-ai-metadata',
           () => HttpResponse.json({ data: [{ id: 1, status: 'success' }] }),
           { once: true }
         )
@@ -738,7 +738,7 @@ describe('AssetsTable', () => {
     it('keeps the selection and shows an error toast when metadata generation fails', async () => {
       server.use(
         http.post(
-          '*/upload/actions/generate-ai-metadata-for-files',
+          '*/upload/actions/generate-ai-metadata',
           () =>
             HttpResponse.json(
               { error: { message: 'AI Metadata service is not enabled' } },
@@ -766,7 +766,7 @@ describe('AssetsTable', () => {
     it('keeps the selection and shows an error toast when every file fails server-side', async () => {
       server.use(
         http.post(
-          '*/upload/actions/generate-ai-metadata-for-files',
+          '*/upload/actions/generate-ai-metadata',
           () =>
             HttpResponse.json({
               data: [

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
@@ -621,7 +621,7 @@ describe('AssetsTable', () => {
       let requestBody: unknown;
       server.use(
         http.post(
-          '*/upload/unstable/generate-ai-metadata',
+          '*/upload/actions/generate-ai-metadata-for-files',
           async ({ request }) => {
             requestBody = await request.json();
             return HttpResponse.json({
@@ -655,7 +655,7 @@ describe('AssetsTable', () => {
     it('summarises a partial metadata result in a warning toast', async () => {
       server.use(
         http.post(
-          '*/upload/unstable/generate-ai-metadata',
+          '*/upload/actions/generate-ai-metadata-for-files',
           () =>
             HttpResponse.json({
               data: [
@@ -713,7 +713,7 @@ describe('AssetsTable', () => {
     it('reports folders in the selection as ignored rather than silently dropping them', async () => {
       server.use(
         http.post(
-          '*/upload/unstable/generate-ai-metadata',
+          '*/upload/actions/generate-ai-metadata-for-files',
           () => HttpResponse.json({ data: [{ id: 1, status: 'success' }] }),
           { once: true }
         )
@@ -738,7 +738,7 @@ describe('AssetsTable', () => {
     it('keeps the selection and shows an error toast when metadata generation fails', async () => {
       server.use(
         http.post(
-          '*/upload/unstable/generate-ai-metadata',
+          '*/upload/actions/generate-ai-metadata-for-files',
           () =>
             HttpResponse.json(
               { error: { message: 'AI Metadata service is not enabled' } },
@@ -766,7 +766,7 @@ describe('AssetsTable', () => {
     it('keeps the selection and shows an error toast when every file fails server-side', async () => {
       server.use(
         http.post(
-          '*/upload/unstable/generate-ai-metadata',
+          '*/upload/actions/generate-ai-metadata-for-files',
           () =>
             HttpResponse.json({
               data: [

--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -21,7 +21,7 @@ import type {
   CreateFilesStream,
   CreateFilesStreamEvents,
   File as UploadedFile,
-  UnstableGenerateAIMetadata,
+  GenerateAIMetadataForFiles,
   UploadFileInfo,
 } from '../../../../shared/contracts/files';
 import type { FileMetadataResultStatus } from '../store/uploadProgress';
@@ -153,7 +153,7 @@ type UploadPoolResult =
 
 /** Maps a server per-file outcome onto the row's terminal metadata status. */
 const METADATA_STATUS_BY_RESULT: Record<
-  UnstableGenerateAIMetadata.FileStatus,
+  GenerateAIMetadataForFiles.FileStatus,
   FileMetadataResultStatus
 > = {
   success: 'generated',
@@ -245,7 +245,7 @@ const runUploadPool = async ({
   concurrency?: number;
   generateAiMetadata: boolean;
 }): Promise<UploadPoolResult> => {
-  const url = `${window.strapi.backendURL}/upload/unstable/upload-file`;
+  const url = `${window.strapi.backendURL}/upload/files`;
   const uploaded: UploadedFile[] = [];
 
   // Shared queue: each worker shifts the next index when it frees up, so N
@@ -390,7 +390,7 @@ const fetchUrlUploadStream = async ({
     headers.Authorization = `Bearer ${token}`;
   }
 
-  return fetch(`${backendURL}/upload/unstable/stream-from-urls`, {
+  return fetch(`${backendURL}/upload/actions/upload-from-urls`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ urls, folderId }),
@@ -498,10 +498,9 @@ const uploadApi = adminApi
   .injectEndpoints({
     endpoints: (builder) => ({
       /**
-       * Upload files to `/upload/unstable/upload-file`, one request per file,
-       * through a worker pool of `concurrency` parallel requests (default 1 =
-       * sequential). Real per-file byte progress comes from
-       * `XHR.upload.onprogress`.
+       * Upload files to `/upload/files`, one request per file, through a worker
+       * pool of `concurrency` parallel requests (default 1 = sequential). Real
+       * per-file byte progress comes from `XHR.upload.onprogress`.
        */
       uploadFiles: builder.mutation<UploadedFile[], UploadFilesArgs>({
         queryFn: async (
@@ -570,7 +569,7 @@ const uploadApi = adminApi
       uploadFileSilently: builder.mutation<UploadedFile, UploadEntry>({
         queryFn: async ({ file, fileInfo }, { getState }) => {
           const token = (getState() as RootState).admin_app?.token;
-          const url = `${window.strapi.backendURL}/upload/unstable/upload-file`;
+          const url = `${window.strapi.backendURL}/upload/files`;
 
           const formData = new FormData();
           formData.append('files', file);
@@ -762,15 +761,15 @@ const uploadApi = adminApi
        * Re-exported from `assets.ts` for the components that consume the hook.
        */
       generateAiMetadata: builder.mutation<
-        UnstableGenerateAIMetadata.Response['data'],
+        GenerateAIMetadataForFiles.Response['data'],
         { fileIds: number[] }
       >({
         query: ({ fileIds }) => ({
-          url: '/upload/unstable/generate-ai-metadata',
+          url: '/upload/actions/generate-ai-metadata-for-files',
           method: 'POST',
           data: { fileIds },
         }),
-        transformResponse: (response: { data: UnstableGenerateAIMetadata.Response['data'] }) =>
+        transformResponse: (response: { data: GenerateAIMetadataForFiles.Response['data'] }) =>
           response.data,
         invalidatesTags: (_result, _error, { fileIds }) => [
           ...fileIds.map((id) => ({ type: 'Asset' as const, id })),

--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -21,7 +21,7 @@ import type {
   CreateFilesStream,
   CreateFilesStreamEvents,
   File as UploadedFile,
-  GenerateAIMetadataForFiles,
+  GenerateAIMetadata,
   UploadFileInfo,
 } from '../../../../shared/contracts/files';
 import type { FileMetadataResultStatus } from '../store/uploadProgress';
@@ -152,10 +152,7 @@ type UploadPoolResult =
   | { error: UploadError; data?: undefined };
 
 /** Maps a server per-file outcome onto the row's terminal metadata status. */
-const METADATA_STATUS_BY_RESULT: Record<
-  GenerateAIMetadataForFiles.FileStatus,
-  FileMetadataResultStatus
-> = {
+const METADATA_STATUS_BY_RESULT: Record<GenerateAIMetadata.FileStatus, FileMetadataResultStatus> = {
   success: 'generated',
   skipped: 'skipped',
   error: 'failed',
@@ -761,15 +758,15 @@ const uploadApi = adminApi
        * Re-exported from `assets.ts` for the components that consume the hook.
        */
       generateAiMetadata: builder.mutation<
-        GenerateAIMetadataForFiles.Response['data'],
+        GenerateAIMetadata.Response['data'],
         { fileIds: number[] }
       >({
         query: ({ fileIds }) => ({
-          url: '/upload/actions/generate-ai-metadata-for-files',
+          url: '/upload/actions/generate-ai-metadata',
           method: 'POST',
           data: { fileIds },
         }),
-        transformResponse: (response: { data: GenerateAIMetadataForFiles.Response['data'] }) =>
+        transformResponse: (response: { data: GenerateAIMetadata.Response['data'] }) =>
           response.data,
         invalidatesTags: (_result, _error, { fileIds }) => [
           ...fileIds.map((id) => ({ type: 'Asset' as const, id })),

--- a/packages/core/upload/admin/src/future/services/assets.ts
+++ b/packages/core/upload/admin/src/future/services/assets.ts
@@ -89,9 +89,8 @@ const assetsApi = uploadApi.injectEndpoints({
       providesTags: (_result, _error, id) => [{ type: 'Asset' as const, id }],
     }),
     /**
-     * Update the editable metadata of an existing asset.
-     * Hits the legacy `POST /upload?id=<id>` endpoint which dispatches to
-     * `admin-upload.updateFileInfo`.
+     * Update the editable metadata of an existing asset, through
+     * `PUT /upload/files/<id>` (`admin-upload.updateFileInfo`).
      */
     updateAsset: builder.mutation<AssetWithPopulatedCreatedBy, UpdateAssetArgs>({
       query: ({ id, fileInfo }) => {
@@ -99,10 +98,9 @@ const assetsApi = uploadApi.injectEndpoints({
         formData.append('fileInfo', JSON.stringify(fileInfo));
 
         return {
-          url: '/upload',
-          method: 'POST',
+          url: `/upload/files/${id}`,
+          method: 'PUT',
           data: formData,
-          config: { params: { id } },
         };
       },
       invalidatesTags: (_result, _error, { id }) => [
@@ -114,11 +112,10 @@ const assetsApi = uploadApi.injectEndpoints({
       ],
     }),
     /**
-     * Replace the binary content of an existing asset.
-     * Hits `POST /upload?id=<id>` with a multipart body — the controller
-     * dispatches to `admin-upload.replaceFile` when a `files` part is present.
-     * Uses the standard axios baseQuery (no streaming) since we only ever
-     * replace one file at a time and don't need per-byte progress here.
+     * Replace the binary content of an existing asset, through
+     * `POST /upload/files/<id>/replace` (`admin-upload.replaceFile`) with a
+     * multipart body. Uses the standard axios baseQuery (no streaming) since we
+     * only ever replace one file at a time and don't need per-byte progress here.
      */
     replaceAsset: builder.mutation<AssetWithPopulatedCreatedBy, ReplaceAssetArgs>({
       query: ({ id, file, fileInfo }) => {
@@ -128,10 +125,9 @@ const assetsApi = uploadApi.injectEndpoints({
           formData.append('fileInfo', JSON.stringify(fileInfo));
         }
         return {
-          url: '/upload',
+          url: `/upload/files/${id}/replace`,
           method: 'POST',
           data: formData,
-          config: { params: { id } },
         };
       },
       invalidatesTags: (_result, _error, { id }) => [

--- a/packages/core/upload/admin/src/future/services/tests/assets.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/assets.test.ts
@@ -144,7 +144,7 @@ describe('future assets service - generateAiMetadata', () => {
   beforeEach(() => {
     lastRequestBody = undefined;
     server.use(
-      http.post('*/upload/actions/generate-ai-metadata-for-files', async ({ request }) => {
+      http.post('*/upload/actions/generate-ai-metadata', async ({ request }) => {
         lastRequestBody = (await request.json()) as { fileIds?: number[] };
         return HttpResponse.json({
           data: [

--- a/packages/core/upload/admin/src/future/services/tests/assets.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/assets.test.ts
@@ -144,7 +144,7 @@ describe('future assets service - generateAiMetadata', () => {
   beforeEach(() => {
     lastRequestBody = undefined;
     server.use(
-      http.post('*/upload/unstable/generate-ai-metadata', async ({ request }) => {
+      http.post('*/upload/actions/generate-ai-metadata-for-files', async ({ request }) => {
         lastRequestBody = (await request.json()) as { fileIds?: number[] };
         return HttpResponse.json({
           data: [

--- a/packages/core/upload/admin/src/future/services/tests/folders.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/folders.test.ts
@@ -270,7 +270,7 @@ describe('future folder header count invalidation', () => {
           data: { id: 1, name: 'My folder', files: { count: fileCount }, children: { count: 0 } },
         });
       }),
-      http.post('*/upload', () => {
+      http.put('*/upload/files/:id', () => {
         // The move dropped this folder's count on the server.
         fileCount = 2;
         return HttpResponse.json({ data: { id: 99 } });

--- a/packages/core/upload/admin/src/future/services/tests/uploadFileViaXHR.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadFileViaXHR.test.ts
@@ -69,7 +69,7 @@ class MockXHR {
   }
 }
 
-const ENDPOINT = 'http://localhost:1337/upload/unstable/upload-file';
+const ENDPOINT = 'http://localhost:1337/upload/files';
 
 describe('uploadFileViaXHR', () => {
   let OriginalXHR: typeof XMLHttpRequest;

--- a/packages/core/upload/admin/src/future/services/tests/uploadMetadata.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadMetadata.test.ts
@@ -5,7 +5,7 @@ import { maybeGenerateMetadata, uploadApi, useGenerateAiMetadataMutation } from 
 
 import type {
   File as UploadedFile,
-  GenerateAIMetadataForFiles,
+  GenerateAIMetadata,
 } from '../../../../../shared/contracts/files';
 
 const makeUploadedFile = (id: number, mime: string): UploadedFile =>
@@ -27,7 +27,7 @@ const runHelper = async ({
 }: {
   file: UploadedFile;
   enabled?: boolean;
-  result?: { data: GenerateAIMetadataForFiles.Response['data'] } | { error: Error };
+  result?: { data: GenerateAIMetadata.Response['data'] } | { error: Error };
 }) => {
   const actions: Array<{ type: string; payload?: unknown }> = [];
   let didInitiate = false;
@@ -205,7 +205,7 @@ describe('generateAiMetadata endpoint', () => {
   it('posts a single-element fileIds array for one completed file', async () => {
     let body: { fileIds?: number[] } | undefined;
     server.use(
-      http.post('*/upload/actions/generate-ai-metadata-for-files', async ({ request }) => {
+      http.post('*/upload/actions/generate-ai-metadata', async ({ request }) => {
         body = (await request.json()) as { fileIds?: number[] };
         return HttpResponse.json({ data: [{ id: 42, status: 'success' }] });
       })

--- a/packages/core/upload/admin/src/future/services/tests/uploadMetadata.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadMetadata.test.ts
@@ -5,7 +5,7 @@ import { maybeGenerateMetadata, uploadApi, useGenerateAiMetadataMutation } from 
 
 import type {
   File as UploadedFile,
-  UnstableGenerateAIMetadata,
+  GenerateAIMetadataForFiles,
 } from '../../../../../shared/contracts/files';
 
 const makeUploadedFile = (id: number, mime: string): UploadedFile =>
@@ -27,7 +27,7 @@ const runHelper = async ({
 }: {
   file: UploadedFile;
   enabled?: boolean;
-  result?: { data: UnstableGenerateAIMetadata.Response['data'] } | { error: Error };
+  result?: { data: GenerateAIMetadataForFiles.Response['data'] } | { error: Error };
 }) => {
   const actions: Array<{ type: string; payload?: unknown }> = [];
   let didInitiate = false;
@@ -205,7 +205,7 @@ describe('generateAiMetadata endpoint', () => {
   it('posts a single-element fileIds array for one completed file', async () => {
     let body: { fileIds?: number[] } | undefined;
     server.use(
-      http.post('*/upload/unstable/generate-ai-metadata', async ({ request }) => {
+      http.post('*/upload/actions/generate-ai-metadata-for-files', async ({ request }) => {
         body = (await request.json()) as { fileIds?: number[] };
         return HttpResponse.json({ data: [{ id: 42, status: 'success' }] });
       })

--- a/packages/core/upload/admin/src/hooks/useAIMetadataJob.ts
+++ b/packages/core/upload/admin/src/hooks/useAIMetadataJob.ts
@@ -16,7 +16,7 @@ const fetchLatestJob = async (
 ): Promise<AIMetadataJob | null> => {
   try {
     const { data } = await get<GetLatestAIMetadataJob.Response['data']>(
-      '/upload/actions/generate-ai-metadata/latest'
+      '/upload/ai-metadata-jobs/latest'
     );
     return data;
   } catch {

--- a/packages/core/upload/admin/src/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/core/upload/admin/src/pages/SettingsPage/SettingsPage.tsx
@@ -29,7 +29,7 @@ import { useIntl } from 'react-intl';
 import { useMutation, useQuery } from 'react-query';
 
 import { AIMetadataJob } from '../../../../shared/contracts/ai-metadata-jobs';
-import { GetAIMetadataCount, GenerateAIMetadata } from '../../../../shared/contracts/files';
+import { GetAIMetadataPendingCount, CreateAIMetadataJob } from '../../../../shared/contracts/files';
 import { UpdateSettings } from '../../../../shared/contracts/settings';
 import { PERMISSIONS } from '../../constants';
 import { useAIMetadataJob } from '../../hooks/useAIMetadataJob';
@@ -165,13 +165,13 @@ export const SettingsPage = () => {
   const isAIAvailable = useAIAvailability();
 
   const { data: imageCountResponse, isLoading: isLoadingImagesWithoutMetadataCount } = useQuery<
-    GetAIMetadataCount.Response['data'],
-    GetAIMetadataCount.Response['error']
+    GetAIMetadataPendingCount.Response['data'],
+    GetAIMetadataPendingCount.Response['error']
   >(
     ['ai-metadata-count'],
     async () => {
-      const { data } = await get<GetAIMetadataCount.Response['data']>(
-        '/upload/actions/generate-ai-metadata/count'
+      const { data } = await get<GetAIMetadataPendingCount.Response['data']>(
+        '/upload/ai-metadata-jobs/pending-count'
       );
       return data;
     },
@@ -231,15 +231,15 @@ export const SettingsPage = () => {
   });
 
   const { mutateAsync: startGenerateAIMetadata } = useMutation<
-    GenerateAIMetadata.Response['data'],
-    GenerateAIMetadata.Response['error'],
+    CreateAIMetadataJob.Response['data'],
+    CreateAIMetadataJob.Response['error'],
     void
   >(
     async () => {
       const { data } = await post<
-        GenerateAIMetadata.Response['data'],
-        GenerateAIMetadata.Request['body']
-      >('/upload/actions/generate-ai-metadata', {});
+        CreateAIMetadataJob.Response['data'],
+        CreateAIMetadataJob.Request['body']
+      >('/upload/ai-metadata-jobs', {});
       return data;
     },
     {

--- a/packages/core/upload/admin/tests/handlers.ts
+++ b/packages/core/upload/admin/tests/handlers.ts
@@ -183,10 +183,10 @@ const handlers: HttpHandler[] = [
     return HttpResponse.json(null);
   }),
 
-  // Unstable media library: per-file AI metadata generation, reported per file so a
-  // single failure never fails the batch. Fired after each upload completes — for
-  // every file, including non-images, which the server reports as `skipped`.
-  http.post('*/upload/unstable/generate-ai-metadata', async ({ request }) => {
+  // Per-file AI metadata generation, reported per file so a single failure never
+  // fails the batch. Fired after each upload completes — for every file, including
+  // non-images, which the server reports as `skipped`.
+  http.post('*/upload/actions/generate-ai-metadata-for-files', async ({ request }) => {
     const { fileIds } = (await request.json()) as { fileIds: number[] };
 
     return HttpResponse.json({

--- a/packages/core/upload/admin/tests/handlers.ts
+++ b/packages/core/upload/admin/tests/handlers.ts
@@ -173,20 +173,20 @@ const handlers: HttpHandler[] = [
     });
   }),
 
-  http.get('/upload/actions/generate-ai-metadata/count', () => {
+  http.get('/upload/ai-metadata-jobs/pending-count', () => {
     return HttpResponse.json({
       count: 0,
     });
   }),
 
-  http.get('/upload/actions/generate-ai-metadata/latest', () => {
+  http.get('/upload/ai-metadata-jobs/latest', () => {
     return HttpResponse.json(null);
   }),
 
   // Per-file AI metadata generation, reported per file so a single failure never
   // fails the batch. Fired after each upload completes — for every file, including
   // non-images, which the server reports as `skipped`.
-  http.post('*/upload/actions/generate-ai-metadata-for-files', async ({ request }) => {
+  http.post('*/upload/actions/generate-ai-metadata', async ({ request }) => {
     const { fileIds } = (await request.json()) as { fileIds: number[] };
 
     return HttpResponse.json({

--- a/packages/core/upload/server/src/controllers/__tests__/admin-file.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-file.test.ts
@@ -7,12 +7,12 @@ jest.mock('../../utils');
 
 const mockGetService = getService as jest.MockedFunction<typeof getService>;
 
-describe('Admin File Controller - generateAIMetadataForFiles', () => {
+describe('Admin File Controller - generateAIMetadata', () => {
   let ctx: Partial<Context>;
   let pm: { isAllowed: boolean };
   let mockAiMetadataService: any;
 
-  const call = () => adminFileController.generateAIMetadataForFiles(ctx as Context);
+  const call = () => adminFileController.generateAIMetadata(ctx as Context);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/core/upload/server/src/controllers/__tests__/admin-file.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-file.test.ts
@@ -7,12 +7,12 @@ jest.mock('../../utils');
 
 const mockGetService = getService as jest.MockedFunction<typeof getService>;
 
-describe('Admin File Controller - unstable_generateAIMetadata', () => {
+describe('Admin File Controller - generateAIMetadataForFiles', () => {
   let ctx: Partial<Context>;
   let pm: { isAllowed: boolean };
   let mockAiMetadataService: any;
 
-  const call = () => adminFileController.unstable_generateAIMetadata(ctx as Context);
+  const call = () => adminFileController.generateAIMetadataForFiles(ctx as Context);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -212,6 +212,42 @@ describe('Admin Upload Controller - AI Service Connection', () => {
       });
     });
 
+    // `POST /upload/files/:id/replace` delivers the id in route params; the
+    // legacy `POST /upload` multiplexer delegates here with it in the query.
+    it('reads the id from route params, preferring them over the query', async () => {
+      const replacementFile = {
+        filepath: '/tmp/replacement.pdf',
+        originalFilename: 'replacement.pdf',
+        mimetype: 'application/pdf',
+      };
+
+      mockContext.params = { id: '9' } as any;
+      mockContext.query = { id: '1' } as any;
+      mockContext.request!.files = { files: replacementFile } as any;
+
+      mockPrepareUploadRequest.mockResolvedValue({
+        validFiles: [replacementFile],
+        filteredBody: {},
+        errors: [],
+      });
+
+      uploadService.replace.mockResolvedValue({ id: 9, name: 'replacement.pdf' });
+
+      await adminUploadController.replaceFile(mockContext as Context);
+
+      expect(uploadService.replace).toHaveBeenCalledWith('9', expect.anything(), {
+        user: { id: 1 },
+      });
+    });
+
+    it('throws when neither params nor query carry an id', async () => {
+      mockContext.query = {} as any;
+
+      await expect(adminUploadController.replaceFile(mockContext as Context)).rejects.toThrow(
+        'File id is required'
+      );
+    });
+
     it('rejects multiple replacement files', async () => {
       mockContext.query = { id: '1' } as any;
       mockContext.request!.files = {
@@ -731,6 +767,42 @@ describe('Admin Upload Controller - AI Service Connection', () => {
 
       expect(fileService.signFileUrls).toHaveBeenCalledWith({ id: 7 });
       expect(mockContext.body).toEqual(expect.objectContaining({ id: 7, isUrlSigned: true }));
+    });
+
+    // `PUT /upload/files/:id` delivers the id in route params; the legacy
+    // `POST /upload` multiplexer delegates here with it in the query string.
+    it('reads the id from route params', async () => {
+      mockContext.params = { id: '9' } as any;
+      mockContext.query = {} as any;
+
+      uploadService.updateFileInfo.mockResolvedValue({ id: 9 });
+
+      await adminUploadController.updateFileInfo(mockContext as Context);
+
+      expect(uploadService.updateFileInfo).toHaveBeenCalledWith('9', expect.anything(), {
+        user: { id: 1 },
+      });
+    });
+
+    it('prefers route params over the query id when both are present', async () => {
+      mockContext.params = { id: '9' } as any;
+      mockContext.query = { id: '7' } as any;
+
+      uploadService.updateFileInfo.mockResolvedValue({ id: 9 });
+
+      await adminUploadController.updateFileInfo(mockContext as Context);
+
+      expect(uploadService.updateFileInfo).toHaveBeenCalledWith('9', expect.anything(), {
+        user: { id: 1 },
+      });
+    });
+
+    it('throws when neither params nor query carry an id', async () => {
+      mockContext.query = {} as any;
+
+      await expect(adminUploadController.updateFileInfo(mockContext as Context)).rejects.toThrow(
+        'File id is required'
+      );
     });
   });
 });

--- a/packages/core/upload/server/src/controllers/admin-file.ts
+++ b/packages/core/upload/server/src/controllers/admin-file.ts
@@ -84,7 +84,13 @@ export default {
     ctx.body = body;
   },
 
-  async getAIMetadataCount(ctx: Context) {
+  /**
+   * `GET /upload/ai-metadata-jobs/pending-count`
+   *
+   * How many images a backfill job would have to process, i.e. those still
+   * missing AI metadata, alongside the total image count.
+   */
+  async getAIMetadataPendingCount(ctx: Context) {
     const { userAbility } = ctx.state;
 
     const pm = strapi.service('admin::permission').createPermissionsManager({
@@ -124,7 +130,15 @@ export default {
     }
   },
 
-  async generateAIMetadata(ctx: Context) {
+  /**
+   * `POST /upload/ai-metadata-jobs`
+   *
+   * Create a backfill job that generates AI metadata for every image still
+   * missing it, and return the job so the client can poll it. Processing runs
+   * detached from this request; see `generateAIMetadata` for the synchronous
+   * counterpart that works on an explicit selection.
+   */
+  async createAIMetadataJob(ctx: Context) {
     const { userAbility } = ctx.state;
 
     const pm = strapi.service('admin::permission').createPermissionsManager({
@@ -185,15 +199,16 @@ export default {
   },
 
   /**
-   * `POST /upload/actions/generate-ai-metadata-for-files`
+   * `POST /upload/actions/generate-ai-metadata`
    *
-   * Generate AI metadata for an explicit selection of files, synchronously.
+   * Generate AI metadata for the explicit selection of files in the body,
+   * synchronously: the request resolves once every file has been processed and
+   * reports the outcome per file, so a single bad id or a non-image in the
+   * selection never fails the whole batch.
    *
-   * Unlike `generateAIMetadata`, no job is created: the request resolves once
-   * every file has been processed and reports the outcome per file, so a single
-   * bad id or a non-image in the selection never fails the whole batch.
+   * For the whole-library backfill, see `createAIMetadataJob`.
    */
-  async generateAIMetadataForFiles(ctx: Context) {
+  async generateAIMetadata(ctx: Context) {
     const { userAbility } = ctx.state;
     const { body } = ctx.request;
 
@@ -220,6 +235,12 @@ export default {
     ctx.body = { data: results };
   },
 
+  /**
+   * `GET /upload/ai-metadata-jobs/latest`
+   *
+   * The most recent still-active backfill job, so a client that reloads mid-run
+   * can pick the progress bar back up. 404s when nothing is running.
+   */
   async getLatestAIMetadataJob(ctx: Context) {
     if ((await getService('aiMetadata').isEnabled()) === false) {
       return ctx.notFound();

--- a/packages/core/upload/server/src/controllers/admin-file.ts
+++ b/packages/core/upload/server/src/controllers/admin-file.ts
@@ -185,15 +185,15 @@ export default {
   },
 
   /**
+   * `POST /upload/actions/generate-ai-metadata-for-files`
+   *
    * Generate AI metadata for an explicit selection of files, synchronously.
    *
    * Unlike `generateAIMetadata`, no job is created: the request resolves once
    * every file has been processed and reports the outcome per file, so a single
    * bad id or a non-image in the selection never fails the whole batch.
-   *
-   * @experimental
    */
-  async unstable_generateAIMetadata(ctx: Context) {
+  async generateAIMetadataForFiles(ctx: Context) {
     const { userAbility } = ctx.state;
     const { body } = ctx.request;
 

--- a/packages/core/upload/server/src/controllers/admin-upload.ts
+++ b/packages/core/upload/server/src/controllers/admin-upload.ts
@@ -46,12 +46,20 @@ export default {
     ctx.body = results;
   },
 
+  /**
+   * `PUT /upload/files/:id`
+   *
+   * Update the editable metadata (`fileInfo`) of an existing file. Also reached
+   * through the `POST /upload` multiplexer, which delegates here with the id in
+   * `ctx.query` — hence the dual read below, route params winning.
+   */
   async updateFileInfo(ctx: Context) {
     const {
       state: { userAbility, user },
-      query: { id },
       request: { body },
     } = ctx;
+
+    const id = ctx.params?.id ?? ctx.query.id;
 
     if (typeof id !== 'string') {
       throw new errors.ValidationError('File id is required');
@@ -75,12 +83,20 @@ export default {
     ctx.body = await pm.sanitizeOutput(signedFile, { action: ACTIONS.read });
   },
 
+  /**
+   * `POST /upload/files/:id/replace`
+   *
+   * Replace the binary content of an existing file. Also reached through the
+   * `POST /upload` multiplexer, which delegates here with the id in `ctx.query`
+   * — hence the dual read below, route params winning.
+   */
   async replaceFile(ctx: Context) {
     const {
       state: { userAbility, user },
-      query: { id },
       request: { body, files: { files: filesInput } = {} },
     } = ctx;
+
+    const id = ctx.params?.id ?? ctx.query.id;
 
     if (typeof id !== 'string') {
       throw new errors.ValidationError('File id is required');
@@ -209,7 +225,8 @@ export default {
   },
 
   /**
-   * @experimental
+   * `POST /upload/files`
+   *
    * Upload a single file and return the created File.
    *
    * Accepts one file per request (multipart `files` + `fileInfo`) and returns a
@@ -217,7 +234,7 @@ export default {
    * generation inline — that responsibility is decoupled and will be handled by a
    * background job. Auth and permission checks mirror `POST /upload`.
    */
-  async unstable_uploadFile(ctx: Context) {
+  async uploadFile(ctx: Context) {
     const {
       state: { userAbility, user },
       request: { body, files: { files } = {} },
@@ -288,7 +305,8 @@ export default {
   },
 
   /**
-   * @experimental
+   * `POST /upload/actions/upload-from-urls`
+   *
    * Upload files from URLs with SSE streaming for per-file progress
    *
    * Accepts JSON body with URLs and fetches them server-side.
@@ -299,7 +317,7 @@ export default {
    * - file:error     — when a URL fetch or upload fails
    * - stream:complete — final summary with all results
    */
-  async unstable_uploadFromUrls(ctx: Context) {
+  async uploadFromUrls(ctx: Context) {
     const {
       state: { userAbility, user },
       request: { body },

--- a/packages/core/upload/server/src/routes/admin.ts
+++ b/packages/core/upload/server/src/routes/admin.ts
@@ -90,6 +90,22 @@ export const routes = {
       },
     },
     {
+      method: 'PUT',
+      path: '/files/:id',
+      handler: 'admin-upload.updateFileInfo',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/files/:id/replace',
+      handler: 'admin-upload.replaceFile',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
       method: 'DELETE',
       path: '/files/:id',
       handler: 'admin-file.destroy',

--- a/packages/core/upload/server/src/routes/admin.ts
+++ b/packages/core/upload/server/src/routes/admin.ts
@@ -50,14 +50,6 @@ export const routes = {
       },
     },
     {
-      method: 'POST',
-      path: '/files',
-      handler: 'admin-upload.uploadFile',
-      config: {
-        policies: ['admin::isAuthenticatedAdmin'],
-      },
-    },
-    {
       method: 'GET',
       path: '/files',
       handler: 'admin-file.find',
@@ -71,6 +63,14 @@ export const routes = {
             },
           },
         ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/files',
+      handler: 'admin-upload.uploadFile',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
       },
     },
     {
@@ -266,33 +266,9 @@ export const routes = {
       },
     },
     {
-      method: 'GET',
-      path: '/actions/generate-ai-metadata/count',
-      handler: 'admin-file.getAIMetadataCount',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.read'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/actions/generate-ai-metadata/latest',
-      handler: 'admin-file.getLatestAIMetadataJob',
-      config: {
-        policies: ['admin::isAuthenticatedAdmin'],
-      },
-    },
-    {
       method: 'POST',
-      path: '/actions/generate-ai-metadata-for-files',
-      handler: 'admin-file.generateAIMetadataForFiles',
+      path: '/ai-metadata-jobs',
+      handler: 'admin-file.createAIMetadataJob',
       config: {
         policies: [
           'admin::isAuthenticatedAdmin',
@@ -300,6 +276,30 @@ export const routes = {
             name: 'admin::hasPermissions',
             config: {
               actions: ['plugin::upload.assets.update'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/ai-metadata-jobs/latest',
+      handler: 'admin-file.getLatestAIMetadataJob',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/ai-metadata-jobs/pending-count',
+      handler: 'admin-file.getAIMetadataPendingCount',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.read'],
             },
           },
         ],

--- a/packages/core/upload/server/src/routes/admin.ts
+++ b/packages/core/upload/server/src/routes/admin.ts
@@ -43,16 +43,16 @@ export const routes = {
     },
     {
       method: 'POST',
-      path: '/unstable/upload-file',
-      handler: 'admin-upload.unstable_uploadFile',
+      path: '/actions/upload-from-urls',
+      handler: 'admin-upload.uploadFromUrls',
       config: {
         policies: ['admin::isAuthenticatedAdmin'],
       },
     },
     {
       method: 'POST',
-      path: '/unstable/stream-from-urls',
-      handler: 'admin-upload.unstable_uploadFromUrls',
+      path: '/files',
+      handler: 'admin-upload.uploadFile',
       config: {
         policies: ['admin::isAuthenticatedAdmin'],
       },
@@ -275,8 +275,8 @@ export const routes = {
     },
     {
       method: 'POST',
-      path: '/unstable/generate-ai-metadata',
-      handler: 'admin-file.unstable_generateAIMetadata',
+      path: '/actions/generate-ai-metadata-for-files',
+      handler: 'admin-file.generateAIMetadataForFiles',
       config: {
         policies: [
           'admin::isAuthenticatedAdmin',

--- a/packages/core/upload/server/src/services/ai-metadata.ts
+++ b/packages/core/upload/server/src/services/ai-metadata.ts
@@ -8,9 +8,9 @@ import { AI_METADATA_CHUNK_SIZE, AI_METADATA_SUPPORTED_IMAGE_TYPES } from '../co
 
 import { isAIMetadataSupportedMime } from '../../../shared/constants';
 
-import type { GenerateAIMetadataForFiles } from '../../../shared/contracts/files';
+import type { GenerateAIMetadata } from '../../../shared/contracts/files';
 
-export type AIMetadataFileResult = GenerateAIMetadataForFiles.FileResult;
+export type AIMetadataFileResult = GenerateAIMetadata.FileResult;
 
 /**
  * Supported image types for AI metadata generation. Lives in `shared/` so the

--- a/packages/core/upload/server/src/services/ai-metadata.ts
+++ b/packages/core/upload/server/src/services/ai-metadata.ts
@@ -8,9 +8,9 @@ import { AI_METADATA_CHUNK_SIZE, AI_METADATA_SUPPORTED_IMAGE_TYPES } from '../co
 
 import { isAIMetadataSupportedMime } from '../../../shared/constants';
 
-import type { UnstableGenerateAIMetadata } from '../../../shared/contracts/files';
+import type { GenerateAIMetadataForFiles } from '../../../shared/contracts/files';
 
-export type AIMetadataFileResult = UnstableGenerateAIMetadata.FileResult;
+export type AIMetadataFileResult = GenerateAIMetadataForFiles.FileResult;
 
 /**
  * Supported image types for AI metadata generation. Lives in `shared/` so the

--- a/packages/core/upload/shared/contracts/ai-metadata-jobs.ts
+++ b/packages/core/upload/shared/contracts/ai-metadata-jobs.ts
@@ -10,7 +10,7 @@ export interface AIMetadataJob {
 }
 
 /**
- * GET /upload/actions/generate-ai-metadata/latest
+ * GET /upload/ai-metadata-jobs/latest
  *
  * Return the latest AI metadata job
  */
@@ -25,7 +25,7 @@ export declare namespace GetLatestAIMetadataJob {
 }
 
 /**
- * POST /upload/actions/generate-ai-metadata
+ * POST /upload/ai-metadata-jobs
  *
  * Start a new AI metadata generation job
  */
@@ -43,7 +43,7 @@ export declare namespace StartAIMetadataJob {
 }
 
 /**
- * GET /upload/actions/generate-ai-metadata/count
+ * GET /upload/ai-metadata-jobs/pending-count
  *
  * Return count of images without metadata
  */

--- a/packages/core/upload/shared/contracts/ai-metadata-jobs.ts
+++ b/packages/core/upload/shared/contracts/ai-metadata-jobs.ts
@@ -12,7 +12,8 @@ export interface AIMetadataJob {
 /**
  * GET /upload/ai-metadata-jobs/latest
  *
- * Return the latest AI metadata job
+ * The most recent still-active backfill job. 404s when nothing is running, so
+ * there is no `null` on the wire — callers get an error response instead.
  */
 export declare namespace GetLatestAIMetadataJob {
   export interface Request {
@@ -20,41 +21,15 @@ export declare namespace GetLatestAIMetadataJob {
   }
 
   export interface Response {
-    data: AIMetadataJob | null;
+    data: AIMetadataJob;
   }
 }
 
 /**
- * POST /upload/ai-metadata-jobs
- *
- * Start a new AI metadata generation job
+ * The other two job endpoints — `POST /upload/ai-metadata-jobs` and
+ * `GET /upload/ai-metadata-jobs/pending-count` — are declared in `./files.ts`
+ * as `CreateAIMetadataJob` and `GetAIMetadataPendingCount`. They used to be
+ * duplicated here under different names and with response shapes that had
+ * drifted from what the controllers actually return; `./files.ts` is the one
+ * that matched, so it is the single source of truth for both.
  */
-export declare namespace StartAIMetadataJob {
-  export interface Request {
-    body?: {};
-  }
-
-  export interface Response {
-    data: {
-      jobId: number;
-      status: string;
-    };
-  }
-}
-
-/**
- * GET /upload/ai-metadata-jobs/pending-count
- *
- * Return count of images without metadata
- */
-export declare namespace GetAIMetadataCount {
-  export interface Request {
-    query?: {};
-  }
-
-  export interface Response {
-    data: {
-      count: number;
-    };
-  }
-}

--- a/packages/core/upload/shared/contracts/files.ts
+++ b/packages/core/upload/shared/contracts/files.ts
@@ -234,12 +234,12 @@ export declare namespace CreateFile {
 }
 
 /**
- * POST /upload/unstable/upload-file - Upload a single file
+ * POST /upload/files - Upload a single file
  *
  * Accepts one file per request (multipart `files` + `fileInfo`) and returns the
  * single created `File`. Does not run inline AI metadata generation.
  */
-export declare namespace UnstableCreateFile {
+export declare namespace UploadFile {
   export interface Request {
     body: FormData;
   }
@@ -250,7 +250,7 @@ export declare namespace UnstableCreateFile {
 }
 
 /**
- * POST /upload/unstable/stream-from-urls - Stream upload files with partial success support
+ * POST /upload/actions/upload-from-urls - Stream upload files with partial success support
  *
  * Still used by the URL upload flow (`uploadFromUrls`).
  */
@@ -269,7 +269,7 @@ export declare namespace CreateFilesStream {
 }
 
 /**
- * POST /upload/unstable/stream-from-urls - SSE streaming event types
+ * POST /upload/actions/upload-from-urls - SSE streaming event types
  *
  * The endpoint streams Server-Sent Events as each file is processed.
  * The final `stream:complete` event carries the same shape as CreateFilesStream.Response.
@@ -386,14 +386,14 @@ export declare namespace GenerateAIMetadata {
 }
 
 /**
- * POST /upload/unstable/generate-ai-metadata - Generate AI metadata for selected files
+ * POST /upload/actions/generate-ai-metadata-for-files - Generate AI metadata for selected files
  *
  * Synchronous (no job): generates and persists alt text / caption for the given
  * files and reports the outcome per file. Non-images are `skipped`; ids that no
  * longer exist and files whose generation failed are reported as `error` rather
  * than failing the whole request.
  */
-export declare namespace UnstableGenerateAIMetadata {
+export declare namespace GenerateAIMetadataForFiles {
   export type FileStatus = 'success' | 'skipped' | 'error';
 
   export interface FileResult {

--- a/packages/core/upload/shared/contracts/files.ts
+++ b/packages/core/upload/shared/contracts/files.ts
@@ -347,9 +347,9 @@ export declare namespace BulkUpdateFiles {
 }
 
 /**
- * GET /upload/actions/generate-ai-metadata/count - Get count of images without metadata
+ * GET /upload/ai-metadata-jobs/pending-count - Get count of images without metadata
  */
-export declare namespace GetAIMetadataCount {
+export declare namespace GetAIMetadataPendingCount {
   export interface Request {
     query: {};
   }
@@ -364,9 +364,9 @@ export declare namespace GetAIMetadataCount {
 }
 
 /**
- * POST /upload/actions/generate-ai-metadata - Start AI metadata generation job
+ * POST /upload/ai-metadata-jobs - Create a backfill job over every image missing metadata
  */
-export declare namespace GenerateAIMetadata {
+export declare namespace CreateAIMetadataJob {
   export interface Request {
     body: {};
   }
@@ -386,14 +386,14 @@ export declare namespace GenerateAIMetadata {
 }
 
 /**
- * POST /upload/actions/generate-ai-metadata-for-files - Generate AI metadata for selected files
+ * POST /upload/actions/generate-ai-metadata - Generate AI metadata for selected files
  *
  * Synchronous (no job): generates and persists alt text / caption for the given
  * files and reports the outcome per file. Non-images are `skipped`; ids that no
  * longer exist and files whose generation failed are reported as `error` rather
  * than failing the whole request.
  */
-export declare namespace GenerateAIMetadataForFiles {
+export declare namespace GenerateAIMetadata {
   export type FileStatus = 'success' | 'skipped' | 'error';
 
   export interface FileResult {

--- a/tests/api/core/upload/admin/file-upload-and-url-import.test.api.js
+++ b/tests/api/core/upload/admin/file-upload-and-url-import.test.api.js
@@ -92,7 +92,7 @@ const makeRawRequest = (strapi, options) => {
   });
 };
 
-describe('Upload SSE Streaming', () => {
+describe('File upload and URL import', () => {
   beforeAll(async () => {
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
@@ -102,12 +102,12 @@ describe('Upload SSE Streaming', () => {
     await strapi.destroy();
   });
 
-  describe('POST /upload/unstable/upload-file - Single file upload', () => {
+  describe('POST /upload/files - Single file upload', () => {
     describe('Authentication', () => {
       test('Rejects unauthenticated requests', async () => {
         const res = await makeRawRequest(strapi, {
           method: 'POST',
-          path: '/upload/unstable/upload-file',
+          path: '/upload/files',
           headers: {},
           formData: true,
         });
@@ -120,7 +120,7 @@ describe('Upload SSE Streaming', () => {
       test('Rejects when no files are provided', async () => {
         const res = await rq({
           method: 'POST',
-          url: '/upload/unstable/upload-file',
+          url: '/upload/files',
           formData: {},
         });
 
@@ -132,7 +132,7 @@ describe('Upload SSE Streaming', () => {
       test('Uploads a single file and returns the created File', async () => {
         const res = await rq({
           method: 'POST',
-          url: '/upload/unstable/upload-file',
+          url: '/upload/files',
           formData: {
             files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
           },
@@ -154,7 +154,7 @@ describe('Upload SSE Streaming', () => {
 
         const res = await rq({
           method: 'POST',
-          url: '/upload/unstable/upload-file',
+          url: '/upload/files',
           formData: {
             files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
             fileInfo: JSON.stringify(fileInfo),
@@ -178,7 +178,7 @@ describe('Upload SSE Streaming', () => {
 
         const res = await rq({
           method: 'POST',
-          url: '/upload/unstable/upload-file',
+          url: '/upload/files',
           formData: {
             files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
           },
@@ -189,12 +189,12 @@ describe('Upload SSE Streaming', () => {
     });
   });
 
-  describe('POST /upload/unstable/stream-from-urls - URL import', () => {
+  describe('POST /upload/actions/upload-from-urls - URL import', () => {
     describe('Authentication', () => {
       test('Rejects unauthenticated requests', async () => {
         const res = await makeRawRequest(strapi, {
           method: 'POST',
-          path: '/upload/unstable/stream-from-urls',
+          path: '/upload/actions/upload-from-urls',
           headers: {},
           body: { urls: ['https://example.com/image.jpg'] },
         });
@@ -207,7 +207,7 @@ describe('Upload SSE Streaming', () => {
       test('Rejects when no URLs are provided', async () => {
         const res = await rq({
           method: 'POST',
-          url: '/upload/unstable/stream-from-urls',
+          url: '/upload/actions/upload-from-urls',
           body: {},
         });
 
@@ -217,7 +217,7 @@ describe('Upload SSE Streaming', () => {
       test('Rejects when URLs is empty array', async () => {
         const res = await rq({
           method: 'POST',
-          url: '/upload/unstable/stream-from-urls',
+          url: '/upload/actions/upload-from-urls',
           body: { urls: [] },
         });
 
@@ -227,7 +227,7 @@ describe('Upload SSE Streaming', () => {
       test('Rejects when URLs is not an array', async () => {
         const res = await rq({
           method: 'POST',
-          url: '/upload/unstable/stream-from-urls',
+          url: '/upload/actions/upload-from-urls',
           body: { urls: 'https://example.com/image.jpg' },
         });
 
@@ -239,7 +239,7 @@ describe('Upload SSE Streaming', () => {
 
         const res = await rq({
           method: 'POST',
-          url: '/upload/unstable/stream-from-urls',
+          url: '/upload/actions/upload-from-urls',
           body: { urls },
         });
 
@@ -273,7 +273,7 @@ describe('Upload SSE Streaming', () => {
           async () => {
             const res = await makeRawRequest(strapi, {
               method: 'POST',
-              path: '/upload/unstable/stream-from-urls',
+              path: '/upload/actions/upload-from-urls',
               headers: {
                 Authorization: `Bearer ${authToken}`,
                 'Content-Type': 'application/json',
@@ -305,7 +305,7 @@ describe('Upload SSE Streaming', () => {
 
         const res = await makeRawRequest(strapi, {
           method: 'POST',
-          path: '/upload/unstable/stream-from-urls',
+          path: '/upload/actions/upload-from-urls',
           headers: {
             Authorization: `Bearer ${authToken}`,
             'Content-Type': 'application/json',
@@ -337,7 +337,7 @@ describe('Upload SSE Streaming', () => {
           async () => {
             const res = await makeRawRequest(strapi, {
               method: 'POST',
-              path: '/upload/unstable/stream-from-urls',
+              path: '/upload/actions/upload-from-urls',
               headers: {
                 Authorization: `Bearer ${authToken}`,
                 'Content-Type': 'application/json',
@@ -386,7 +386,7 @@ describe('Upload SSE Streaming', () => {
           async () => {
             const res = await makeRawRequest(strapi, {
               method: 'POST',
-              path: '/upload/unstable/stream-from-urls',
+              path: '/upload/actions/upload-from-urls',
               headers: {
                 Authorization: `Bearer ${authToken}`,
                 'Content-Type': 'application/json',
@@ -418,7 +418,7 @@ describe('Upload SSE Streaming', () => {
           async () => {
             const res = await makeRawRequest(strapi, {
               method: 'POST',
-              path: '/upload/unstable/stream-from-urls',
+              path: '/upload/actions/upload-from-urls',
               headers: {
                 Authorization: `Bearer ${authToken}`,
                 'Content-Type': 'application/json',
@@ -481,7 +481,7 @@ describe('Upload SSE Streaming', () => {
           async () => {
             const res = await makeRawRequest(strapi, {
               method: 'POST',
-              path: '/upload/unstable/stream-from-urls',
+              path: '/upload/actions/upload-from-urls',
               headers: {
                 Authorization: `Bearer ${authToken}`,
                 'Content-Type': 'application/json',
@@ -532,7 +532,7 @@ describe('Upload SSE Streaming', () => {
           async () => {
             const res = await makeRawRequest(strapi, {
               method: 'POST',
-              path: '/upload/unstable/stream-from-urls',
+              path: '/upload/actions/upload-from-urls',
               headers: {
                 Authorization: `Bearer ${authToken}`,
                 'Content-Type': 'application/json',

--- a/tests/api/core/upload/admin/file-upload-and-url-import.test.api.js
+++ b/tests/api/core/upload/admin/file-upload-and-url-import.test.api.js
@@ -555,4 +555,107 @@ describe('File upload and URL import', () => {
       });
     });
   });
+
+  describe('PUT /upload/files/:id - Update file info', () => {
+    let fileId;
+
+    beforeAll(async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/upload/files',
+        formData: {
+          files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+        },
+      });
+      fileId = res.body.id;
+    });
+
+    test('Updates the editable metadata of a file', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: `/upload/files/${fileId}`,
+        formData: {
+          fileInfo: JSON.stringify({
+            name: 'renamed',
+            caption: 'Updated caption',
+            alternativeText: 'Updated alt text',
+          }),
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.id).toBe(fileId);
+      expect(res.body.caption).toBe('Updated caption');
+      expect(res.body.alternativeText).toBe('Updated alt text');
+    });
+
+    test('Returns 404 for an unknown file id', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/upload/files/999999',
+        formData: {
+          fileInfo: JSON.stringify({ caption: 'nope' }),
+        },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('POST /upload/files/:id/replace - Replace file', () => {
+    let fileId;
+
+    beforeAll(async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/upload/files',
+        formData: {
+          files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+        },
+      });
+      fileId = res.body.id;
+    });
+
+    test('Replaces the binary content of a file, keeping its id', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: `/upload/files/${fileId}/replace`,
+        formData: {
+          files: fs.createReadStream(path.join(__dirname, '../utils/strapi.jpg')),
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.id).toBe(fileId);
+      expect(res.body.name).toBe('strapi.jpg');
+    });
+
+    test('Rejects replacing with multiple files', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: `/upload/files/${fileId}/replace`,
+        formData: {
+          files: [
+            fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+            fs.createReadStream(path.join(__dirname, '../utils/strapi.jpg')),
+          ],
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error.message).toBe('Cannot replace a file with multiple ones');
+    });
+
+    test('Returns 404 for an unknown file id', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/upload/files/999999/replace',
+        formData: {
+          files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+        },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
 });

--- a/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
@@ -262,8 +262,8 @@ exports[`routes:list should output list of routes 1`] = `
 │ PUT                │ /upload/settings                                                                │
 │ POST               │ /upload                                                                         │
 │ POST               │ /upload/actions/upload-from-urls                                                │
-│ POST               │ /upload/files                                                                   │
 │ HEAD|GET           │ /upload/files                                                                   │
+│ POST               │ /upload/files                                                                   │
 │ HEAD|GET           │ /upload/files/:id                                                               │
 │ PUT                │ /upload/files/:id                                                               │
 │ POST               │ /upload/files/:id/replace                                                       │
@@ -277,9 +277,9 @@ exports[`routes:list should output list of routes 1`] = `
 │ POST               │ /upload/actions/bulk-move                                                       │
 │ POST               │ /upload/actions/bulk-update                                                     │
 │ POST               │ /upload/actions/generate-ai-metadata                                            │
-│ HEAD|GET           │ /upload/actions/generate-ai-metadata/count                                      │
-│ HEAD|GET           │ /upload/actions/generate-ai-metadata/latest                                     │
-│ POST               │ /upload/actions/generate-ai-metadata-for-files                                  │
+│ POST               │ /upload/ai-metadata-jobs                                                        │
+│ HEAD|GET           │ /upload/ai-metadata-jobs/latest                                                 │
+│ HEAD|GET           │ /upload/ai-metadata-jobs/pending-count                                          │
 │ HEAD|GET           │ /upload/configuration                                                           │
 │ PUT                │ /upload/configuration                                                           │
 │ HEAD|GET           │ /i18n/iso-locales                                                               │

--- a/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
@@ -261,10 +261,12 @@ exports[`routes:list should output list of routes 1`] = `
 │ HEAD|GET           │ /upload/settings                                                                │
 │ PUT                │ /upload/settings                                                                │
 │ POST               │ /upload                                                                         │
-│ POST               │ /upload/unstable/upload-file                                                    │
-│ POST               │ /upload/unstable/stream-from-urls                                               │
+│ POST               │ /upload/actions/upload-from-urls                                                │
+│ POST               │ /upload/files                                                                   │
 │ HEAD|GET           │ /upload/files                                                                   │
 │ HEAD|GET           │ /upload/files/:id                                                               │
+│ PUT                │ /upload/files/:id                                                               │
+│ POST               │ /upload/files/:id/replace                                                       │
 │ DELETE             │ /upload/files/:id                                                               │
 │ HEAD|GET           │ /upload/folders/:id                                                             │
 │ HEAD|GET           │ /upload/folders                                                                 │
@@ -277,7 +279,7 @@ exports[`routes:list should output list of routes 1`] = `
 │ POST               │ /upload/actions/generate-ai-metadata                                            │
 │ HEAD|GET           │ /upload/actions/generate-ai-metadata/count                                      │
 │ HEAD|GET           │ /upload/actions/generate-ai-metadata/latest                                     │
-│ POST               │ /upload/unstable/generate-ai-metadata                                           │
+│ POST               │ /upload/actions/generate-ai-metadata-for-files                                  │
 │ HEAD|GET           │ /upload/configuration                                                           │
 │ PUT                │ /upload/configuration                                                           │
 │ HEAD|GET           │ /i18n/iso-locales                                                               │


### PR DESCRIPTION
### What does it do?

Gives the new media library's admin endpoints the names they will keep, and splits file update and replace out of the `POST /upload` multiplexer.

Renames:

- `POST /upload/unstable/upload-file` → `POST /upload/files`
- `POST /upload/unstable/stream-from-urls` → `POST /upload/actions/upload-from-urls`
- `POST /upload/unstable/generate-ai-metadata` → `POST /upload/actions/generate-ai-metadata`

`/files` completes the collection that already had `GET /files` and `GET|DELETE /files/:id`. The other two are SSE/batch verbs rather than CRUD, so they join the existing `/actions/*` bucket.

New routes:

- `PUT /upload/files/:id` → `admin-upload.updateFileInfo`
- `POST /upload/files/:id/replace` → `admin-upload.replaceFile`

Both handlers already existed but were only reachable through `POST /upload`, which inspects the request and dispatches to update, replace, or bulk upload depending on whether a `files` part and an `?id=` query param are present. The new media library now calls the dedicated routes.

Controllers and shared contract namespaces follow the routes: `unstable_uploadFile` → `uploadFile`, `unstable_uploadFromUrls` → `uploadFromUrls`, `unstable_generateAIMetadata` → `generateAIMetadataForFiles`, `UnstableCreateFile` → `UploadFile`, `UnstableGenerateAIMetadata` → `GenerateAIMetadataForFiles`. `UploadFile` rather than `CreateFile` because that namespace is already taken by the legacy `POST /upload` and is still imported by `hooks/useUpload.ts`.

`POST /upload` itself is untouched. It stays load-bearing for the legacy media library and the content-manager media field picker in every install.

One thing to know when reviewing: the multiplexer delegates by calling `this.updateFileInfo(ctx)` / `this.replaceFile(ctx)` with the *same* ctx, which carries the id in `ctx.query`, while the new routes deliver it in `ctx.params`. Both handlers therefore read `ctx.params?.id ?? ctx.query.id` — swapping query for params outright would have broken the legacy path. The existing `typeof id !== 'string'` guard still rejects a missing id and a repeated query param (which arrives as an array).

Beyond the ticket: the two AI-metadata endpoints are deliberately **not** merged. The job endpoint returns a job, the synchronous one returns per-file results; merging them would mean a permanent union response type.

They are, however, renamed so the split is readable from the route alone (thanks @Adzouz). `-for-files` distinguished nothing — both generate metadata for files — so the job family becomes a resource and the synchronous call takes the plain action name:

- `POST /upload/actions/generate-ai-metadata/count` → `GET /upload/ai-metadata-jobs/pending-count`
- `POST /upload/actions/generate-ai-metadata` (job) → `POST /upload/ai-metadata-jobs`
- `GET /upload/actions/generate-ai-metadata/latest` → `GET /upload/ai-metadata-jobs/latest`
- `POST /upload/actions/generate-ai-metadata-for-files` → `POST /upload/actions/generate-ai-metadata`

This gives a future `GET /ai-metadata-jobs/:jobId` somewhere to live and stops `count`/`latest` hanging off a verb path. Handlers and contract namespaces follow the routes. These three job endpoints are outside CMS-1581's original scope — they already existed under those names — but this is the PR that freezes the naming, so they are corrected here rather than left to a breaking change later. Both are consumed only by the legacy Settings page, which moves with them.

### Why is it needed?

The three endpoints shipped behind an `/unstable/` prefix while their shape settled. It is settled, so they need their final names before the beta media library is exposed more widely — renaming later means breaking anyone who has started calling them.

Updating an asset's metadata and replacing its binary are also ordinary operations that had no route of their own. They went through a heavily overloaded endpoint that the legacy UI and the content-manager picker also depend on, which makes both harder to reason about and to change.

### How to test it?

Environment: `examples/getstarted`, `BETA_MEDIA_LIBRARY=true yarn develop`.

New media library (flag on) — watch the server log to confirm the route each action hits:

1. Upload one file, then several at once → one `POST /upload/files` per file.
2. New → File upload from URL, paste an image URL → `POST /upload/actions/upload-from-urls`, per-file progress streams in.
3. Open an asset, edit caption/alt text, Save → `PUT /upload/files/:id`.
4. In the same drawer change **Location** to another folder, Save → `PUT /upload/files/:id`, and the folder header count updates.
5. Replace this file → pick a different image → `POST /upload/files/:id/replace`; the asset keeps its id, the content/size/dimensions change.
6. Select images → Create metadata (needs a license and Settings → Media Library → AI metadata on) → `POST /upload/actions/generate-ai-metadata`. Files that already have alt text keep it.

Legacy path (flag off, `BETA_MEDIA_LIBRARY=false`) — this is the regression risk, since the dual-read change sits in the multiplexer's code path:

7. Media Library → open an asset → edit alt text → Finish → `POST /upload?id=<id>`, change persists.
8. Same modal → Replace Media → pick a file → Finish → `POST /upload?id=<id>`, same asset id, new content.
9. Content-Manager → Article → a media field → Add more assets → upload → `POST /upload`, field populates.

Settings → Media Library, with a license and AI metadata on — the only consumer of the renamed job endpoints, and the second regression risk:

10. Load the page with images missing metadata → `GET /upload/ai-metadata-jobs/pending-count`, the count renders.
11. Generate metadata → Confirm → `POST /upload/ai-metadata-jobs`, the page switches to "AI is generating your metadata".
12. Reload mid-run → `GET /upload/ai-metadata-jobs/latest`, progress is picked back up rather than reset.

Automated, in addition to the manual steps:

```bash
yarn nx test:unit @strapi/upload
yarn nx test:front @strapi/upload
yarn test:generate-app && yarn test:api core/upload
yarn test:cli routes-list
```

### Recommended release note

⚠️ **Breaking (admin API):** three AI-metadata endpoints that shipped in 5.51.x have changed. There are no aliases on the old paths.

| Old (5.51.x) | New | Effect on a 5.51.x client |
| --- | --- | --- |
| `GET /upload/actions/generate-ai-metadata/count` | `GET /upload/ai-metadata-jobs/pending-count` | 404 |
| `GET /upload/actions/generate-ai-metadata/latest` | `GET /upload/ai-metadata-jobs/latest` | 404 |
| `POST /upload/actions/generate-ai-metadata` | `POST /upload/ai-metadata-jobs` | **path still exists, different behaviour** |

The last row needs care. In 5.51.x, `POST /upload/actions/generate-ai-metadata` started a backfill job over every image missing metadata and returned a `jobId`. That path still exists, but it now runs the **synchronous** generator over an explicit selection: it requires a `fileIds` array in the body and returns per-file results. A client that posts an empty body to start a backfill no longer gets a job — it gets a validation error. To keep the old behaviour, move that call to `POST /upload/ai-metadata-jobs`.

Response shapes for the two `GET` endpoints are unchanged; only their paths move.

All three are admin-only and require the AI-metadata service to be enabled. In-product they are called solely by Settings → Media Library, which moves with them — so an upgrade needs no action unless you call these paths from your own tooling.

### Related issue(s)/PR(s)

fix CMS-1581

Follows #27278 (now merged) — this PR targets `develop` directly.




