### PR TITLE
chore(core): upgrade @koa/router to 15.7.0

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@casl/ability": "6.7.5",
     "@koa/cors": "5.0.0",
-    "@koa/router": "12.0.2",
+    "@koa/router": "15.7.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@paralleldrive/cuid2": "2.2.2",
     "@strapi/admin": "5.51.2",

--- a/packages/core/core/src/middlewares/public.ts
+++ b/packages/core/core/src/middlewares/public.ts
@@ -23,10 +23,10 @@ export const publicStatic: Core.MiddlewareFactory = (
       },
       config: { auth: false },
     },
-    // All other public GET-routes except /uploads/(.*) which is handled in upload middleware
+    // All other public GET-routes except /uploads/{*path} which is handled in upload middleware
     {
       method: 'GET',
-      path: '/((?!uploads/).+)',
+      path: /^\/(?!uploads\/).+/,
       handler: koaStatic(strapi.dirs.static.public, {
         maxage: maxAge,
         defer: true,

--- a/packages/core/core/src/services/server/compose-endpoint.ts
+++ b/packages/core/core/src/services/server/compose-endpoint.ts
@@ -11,7 +11,8 @@ const getMethod = (route: Core.Route) => {
   return trim(toLower(route.method)) as Lowercase<Core.Route['method']>;
 };
 
-const getPath = (route: Core.Route) => trim(route.path);
+const getPath = (route: Core.Route) =>
+  typeof route.path === 'string' ? trim(route.path) : route.path;
 
 const createRouteInfoMiddleware =
   (routeInfo: Core.Route): Core.MiddlewareHandler =>

--- a/packages/core/core/src/services/server/routing.ts
+++ b/packages/core/core/src/services/server/routing.ts
@@ -22,7 +22,14 @@ const policyOrMiddlewareSchema = yup.lazy((value) => {
 
 const routeSchema = yup.object({
   method: yup.string().oneOf(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'ALL']).required(),
-  path: yup.string().required(),
+  path: yup
+    .mixed()
+    .test(
+      'string-or-regexp',
+      'path must be a string or RegExp',
+      (value) => typeof value === 'string' || value instanceof RegExp
+    )
+    .required(),
   handler: yup.lazy((value) => {
     if (typeof value === 'string') {
       return yup.string().required();

--- a/packages/core/review-workflows/server/src/routes/review-workflows.ts
+++ b/packages/core/review-workflows/server/src/routes/review-workflows.ts
@@ -108,7 +108,16 @@ export default {
     },
     {
       method: 'PUT',
-      path: '/content-manager/(collection|single)-types/:model_uid/:id/stage',
+      path: '/content-manager/collection-types/:model_uid/:id/stage',
+      handler: 'stages.updateEntity',
+      config: {
+        middlewares: [enableFeatureMiddleware('review-workflows')],
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/content-manager/single-types/:model_uid/:id/stage',
       handler: 'stages.updateEntity',
       config: {
         middlewares: [enableFeatureMiddleware('review-workflows')],
@@ -117,7 +126,16 @@ export default {
     },
     {
       method: 'GET',
-      path: '/content-manager/(collection|single)-types/:model_uid/:id/stages',
+      path: '/content-manager/collection-types/:model_uid/:id/stages',
+      handler: 'stages.listAvailableStages',
+      config: {
+        middlewares: [enableFeatureMiddleware('review-workflows')],
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/content-manager/single-types/:model_uid/:id/stages',
       handler: 'stages.listAvailableStages',
       config: {
         middlewares: [enableFeatureMiddleware('review-workflows')],
@@ -126,7 +144,24 @@ export default {
     },
     {
       method: 'PUT',
-      path: '/content-manager/(collection|single)-types/:model_uid/:id/assignee',
+      path: '/content-manager/collection-types/:model_uid/:id/assignee',
+      handler: 'assignees.updateEntity',
+      config: {
+        middlewares: [enableFeatureMiddleware('review-workflows')],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['admin::users.read'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/content-manager/single-types/:model_uid/:id/assignee',
       handler: 'assignees.updateEntity',
       config: {
         middlewares: [enableFeatureMiddleware('review-workflows')],

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@casl/ability": "6.7.5",
     "@koa/cors": "5.0.0",
-    "@koa/router": "12.0.2",
+    "@koa/router": "15.7.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@strapi/database": "5.51.2",
     "@strapi/logger": "5.51.2",

--- a/packages/core/types/src/core/route.ts
+++ b/packages/core/types/src/core/route.ts
@@ -23,7 +23,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'ALL' | '
 
 export interface Route {
   method: HTTPMethod;
-  path: string;
+  path: string | RegExp;
   handler: HandlerReference | MiddlewareHandler | MiddlewareHandler[];
   info: RouteInfo;
   config?: RouteConfig;

--- a/packages/core/upload/server/src/middlewares/upload.ts
+++ b/packages/core/upload/server/src/middlewares/upload.ts
@@ -23,7 +23,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
   strapi.server.routes([
     {
       method: 'GET',
-      path: '/uploads/(.*)',
+      path: '/uploads/{*path}',
       handler: [range, koaStatic(strapi.dirs.static.public, { defer: true, ...localServerConfig })],
       config: { auth: false },
     },

--- a/packages/plugins/documentation/server/src/controllers/documentation.ts
+++ b/packages/plugins/documentation/server/src/controllers/documentation.ts
@@ -56,7 +56,10 @@ export default {
        * We don't expose the specs using koa-static or something else due to security reasons.
        * That's why, we need to read the file localy and send the specs through it when we serve the Swagger UI.
        */
-      const { major, minor, patch } = ctx.params;
+      const captures = (ctx as { captures?: string[] }).captures;
+      const major = ctx.params.major ?? captures?.[0];
+      const minor = ctx.params.minor ?? captures?.[1];
+      const patch = ctx.params.patch ?? captures?.[2];
       const version =
         major && minor && patch
           ? `${major}.${minor}.${patch}`

--- a/packages/plugins/documentation/server/src/controllers/documentation.ts
+++ b/packages/plugins/documentation/server/src/controllers/documentation.ts
@@ -56,10 +56,7 @@ export default {
        * We don't expose the specs using koa-static or something else due to security reasons.
        * That's why, we need to read the file localy and send the specs through it when we serve the Swagger UI.
        */
-      const captures = (ctx as { captures?: string[] }).captures;
-      const major = ctx.params.major ?? captures?.[0];
-      const minor = ctx.params.minor ?? captures?.[1];
-      const patch = ctx.params.patch ?? captures?.[2];
+      const { major, minor, patch } = ctx.params;
       const version =
         major && minor && patch
           ? `${major}.${minor}.${patch}`

--- a/packages/plugins/documentation/server/src/middlewares/documentation.ts
+++ b/packages/plugins/documentation/server/src/middlewares/documentation.ts
@@ -8,7 +8,7 @@ export const addDocumentMiddlewares = async ({ strapi }: { strapi: Core.Strapi }
   strapi.server.routes([
     {
       method: 'GET',
-      path: '/plugins/documentation/(.*)',
+      path: '/plugins/documentation/{*path}',
       async handler(ctx, next) {
         ctx.url = path.basename(ctx.url);
 

--- a/packages/plugins/documentation/server/src/routes/index.ts
+++ b/packages/plugins/documentation/server/src/routes/index.ts
@@ -12,7 +12,8 @@ export default [
   },
   {
     method: 'GET',
-    path: /^\/documentation\/v(\d+)\.(\d+)\.(\d+)\/?$/,
+    // Named params so the plugin prefix (`/documentation`) is applied; RegExp paths skip prefix.
+    path: '/v:major.:minor.:patch',
     handler: 'documentation.index',
     config: {
       auth: false,

--- a/packages/plugins/documentation/server/src/routes/index.ts
+++ b/packages/plugins/documentation/server/src/routes/index.ts
@@ -12,7 +12,7 @@ export default [
   },
   {
     method: 'GET',
-    path: '/v:major(\\d+).:minor(\\d+).:patch(\\d+)',
+    path: /^\/documentation\/v(\d+)\.(\d+)\.(\d+)/,
     handler: 'documentation.index',
     config: {
       auth: false,

--- a/packages/plugins/documentation/server/src/routes/index.ts
+++ b/packages/plugins/documentation/server/src/routes/index.ts
@@ -12,7 +12,7 @@ export default [
   },
   {
     method: 'GET',
-    path: /^\/documentation\/v(\d+)\.(\d+)\.(\d+)/,
+    path: /^\/documentation\/v(\d+)\.(\d+)\.(\d+)\/?$/,
     handler: 'documentation.index',
     config: {
       auth: false,

--- a/packages/plugins/users-permissions/server/src/routes/content-api/auth.js
+++ b/packages/plugins/users-permissions/server/src/routes/content-api/auth.js
@@ -8,7 +8,7 @@ module.exports = (strapi) => {
   return [
     {
       method: 'GET',
-      path: '/connect/(.*)',
+      path: '/connect/{*path}',
       handler: 'auth.connect',
       config: {
         middlewares: ['plugin::users-permissions.rateLimit'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4975,16 +4975,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@koa/router@npm:12.0.2":
-  version: 12.0.2
-  resolution: "@koa/router@npm:12.0.2"
+"@koa/router@npm:15.7.0":
+  version: 15.7.0
+  resolution: "@koa/router@npm:15.7.0"
   dependencies:
-    debug: "npm:^4.3.4"
-    http-errors: "npm:^2.0.0"
+    debug: "npm:^4.4.3"
+    http-errors: "npm:^2.0.1"
     koa-compose: "npm:^4.1.0"
-    methods: "npm:^1.1.2"
-    path-to-regexp: "npm:^6.3.0"
-  checksum: 10c0/9d33af8b5cb7e80cf2a17e156fe1821ad31ad672ff8e9df62a3af2d2e4a6f49abbbb7038edaea45ef078cabdd8a1ce595ad7da810e96b17c5b954ee46f7e554d
+    path-to-regexp: "npm:^8.4.2"
+  peerDependencies:
+    koa: ^2.0.0 || ^3.0.0
+  peerDependenciesMeta:
+    koa:
+      optional: false
+  checksum: 10c0/da1f23f07684f5b39db5536cd6d4b77f7e38930786c2c0c13cf27d84ab90b6c9eea5ecf17f8f4c1b87ccc822a874f64c351b6e9b4c2e6c9324765564fce689cb
   languageName: node
   linkType: hard
 
@@ -9308,7 +9312,7 @@ __metadata:
   dependencies:
     "@casl/ability": "npm:6.7.5"
     "@koa/cors": "npm:5.0.0"
-    "@koa/router": "npm:12.0.2"
+    "@koa/router": "npm:15.7.0"
     "@modelcontextprotocol/sdk": "npm:1.29.0"
     "@paralleldrive/cuid2": "npm:2.2.2"
     "@strapi/admin": "npm:5.51.2"
@@ -10173,7 +10177,7 @@ __metadata:
   dependencies:
     "@casl/ability": "npm:6.7.5"
     "@koa/cors": "npm:5.0.0"
-    "@koa/router": "npm:12.0.2"
+    "@koa/router": "npm:15.7.0"
     "@modelcontextprotocol/sdk": "npm:1.29.0"
     "@strapi/database": "npm:5.51.2"
     "@strapi/logger": "npm:5.51.2"
@@ -25844,7 +25848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:8.4.2, path-to-regexp@npm:^8.0.0":
+"path-to-regexp@npm:8.4.2, path-to-regexp@npm:^8.0.0, path-to-regexp@npm:^8.4.2":
   version: 8.4.2
   resolution: "path-to-regexp@npm:8.4.2"
   checksum: 10c0/05b115c49b47ad252ce05faa32930f643f23769c68b8bcfe78ad833545140c48bbffb3266986d6c8d5db13a64cf12e07e0d72d9882cab830efeefa553533ebaf


### PR DESCRIPTION
### What does it do?

Upgrades `@koa/router` from `12.0.2` to `15.7.0` (path-to-regexp v8) in `@strapi/core` and `@strapi/types`, and updates first-party route paths that are invalid under the new matcher.

- Splat routes: `(.*)` → `{*path}`
- Documentation version route: drop unsupported `:param(regex)` → `/v:major.:minor.:patch` (named params; plugin prefix still applied)
- Review Workflows: `(collection|single)-types` alternation → two explicit routes each
- Public static middleware: negative-lookahead string → RegExp
- Route registration: allow `path: string | RegExp` in types/validation/`compose-endpoint`

### Why is it needed?

`@koa/router` 12 depends on an older path-to-regexp and is on the deprecated/security upgrade path. v15 is required for CMS-466; existing regex-group route syntax breaks at boot under path-to-regexp v8.

### How to test it?

1. Fresh install / monorepo build with this branch.
2. Boot `examples/getstarted` (`yarn develop`) — confirm no path-to-regexp errors at startup.
3. OAuth connect: hit `/api/connect/<provider>` (users-permissions).
4. Upload/public assets: `GET /uploads/...` still served; other public files still served; `/uploads` not swallowed by public static.
5. Documentation plugin: open `/documentation` and `/documentation/vX.Y.Z`.
6. Review Workflows: change stage/assignee on both collection-type and single-type entries.

### Related issue(s)/PR(s)

Fixes CMS-466