### PR TITLE
fix(types): allow undefined on optional document input properties

### DIFF
--- a/packages/core/core/src/services/document-service/attributes/index.ts
+++ b/packages/core/core/src/services/document-service/attributes/index.ts
@@ -8,6 +8,11 @@ import transforms from './transforms';
 type Data = Modules.Documents.Params.Data.Input<UID.Schema>;
 
 const applyTransforms = curry((schema: Schema.Schema, data: Data) => {
+  // NOTE: this iterates the *data* keys, so unlike the rest of the write path it does visit keys
+  // that were passed explicitly as `undefined`. The input types deliberately allow that
+  // (`{ foo: undefined }` must behave like `{}` — see `processData` in `@strapi/database`), so
+  // every transform registered below has to leave a non-matching value untouched rather than
+  // assume a present key holds a value.
   const attributeNames = Object.keys(data) as Array<keyof typeof data & string>;
 
   for (const attributeName of attributeNames) {

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -52,7 +52,7 @@
     "doc:ts": "typedoc",
     "doc:ts:watch": "typedoc --watch",
     "lint": "run -T eslint . --max-warnings=0",
-    "test:ts": "run -T tsc -p tsconfig.json",
+    "test:ts": "run -T tsc -p tsconfig.json && run -T tsc -p tests/tsconfig.json",
     "watch": "run -T tsc -p tsconfig.build.json -w"
   },
   "dependencies": {

--- a/packages/core/types/src/modules/documents/params/attributes/index.ts
+++ b/packages/core/types/src/modules/documents/params/attributes/index.ts
@@ -74,16 +74,27 @@ export type ScalarValues = GetValue<
 
 /**
  * Attribute.GetValues override with extended values
+ *
+ * @remark
+ * Optional properties explicitly allow `undefined` so that the type stays usable under
+ * `exactOptionalPropertyTypes`. This mirrors the runtime, which does not distinguish an absent key
+ * from an explicitly `undefined` one: the database layer iterates the schema attributes and skips
+ * any value failing `isUndefined` (see `processData` in `@strapi/database`), so `{}` and
+ * `{ foo: undefined }` produce the exact same query.
+ *
+ * Note that `null` is *not* equivalent: it means "write NULL" and must keep being spelled out.
+ *
+ * The required branch below (`-?`) is intentionally left alone.
  */
 export type GetValues<TSchemaUID extends UID.Schema> = {
-  id?: ID;
-  documentId?: DocumentID;
+  id?: ID | undefined;
+  documentId?: DocumentID | undefined;
 } & OmitRelationsWithoutTarget<
   TSchemaUID,
   {
-    [TKey in Schema.OptionalAttributeNames<TSchemaUID>]?: GetValue<
-      Schema.AttributeByName<TSchemaUID, TKey>
-    >;
+    [TKey in Schema.OptionalAttributeNames<TSchemaUID>]?:
+      | GetValue<Schema.AttributeByName<TSchemaUID, TKey>>
+      | undefined;
   } & {
     [TKey in Schema.RequiredAttributeNames<TSchemaUID>]-?: GetValue<
       Schema.AttributeByName<TSchemaUID, TKey>

--- a/packages/core/types/src/modules/documents/params/attributes/relations.ts
+++ b/packages/core/types/src/modules/documents/params/attributes/relations.ts
@@ -1,30 +1,30 @@
 import type * as Schema from '../../../../schema';
 
 import type * as UID from '../../../../uid';
-import type { If } from '../../../../utils';
+import type { If, Object } from '../../../../utils';
 
 import type { ID, DocumentID } from './id';
 
 type ShortHand = ID;
 type LongHandEntity = { id: ID };
-type LongHandDocument = { documentId: DocumentID; locale?: string };
+type LongHandDocument = { documentId: DocumentID; locale?: string | undefined };
 type LongHand = LongHandEntity | LongHandDocument;
 
 interface PositionalArguments {
-  before?: ID;
-  after?: ID;
-  start?: boolean;
-  end?: boolean;
+  before?: ID | undefined;
+  after?: ID | undefined;
+  start?: boolean | undefined;
+  end?: boolean | undefined;
 }
 
-type WithPositionArguments<T> = T & { position?: PositionalArguments };
+type WithPositionArguments<T> = T & { position?: PositionalArguments | undefined };
 
 type Set = { set: ShortHand[] | LongHand[] | null };
 type Connect = { connect: ShortHand[] | WithPositionArguments<LongHand>[] };
 type Disconnect = { disconnect: ShortHand[] | LongHand[] };
 
 type FullUpdate = Set;
-type PartialUpdate = Partial<Connect & Disconnect>;
+type PartialUpdate = Object.PartialWithUndefined<Connect & Disconnect>;
 
 type XOneInput = ShortHand | LongHand | null;
 type XManyInput = ShortHand[] | LongHand[] | null | PartialUpdate | FullUpdate;

--- a/packages/core/types/src/modules/documents/params/data.ts
+++ b/packages/core/types/src/modules/documents/params/data.ts
@@ -67,6 +67,6 @@ export type Input<TSchemaUID extends UID.Schema> = AttributeUtils.GetValues<TSch
  */
 export type PartialInput<TSchemaUID extends UID.Schema> = Utils.If<
   Utils.Constants.AreSchemaRegistriesExtended,
-  Partial<Input<TSchemaUID>>,
+  Utils.Object.PartialWithUndefined<Input<TSchemaUID>>,
   Input<TSchemaUID>
 >;

--- a/packages/core/types/src/modules/documents/params/index.ts
+++ b/packages/core/types/src/modules/documents/params/index.ts
@@ -1,5 +1,5 @@
 import type * as UID from '../../../uid';
-import { Extends, MatchAllIntersect } from '../../../utils';
+import { Extends, MatchAllIntersect, Object } from '../../../utils';
 
 import type { GetPluginParams } from '..';
 
@@ -17,24 +17,39 @@ import type * as Locale from './locale';
 // Utils
 import type * as Attribute from './attributes';
 
+/**
+ * @remark
+ * Every optional param below explicitly allows `undefined` so that callers compiling with
+ * `exactOptionalPropertyTypes` can forward their own optional values (`{ populate: maybePopulate }`)
+ * without having to conditionally spread each key. This is a no-op when the flag is off.
+ */
 export type Pick<TSchemaUID extends UID.Schema, TKind extends Kind> = MatchAllIntersect<
   [
     // Sort
-    [HasMember<TKind, 'sort'>, { sort?: Sort.Any<TSchemaUID> }],
-    [HasMember<TKind, 'sort:string'>, { sort?: Sort.StringNotation<TSchemaUID> }],
-    [HasMember<TKind, 'sort:array'>, { sort?: Sort.ArrayNotation<TSchemaUID> }],
-    [HasMember<TKind, 'sort:object'>, { sort?: Sort.ObjectNotation<TSchemaUID> }],
+    [HasMember<TKind, 'sort'>, { sort?: Sort.Any<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'sort:string'>, { sort?: Sort.StringNotation<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'sort:array'>, { sort?: Sort.ArrayNotation<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'sort:object'>, { sort?: Sort.ObjectNotation<TSchemaUID> | undefined }],
     // Fields
-    [HasMember<TKind, 'fields'>, { fields?: Fields.Any<TSchemaUID> }],
-    [HasMember<TKind, 'fields:string'>, { fields?: Fields.StringNotation<TSchemaUID> }],
-    [HasMember<TKind, 'fields:array'>, { fields?: Fields.ArrayNotation<TSchemaUID> }],
+    [HasMember<TKind, 'fields'>, { fields?: Fields.Any<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'fields:string'>, { fields?: Fields.StringNotation<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'fields:array'>, { fields?: Fields.ArrayNotation<TSchemaUID> | undefined }],
     // Filters
-    [HasMember<TKind, 'filters'>, { filters?: Filters.Any<TSchemaUID> }],
+    [HasMember<TKind, 'filters'>, { filters?: Filters.Any<TSchemaUID> | undefined }],
     // Populate
-    [HasMember<TKind, 'populate'>, { populate?: Populate.Any<TSchemaUID> }],
-    [HasMember<TKind, 'populate:string'>, { populate?: Populate.StringNotation<TSchemaUID> }],
-    [HasMember<TKind, 'populate:array'>, { populate?: Populate.ArrayNotation<TSchemaUID> }],
-    [HasMember<TKind, 'populate:object'>, { populate?: Populate.ObjectNotation<TSchemaUID> }],
+    [HasMember<TKind, 'populate'>, { populate?: Populate.Any<TSchemaUID> | undefined }],
+    [
+      HasMember<TKind, 'populate:string'>,
+      { populate?: Populate.StringNotation<TSchemaUID> | undefined },
+    ],
+    [
+      HasMember<TKind, 'populate:array'>,
+      { populate?: Populate.ArrayNotation<TSchemaUID> | undefined },
+    ],
+    [
+      HasMember<TKind, 'populate:object'>,
+      { populate?: Populate.ObjectNotation<TSchemaUID> | undefined },
+    ],
     // Pagination
     [HasMember<TKind, 'pagination'>, Pagination.Any],
     [HasMember<TKind, 'pagination:offset'>, Pagination.OffsetNotation],
@@ -45,18 +60,21 @@ export type Pick<TSchemaUID extends UID.Schema, TKind extends Kind> = MatchAllIn
     [HasMember<TKind, 'hasPublishedVersion'>, PublicationStatus.Param],
     [HasMember<TKind, 'publicationFilter'>, PublicationStatus.PublicationFilterParam],
     // Locale
-    [HasMember<TKind, 'locale'>, { locale?: Locale.Any }],
-    [HasMember<TKind, 'locale:string'>, { locale?: Locale.StringNotation }],
-    [HasMember<TKind, 'locale:array'>, { locale?: Locale.ArrayNotation }],
+    [HasMember<TKind, 'locale'>, { locale?: Locale.Any | undefined }],
+    [HasMember<TKind, 'locale:string'>, { locale?: Locale.StringNotation | undefined }],
+    [HasMember<TKind, 'locale:array'>, { locale?: Locale.ArrayNotation | undefined }],
     // Plugin
     [HasMember<TKind, 'plugin'>, GetPluginParams<TSchemaUID>],
     // Data
-    [HasMember<TKind, 'data'>, { data?: Data.Input<TSchemaUID> }],
-    [HasMember<TKind, 'data:partial'>, { data?: Partial<Data.Input<TSchemaUID>> }],
+    [HasMember<TKind, 'data'>, { data?: Data.Input<TSchemaUID> | undefined }],
+    [
+      HasMember<TKind, 'data:partial'>,
+      { data?: Object.PartialWithUndefined<Data.Input<TSchemaUID>> | undefined },
+    ],
     // Search
-    [HasMember<TKind, '_q'>, { _q?: Search.Q }],
+    [HasMember<TKind, '_q'>, { _q?: Search.Q | undefined }],
     // Look Up - For internal use only
-    [HasMember<TKind, 'lookup'>, { lookup?: Record<string, unknown> }],
+    [HasMember<TKind, 'lookup'>, { lookup?: Record<string, unknown> | undefined }],
   ]
 >;
 

--- a/packages/core/types/src/modules/documents/params/pagination.ts
+++ b/packages/core/types/src/modules/documents/params/pagination.ts
@@ -1,13 +1,13 @@
 import type { XOR } from '../../../utils';
 
 export type PageNotation = {
-  page?: number;
-  pageSize?: number;
+  page?: number | undefined;
+  pageSize?: number | undefined;
 };
 
 export type OffsetNotation = {
-  start?: number;
-  limit?: number;
+  start?: number | undefined;
+  limit?: number | undefined;
 };
 
 export type Any = XOR<PageNotation, OffsetNotation>;

--- a/packages/core/types/src/modules/documents/params/status.ts
+++ b/packages/core/types/src/modules/documents/params/status.ts
@@ -5,9 +5,9 @@ export type Kind = 'draft' | 'published';
 export type { PublicationFilterMode };
 
 export type Param = {
-  status?: Kind;
+  status?: Kind | undefined;
   /** @deprecated Use `publicationFilter` instead (`never-published`, `has-published-version`, …). */
-  hasPublishedVersion?: boolean;
+  hasPublishedVersion?: boolean | undefined;
 };
 
-export type PublicationFilterParam = { publicationFilter?: PublicationFilterMode };
+export type PublicationFilterParam = { publicationFilter?: PublicationFilterMode | undefined };

--- a/packages/core/types/src/utils/object.ts
+++ b/packages/core/types/src/utils/object.ts
@@ -99,6 +99,34 @@ export type PartialBy<TValue, TKeys extends keyof TValue> = Omit<TValue, TKeys> 
   Partial<Pick<TValue, TKeys>>;
 
 /**
+ * Same as the built-in `Partial<TValue>`, but also adds `undefined` to every property type.
+ *
+ * @template TValue The original object type.
+ *
+ * @remark
+ * The built-in `Partial` only adds the `?` modifier; it does not add `undefined` to the property
+ * type. Under `exactOptionalPropertyTypes`, `{ foo?: string }` rejects `{ foo: undefined }`, so
+ * `Partial` alone is not enough to describe an input object whose properties may be explicitly set
+ * to `undefined`.
+ *
+ * Use this helper for **input** types where an absent property and an explicitly `undefined` one are
+ * handled identically at runtime. It is a no-op when `exactOptionalPropertyTypes` is disabled.
+ *
+ * @example
+ * ```typescript
+ * type Person = { name: string; age: number };
+ *
+ * declare const age: number | undefined;
+ *
+ * const a: Partial<Person> = { age };              // error under exactOptionalPropertyTypes
+ * const b: PartialWithUndefined<Person> = { age }; // ok
+ * ```
+ */
+export type PartialWithUndefined<TValue> = {
+  [TKey in keyof TValue]?: TValue[TKey] | undefined;
+};
+
+/**
  * Extracts all unique values from a given object as a union type.
  *
  * @template TObject - An object from which values are to be extracted. It must extend the `object` type.

--- a/packages/core/types/tests/exact-optional-property-types.ts
+++ b/packages/core/types/tests/exact-optional-property-types.ts
@@ -1,0 +1,250 @@
+/**
+ * Type-level fixture compiled with `exactOptionalPropertyTypes: true`.
+ *
+ * The repository default is `exactOptionalPropertyTypes: false`, under which `p?: T` and
+ * `p?: T | undefined` are indistinguishable — meaning the regression this file guards against is
+ * invisible in the regular `test:ts` program. It therefore has its own tsconfig
+ * (`tests/tsconfig.json`) that turns the flag on.
+ *
+ * What it asserts:
+ *
+ *  - optional **input** properties accept an explicit `undefined` (an absent key and an explicitly
+ *    `undefined` one are handled identically by the runtime — `processData` in `@strapi/database`
+ *    iterates the schema attributes and skips anything failing `isUndefined`);
+ *  - `null` keeps meaning "write NULL" and is still rejected where the schema does not allow it;
+ *  - required attributes are still required, and still reject `undefined`.
+ *
+ * This file is type-checked only; nothing is executed.
+ */
+
+/* eslint-disable no-void -- `void` marks the calls as type-checked-only, never awaited */
+
+import type { Modules, Schema, Struct } from '../src';
+
+/* -------------------------------------------------------------------------------------------------
+ * Fixture schemas
+ * ---------------------------------------------------------------------------------------------- */
+
+interface AddressComponent extends Struct.ComponentSchema {
+  collectionName: 'components_default_addresses';
+  category: 'default';
+  info: { displayName: 'Address' };
+  attributes: {
+    street: Schema.Attribute.String & Schema.Attribute.Required;
+    zipCode: Schema.Attribute.String;
+  };
+}
+
+interface Organization extends Struct.CollectionTypeSchema {
+  collectionName: 'organizations';
+  info: { singularName: 'organization'; pluralName: 'organizations'; displayName: 'Organization' };
+  attributes: {
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
+interface Invoice extends Struct.CollectionTypeSchema {
+  collectionName: 'invoices';
+  info: { singularName: 'invoice'; pluralName: 'invoices'; displayName: 'Invoice' };
+  attributes: {
+    // Required scalar
+    amount: Schema.Attribute.Decimal & Schema.Attribute.Required;
+    // Optional scalars
+    description: Schema.Attribute.Text;
+    issuedByUserId: Schema.Attribute.Integer;
+    // Optional xToOne relation
+    organization: Schema.Attribute.Relation<'oneToOne', 'api::organization.organization'>;
+    // Optional component
+    billingAddress: Schema.Attribute.Component<'default.address', false>;
+    // Optional JSON column
+    metadata: Schema.Attribute.JSON;
+  };
+}
+
+declare module '../src/public/registries' {
+  export interface ContentTypeSchemas {
+    'api::invoice.invoice': Invoice;
+    'api::organization.organization': Organization;
+  }
+
+  export interface ComponentSchemas {
+    'default.address': AddressComponent;
+  }
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * The caller's own domain type — the shape that triggered the bug
+ * ---------------------------------------------------------------------------------------------- */
+
+type IssueInvoiceCommand = {
+  organizationDocumentId: string;
+  amount: number;
+  description?: string;
+  issuedByUserId?: number;
+  metadata?: Record<string, string>;
+};
+
+declare const command: IssueInvoiceCommand;
+declare const documents: Modules.Documents.ServiceInstance<'api::invoice.invoice'>;
+
+/* -------------------------------------------------------------------------------------------------
+ * create() — explicit `undefined` on optional properties
+ * ---------------------------------------------------------------------------------------------- */
+
+// Every optional field is forwarded as `T | undefined` straight from the caller's own optional
+// properties, without conditional spreads or an undefined-stripping helper.
+void documents.create({
+  data: {
+    amount: command.amount,
+    description: command.description,
+    issuedByUserId: command.issuedByUserId,
+    metadata: command.metadata,
+    organization: { documentId: command.organizationDocumentId },
+    billingAddress: undefined,
+  },
+});
+
+// Explicit `undefined` on the relation and the component too.
+void documents.create({
+  data: {
+    amount: 1,
+    organization: undefined,
+    billingAddress: undefined,
+    description: undefined,
+    metadata: undefined,
+  },
+});
+
+// `id` / `documentId` are optional input properties as well.
+void documents.create({
+  data: {
+    amount: 1,
+    id: undefined,
+    documentId: undefined,
+  },
+});
+
+// Optional properties of the relation long-hand notation.
+void documents.create({
+  data: {
+    amount: 1,
+    organization: { documentId: 'abc', locale: undefined },
+  },
+});
+
+// Component input reuses the same machinery: optional member accepts `undefined`, required does not.
+void documents.create({
+  data: {
+    amount: 1,
+    billingAddress: { street: 'Main street', zipCode: undefined },
+  },
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * `null` still means "write NULL" and is not interchangeable with `undefined`
+ * ---------------------------------------------------------------------------------------------- */
+
+// Relations explicitly accept `null` (clear the relation).
+void documents.create({
+  data: {
+    amount: 1,
+    organization: null,
+  },
+});
+
+// A nullable JSON column accepts `null`.
+void documents.create({
+  data: {
+    amount: 1,
+    metadata: null,
+  },
+});
+
+// A non-nullable scalar does not silently gain `null` from this change.
+void documents.create({
+  data: {
+    amount: 1,
+    // @ts-expect-error `null` is not a valid value for a text attribute
+    description: null,
+  },
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * Required attributes stay required — the `-?` branch of GetValues is untouched
+ * ---------------------------------------------------------------------------------------------- */
+
+// @ts-expect-error `amount` is required and missing
+void documents.create({ data: { description: 'no amount' } });
+
+void documents.create({
+  data: {
+    // @ts-expect-error `amount` is required and cannot be explicitly undefined
+    amount: undefined,
+  },
+});
+
+void documents.create({
+  data: {
+    amount: 1,
+    // @ts-expect-error `street` is required on the component and cannot be explicitly undefined
+    billingAddress: { street: undefined },
+  },
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * update() — the `data:partial` fragment goes through PartialWithUndefined
+ * ---------------------------------------------------------------------------------------------- */
+
+void documents.update({
+  documentId: 'abc',
+  data: {
+    amount: command.amount,
+    description: command.description,
+    issuedByUserId: command.issuedByUserId,
+    organization: undefined,
+  },
+});
+
+// Every property is optional on update, including the ones that are required on create.
+void documents.update({
+  documentId: 'abc',
+  data: { amount: undefined },
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * Top-level method params — `{ data, populate: maybePopulate }` hits the same wall
+ * ---------------------------------------------------------------------------------------------- */
+
+declare const maybeLocale: string | undefined;
+declare const maybeStatus: 'draft' | 'published' | undefined;
+declare const maybeFields: ['description'] | undefined;
+declare const maybePopulate: ['organization'] | undefined;
+declare const maybeSearch: string | undefined;
+declare const maybeLimit: number | undefined;
+
+void documents.create({
+  data: { amount: 1 },
+  locale: maybeLocale,
+  status: maybeStatus,
+  fields: maybeFields,
+  populate: maybePopulate,
+});
+
+void documents.findMany({
+  locale: maybeLocale,
+  status: maybeStatus,
+  fields: maybeFields,
+  populate: maybePopulate,
+  _q: maybeSearch,
+  limit: maybeLimit,
+  sort: undefined,
+  filters: undefined,
+});
+
+void documents.findOne({
+  documentId: 'abc',
+  locale: maybeLocale,
+  status: maybeStatus,
+  fields: maybeFields,
+  populate: maybePopulate,
+});

--- a/packages/core/types/tests/tsconfig.json
+++ b/packages/core/types/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    // The repository default is `false`. These fixtures exist specifically to guarantee the
+    // published input types stay usable for consumers who turn the flag on.
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["."],
+  "exclude": ["node_modules"]
+}

--- a/packages/core/types/tsconfig.eslint.json
+++ b/packages/core/types/tsconfig.eslint.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
### What does it do?

Adds `| undefined` to the optional properties of the **document service input types**, so that
`@strapi/types` is usable by consumers compiling with
[`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes).

Changed sites, all in `packages/core/types/src/modules/documents/params/`:

- `attributes/index.ts` — `GetValues`: the optional mapped branch, plus `id?` / `documentId?`. The
  required branch (`-?`) is untouched.
- `attributes/relations.ts` — `LongHandDocument.locale?`, `PositionalArguments`,
  `WithPositionArguments`, and `PartialUpdate`.
- `index.ts` — the per-kind param fragments produced by `Params.Pick` (`data?`, `fields?`,
  `filters?`, `populate?`, `sort?`, `locale?`, `_q?`, `lookup?`).
- `status.ts`, `pagination.ts` — the same for `status?` / `hasPublishedVersion?` /
  `publicationFilter?` and the pagination notations.
- `data.ts` — `PartialInput`.

`Partial<T>` adds `?` **without** adding `undefined`, so it does not do what the author expected
under the flag. The two spots that used it to build an input type (`data:partial` in `params/index.ts`
and `PartialInput` in `params/data.ts`, plus `PartialUpdate` in `relations.ts`) now use a new
`Utils.Object.PartialWithUndefined<T>` helper (`packages/core/types/src/utils/object.ts`) rather than
being hand-expanded.

The only non-type edit is a comment in
`packages/core/core/src/services/document-service/attributes/index.ts` — see point 3 of the trace
below. **No runtime behaviour changes.**

### Why is it needed?

A consumer with `exactOptionalPropertyTypes: true` cannot assemble a `data` object out of their own
optional fields:

```ts
type IssueInvoiceCommand = {
  organizationDocumentId: string;
  amount: number;
  description?: string;      // genuinely optional in the caller's domain
  issuedByUserId?: number;
};

await strapi.documents('api::invoice.invoice').create({
  data: {
    amount: command.amount,
    organization: org.id,
    description: command.description,       // string | undefined
    issuedByUser: command.issuedByUserId,   // number | undefined
  },
});
```

```
error TS2375: Type '{ ...; description: string | undefined; issuedByUser: number | undefined; }'
is not assignable to type 'Input<"api::invoice.invoice">' with 'exactOptionalPropertyTypes: true'.
  Types of property 'issuedByUser' are incompatible.
    Type 'number | undefined' is not assignable to type 'XOneInput'.
```

There is no reasonable workaround at the call site. `?? null` works for relations (`XOneInput`
includes `null`) but not for scalars; conditionally spreading each field
(`...(x === undefined ? {} : { x })`) is unreadable once a create has 5–10 optional columns; and the
target type lives in `node_modules`, so it cannot be widened locally. Consumers are currently forced
to route every `data` object through a helper that strips `undefined` keys purely to satisfy the
compiler.

#### The runtime already ignores `undefined`

This is a type bug, not intended strictness — the write path does not distinguish an absent key from
an explicitly-`undefined` one:

1. **`packages/core/core/src/services/entity-validator/index.ts:544`** — `createModelValidator`
   builds the yup schema from the *content type's* attributes and reads each value with
   `prop(attributeName, data)`. Lodash `prop` returns `undefined` for an absent key and for an
   explicit `undefined` alike.

2. **yup's object cast** — reads `value[prop]` and writes the key back only when the cast result
   `!== undefined`. Both inputs take the identical branch.

3. **`packages/core/core/src/services/document-service/attributes/index.ts:11`** — `applyTransforms`
   iterates `Object.keys(data)`, so it is the one place that *visits* an explicit-`undefined` key
   that an absent one would not produce. The transform registry
   (`.../document-service/attributes/transforms.ts:15`) has a single entry (`password`) which returns
   non-strings unchanged, so there is no behavioural difference today. A comment has been added there
   so it stays that way.

4. **Decisive — `packages/core/database/src/entity-manager/index.ts:191-206`, `processData`:**

   ```js
   for (const attributeName of Object.keys(attributes)) {   // schema attributes, not data keys
       if (isUndefined(data[attributeName])) {
           if (!isUndefined(attribute.default) && withDefaults) { obj[attributeName] = ... }
           continue;                                        // column omitted from the INSERT
       }
   ```

   It iterates the **schema**, reads `data[attributeName]`, and branches on `isUndefined`. Relational
   attributes use the same guard (`:227`, `:251`, `:272`). There is no `in` / `hasOwnProperty` check
   anywhere on the path, so the object handed to knex `.insert()` is identical for `{}` and
   `{ description: undefined }`.

The same holds for the top-level params: `transformParamsToQuery`
(`packages/core/utils/src/convert-query-params.ts:787-825`) guards every single param with
`!isNil(...)` before copying it into the query, so `{ populate: undefined }` and `{}` produce the
same query.

**`null` is deliberately not collapsed into this.** `processData` writes it explicitly
(`data[x] === null ? null : field.toDB(...)` at `:216`, plus an "allow setting to null" branch for
relations at `:249`), so `null` still means "write NULL" and `undefined` still means "don't mention
this column". The fixture asserts both directions.

### How to test it?

`packages/core/types/tests/exact-optional-property-types.ts` is a new type-level fixture compiled
**with `exactOptionalPropertyTypes: true`** via its own `tests/tsconfig.json` — the repo default is
`false`, and the regression is invisible without it. It declares a content type with a required
scalar, optional scalars, an optional `xToOne` relation, an optional component and a JSON column, and
asserts:

- `create({ data })` and `update({ data })` accept explicit `undefined` on every optional property,
  including `id` / `documentId`, the relation long-hand `locale`, and optional component members;
- `null` is still accepted where the schema allows it, and still rejected where it does not
  (`@ts-expect-error` on `description: null`);
- required attributes are still required and still reject `undefined` (`@ts-expect-error`), i.e. the
  `-?` branch of `GetValues` is unaffected;
- the top-level params (`locale`, `status`, `fields`, `populate`, `_q`, `limit`, `sort`, `filters`)
  accept `undefined`.

It follows the package's existing harness (`test:ts` = `tsc -p <tsconfig>`); the package script is
now `tsc -p tsconfig.json && tsc -p tests/tsconfig.json`, so it runs as part of `yarn test:ts`.

I verified the fixture fails on `develop` without the type change (8 × `TS2375`/`TS2379`) and passes
with it.

```bash
yarn test:ts     # ✅ 37 projects
yarn test:unit   # ✅
yarn test:front  # ✅
yarn lint && yarn prettier:check   # ✅
```

No existing type test changed behaviour.

#### Backwards compatibility

**Adding `| undefined` to an optional property is a no-op when the flag is off.** Under default
settings TypeScript already implicitly adds `undefined` to every `?` property, so `p?: T` and
`p?: T | undefined` are the same type. Existing users — including everyone in this repo, since
`exactOptionalPropertyTypes` stays **off** in Strapi's own tsconfig — see no change. That is confirmed
by the full type-check above passing unmodified.

#### Deliberately out of scope

- **Result / read types** (`Schema.Attribute.GetValues` and friends). Widening those weakens what
  consumers can assume about rows they read back; that is a separate trade-off and is not bundled in
  here.
- **Enabling `exactOptionalPropertyTypes` in Strapi's own tsconfig.** That is a large independent
  migration. The goal here is only that the *published* types work for consumers who have it on.
- **The nested members of the populate object notation** (`PopulateClause`, `Fragment.on`,
  `CountClause.count`). Unlike the write path, `processPopulate`
  (`packages/core/database/src/query/helpers/populate/process.ts:90-113`) iterates
  `Object.keys(populateMap)` and would forward an explicitly-`undefined` value into `applyPopulate`,
  so absent and `undefined` are *not* provably equivalent there. Widening them would need its own
  runtime justification. The top-level `populate?` is safe and is widened (`processPopulate` returns
  `null` on `isNil(populate)` at `:50`).
- **Filter operand types.** Same reasoning: `{ id: undefined }` inside `filters` has different
  semantics from an absent key, and collapsing them could mask bugs.

### Related issue(s)/PR(s)

Related #23480 — "Support `exactOptionalPropertyTypes` compiler flag in TypeScript".

That issue covers the whole package surface; this PR fixes the part that actually blocks consumers
today — the document service input types, where there is no workaround at the call site. Read/result
types and Strapi's own tsconfig are out of scope, for the reasons given above. If maintainers would
rather keep #23480 open as a tracking issue for the remaining surface, drop the `Closes` keyword on
merge.
