### PR TITLE
fix(admin): render enumeration placeholder once instead of twice

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Enumeration.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Enumeration.tsx
@@ -9,7 +9,7 @@ import { useField } from '../Form';
 import { EnumerationProps } from './types';
 
 const EnumerationInput = forwardRef<HTMLDivElement, EnumerationProps>(
-  ({ name, required, label, hint, labelAction, options = [], ...props }, ref) => {
+  ({ name, required, label, hint, labelAction, options = [], placeholder, ...props }, ref) => {
     const { formatMessage } = useIntl();
     const field = useField<string | number | null>(name);
     const fieldRef = useFocusInputField<HTMLDivElement>(name);
@@ -27,11 +27,17 @@ const EnumerationInput = forwardRef<HTMLDivElement, EnumerationProps>(
           value={field.value}
           {...props}
         >
+          {/**
+           * The empty option is selected whenever the field has no value, so the select already
+           * renders its label in the trigger. Forwarding `placeholder` to the select as well would
+           * render both strings side by side, so it is used as this option's label instead.
+           */}
           <SingleSelectOption value="" disabled={required} hidden={required}>
-            {formatMessage({
-              id: 'components.InputSelect.option.placeholder',
-              defaultMessage: 'Choose here',
-            })}
+            {placeholder ??
+              formatMessage({
+                id: 'components.InputSelect.option.placeholder',
+                defaultMessage: 'Choose here',
+              })}
           </SingleSelectOption>
           {options.map(({ value, label, disabled, hidden }) => {
             return (

--- a/packages/core/admin/admin/src/components/FormInputs/tests/Enumeration.test.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/tests/Enumeration.test.tsx
@@ -59,3 +59,53 @@ describe('EnumerationInput (via InputRenderer)', () => {
     expect(screen.getByRole('option', { name: 'evening' })).toBeInTheDocument();
   });
 });
+
+/**
+ * Regression test for https://github.com/strapi/strapi/issues/27283
+ *
+ * The empty option that lets you unset the field is selected while the field has
+ * no value, so the select renders its label in the trigger. Forwarding a
+ * `placeholder` down to the select made it render that too, so both strings
+ * ended up in the trigger ("Choose hereChoose here" on Settings > Single Sign-On).
+ */
+describe('EnumerationInput placeholder', () => {
+  const enumerationField = {
+    label: 'Default role',
+    name: 'defaultRole',
+    type: 'enumeration' as const,
+    required: false,
+    options: [{ value: 'editor', label: 'Editor' }],
+  };
+
+  const renderField = (props: Partial<typeof enumerationField> & { placeholder?: string } = {}) =>
+    render(<InputRenderer {...enumerationField} {...props} />, {
+      renderOptions: {
+        wrapper: ({ children }) => <Form method="POST">{children}</Form>,
+      },
+    });
+
+  it('renders the placeholder exactly once when the field has no value', () => {
+    renderField({ placeholder: 'Choose here' });
+
+    const trigger = screen.getByRole('combobox', { name: 'Default role' });
+
+    expect(trigger.textContent?.match(/Choose here/g)).toHaveLength(1);
+  });
+
+  it('uses the placeholder as the label of the empty option', async () => {
+    const { user } = renderField({ placeholder: 'Pick a role' });
+
+    await user.click(screen.getByRole('combobox', { name: 'Default role' }));
+
+    expect(await screen.findByRole('option', { name: 'Pick a role' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Choose here' })).not.toBeInTheDocument();
+  });
+
+  it('falls back to the default placeholder when none is provided', () => {
+    renderField();
+
+    const trigger = screen.getByRole('combobox', { name: 'Default role' });
+
+    expect(trigger.textContent?.match(/Choose here/g)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
### What does it do?

`EnumerationInput` renders an empty `<SingleSelectOption value="">` so the field can be unset. That option is selected whenever the field has no value, and the design system portals the selected option's label into the select trigger. The component also spread its `placeholder` prop straight onto `SingleSelect`, and the underlying `Select.Value` renders the placeholder when the value is empty. Both strings therefore rendered into the same trigger node at the same time.

This PR stops forwarding `placeholder` to `SingleSelect` and uses it as the label of the empty option instead, falling back to the existing `components.InputSelect.option.placeholder` translation. There is now a single source of truth for that text, so it renders once.

Added regression tests in `Enumeration.test.tsx` covering the duplication, the placeholder being used as the empty option label, and the fallback when no placeholder is passed.

### Why is it needed?

Settings > Single Sign-On passes "Choose here" as the placeholder for the Default role field, and the empty option fell back to the same string, so the field read "Choose hereChoose here" whenever no default role was set.

The same duplication applied to every `enumeration` field that passes a placeholder, for example the Interface language and Interface mode fields on the Profile page and the filter select in the Filters popover. It was only visible while the field had no value, which is why Single Sign-On surfaced it first.

### How to test it?

1. Run an instance with an EE license (Launchpad or `examples/getstarted`).
2. Go to Settings > Single Sign-On with no default role set.
3. The Default role field shows "Choose here" once.
4. Check Settings > Profile too, where Interface language and Interface mode pass their own placeholder.

Unit tests:

```
yarn nx run @strapi/admin:test:front -- src/components/FormInputs/tests/Enumeration.test.tsx
```

Before the fix the trigger's text content was `["Choose here", "Choose here"]`.

### Related issue(s)/PR(s)

Fix strapi/strapi#27283