### PR TITLE
security(deps): bump @modelcontextprotocol/sdk to 1.30.0

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -60,7 +60,7 @@
     "@casl/ability": "6.7.5",
     "@koa/cors": "5.0.0",
     "@koa/router": "12.0.2",
-    "@modelcontextprotocol/sdk": "1.29.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@paralleldrive/cuid2": "2.2.2",
     "@strapi/admin": "5.51.2",
     "@strapi/database": "5.51.2",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -59,7 +59,7 @@
     "@casl/ability": "6.7.5",
     "@koa/cors": "5.0.0",
     "@koa/router": "12.0.2",
-    "@modelcontextprotocol/sdk": "1.29.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@strapi/database": "5.51.2",
     "@strapi/logger": "5.51.2",
     "@strapi/permissions": "5.51.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4171,12 +4171,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hono/node-server@npm:^1.19.9":
-  version: 1.19.17
-  resolution: "@hono/node-server@npm:1.19.17"
+"@hono/node-server@npm:^1.19.9 || ^2.0.5":
+  version: 2.1.0
+  resolution: "@hono/node-server@npm:2.1.0"
   peerDependencies:
     hono: ^4
-  checksum: 10c0/e77907e3b5db8ab68ed4f297ad84807bfdd698636408de86ab8d36dab4658504ac4c0ed9d9436bc272a0172b9b7a5a4b578532e0b5baf97674c7b420cb5cff4b
+  checksum: 10c0/907aa2cabb804cf6f9c6bc329a898803b0794992d1c2d1bea7e4ae803f5d205fd2733d684c9c87b28338964dc437341e3bee1544b4d504a6b19f9e65ba28b198
   languageName: node
   linkType: hard
 
@@ -5131,11 +5131,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modelcontextprotocol/sdk@npm:1.29.0":
-  version: 1.29.0
-  resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
+"@modelcontextprotocol/sdk@npm:1.30.0":
+  version: 1.30.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.30.0"
   dependencies:
-    "@hono/node-server": "npm:^1.19.9"
+    "@hono/node-server": "npm:^1.19.9 || ^2.0.5"
     ajv: "npm:^8.17.1"
     ajv-formats: "npm:^3.0.1"
     content-type: "npm:^1.0.5"
@@ -5160,7 +5160,7 @@ __metadata:
       optional: true
     zod:
       optional: false
-  checksum: 10c0/7c4bc339205b1652330cd4e6b121cc859079655f2b9c0506bbb15563ba0d07924bda3d949705530532db7f4d2cb86d633dc8f92bc32803d97c7bece2ac63e29f
+  checksum: 10c0/6d12d5c88048b42b0d64906222f804eecbfc0aae02fc42a200d2438f037276cc7863510a8ce649e82c96d5972f62a58bfbdedf79624b0558a607738f5e58b97e
   languageName: node
   linkType: hard
 
@@ -9309,7 +9309,7 @@ __metadata:
     "@casl/ability": "npm:6.7.5"
     "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:12.0.2"
-    "@modelcontextprotocol/sdk": "npm:1.29.0"
+    "@modelcontextprotocol/sdk": "npm:1.30.0"
     "@paralleldrive/cuid2": "npm:2.2.2"
     "@strapi/admin": "npm:5.51.2"
     "@strapi/database": "npm:5.51.2"
@@ -10174,7 +10174,7 @@ __metadata:
     "@casl/ability": "npm:6.7.5"
     "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:12.0.2"
-    "@modelcontextprotocol/sdk": "npm:1.29.0"
+    "@modelcontextprotocol/sdk": "npm:1.30.0"
     "@strapi/database": "npm:5.51.2"
     "@strapi/logger": "npm:5.51.2"
     "@strapi/permissions": "npm:5.51.2"


### PR DESCRIPTION
### What does it do?

Bumps `@modelcontextprotocol/sdk` from `1.29.0` to `1.30.0` in `@strapi/core` and `@strapi/types`, and refreshes the Yarn lockfile.

That release widens `@hono/node-server` to `^1.19.9 || ^2.0.5`; the lockfile resolves `@hono/node-server@2.1.0`.

### Why is it needed?

Clears [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) (Windows `serve-static` path traversal via encoded backslash), which npm audit surfaces on a default Strapi consumer install via the MCP HTTP stack.

`1.30.0` is a v1 minor (fixes only; not the v2 SDK split). Strapi’s MCP imports (`McpServer`, `StreamableHTTPServerTransport`, shared types) are unchanged.

### How to test it?

```bash
# From monorepo root after install
yarn why @modelcontextprotocol/sdk
yarn why @hono/node-server
# Expect sdk 1.30.0 and @hono/node-server >= 2.0.5

# Existing MCP unit coverage
yarn test:unit --testPathPattern=packages/core/core/src/services/mcp
```

Optional: smoke an MCP session against a local app (tools/resources list + one tool call).

### Related issue(s)/PR(s)

Fixes CMS-1602

- Advisory: https://github.com/advisories/GHSA-frvp-7c67-39w9
- Upstream fix: https://github.com/modelcontextprotocol/typescript-sdk/pull/2549