### PR TITLE
fix(strapi): declare-only Vite optimizeDeps.exclude

### DIFF
--- a/packages/cli/create-strapi-app/templates/example-js/src/admin/vite.config.example.js
+++ b/packages/cli/create-strapi-app/templates/example-js/src/admin/vite.config.example.js
@@ -8,5 +8,12 @@ module.exports = (config) => {
         '@': '/src',
       },
     },
+    // Optional: exclude a thin shared UI kit that breaks when Vite rebundles it against
+    // Strapi's React / design-system singletons. Kit authors can instead set in package.json:
+    //   "strapi": { "admin": { "vite": { "optimizeDepsExclude": true } } }
+    // Do not exclude large plugins (editors, charts, …) — that orphans their CJS deps.
+    // optimizeDeps: {
+    //   exclude: ['strapi-design-extended'],
+    // },
   });
 };

--- a/packages/cli/create-strapi-app/templates/example/src/admin/vite.config.example.ts
+++ b/packages/cli/create-strapi-app/templates/example/src/admin/vite.config.example.ts
@@ -8,5 +8,12 @@ export default (config: UserConfig) => {
         '@': '/src',
       },
     },
+    // Optional: exclude a thin shared UI kit that breaks when Vite rebundles it against
+    // Strapi's React / design-system singletons. Kit authors can instead set in package.json:
+    //   "strapi": { "admin": { "vite": { "optimizeDepsExclude": true } } }
+    // Do not exclude large plugins (editors, charts, …) — that orphans their CJS deps.
+    // optimizeDeps: {
+    //   exclude: ['strapi-design-extended'],
+    // },
   });
 };

--- a/packages/cli/create-strapi-app/templates/vanilla-js/src/admin/vite.config.example.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/src/admin/vite.config.example.js
@@ -8,5 +8,12 @@ module.exports = (config) => {
         '@': '/src',
       },
     },
+    // Optional: exclude a thin shared UI kit that breaks when Vite rebundles it against
+    // Strapi's React / design-system singletons. Kit authors can instead set in package.json:
+    //   "strapi": { "admin": { "vite": { "optimizeDepsExclude": true } } }
+    // Do not exclude large plugins (editors, charts, …) — that orphans their CJS deps.
+    // optimizeDeps: {
+    //   exclude: ['strapi-design-extended'],
+    // },
   });
 };

--- a/packages/cli/create-strapi-app/templates/vanilla/src/admin/vite.config.example.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/src/admin/vite.config.example.ts
@@ -8,5 +8,12 @@ export default (config: UserConfig) => {
         '@': '/src',
       },
     },
+    // Optional: exclude a thin shared UI kit that breaks when Vite rebundles it against
+    // Strapi's React / design-system singletons. Kit authors can instead set in package.json:
+    //   "strapi": { "admin": { "vite": { "optimizeDepsExclude": true } } }
+    // Do not exclude large plugins (editors, charts, …) — that orphans their CJS deps.
+    // optimizeDeps: {
+    //   exclude: ['strapi-design-extended'],
+    // },
   });
 };

--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
@@ -1,8 +1,11 @@
 import {
+  ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST,
   collectAdminOptimizeDepsExclude,
   getPluginPackageName,
   hasReactPeerDependency,
+  isEligibleForOptimizeDepsExclude,
   isEsmPackage,
+  packageOptsIntoOptimizeDepsExclude,
   shipsPreBuiltDist,
   shouldExcludeFromOptimizeDeps,
 } from '../admin-vite-optimize-exclude';
@@ -30,7 +33,7 @@ const PINNED_OPTIMIZE_MODULES = [
   '@strapi/strapi',
 ] as const;
 
-const preBuiltReactPeerPackage = (name: string) => ({
+const preBuiltReactPeerPackage = (name: string, extras: Record<string, unknown> = {}) => ({
   name,
   type: 'module',
   module: './dist/index.js',
@@ -39,6 +42,7 @@ const preBuiltReactPeerPackage = (name: string) => ({
     react: '^18.0.0',
     'react-dom': '^18.0.0',
   },
+  ...extras,
 });
 
 const strapiDesignExtendedLike = {
@@ -57,6 +61,15 @@ const strapiDesignExtendedLike = {
     '@strapi/design-system': '^2.2.0',
   },
 };
+
+/** CKEditor-class: matches the UI-kit shape but must not auto-exclude (#27136). */
+const ckeditorPluginLike = preBuiltReactPeerPackage('@_sh/strapi-plugin-ckeditor', {
+  dependencies: {
+    ckeditor5: '^43.0.0',
+    yup: '^0.32.0',
+    fuzzysort: '^3.0.0',
+  },
+});
 
 describe('admin vite optimize exclude heuristics', () => {
   it('matches pre-built ESM libraries with React peers', () => {
@@ -130,7 +143,55 @@ describe('admin vite optimize exclude heuristics', () => {
     expect(shipsPreBuiltDist({ files: ['dist'] })).toBe(true);
     expect(shipsPreBuiltDist({ module: './lib/index.js' })).toBe(false);
   });
+
+  it('allowlists only known thin UI kits', () => {
+    expect(ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has('strapi-design-extended')).toBe(true);
+    expect(ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has('@_sh/strapi-plugin-ckeditor')).toBe(
+      false
+    );
+  });
+
+  it('reads package.json opt-in for optimizeDeps.exclude', () => {
+    expect(
+      packageOptsIntoOptimizeDepsExclude({
+        strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+      } as PackageJsonLike)
+    ).toBe(true);
+    expect(packageOptsIntoOptimizeDepsExclude(strapiDesignExtendedLike as PackageJsonLike)).toBe(
+      false
+    );
+  });
+
+  it('requires allowlist or opt-in on top of the UI-kit shape (#27136)', () => {
+    expect(isEligibleForOptimizeDepsExclude('strapi-design-extended', strapiDesignExtendedLike)).toBe(
+      true
+    );
+    expect(isEligibleForOptimizeDepsExclude('@_sh/strapi-plugin-ckeditor', ckeditorPluginLike)).toBe(
+      false
+    );
+    expect(
+      isEligibleForOptimizeDepsExclude(
+        'my-thin-ui-kit',
+        preBuiltReactPeerPackage('my-thin-ui-kit', {
+          strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+        })
+      )
+    ).toBe(true);
+    expect(
+      isEligibleForOptimizeDepsExclude(
+        'opted-in-but-cjs',
+        {
+          name: 'opted-in-but-cjs',
+          main: 'index.js',
+          peerDependencies: { react: '^18.0.0' },
+          strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+        } as PackageJsonLike
+      )
+    ).toBe(false);
+  });
 });
+
+type PackageJsonLike = Parameters<typeof packageOptsIntoOptimizeDepsExclude>[0];
 
 describe('collectAdminOptimizeDepsExclude', () => {
   const getModuleMock = getModule as jest.Mock;
@@ -140,7 +201,7 @@ describe('collectAdminOptimizeDepsExclude', () => {
     readPkgUp.mockResolvedValue(undefined);
   });
 
-  it('excludes pre-built React peer libraries from plugin dependencies', async () => {
+  it('excludes allowlisted pre-built React peer libraries from plugin dependencies', async () => {
     const plugins: PluginMeta[] = [
       {
         name: 'my-plugin',
@@ -171,7 +232,69 @@ describe('collectAdminOptimizeDepsExclude', () => {
     ]);
   });
 
-  it('never excludes @strapi/strapi from app root but still excludes matching UI kits', async () => {
+  it('does not auto-exclude CKEditor-class plugins that only match the UI-kit shape (#27136)', async () => {
+    const plugins: PluginMeta[] = [
+      {
+        name: 'ckeditor',
+        importName: 'ckeditor',
+        type: 'module',
+        modulePath: '@_sh/strapi-plugin-ckeditor/strapi-admin',
+      },
+    ];
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === '@_sh/strapi-plugin-ckeditor') {
+        return ckeditorPluginLike;
+      }
+
+      return null;
+    });
+
+    readPkgUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          '@_sh/strapi-plugin-ckeditor': '^1.0.0',
+        },
+      },
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', plugins)).resolves.toEqual([]);
+  });
+
+  it('excludes packages that opt in via strapi.admin.vite.optimizeDepsExclude', async () => {
+    const plugins: PluginMeta[] = [
+      {
+        name: 'my-plugin',
+        importName: 'myPlugin',
+        type: 'module',
+        modulePath: '@org/my-plugin/strapi-admin',
+      },
+    ];
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === '@org/my-plugin') {
+        return {
+          dependencies: {
+            'my-thin-ui-kit': '^1.0.0',
+          },
+        };
+      }
+
+      if (name === 'my-thin-ui-kit') {
+        return preBuiltReactPeerPackage('my-thin-ui-kit', {
+          strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+        });
+      }
+
+      return null;
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', plugins)).resolves.toEqual([
+      'my-thin-ui-kit',
+    ]);
+  });
+
+  it('never excludes @strapi/strapi from app root but still excludes allowlisted UI kits', async () => {
     readPkgUp.mockResolvedValue({
       packageJson: {
         dependencies: {

--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
@@ -163,12 +163,12 @@ describe('admin vite optimize exclude heuristics', () => {
   });
 
   it('requires allowlist or opt-in on top of the UI-kit shape (#27136)', () => {
-    expect(isEligibleForOptimizeDepsExclude('strapi-design-extended', strapiDesignExtendedLike)).toBe(
-      true
-    );
-    expect(isEligibleForOptimizeDepsExclude('@_sh/strapi-plugin-ckeditor', ckeditorPluginLike)).toBe(
-      false
-    );
+    expect(
+      isEligibleForOptimizeDepsExclude('strapi-design-extended', strapiDesignExtendedLike)
+    ).toBe(true);
+    expect(
+      isEligibleForOptimizeDepsExclude('@_sh/strapi-plugin-ckeditor', ckeditorPluginLike)
+    ).toBe(false);
     expect(
       isEligibleForOptimizeDepsExclude(
         'my-thin-ui-kit',
@@ -178,15 +178,12 @@ describe('admin vite optimize exclude heuristics', () => {
       )
     ).toBe(true);
     expect(
-      isEligibleForOptimizeDepsExclude(
-        'opted-in-but-cjs',
-        {
-          name: 'opted-in-but-cjs',
-          main: 'index.js',
-          peerDependencies: { react: '^18.0.0' },
-          strapi: { admin: { vite: { optimizeDepsExclude: true } } },
-        } as PackageJsonLike
-      )
+      isEligibleForOptimizeDepsExclude('opted-in-but-cjs', {
+        name: 'opted-in-but-cjs',
+        main: 'index.js',
+        peerDependencies: { react: '^18.0.0' },
+        strapi: { admin: { vite: { optimizeDepsExclude: true } } },
+      } as PackageJsonLike)
     ).toBe(false);
   });
 });

--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-optimize-exclude.test.ts
@@ -162,10 +162,12 @@ describe('admin vite optimize exclude heuristics', () => {
     );
   });
 
-  it('requires allowlist or opt-in on top of the UI-kit shape (#27136)', () => {
+  it('excludes by allowlist or opt-in only — never by package shape (#27136)', () => {
     expect(
       isEligibleForOptimizeDepsExclude('strapi-design-extended', strapiDesignExtendedLike)
     ).toBe(true);
+    // Allowlisted even when package metadata is missing (exports often omit package.json)
+    expect(isEligibleForOptimizeDepsExclude('strapi-design-extended', null)).toBe(true);
     expect(
       isEligibleForOptimizeDepsExclude('@_sh/strapi-plugin-ckeditor', ckeditorPluginLike)
     ).toBe(false);
@@ -177,13 +179,18 @@ describe('admin vite optimize exclude heuristics', () => {
         })
       )
     ).toBe(true);
+    // Opt-in alone is enough — shape is not required
     expect(
-      isEligibleForOptimizeDepsExclude('opted-in-but-cjs', {
-        name: 'opted-in-but-cjs',
+      isEligibleForOptimizeDepsExclude('opted-in-cjs', {
+        name: 'opted-in-cjs',
         main: 'index.js',
         peerDependencies: { react: '^18.0.0' },
         strapi: { admin: { vite: { optimizeDepsExclude: true } } },
       } as PackageJsonLike)
+    ).toBe(true);
+    // Shape without declare is never enough
+    expect(
+      isEligibleForOptimizeDepsExclude('shape-only-kit', preBuiltReactPeerPackage('shape-only-kit'))
     ).toBe(false);
   });
 });
@@ -256,6 +263,42 @@ describe('collectAdminOptimizeDepsExclude', () => {
     });
 
     await expect(collectAdminOptimizeDepsExclude('/app', plugins)).resolves.toEqual([]);
+  });
+
+  it('excludes allowlisted packages even when getModule cannot read package.json', async () => {
+    readPkgUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          'strapi-design-extended': '^0.0.13',
+        },
+      },
+    });
+
+    getModuleMock.mockResolvedValue(null);
+
+    await expect(collectAdminOptimizeDepsExclude('/app', [])).resolves.toEqual([
+      'strapi-design-extended',
+    ]);
+  });
+
+  it('does not exclude shape-matching packages without allowlist or opt-in', async () => {
+    readPkgUp.mockResolvedValue({
+      packageJson: {
+        dependencies: {
+          'shape-only-kit': '^1.0.0',
+        },
+      },
+    });
+
+    getModuleMock.mockImplementation(async (name: string) => {
+      if (name === 'shape-only-kit') {
+        return preBuiltReactPeerPackage('shape-only-kit');
+      }
+
+      return null;
+    });
+
+    await expect(collectAdminOptimizeDepsExclude('/app', [])).resolves.toEqual([]);
   });
 
   it('excludes packages that opt in via strapi.admin.vite.optimizeDepsExclude', async () => {

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -26,9 +26,9 @@ const PINNED_OPTIMIZE_MODULES = new Set<string>([
 
 /**
  * Thin shared plugin UI kits that are known to break when Vite re-optimizes their pre-built
- * dist (original #26944 victims). Only these names — plus packages that opt in via package.json —
- * may be auto-excluded. Broad heuristic matching alone was too aggressive for large plugins
- * (e.g. CKEditor) and orphaned their transitive CJS/UMD deps (#27136).
+ * dist (original #26944 victims). Exclude is declare-only: these names, packages that set
+ * `strapi.admin.vite.optimizeDepsExclude`, or app `src/admin/vite.config` — never inferred
+ * from package shape (#27136 / follow-up to #27264).
  *
  * @internal exported for tests
  */
@@ -113,8 +113,9 @@ export const shipsPreBuiltDist = (pkg: PackageJson): boolean => {
 };
 
 /**
- * Shape check for packages that *could* be excluded (pre-built ESM + React peer + dist).
- * Matching alone is not enough to exclude — see {@link isEligibleForOptimizeDepsExclude}.
+ * Historical UI-kit shape (pre-built ESM + React peer + dist). Kept for tests and debugging —
+ * it is **not** used to decide exclude eligibility (declare-only; see
+ * {@link isEligibleForOptimizeDepsExclude}).
  *
  * @internal exported for tests
  */
@@ -132,8 +133,25 @@ type StrapiPackageMeta = {
 };
 
 /**
- * Packages may opt into optimizeDeps.exclude via package.json:
- * `{ "strapi": { "admin": { "vite": { "optimizeDepsExclude": true } } } }`
+ * Plugin / shared UI kit authors may opt into `optimizeDeps.exclude` via package.json so Vite
+ * does not rebundle a pre-built dist that conflicts with Strapi's React / design-system
+ * singletons:
+ *
+ * ```json
+ * {
+ *   "strapi": {
+ *     "admin": {
+ *       "vite": {
+ *         "optimizeDepsExclude": true
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Apps can also exclude packages in `src/admin/vite.config` without this flag.
+ * Do **not** set this on large plugins (editors, charts, …): excluding the package root
+ * orphans transitive CJS/UMD deps (#27136).
  *
  * @internal exported for tests
  */
@@ -144,20 +162,20 @@ export const packageOptsIntoOptimizeDepsExclude = (pkg: PackageJson): boolean =>
 };
 
 /**
- * A candidate is excluded only when it matches the UI-kit shape AND is either on the
- * known-safe allowlist or explicitly opts in. This keeps #26944 working for thin kits
- * without auto-excluding large editor/chart plugins (#27136).
+ * Exclude is declare-only: known allowlist name **or** package.json opt-in.
+ * Package shape is intentionally ignored so fat plugins are never auto-excluded (#27136).
  *
  * @internal exported for tests
  */
-export const isEligibleForOptimizeDepsExclude = (name: string, pkg: PackageJson): boolean => {
-  if (!shouldExcludeFromOptimizeDeps(pkg)) {
-    return false;
+export const isEligibleForOptimizeDepsExclude = (
+  name: string,
+  pkg: PackageJson | null
+): boolean => {
+  if (ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has(name)) {
+    return true;
   }
 
-  return (
-    ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has(name) || packageOptsIntoOptimizeDepsExclude(pkg)
-  );
+  return pkg !== null && packageOptsIntoOptimizeDepsExclude(pkg);
 };
 
 /**
@@ -211,14 +229,16 @@ const loadAppPackageJson = async (cwd: string): Promise<PackageJson | null> => {
 };
 
 /**
- * Pre-built ESM libraries with React peers (shared plugin UI kits) are incompatible with
- * Strapi's React/design-system pre-bundling. Skip dep optimization so they resolve through
- * the admin resolve aliases instead of being re-bundled by Vite.
+ * Collects `optimizeDeps.exclude` entries for admin Vite develop.
  *
- * Scans app and plugin dependency trees (#26944). Only allowlisted or opt-in packages that
- * also match the UI-kit shape are excluded (#27136). Official @strapi/* packages and pinned
- * singletons are never auto-excluded — @strapi/strapi matches the heuristic but must stay on
- * the optimizeDeps.include path (#26944, #27014).
+ * Scans app and plugin dependency trees. A package is excluded only when it is on
+ * {@link ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST} or sets
+ * `strapi.admin.vite.optimizeDepsExclude: true` (#27264 follow-up: declare-only, no shape
+ * heuristic). Official `@strapi/*` packages and pinned singletons are never auto-excluded
+ * (#26944, #27014).
+ *
+ * Allowlisted names are excluded even when `getModule` cannot read `package.json` (some
+ * packages omit `./package.json` from `exports`).
  *
  * Apps can still exclude additional packages via `src/admin/vite.config` optimizeDeps.exclude.
  *
@@ -254,9 +274,14 @@ export const collectAdminOptimizeDepsExclude = async (
       continue;
     }
 
+    if (ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has(name)) {
+      exclude.push(name);
+      continue;
+    }
+
     const pkg = await getModule(name, cwd);
 
-    if (pkg && isEligibleForOptimizeDepsExclude(name, pkg)) {
+    if (pkg && packageOptsIntoOptimizeDepsExclude(pkg)) {
       exclude.push(name);
     }
   }

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -155,7 +155,9 @@ export const isEligibleForOptimizeDepsExclude = (name: string, pkg: PackageJson)
     return false;
   }
 
-  return ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has(name) || packageOptsIntoOptimizeDepsExclude(pkg);
+  return (
+    ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has(name) || packageOptsIntoOptimizeDepsExclude(pkg)
+  );
 };
 
 /**

--- a/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-optimize-exclude.ts
@@ -22,7 +22,18 @@ const PINNED_OPTIMIZE_MODULES = new Set<string>([
   ...ADMIN_VITE_ALIAS_MODULES,
   ...ADMIN_VITE_SINGLETON_MODULES,
   '@strapi/strapi',
-  'react-colorful',
+]);
+
+/**
+ * Thin shared plugin UI kits that are known to break when Vite re-optimizes their pre-built
+ * dist (original #26944 victims). Only these names — plus packages that opt in via package.json —
+ * may be auto-excluded. Broad heuristic matching alone was too aggressive for large plugins
+ * (e.g. CKEditor) and orphaned their transitive CJS/UMD deps (#27136).
+ *
+ * @internal exported for tests
+ */
+export const ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST = new Set<string>([
+  'strapi-design-extended',
 ]);
 
 const isOfficialStrapiPackage = (name: string): boolean => name.startsWith('@strapi/');
@@ -102,10 +113,50 @@ export const shipsPreBuiltDist = (pkg: PackageJson): boolean => {
 };
 
 /**
+ * Shape check for packages that *could* be excluded (pre-built ESM + React peer + dist).
+ * Matching alone is not enough to exclude — see {@link isEligibleForOptimizeDepsExclude}.
+ *
  * @internal exported for tests
  */
 export const shouldExcludeFromOptimizeDeps = (pkg: PackageJson): boolean =>
   hasReactPeerDependency(pkg) && isEsmPackage(pkg) && shipsPreBuiltDist(pkg);
+
+type StrapiAdminViteMeta = {
+  optimizeDepsExclude?: unknown;
+};
+
+type StrapiPackageMeta = {
+  admin?: {
+    vite?: StrapiAdminViteMeta;
+  };
+};
+
+/**
+ * Packages may opt into optimizeDeps.exclude via package.json:
+ * `{ "strapi": { "admin": { "vite": { "optimizeDepsExclude": true } } } }`
+ *
+ * @internal exported for tests
+ */
+export const packageOptsIntoOptimizeDepsExclude = (pkg: PackageJson): boolean => {
+  const strapi = (pkg as PackageJson & { strapi?: StrapiPackageMeta }).strapi;
+
+  return strapi?.admin?.vite?.optimizeDepsExclude === true;
+};
+
+/**
+ * A candidate is excluded only when it matches the UI-kit shape AND is either on the
+ * known-safe allowlist or explicitly opts in. This keeps #26944 working for thin kits
+ * without auto-excluding large editor/chart plugins (#27136).
+ *
+ * @internal exported for tests
+ */
+export const isEligibleForOptimizeDepsExclude = (name: string, pkg: PackageJson): boolean => {
+  if (!shouldExcludeFromOptimizeDeps(pkg)) {
+    return false;
+  }
+
+  return ADMIN_VITE_OPTIMIZE_DEPS_EXCLUDE_ALLOWLIST.has(name) || packageOptsIntoOptimizeDepsExclude(pkg);
+};
 
 /**
  * @internal exported for tests
@@ -162,9 +213,12 @@ const loadAppPackageJson = async (cwd: string): Promise<PackageJson | null> => {
  * Strapi's React/design-system pre-bundling. Skip dep optimization so they resolve through
  * the admin resolve aliases instead of being re-bundled by Vite.
  *
- * Scans app and plugin dependency trees (#26944). Official @strapi/* packages and pinned
+ * Scans app and plugin dependency trees (#26944). Only allowlisted or opt-in packages that
+ * also match the UI-kit shape are excluded (#27136). Official @strapi/* packages and pinned
  * singletons are never auto-excluded — @strapi/strapi matches the heuristic but must stay on
  * the optimizeDeps.include path (#26944, #27014).
+ *
+ * Apps can still exclude additional packages via `src/admin/vite.config` optimizeDeps.exclude.
  *
  * @internal
  */
@@ -200,7 +254,7 @@ export const collectAdminOptimizeDepsExclude = async (
 
     const pkg = await getModule(name, cwd);
 
-    if (pkg && shouldExcludeFromOptimizeDeps(pkg)) {
+    if (pkg && isEligibleForOptimizeDepsExclude(name, pkg)) {
       exclude.push(name);
     }
   }

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -53,7 +53,7 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
       // - The admin entry host (@strapi/strapi) MUST NOT be in optimizeDeps.exclude.
       // When design-system is linked (portal:, file:, yarn link), exclude from pre-bundling
       // so changes are reflected without clearing node_modules/.strapi/vite cache.
-      // Also skip pre-built ESM plugin UI libraries with React peers (see collectAdminOptimizeDepsExclude).
+      // Also skip allowlisted / opt-in pre-built ESM plugin UI kits (see collectAdminOptimizeDepsExclude).
       ...(optimizeDepsExclude.length > 0 && { exclude: optimizeDepsExclude }),
       include: [
         // pre-bundle React dependencies to avoid React duplicates,


### PR DESCRIPTION
### What does it do?

Follow-up to #27264: make admin Vite `optimizeDeps.exclude` **declare-only**.

A dependency is auto-excluded only when:

1. it is on the known-safe allowlist (`strapi-design-extended`), or
2. it opts in via `package.json`:

```json
{
  "strapi": {
    "admin": {
      "vite": {
        "optimizeDepsExclude": true
      }
    }
  }
}
```

Package **shape** (ESM + React peer + `dist/`) is no longer consulted. Allowlisted names are excluded even when `getModule` cannot read `package.json` (common when `exports` omits that path).

Apps can still exclude packages in `src/admin/vite.config`. CSA `vite.config.example` files document both options.

Official `@strapi/*` and pinned singletons remain never auto-excluded.

### Why is it needed?

#27264 stopped auto-excluding fat plugins by requiring allowlist/opt-in **on top of** the old shape heuristic. The shape check is leftover guessing: it cannot distinguish thin kits from large plugins, and it is not needed once exclude is intentional.

Declare-only is the durable policy:

- default = let Vite discover/prebundle (safe for CKEditor-class plugins)
- exclude = kit author opt-in, core allowlist, or app `vite.config`

### How to use it (authors / apps)

**Shared UI kit author** (kit breaks when Vite rebundles it against Strapi’s React / design-system singletons):

```json
"strapi": {
  "admin": {
    "vite": {
      "optimizeDepsExclude": true
    }
  }
}
```

**App** (kit has no flag yet):

```ts
// src/admin/vite.config.ts
export default (config) =>
  mergeConfig(config, {
    optimizeDeps: {
      exclude: ['strapi-design-extended'],
    },
  });
```

Do **not** opt in / exclude large plugins (editors, charts, …): that orphans transitive CJS/UMD deps (#27136).

### How to test it?

- Unit: `yarn nx run @strapi/strapi:test:unit --testPathPattern=admin-vite-optimize-exclude`
- Confirm shape-only packages stay off exclude; allowlist works with `getModule` → null; opt-in works without shape

### Related issue(s)/PR(s)

- Stacked on #27264 (merge that first, then retarget this to `develop` if needed)
- Follow-up to #26944 / #27264
- Relates to #27136

- Fixes CMS-1598
