### PR TITLE
chore(utils): add lazyInit helper for deferred module loading

### DIFF
--- a/packages/core/admin/server/src/controllers/admin.ts
+++ b/packages/core/admin/server/src/controllers/admin.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { map, values, sumBy, pipe, flatMap, propEq } from 'lodash/fp';
 import _ from 'lodash';
 import { exists } from 'fs-extra';
-import { env } from '@strapi/utils';
+import { env, lazyInit } from '@strapi/utils';
 import {
   validateUpdateProjectSettings,
   validateUpdateProjectSettingsFiles,
@@ -24,17 +24,9 @@ import type {
 } from '../../../shared/contracts/admin';
 
 // Lazy: only resolved on first GET /admin/project-type request
-type TsUtilsModule = typeof import('@strapi/typescript-utils');
-let lazyTsUtils: TsUtilsModule | undefined;
-const isUsingTypeScript: TsUtilsModule['isUsingTypeScript'] = (
-  ...args: Parameters<TsUtilsModule['isUsingTypeScript']>
-) => {
-  if (!lazyTsUtils) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    lazyTsUtils = require('@strapi/typescript-utils');
-  }
-  return (lazyTsUtils as TsUtilsModule).isUsingTypeScript(...args);
-};
+const importTsUtils = lazyInit<typeof import('@strapi/typescript-utils')>(() =>
+  require('@strapi/typescript-utils')
+);
 
 /**
  * A set of functions called "actions" for `Admin`
@@ -107,8 +99,10 @@ export default {
       return;
     }
 
-    const useTypescriptOnServer = await isUsingTypeScript(strapi.dirs.app.root);
-    const useTypescriptOnAdmin = await isUsingTypeScript(
+    const tsUtils = importTsUtils();
+
+    const useTypescriptOnServer = await tsUtils.isUsingTypeScript(strapi.dirs.app.root);
+    const useTypescriptOnAdmin = await tsUtils.isUsingTypeScript(
       path.join(strapi.dirs.app.root, 'src', 'admin')
     );
     const isHostedOnStrapiCloud = env('STRAPI_HOSTING', null) === 'strapi.cloud';

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -7,6 +7,7 @@ import { Database } from '@strapi/database';
 
 import type { Core, Modules, UID, Schema } from '@strapi/types';
 
+import { lazyInit } from '@strapi/utils';
 import { loadConfiguration } from './configuration';
 import { warnDeprecatedServerConfig } from './configuration/server-config';
 
@@ -40,14 +41,9 @@ import { createConfigProvider } from './services/config';
 import { cleanComponentJoinTable } from './services/document-service/utils/clean-component-join-table';
 
 // Lazy: only resolved when `useTypescriptMigrations` is true (default false)
-let lazyTsUtils: typeof import('@strapi/typescript-utils') | undefined;
-const tsUtils = (): typeof import('@strapi/typescript-utils') => {
-  if (!lazyTsUtils) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    lazyTsUtils = require('@strapi/typescript-utils');
-  }
-  return lazyTsUtils as typeof import('@strapi/typescript-utils');
-};
+const tsUtils = lazyInit<typeof import('@strapi/typescript-utils')>(() =>
+  require('@strapi/typescript-utils')
+);
 
 class Strapi extends Container implements Core.Strapi {
   app: any;

--- a/packages/core/core/src/compile.ts
+++ b/packages/core/core/src/compile.ts
@@ -1,12 +1,9 @@
+import { lazyInit } from '@strapi/utils';
+
 // Lazy: only resolved when compileStrapi is invoked (develop / build)
-let lazyTsUtils: typeof import('@strapi/typescript-utils') | undefined;
-const tsUtils = (): typeof import('@strapi/typescript-utils') => {
-  if (!lazyTsUtils) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    lazyTsUtils = require('@strapi/typescript-utils');
-  }
-  return lazyTsUtils as typeof import('@strapi/typescript-utils');
-};
+const tsUtils = lazyInit<typeof import('@strapi/typescript-utils')>(() =>
+  require('@strapi/typescript-utils')
+);
 
 interface Options {
   appDir?: string;

--- a/packages/core/core/src/services/metrics/sender.ts
+++ b/packages/core/core/src/services/metrics/sender.ts
@@ -3,19 +3,14 @@ import path from 'path';
 import _ from 'lodash';
 import isDocker from 'is-docker';
 import ciEnv from 'ci-info';
-import { env, generateInstallId } from '@strapi/utils';
+import { env, generateInstallId, lazyInit } from '@strapi/utils';
 import type { Core } from '@strapi/types';
 import { generateAdminUserHash } from './admin-user-hash';
 
 // Lazy: only resolved when telemetry is enabled and a sender is constructed
-let lazyTsUtils: typeof import('@strapi/typescript-utils') | undefined;
-const tsUtils = (): typeof import('@strapi/typescript-utils') => {
-  if (!lazyTsUtils) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    lazyTsUtils = require('@strapi/typescript-utils');
-  }
-  return lazyTsUtils as typeof import('@strapi/typescript-utils');
-};
+const tsUtils = lazyInit<typeof import('@strapi/typescript-utils')>(() =>
+  require('@strapi/typescript-utils')
+);
 
 export interface Payload {
   eventProperties?: Record<string, unknown>;

--- a/packages/core/strapi/src/cli/commands/start.ts
+++ b/packages/core/strapi/src/cli/commands/start.ts
@@ -3,9 +3,14 @@ import fs from 'fs';
 import path from 'path';
 import { createStrapi } from '@strapi/core';
 
+import { lazyInit } from '@strapi/utils';
 import type { StrapiCommand } from '../types';
 import { runAction } from '../utils/helpers';
 import { tryQuickOutDir } from '../utils/try-quick-outdir';
+
+const importTsUtils = lazyInit<typeof import('@strapi/typescript-utils')>(() =>
+  require('@strapi/typescript-utils')
+);
 
 const action = async () => {
   const appDir = process.cwd();
@@ -23,11 +28,10 @@ const action = async () => {
       distDir = quickOutDir;
     } else {
       // Custom/extended tsconfig or unbuilt project — fall back to the slow correct path
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const tsUtils = require('@strapi/typescript-utils');
+      const tsUtils = importTsUtils();
       const outDir = await tsUtils.resolveOutDir(appDir);
 
-      if (!fs.existsSync(outDir)) {
+      if (!outDir || !fs.existsSync(outDir)) {
         throw new Error(
           `${outDir} directory not found. Please run the build command before starting your application`
         );

--- a/packages/core/strapi/src/cli/commands/ts/generate-types.ts
+++ b/packages/core/strapi/src/cli/commands/ts/generate-types.ts
@@ -1,5 +1,6 @@
 import { createCommand } from 'commander';
 
+import { lazyInit } from '@strapi/utils';
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
 
@@ -10,6 +11,10 @@ interface CmdOptions {
   outDir?: string;
 }
 
+const importTsUtils = lazyInit<typeof import('@strapi/typescript-utils')>(() =>
+  require('@strapi/typescript-utils')
+);
+
 const action = async ({ debug, silent, verbose, outDir }: CmdOptions) => {
   if ((debug || verbose) && silent) {
     console.error('Flags conflict: both silent and debug mode are enabled, exiting...');
@@ -18,7 +23,7 @@ const action = async ({ debug, silent, verbose, outDir }: CmdOptions) => {
 
   // Defer heavy requires until the command actually runs
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const tsUtils = require('@strapi/typescript-utils');
+  const tsUtils = importTsUtils();
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { createStrapi, compileStrapi } = require('@strapi/core');
 

--- a/packages/core/strapi/src/cli/utils/tsconfig.ts
+++ b/packages/core/strapi/src/cli/utils/tsconfig.ts
@@ -1,16 +1,10 @@
 import os from 'os';
 import type ts from 'typescript';
+import { lazyInit } from '@strapi/utils';
 import type { Logger } from './logger';
 
 // Lazy: defer `typescript` (~115 ms) until a CLI command actually loads tsconfig
-let lazyTs: typeof ts | undefined;
-const tsLib = (): typeof ts => {
-  if (!lazyTs) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    lazyTs = require('typescript');
-  }
-  return lazyTs as typeof ts;
-};
+const tsLib = lazyInit<typeof import('typescript')>(() => require('typescript'));
 
 interface TsConfig {
   config: ts.ParsedCommandLine;

--- a/packages/core/strapi/src/node/develop.ts
+++ b/packages/core/strapi/src/node/develop.ts
@@ -2,8 +2,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import cluster from 'node:cluster';
 
-import type chokidarType from 'chokidar';
 import type { createStrapi as CreateStrapi } from '@strapi/core';
+import { lazyInit } from '@strapi/utils';
 import type { CLIContext } from '../cli/types';
 import { handleAdminDependencies } from './core/ensure-admin-dependencies';
 import { getTimer, prettyTime, type TimeMeasurer } from './core/timer';
@@ -12,19 +12,11 @@ import type { ViteWatcher } from './vite/watch';
 import type { Logger } from '../cli/utils/logger';
 
 // Lazy: worker-only deps; primary cluster process should not pay for them
-const lazy = <T>(spec: string): (() => T) => {
-  let cached: T | undefined;
-  return (): T => {
-    if (cached === undefined) {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      cached = require(spec);
-    }
-    return cached as T;
-  };
-};
+const lazy = <T>(spec: string): (() => T) => lazyInit(() => require(spec));
+
 const tsUtils = lazy<typeof import('@strapi/typescript-utils')>('@strapi/typescript-utils');
 const utils = lazy<typeof import('@strapi/utils')>('@strapi/utils');
-const chokidar = lazy<typeof chokidarType>('chokidar');
+const chokidar = lazy<typeof import('chokidar')>('chokidar');
 const core = lazy<typeof import('@strapi/core')>('@strapi/core');
 const buildCtx = lazy<typeof import('./create-build-context')>('./create-build-context');
 const staticFs = lazy<typeof import('./staticFiles')>('./staticFiles');

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -10,6 +10,7 @@ export { createModelCache } from './model-cache';
 export { validateYupSchema, validateYupSchemaSync } from './validators';
 export { formatYupErrors } from './format-yup-error';
 export { isOperator, isOperatorOfType } from './operators';
+export { lazyInit } from './lazy';
 
 export * as queryParams from './convert-query-params';
 export {

--- a/packages/core/utils/src/lazy.ts
+++ b/packages/core/utils/src/lazy.ts
@@ -1,0 +1,13 @@
+/**
+ * Lazy Singleton pattern
+ */
+export function lazyInit<TReturn, const TArgs extends unknown[] = []>(
+  init: (...args: TArgs) => TReturn
+): (...args: TArgs) => TReturn {
+  let instance: TReturn | undefined;
+
+  return (...args: TArgs): TReturn => {
+    if (!instance) instance = init(...args);
+    return instance;
+  };
+}


### PR DESCRIPTION
### What does it do?

Adds a `lazyInit` helper to `@strapi/utils` (`packages/core/utils/src/lazy.ts`) and replaces every hand-rolled lazy-require singleton in the codebase with it.

```ts
export function lazyInit<TReturn, const TArgs extends unknown[] = []>(
  init: (...args: TArgs) => TReturn
): (...args: TArgs) => TReturn;
```

It memoises the first result and returns it on every later call, which is exactly the shape the existing deferred-`require` blocks implemented by hand.

Call sites migrated:

| File | Deferred module |
| --- | --- |
| `packages/core/admin/server/src/controllers/admin.ts` | `@strapi/typescript-utils` |
| `packages/core/core/src/Strapi.ts` | `@strapi/typescript-utils` |
| `packages/core/core/src/compile.ts` | `@strapi/typescript-utils` |
| `packages/core/core/src/services/metrics/sender.ts` | `@strapi/typescript-utils` |
| `packages/core/strapi/src/cli/commands/start.ts` | `@strapi/typescript-utils` |
| `packages/core/strapi/src/cli/commands/ts/generate-types.ts` | `@strapi/typescript-utils` |
| `packages/core/strapi/src/cli/utils/tsconfig.ts` | `typescript` |
| `packages/core/strapi/src/node/develop.ts` | `@strapi/typescript-utils`, `@strapi/utils`, `chokidar`, `@strapi/core`, `./create-build-context`, `./staticFiles` |

Two incidental changes ride along because they are in the same hunks:

- `cli/commands/start.ts` — `resolveOutDir` can return `undefined`, so the existence check is now `if (!outDir || !fs.existsSync(outDir))`. Previously `fs.existsSync(undefined)` would have thrown before the intended error message was produced.
- `node/develop.ts` — the `chokidar` type import moves from a top-level `import type chokidarType from 'chokidar'` to an inline `typeof import('chokidar')`, keeping all deferred-module typing consistent in that file.

### Why is it needed?

The same ~8-line lazy-require singleton had been copy-pasted into seven files, each with its own `let lazyX`, its own cast back to the module type, and its own `eslint-disable` for `no-var-requires`. That is duplicated logic with no single place to fix if the caching semantics ever need to change, and each copy re-states the module type twice.

The pattern exists for a real reason — keeping `typescript` (~115 ms) and `@strapi/typescript-utils` off the startup path, and keeping worker-only deps out of the primary cluster process — so this PR preserves it exactly and only removes the duplication.

### How to test it?

There is no behaviour change to observe; the deferred modules are still resolved on first call and cached afterwards. Verification is therefore mostly static:

```bash
yarn nx run-many -t test:ts --projects @strapi/strapi,@strapi/core,@strapi/utils,@strapi/typescript-utils
yarn test:unit
yarn lint
```

To confirm the laziness is still intact, from a sandbox app (`examples/getstarted`):

- `yarn strapi version` — a command that never reads a tsconfig should still not pull in `typescript` or `@strapi/typescript-utils`.
- `yarn build` and `yarn develop` in a TypeScript project — must compile exactly as before.

### Related issue(s)/PR(s)

None — this is standalone. It was split out of a larger change alongside #27300 (custom tsconfig path for the CLI); the two are independent and can be reviewed and merged in either order. If both land, the `lazyLoadTsConfig` memo added there is a natural follow-up candidate for `lazyInit`.
