### PR TITLE
chore(tooling): add consumer dependency audit workflow

### DIFF
--- a/.github/workflows/consumer-audit.yml
+++ b/.github/workflows/consumer-audit.yml
@@ -1,0 +1,61 @@
+# Consumer dependency audit
+#
+# Installs the third-party production dependency closure of a default
+# create-strapi-app (from develop package.json pins), runs npm audit, captures
+# deprecation warnings, and diffs against scripts/consumer-audit/baseline.json.
+#
+# Fails only on *novel* findings (not listed under accepted or known).
+
+name: Consumer dependency audit
+
+on:
+  schedule:
+    # Mondays 06:00 UTC — early in the week, after Dependabot Sunday night
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'scripts/consumer-audit/**'
+      - '.github/workflows/consumer-audit.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: consumer-audit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit CSA dependency closure
+    runs-on: ubuntu-latest
+    if: github.repository == 'strapi/strapi'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Run consumer audit
+        run: node scripts/consumer-audit/run.mjs --out "$RUNNER_TEMP/consumer-audit"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: consumer-audit-report
+          path: ${{ runner.temp }}/consumer-audit/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Print summary
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/consumer-audit/report.md" ]; then
+            cat "$RUNNER_TEMP/consumer-audit/report.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No report.md produced" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ examples/**/types/generated
 
 # Ignore yarn.lock inside templates
 templates/yarn.lock
+
+# Local consumer-audit output
+scripts/consumer-audit/.output/

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "clean": "nx run-many --target=clean --nx-ignore-cycles",
     "commit": "commit",
     "doc:api": "node scripts/open-api/serve.js",
+    "consumer-audit": "node scripts/consumer-audit/run.mjs",
     "format": "yarn format:code && yarn format:other",
     "format:code": "yarn prettier:code --write",
     "format:other": "yarn prettier:other --write",

--- a/scripts/consumer-audit/README.md
+++ b/scripts/consumer-audit/README.md
@@ -1,0 +1,14 @@
+# Consumer dependency audit
+
+Audits the **third-party production dependency closure** of a default `create-strapi-app` using pins from this monorepo’s `package.json` files (not the Yarn lockfile / monorepo devDeps).
+
+```bash
+# From repo root (needs network for npm install of the scratch app; no monorepo yarn install required)
+node scripts/consumer-audit/run.mjs
+node scripts/consumer-audit/run.mjs --out /tmp/consumer-audit
+node scripts/consumer-audit/run.mjs --no-fail   # report only
+```
+
+- **`packages.json`** — CSA root packages + app-level deps  
+- **`baseline.json`** — `accepted` (holds) and `known` (tracked debt); CI fails only on **novel** findings  
+- **CI** — `.github/workflows/consumer-audit.yml` (weekly + `workflow_dispatch`)

--- a/scripts/consumer-audit/README.md
+++ b/scripts/consumer-audit/README.md
@@ -10,5 +10,5 @@ node scripts/consumer-audit/run.mjs --no-fail   # report only
 ```
 
 - **`packages.json`** — CSA root packages + app-level deps
-- **`baseline.json`** — `accepted` (holds) and `known` (tracked debt); CI fails only on **novel** findings
-- **CI** — `.github/workflows/consumer-audit.yml` (weekly + `workflow_dispatch`)
+- **`baseline.json`** — `accepted` (holds) and `known` (tracked debt); CI fails only on **novel** findings. Remove entries once fixed so regressions alert again.
+- **CI** — `.github/workflows/consumer-audit.yml` (weekly Mondays, `workflow_dispatch`, and PRs that touch these files)

--- a/scripts/consumer-audit/README.md
+++ b/scripts/consumer-audit/README.md
@@ -9,6 +9,6 @@ node scripts/consumer-audit/run.mjs --out /tmp/consumer-audit
 node scripts/consumer-audit/run.mjs --no-fail   # report only
 ```
 
-- **`packages.json`** — CSA root packages + app-level deps  
-- **`baseline.json`** — `accepted` (holds) and `known` (tracked debt); CI fails only on **novel** findings  
+- **`packages.json`** — CSA root packages + app-level deps
+- **`baseline.json`** — `accepted` (holds) and `known` (tracked debt); CI fails only on **novel** findings
 - **CI** — `.github/workflows/consumer-audit.yml` (weekly + `workflow_dispatch`)

--- a/scripts/consumer-audit/baseline.json
+++ b/scripts/consumer-audit/baseline.json
@@ -35,69 +35,15 @@
   ],
   "known": [
     {
-      "id": "vulnerability:sharp",
-      "kind": "vulnerability",
-      "package": "sharp",
-      "reason": "Track: bump sharp in @strapi/upload to >=0.35.0"
-    },
-    {
       "id": "vulnerability:@hono/node-server",
       "kind": "vulnerability",
       "package": "@hono/node-server",
       "reason": "Track: bump @modelcontextprotocol/sdk to >=1.30.0"
     },
     {
-      "id": "vulnerability:@modelcontextprotocol/sdk",
-      "kind": "vulnerability",
-      "package": "@modelcontextprotocol/sdk",
-      "reason": "Track: parent of @hono/node-server; bump to >=1.30.0"
-    },
-    {
-      "id": "vulnerability:ajv",
-      "kind": "vulnerability",
-      "package": "ajv",
-      "reason": "Track: via umzug/@rushstack — upstream"
-    },
-    {
-      "id": "vulnerability:@rushstack/node-core-library",
-      "kind": "vulnerability",
-      "package": "@rushstack/node-core-library",
-      "reason": "Track: via umzug — upstream"
-    },
-    {
-      "id": "vulnerability:@rushstack/terminal",
-      "kind": "vulnerability",
-      "package": "@rushstack/terminal",
-      "reason": "Track: via umzug — upstream"
-    },
-    {
-      "id": "vulnerability:@rushstack/ts-command-line",
-      "kind": "vulnerability",
-      "package": "@rushstack/ts-command-line",
-      "reason": "Track: via umzug — upstream"
-    },
-    {
       "id": "vulnerability:@ai-sdk/provider-utils",
       "kind": "vulnerability",
       "package": "@ai-sdk/provider-utils",
-      "reason": "Track: AI SDK major in content-type-builder"
-    },
-    {
-      "id": "vulnerability:@ai-sdk/gateway",
-      "kind": "vulnerability",
-      "package": "@ai-sdk/gateway",
-      "reason": "Track: AI SDK major in content-type-builder"
-    },
-    {
-      "id": "vulnerability:@ai-sdk/react",
-      "kind": "vulnerability",
-      "package": "@ai-sdk/react",
-      "reason": "Track: AI SDK major in content-type-builder"
-    },
-    {
-      "id": "vulnerability:ai",
-      "kind": "vulnerability",
-      "package": "ai",
       "reason": "Track: AI SDK major in content-type-builder"
     },
     {

--- a/scripts/consumer-audit/baseline.json
+++ b/scripts/consumer-audit/baseline.json
@@ -1,0 +1,134 @@
+{
+  "version": 1,
+  "notes": "Findings listed here are known. CI fails only on findings not present in accepted or known. Move fixed items out; add new holds to accepted with a reason. IDs must match kind:package (e.g. vulnerability:vite, deprecation:glob).",
+  "accepted": [
+    {
+      "id": "vulnerability:vite",
+      "kind": "vulnerability",
+      "package": "vite",
+      "reason": "Known hold — Vite major upgrade"
+    },
+    {
+      "id": "vulnerability:esbuild",
+      "kind": "vulnerability",
+      "package": "esbuild",
+      "reason": "Pulled by Vite — same hold"
+    },
+    {
+      "id": "vulnerability:react-router",
+      "kind": "vulnerability",
+      "package": "react-router",
+      "reason": "Known hold — React Router major"
+    },
+    {
+      "id": "vulnerability:react-router-dom",
+      "kind": "vulnerability",
+      "package": "react-router-dom",
+      "reason": "Known hold — React Router major"
+    },
+    {
+      "id": "deprecation:prebuild-install",
+      "kind": "deprecation",
+      "package": "prebuild-install",
+      "reason": "Pulled by better-sqlite3; not Strapi-owned"
+    }
+  ],
+  "known": [
+    {
+      "id": "vulnerability:sharp",
+      "kind": "vulnerability",
+      "package": "sharp",
+      "reason": "Track: bump sharp in @strapi/upload to >=0.35.0"
+    },
+    {
+      "id": "vulnerability:@hono/node-server",
+      "kind": "vulnerability",
+      "package": "@hono/node-server",
+      "reason": "Track: bump @modelcontextprotocol/sdk to >=1.30.0"
+    },
+    {
+      "id": "vulnerability:@modelcontextprotocol/sdk",
+      "kind": "vulnerability",
+      "package": "@modelcontextprotocol/sdk",
+      "reason": "Track: parent of @hono/node-server; bump to >=1.30.0"
+    },
+    {
+      "id": "vulnerability:ajv",
+      "kind": "vulnerability",
+      "package": "ajv",
+      "reason": "Track: via umzug/@rushstack — upstream"
+    },
+    {
+      "id": "vulnerability:@rushstack/node-core-library",
+      "kind": "vulnerability",
+      "package": "@rushstack/node-core-library",
+      "reason": "Track: via umzug — upstream"
+    },
+    {
+      "id": "vulnerability:@rushstack/terminal",
+      "kind": "vulnerability",
+      "package": "@rushstack/terminal",
+      "reason": "Track: via umzug — upstream"
+    },
+    {
+      "id": "vulnerability:@rushstack/ts-command-line",
+      "kind": "vulnerability",
+      "package": "@rushstack/ts-command-line",
+      "reason": "Track: via umzug — upstream"
+    },
+    {
+      "id": "vulnerability:@ai-sdk/provider-utils",
+      "kind": "vulnerability",
+      "package": "@ai-sdk/provider-utils",
+      "reason": "Track: AI SDK major in content-type-builder"
+    },
+    {
+      "id": "vulnerability:@ai-sdk/gateway",
+      "kind": "vulnerability",
+      "package": "@ai-sdk/gateway",
+      "reason": "Track: AI SDK major in content-type-builder"
+    },
+    {
+      "id": "vulnerability:@ai-sdk/react",
+      "kind": "vulnerability",
+      "package": "@ai-sdk/react",
+      "reason": "Track: AI SDK major in content-type-builder"
+    },
+    {
+      "id": "vulnerability:ai",
+      "kind": "vulnerability",
+      "package": "ai",
+      "reason": "Track: AI SDK major in content-type-builder"
+    },
+    {
+      "id": "deprecation:inflight",
+      "kind": "deprecation",
+      "package": "inflight",
+      "reason": "Track: replace react-query with @tanstack/react-query"
+    },
+    {
+      "id": "deprecation:glob",
+      "kind": "deprecation",
+      "package": "glob",
+      "reason": "Track: replace react-query with @tanstack/react-query"
+    },
+    {
+      "id": "deprecation:rimraf",
+      "kind": "deprecation",
+      "package": "rimraf",
+      "reason": "Track: replace react-query with @tanstack/react-query"
+    },
+    {
+      "id": "deprecation:@koa/router",
+      "kind": "deprecation",
+      "package": "@koa/router",
+      "reason": "Track: bump @koa/router to v15 (path-to-regexp route audit)"
+    },
+    {
+      "id": "deprecation:cron-parser",
+      "kind": "deprecation",
+      "package": "cron-parser",
+      "reason": "Track: replace node-schedule (e.g. croner)"
+    }
+  ]
+}

--- a/scripts/consumer-audit/packages.json
+++ b/scripts/consumer-audit/packages.json
@@ -1,0 +1,16 @@
+{
+  "description": "Default create-strapi-app consumer roots. Transitive @strapi/* deps are walked from these package.json files.",
+  "roots": [
+    "@strapi/strapi",
+    "@strapi/database",
+    "@strapi/plugin-users-permissions",
+    "@strapi/plugin-cloud"
+  ],
+  "appDependencies": {
+    "better-sqlite3": "12.8.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.30.3",
+    "styled-components": "^6.0.0"
+  }
+}

--- a/scripts/consumer-audit/run.mjs
+++ b/scripts/consumer-audit/run.mjs
@@ -315,11 +315,16 @@ function main() {
 
   if (install.status !== 0) {
     rmSync(scratchDir, { recursive: true, force: true });
-    fail(`npm install failed (exit ${install.status}). See ${path.join(outDir, 'npm-install.log')}`);
+    fail(
+      `npm install failed (exit ${install.status}). See ${path.join(outDir, 'npm-install.log')}`
+    );
   }
 
   const deprecations = parseDeprecations(installLog);
-  writeFileSync(path.join(outDir, 'deprecations.json'), `${JSON.stringify(deprecations, null, 2)}\n`);
+  writeFileSync(
+    path.join(outDir, 'deprecations.json'),
+    `${JSON.stringify(deprecations, null, 2)}\n`
+  );
 
   console.log('==> Running npm audit');
   const auditProc = spawnSync('npm', ['audit', '--json'], {
@@ -333,7 +338,10 @@ function main() {
   try {
     audit = JSON.parse(auditProc.stdout || '{}');
   } catch {
-    writeFileSync(path.join(outDir, 'npm-audit.raw.txt'), auditProc.stdout || auditProc.stderr || '');
+    writeFileSync(
+      path.join(outDir, 'npm-audit.raw.txt'),
+      auditProc.stdout || auditProc.stderr || ''
+    );
     rmSync(scratchDir, { recursive: true, force: true });
     fail('failed to parse npm audit JSON');
   }
@@ -361,8 +369,10 @@ function main() {
   const classified = classify(findings, baseline);
 
   const nodeV = spawnSync('node', ['-v'], { encoding: 'utf8' }).stdout.trim();
-  const npmV = spawnSync('npm', ['-v'], { encoding: 'utf8', shell: process.platform === 'win32' })
-    .stdout.trim();
+  const npmV = spawnSync('npm', ['-v'], {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  }).stdout.trim();
 
   const report = writeReport({
     outDir,
@@ -383,7 +393,9 @@ function main() {
   rmSync(scratchDir, { recursive: true, force: true });
 
   console.log('');
-  console.log(`Novel: ${classified.novel.length} · Known: ${classified.known.length} · Accepted: ${classified.accepted.length}`);
+  console.log(
+    `Novel: ${classified.novel.length} · Known: ${classified.known.length} · Accepted: ${classified.accepted.length}`
+  );
   console.log(`Reports: ${path.join(outDir, 'report.md')}`);
 
   if (classified.novel.length > 0) {

--- a/scripts/consumer-audit/run.mjs
+++ b/scripts/consumer-audit/run.mjs
@@ -368,13 +368,20 @@ function main() {
 
   const classified = classify(findings, baseline);
 
+  const seenIds = new Set(findings.map((f) => f.id));
+  for (const entry of [...(baseline.accepted || []), ...(baseline.known || [])]) {
+    if (!seenIds.has(entry.id)) {
+      console.warn(`warn: baseline entry not seen this run (consider removing): ${entry.id}`);
+    }
+  }
+
   const nodeV = spawnSync('node', ['-v'], { encoding: 'utf8' }).stdout.trim();
   const npmV = spawnSync('npm', ['-v'], {
     encoding: 'utf8',
     shell: process.platform === 'win32',
   }).stdout.trim();
 
-  const report = writeReport({
+  writeReport({
     outDir,
     meta: {
       generatedAt: new Date().toISOString(),
@@ -408,9 +415,6 @@ function main() {
     }
     console.log('\n(--no-fail: not failing CI)');
   }
-
-  // silence unused
-  void report;
 }
 
 try {

--- a/scripts/consumer-audit/run.mjs
+++ b/scripts/consumer-audit/run.mjs
@@ -1,0 +1,409 @@
+#!/usr/bin/env node
+/**
+ * Consumer dependency audit — what a default create-strapi-app installs.
+ *
+ * Walks the CSA package closure from monorepo package.json files, installs the
+ * declared third-party production deps with npm, captures deprecation warnings
+ * + npm audit, then diffs against baseline.json.
+ *
+ * Usage (repo root):
+ *   node scripts/consumer-audit/run.mjs
+ *   node scripts/consumer-audit/run.mjs --out /tmp/consumer-audit
+ *   node scripts/consumer-audit/run.mjs --no-fail
+ *
+ * Exit codes:
+ *   0 — no new findings (or --no-fail)
+ *   1 — new findings vs baseline
+ *   2 — script / install error
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const CONFIG_PATH = path.join(__dirname, 'packages.json');
+const BASELINE_PATH = path.join(__dirname, 'baseline.json');
+
+const args = process.argv.slice(2);
+const noFail = args.includes('--no-fail');
+const outIdx = args.indexOf('--out');
+const outDir =
+  outIdx >= 0 && args[outIdx + 1]
+    ? path.resolve(args[outIdx + 1])
+    : path.join(ROOT, 'scripts/consumer-audit/.output');
+
+function fail(message, code = 2) {
+  console.error(`error: ${message}`);
+  process.exit(code);
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function workspacePackages() {
+  // Prefer yarn when available (accurate workspace list); otherwise walk packages/.
+  const result = spawnSync('yarn', ['workspaces', 'list', '--json'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+
+  const byName = new Map();
+  if (result.status === 0 && result.stdout.trim()) {
+    for (const line of result.stdout.split('\n').filter(Boolean)) {
+      const row = JSON.parse(line);
+      if (row.name && row.location) {
+        byName.set(row.name, path.join(ROOT, row.location));
+      }
+    }
+    return byName;
+  }
+
+  // Fallback: no yarn install required — walk published package trees only.
+  const packagesRoot = path.join(ROOT, 'packages');
+  const stack = [packagesRoot];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    const pkgJsonPath = path.join(dir, 'package.json');
+    if (existsSync(pkgJsonPath)) {
+      try {
+        const pkg = readJson(pkgJsonPath);
+        if (pkg.name) byName.set(pkg.name, dir);
+      } catch {
+        /* ignore malformed */
+      }
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      stack.push(path.join(dir, entry.name));
+    }
+  }
+  return byName;
+}
+
+function collectThirdPartyDeps(roots, workspaces) {
+  const visited = new Set();
+  const queue = [...roots];
+  const thirdParty = new Map();
+  const strapiVisited = [];
+
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (visited.has(name)) continue;
+    visited.add(name);
+
+    const pkgDir = workspaces.get(name);
+    if (!pkgDir) {
+      console.warn(`warn: workspace package not found: ${name}`);
+      continue;
+    }
+
+    strapiVisited.push(name);
+    const pkg = readJson(path.join(pkgDir, 'package.json'));
+    for (const [dep, version] of Object.entries(pkg.dependencies || {})) {
+      if (dep.startsWith('@strapi/') || dep === 'strapi') {
+        // In-monorepo packages are walked; published externals (design-system, icons, …)
+        // are treated as third-party pins from the registry.
+        if (workspaces.has(dep)) {
+          queue.push(dep);
+        } else if (!thirdParty.has(dep)) {
+          thirdParty.set(dep, version);
+        }
+        continue;
+      }
+      // Prefer first pin seen (root-most); later pins are ignored if present
+      if (!thirdParty.has(dep)) {
+        thirdParty.set(dep, version);
+      }
+    }
+  }
+
+  return { thirdParty, strapiVisited };
+}
+
+function parseDeprecations(installLog) {
+  const deprecated = new Map();
+  const re = /npm warn deprecated ([^@\s]+)@([^\s:]+):\s*(.*)$/gim;
+  let match;
+  while ((match = re.exec(installLog)) !== null) {
+    const [, name, version, message] = match;
+    deprecated.set(name, { package: name, version, message: message.trim() });
+  }
+  // Scoped packages: npm warn deprecated @scope/name@version:
+  const scopedRe = /npm warn deprecated (@[^@\s]+\/[^@\s]+)@([^\s:]+):\s*(.*)$/gim;
+  while ((match = scopedRe.exec(installLog)) !== null) {
+    const [, name, version, message] = match;
+    deprecated.set(name, { package: name, version, message: message.trim() });
+  }
+  return [...deprecated.values()];
+}
+
+function leafVulnerabilities(audit) {
+  const leaves = [];
+  for (const [name, entry] of Object.entries(audit.vulnerabilities || {})) {
+    const advisories = (entry.via || []).filter((v) => typeof v === 'object' && v.url);
+    if (advisories.length === 0) continue;
+    leaves.push({
+      package: name,
+      severity: entry.severity,
+      range: entry.range,
+      advisories: advisories.map((a) => ({
+        title: a.title,
+        url: a.url,
+        severity: a.severity,
+      })),
+    });
+  }
+  return leaves;
+}
+
+function findingId(kind, pkg) {
+  return `${kind}:${pkg}`;
+}
+
+function classify(findings, baseline) {
+  const accepted = new Map((baseline.accepted || []).map((f) => [f.id, f]));
+  const known = new Map((baseline.known || []).map((f) => [f.id, f]));
+  const classified = { accepted: [], known: [], novel: [] };
+
+  for (const finding of findings) {
+    const id = finding.id;
+    if (accepted.has(id)) {
+      classified.accepted.push({ ...finding, baseline: accepted.get(id) });
+    } else if (known.has(id)) {
+      classified.known.push({ ...finding, baseline: known.get(id) });
+    } else {
+      classified.novel.push(finding);
+    }
+  }
+
+  return classified;
+}
+
+function writeReport({ outDir: dir, meta, classified, deprecations, vulns, auditMeta }) {
+  mkdirSync(dir, { recursive: true });
+
+  const report = {
+    meta,
+    summary: {
+      novel: classified.novel.length,
+      known: classified.known.length,
+      accepted: classified.accepted.length,
+      deprecations: deprecations.length,
+      vulnerabilities: vulns.length,
+      audit: auditMeta,
+    },
+    novel: classified.novel,
+    known: classified.known,
+    accepted: classified.accepted,
+  };
+
+  writeFileSync(path.join(dir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`);
+
+  const lines = [
+    '# Consumer dependency audit',
+    '',
+    `Generated: ${meta.generatedAt}`,
+    `Node: ${meta.node} · npm: ${meta.npm}`,
+    `Scratch: ${meta.scratchDir}`,
+    '',
+    '## Summary',
+    '',
+    `- Novel (fail): **${classified.novel.length}**`,
+    `- Known tracked: ${classified.known.length}`,
+    `- Accepted holds: ${classified.accepted.length}`,
+    `- Deprecations seen: ${deprecations.length}`,
+    `- Audit leaf advisories: ${vulns.length}`,
+    `- npm audit totals: ${JSON.stringify(auditMeta?.vulnerabilities || {})}`,
+    '',
+  ];
+
+  if (classified.novel.length > 0) {
+    lines.push('## Novel findings', '');
+    for (const f of classified.novel) {
+      lines.push(`- \`${f.id}\` (${f.kind}${f.severity ? `, ${f.severity}` : ''})`);
+      if (f.message) lines.push(`  - ${f.message}`);
+      if (f.advisories) {
+        for (const a of f.advisories) lines.push(`  - ${a.title} — ${a.url}`);
+      }
+    }
+    lines.push('');
+  }
+
+  if (classified.known.length > 0) {
+    lines.push('## Known (tracked)', '');
+    for (const f of classified.known) {
+      lines.push(`- \`${f.id}\` — ${f.baseline?.reason || ''}`);
+    }
+    lines.push('');
+  }
+
+  writeFileSync(path.join(dir, 'report.md'), `${lines.join('\n')}\n`);
+  return report;
+}
+
+function main() {
+  const config = readJson(CONFIG_PATH);
+  const baseline = readJson(BASELINE_PATH);
+  const workspaces = workspacePackages();
+
+  const { thirdParty, strapiVisited } = collectThirdPartyDeps(config.roots, workspaces);
+  for (const [name, version] of Object.entries(config.appDependencies || {})) {
+    if (!thirdParty.has(name)) thirdParty.set(name, version);
+  }
+
+  const dependencies = Object.fromEntries(
+    [...thirdParty.entries()].sort(([a], [b]) => a.localeCompare(b))
+  );
+
+  mkdirSync(outDir, { recursive: true });
+  const scratchDir = mkdtempSync(path.join(tmpdir(), 'strapi-consumer-audit-'));
+  const appDir = path.join(scratchDir, 'app');
+  mkdirSync(appDir);
+
+  const appPkg = {
+    name: 'strapi-consumer-audit',
+    version: '0.0.0',
+    private: true,
+    description: 'Synthetic CSA dependency closure for audit (third-party pins only)',
+    dependencies,
+  };
+  writeFileSync(path.join(appDir, 'package.json'), `${JSON.stringify(appPkg, null, 2)}\n`);
+  writeFileSync(
+    path.join(outDir, 'closure.json'),
+    `${JSON.stringify({ strapiPackages: strapiVisited.sort(), dependencies }, null, 2)}\n`
+  );
+
+  console.log(`==> Consumer closure: ${strapiVisited.length} @strapi packages`);
+  console.log(`==> Third-party deps: ${Object.keys(dependencies).length}`);
+  console.log(`==> Installing into ${appDir}`);
+
+  // Match create-strapi-app npm installs (legacy-peer-deps).
+  const install = spawnSync(
+    'npm',
+    ['install', '--no-fund', '--no-audit', '--ignore-scripts', '--legacy-peer-deps'],
+    {
+      cwd: appDir,
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+      env: { ...process.env, npm_config_fund: 'false', npm_config_audit: 'false' },
+    }
+  );
+
+  const installLog = `${install.stdout || ''}\n${install.stderr || ''}`;
+  writeFileSync(path.join(outDir, 'npm-install.log'), installLog);
+
+  if (install.status !== 0) {
+    rmSync(scratchDir, { recursive: true, force: true });
+    fail(`npm install failed (exit ${install.status}). See ${path.join(outDir, 'npm-install.log')}`);
+  }
+
+  const deprecations = parseDeprecations(installLog);
+  writeFileSync(path.join(outDir, 'deprecations.json'), `${JSON.stringify(deprecations, null, 2)}\n`);
+
+  console.log('==> Running npm audit');
+  const auditProc = spawnSync('npm', ['audit', '--json'], {
+    cwd: appDir,
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  // npm audit exits non-zero when vulns exist
+  let audit = {};
+  try {
+    audit = JSON.parse(auditProc.stdout || '{}');
+  } catch {
+    writeFileSync(path.join(outDir, 'npm-audit.raw.txt'), auditProc.stdout || auditProc.stderr || '');
+    rmSync(scratchDir, { recursive: true, force: true });
+    fail('failed to parse npm audit JSON');
+  }
+  writeFileSync(path.join(outDir, 'npm-audit.json'), `${JSON.stringify(audit, null, 2)}\n`);
+
+  const vulns = leafVulnerabilities(audit);
+  const findings = [
+    ...deprecations.map((d) => ({
+      id: findingId('deprecation', d.package),
+      kind: 'deprecation',
+      package: d.package,
+      version: d.version,
+      message: d.message,
+    })),
+    ...vulns.map((v) => ({
+      id: findingId('vulnerability', v.package),
+      kind: 'vulnerability',
+      package: v.package,
+      severity: v.severity,
+      range: v.range,
+      advisories: v.advisories,
+    })),
+  ];
+
+  const classified = classify(findings, baseline);
+
+  const nodeV = spawnSync('node', ['-v'], { encoding: 'utf8' }).stdout.trim();
+  const npmV = spawnSync('npm', ['-v'], { encoding: 'utf8', shell: process.platform === 'win32' })
+    .stdout.trim();
+
+  const report = writeReport({
+    outDir,
+    meta: {
+      generatedAt: new Date().toISOString(),
+      node: nodeV,
+      npm: npmV,
+      scratchDir,
+      roots: config.roots,
+    },
+    classified,
+    deprecations,
+    vulns,
+    auditMeta: audit.metadata,
+  });
+
+  // Keep install tree out of the repo; remove scratch after writing reports
+  rmSync(scratchDir, { recursive: true, force: true });
+
+  console.log('');
+  console.log(`Novel: ${classified.novel.length} · Known: ${classified.known.length} · Accepted: ${classified.accepted.length}`);
+  console.log(`Reports: ${path.join(outDir, 'report.md')}`);
+
+  if (classified.novel.length > 0) {
+    console.log('\nNovel findings:');
+    for (const f of classified.novel) {
+      console.log(`  - ${f.id}${f.severity ? ` (${f.severity})` : ''}`);
+    }
+    if (!noFail) {
+      process.exit(1);
+    }
+    console.log('\n(--no-fail: not failing CI)');
+  }
+
+  // silence unused
+  void report;
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exit(2);
+}


### PR DESCRIPTION
### What does it do?

Adds a **consumer dependency audit** workflow and script that:

1. Walks the default create-strapi-app package closure from monorepo `package.json` pins
2. `npm install`s those third-party deps into a scratch app (`--legacy-peer-deps`, matching CSA)
3. Captures `npm warn deprecated` lines + `npm audit --json`
4. Diffs against `scripts/consumer-audit/baseline.json` (`accepted` holds vs `known` tracked debt)
5. Fails CI only on **novel** findings

Runnable locally via `yarn consumer-audit` / `node scripts/consumer-audit/run.mjs`. CI runs weekly (Mondays) and on `workflow_dispatch`, plus on PRs that touch the audit files.

### Why is it needed?

Today we mostly discover CSA install warnings and consumer-facing vulns at release time. Monorepo `yarn audit` / Dependabot do not mirror what a fresh npm CSA app installs. This makes the consumer tree a first-class, diffable signal.

### How to test it?

```bash
yarn consumer-audit
# or
node scripts/consumer-audit/run.mjs --out /tmp/consumer-audit
```

Expect exit 0 with current baseline (novel = 0). Inspect `report.md`.

On GitHub: Actions → “Consumer dependency audit” → Run workflow.

### Related issue(s)/PR(s)

Fixes CMS-461