### PR TITLE
feat(core): add opt-in Zod config factories for runtime validation

### DIFF
--- a/docs/docs/docs/01-core/configuration/00-intro.md
+++ b/docs/docs/docs/01-core/configuration/00-intro.md
@@ -112,7 +112,7 @@ Prefer `factories.defineAdminConfig` / `defineServerConfig` / `defineConfig('adm
 - JavaScript users get the same runtime checks when the config loads
 - Existing plain object / function exports remain supported (non-breaking)
 
-Schemas currently live in `@strapi/core` (`configuration/schemas`) and are intended to move to `@strapi/definitions` (`schemas.config.*`) once that package lands. Load-time validation of *all* configs (without opting into factories) and strict unknown-key rejection are follow-ups.
+Schemas currently live in `@strapi/core` (`configuration/schemas`) and are intended to move to `@strapi/definitions` (`schemas.config.*`) once that package lands. Load-time validation of _all_ configs (without opting into factories) and strict unknown-key rejection are follow-ups.
 
 ### Configuration filename restrictions
 

--- a/docs/docs/docs/01-core/configuration/00-intro.md
+++ b/docs/docs/docs/01-core/configuration/00-intro.md
@@ -104,6 +104,16 @@ In Strapi v5, they will be used for:
 - user-facing config factories to assist in typing project configuration
 - as part of the environment variable configuration loading to validate the structure of the base config file parsers to parse and strongly type values from the environment
 
+### Config factories (opt-in)
+
+Prefer `factories.defineAdminConfig` / `defineServerConfig` / `defineConfig('admin', …)` from `@strapi/strapi` when authoring `config/*` files. These are identity helpers with Zod runtime validation:
+
+- TypeScript users get inference without manual `: Core.Config.*` annotations
+- JavaScript users get the same runtime checks when the config loads
+- Existing plain object / function exports remain supported (non-breaking)
+
+Schemas currently live in `@strapi/core` (`configuration/schemas`) and are intended to move to `@strapi/definitions` (`schemas.config.*`) once that package lands. Load-time validation of *all* configs (without opting into factories) and strict unknown-key rejection are follow-ups.
+
 ### Configuration filename restrictions
 
 In Strapi v5, environment variables with the prefix `STRAPI_` will be loaded automatically into Strapi configuration. Because of that, some naming restrictions have been added to prevent conflicts.

--- a/packages/cli/create-strapi-app/templates/example-js/config/admin.js
+++ b/packages/cli/create-strapi-app/templates/example-js/config/admin.js
@@ -1,4 +1,8 @@
-module.exports = ({ env }) => ({
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
+module.exports = factories.defineAdminConfig(({ env }) => ({
   auth: {
     secret: env('ADMIN_JWT_SECRET'),
   },
@@ -18,4 +22,4 @@ module.exports = ({ env }) => ({
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
     docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
-});
+}));

--- a/packages/cli/create-strapi-app/templates/example-js/config/api.js
+++ b/packages/cli/create-strapi-app/templates/example-js/config/api.js
@@ -1,4 +1,8 @@
-module.exports = {
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
+module.exports = factories.defineApiConfig({
   rest: {
     defaultLimit: 25,
     maxLimit: 100,
@@ -9,4 +13,4 @@ module.exports = {
     strictParams: true,
     strictRelations: true,
   },
-};
+});

--- a/packages/cli/create-strapi-app/templates/example-js/config/database.js
+++ b/packages/cli/create-strapi-app/templates/example-js/config/database.js
@@ -1,9 +1,10 @@
-/** @import { Core } from '@strapi/strapi' */
+'use strict';
 
 const path = require('path');
+const { factories } = require('@strapi/strapi');
 const { isDatabaseClientKind } = require('@strapi/database');
 
-module.exports = ({ env }) => {
+module.exports = factories.defineDatabaseConfig(({ env }) => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
   if (!isDatabaseClientKind(client)) {
@@ -11,8 +12,6 @@ module.exports = ({ env }) => {
       `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
     );
   }
-
-  /** @type {Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']>} */
   const connections = {
     mysql: {
       client: 'mysql',
@@ -69,4 +68,4 @@ module.exports = ({ env }) => {
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
   };
-};
+});

--- a/packages/cli/create-strapi-app/templates/example-js/config/server.js
+++ b/packages/cli/create-strapi-app/templates/example-js/config/server.js
@@ -1,4 +1,8 @@
-module.exports = ({ env }) => ({
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
+module.exports = factories.defineServerConfig(({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
@@ -7,4 +11,4 @@ module.exports = ({ env }) => ({
   webhooks: {
     populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),
   },
-});
+}));

--- a/packages/cli/create-strapi-app/templates/example/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/admin.ts
@@ -1,25 +1,23 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
-const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
+export default factories.defineAdminConfig(({ env }) => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET')!,
+    secret: env('ADMIN_JWT_SECRET'),
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT')!,
+    salt: env('API_TOKEN_SALT'),
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT')!,
+      salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
   secrets: {
-    encryptionKey: env('ENCRYPTION_KEY')!,
+    encryptionKey: env('ENCRYPTION_KEY'),
   },
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
     docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
-});
-
-export default config;
+}));

--- a/packages/cli/create-strapi-app/templates/example/config/api.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/api.ts
@@ -1,6 +1,6 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
-const config: Core.Config.Api = {
+export default factories.defineApiConfig({
   rest: {
     defaultLimit: 25,
     maxLimit: 100,
@@ -11,6 +11,4 @@ const config: Core.Config.Api = {
     strictParams: true,
     strictRelations: true,
   },
-};
-
-export default config;
+});

--- a/packages/cli/create-strapi-app/templates/example/config/database.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/database.ts
@@ -1,8 +1,8 @@
 import path from 'path';
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 import { isDatabaseClientKind } from '@strapi/database';
 
-const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database => {
+export default factories.defineDatabaseConfig(({ env }) => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
   if (!isDatabaseClientKind(client)) {
@@ -11,7 +11,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     );
   }
 
-  const connections: Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']> = {
+  const connections = {
     mysql: {
       client: 'mysql',
       connection: {
@@ -67,6 +67,4 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
   };
-};
-
-export default config;
+});

--- a/packages/cli/create-strapi-app/templates/example/config/server.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/server.ts
@@ -1,14 +1,12 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
-const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server => ({
+export default factories.defineServerConfig(({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS')!,
+    keys: env.array('APP_KEYS'),
   },
   webhooks: {
     populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),
   },
-});
-
-export default config;
+}));

--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/admin.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/admin.js
@@ -1,4 +1,8 @@
-module.exports = ({ env }) => ({
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
+module.exports = factories.defineAdminConfig(({ env }) => ({
   auth: {
     secret: env('ADMIN_JWT_SECRET'),
   },
@@ -18,4 +22,4 @@ module.exports = ({ env }) => ({
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
     docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
-});
+}));

--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/api.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/api.js
@@ -7,5 +7,10 @@ module.exports = factories.defineApiConfig({
     defaultLimit: 25,
     maxLimit: 100,
     withCount: true,
+    strictParams: true,
+  },
+  documents: {
+    strictParams: true,
+    strictRelations: true,
   },
 });

--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/api.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/api.js
@@ -1,12 +1,11 @@
-module.exports = {
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
+module.exports = factories.defineApiConfig({
   rest: {
     defaultLimit: 25,
     maxLimit: 100,
     withCount: true,
-    strictParams: true,
   },
-  documents: {
-    strictParams: true,
-    strictRelations: true,
-  },
-};
+});

--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/database.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/database.js
@@ -1,9 +1,10 @@
-/** @import { Core } from '@strapi/strapi' */
+'use strict';
 
 const path = require('path');
+const { factories } = require('@strapi/strapi');
 const { isDatabaseClientKind } = require('@strapi/database');
 
-module.exports = ({ env }) => {
+module.exports = factories.defineDatabaseConfig(({ env }) => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
   if (!isDatabaseClientKind(client)) {
@@ -12,7 +13,6 @@ module.exports = ({ env }) => {
     );
   }
 
-  /** @type {Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']>} */
   const connections = {
     mysql: {
       client: 'mysql',
@@ -69,4 +69,4 @@ module.exports = ({ env }) => {
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
   };
-};
+});

--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/server.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/server.js
@@ -1,4 +1,8 @@
-module.exports = ({ env }) => ({
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
+module.exports = factories.defineServerConfig(({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
@@ -7,4 +11,4 @@ module.exports = ({ env }) => ({
   webhooks: {
     populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),
   },
-});
+}));

--- a/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
@@ -1,25 +1,23 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
-const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => ({
+export default factories.defineAdminConfig(({ env }) => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET')!,
+    secret: env('ADMIN_JWT_SECRET'),
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT')!,
+    salt: env('API_TOKEN_SALT'),
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT')!,
+      salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
   secrets: {
-    encryptionKey: env('ENCRYPTION_KEY')!,
+    encryptionKey: env('ENCRYPTION_KEY'),
   },
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
     docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
-});
-
-export default config;
+}));

--- a/packages/cli/create-strapi-app/templates/vanilla/config/api.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/api.ts
@@ -1,6 +1,6 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
-const config: Core.Config.Api = {
+export default factories.defineApiConfig({
   rest: {
     defaultLimit: 25,
     maxLimit: 100,
@@ -11,6 +11,4 @@ const config: Core.Config.Api = {
     strictParams: true,
     strictRelations: true,
   },
-};
-
-export default config;
+});

--- a/packages/cli/create-strapi-app/templates/vanilla/config/database.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/database.ts
@@ -1,8 +1,8 @@
 import path from 'path';
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 import { isDatabaseClientKind } from '@strapi/database';
 
-const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database => {
+export default factories.defineDatabaseConfig(({ env }) => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
   if (!isDatabaseClientKind(client)) {
@@ -11,7 +11,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
     );
   }
 
-  const connections: Record<Core.Config.Database.ClientKind, Core.Config.Database['connection']> = {
+  const connections = {
     mysql: {
       client: 'mysql',
       connection: {
@@ -67,6 +67,4 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Database 
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
   };
-};
-
-export default config;
+});

--- a/packages/cli/create-strapi-app/templates/vanilla/config/server.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/server.ts
@@ -1,14 +1,12 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
-const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Server => ({
+export default factories.defineServerConfig(({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS')!,
+    keys: env.array('APP_KEYS'),
   },
   webhooks: {
     populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),
   },
-});
-
-export default config;
+}));

--- a/packages/core/core/src/configuration/__tests__/define-config.test.ts
+++ b/packages/core/core/src/configuration/__tests__/define-config.test.ts
@@ -90,4 +90,26 @@ describe('defineConfig factories', () => {
       defineConfig('not-a-namespace', {})
     ).toThrow(/Unknown Strapi config namespace/);
   });
+
+  it('accepts known Core.Config fields omitted from early schema drafts', () => {
+    expect(() =>
+      defineAdminConfig({
+        forgotPassword: { expiresIn: '15m' },
+      })
+    ).not.toThrow();
+  });
+
+  it('throws when a factory function returns an invalid shape', () => {
+    const factory = defineServerConfig(({ env }) => ({
+      host: env('HOST', '0.0.0.0'),
+      // @ts-expect-error intentional invalid runtime shape
+      port: 'not-a-number',
+    }));
+
+    expect(() =>
+      (factory as (params: { env: (key: string, fallback?: string) => string }) => unknown)({
+        env: (key, fallback) => fallback ?? '',
+      })
+    ).toThrow(/Invalid Strapi config "server"/);
+  });
 });

--- a/packages/core/core/src/configuration/__tests__/define-config.test.ts
+++ b/packages/core/core/src/configuration/__tests__/define-config.test.ts
@@ -1,0 +1,93 @@
+import {
+  defineAdminConfig,
+  defineApiConfig,
+  defineConfig,
+  defineServerConfig,
+} from '../define-config';
+
+describe('defineConfig factories', () => {
+  it('returns a plain object after validating known fields', () => {
+    const config = defineAdminConfig({
+      auth: { secret: 'test-secret' },
+      apiToken: { salt: 'test-salt' },
+      flags: { nps: true },
+    });
+
+    expect(config).toEqual({
+      auth: { secret: 'test-secret' },
+      apiToken: { salt: 'test-salt' },
+      flags: { nps: true },
+    });
+  });
+
+  it('preserves unknown keys (non-breaking passthrough)', () => {
+    const config = defineServerConfig({
+      host: '0.0.0.0',
+      port: 1337,
+      customExtension: { enabled: true },
+    } as Parameters<typeof defineServerConfig>[0]);
+
+    expect(config).toMatchObject({
+      host: '0.0.0.0',
+      port: 1337,
+      customExtension: { enabled: true },
+    });
+  });
+
+  it('wraps factory functions and validates after invocation', () => {
+    const factory = defineAdminConfig(({ env }) => ({
+      auth: { secret: env('ADMIN_JWT_SECRET', 'fallback') },
+    }));
+
+    expect(typeof factory).toBe('function');
+
+    const env = Object.assign(
+      (key: string, defaultValue?: string) => {
+        if (key === 'ADMIN_JWT_SECRET') {
+          return 'from-env';
+        }
+        return defaultValue;
+      },
+      {
+        int: () => 0,
+        float: () => 0,
+        bool: () => false,
+        json: () => ({}),
+        array: () => [],
+        date: () => new Date(),
+        oneOf: () => '',
+      }
+    );
+
+    const resolved = (factory as (params: { env: typeof env }) => unknown)({ env });
+    expect(resolved).toEqual({ auth: { secret: 'from-env' } });
+  });
+
+  it('throws a path-aware error for invalid field types', () => {
+    expect(() =>
+      defineApiConfig({
+        rest: {
+          // @ts-expect-error intentional invalid runtime shape for JS/TS users
+          defaultLimit: 'twenty-five',
+        },
+      })
+    ).toThrow(/Invalid Strapi config "api"/);
+  });
+
+  it('supports the generic defineConfig(namespace, config) form', () => {
+    const config = defineConfig('features', {
+      future: { experimental_firstPublishedAt: true },
+    });
+
+    expect(config).toEqual({
+      future: { experimental_firstPublishedAt: true },
+    });
+  });
+
+  it('rejects an unknown namespace at runtime', () => {
+    expect(() =>
+      // @ts-expect-error unknown namespace
+      defineConfig('not-a-namespace', {})
+    ).toThrow(/Unknown Strapi config namespace/);
+  });
+});

--- a/packages/core/core/src/configuration/define-config.ts
+++ b/packages/core/core/src/configuration/define-config.ts
@@ -1,0 +1,90 @@
+import * as z from 'zod/v4';
+import type { Core } from '@strapi/types';
+
+import { configSchemas, type ConfigSchemaNamespace } from './schemas';
+
+export { configSchemas, type ConfigSchemaNamespace } from './schemas';
+
+type ConfigParams = Core.Config.Shared.ConfigParams;
+
+const formatConfigValidationError = (namespace: string, error: z.ZodError): Error => {
+  const details = error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `  - ${path}: ${issue.message}`;
+    })
+    .join('\n');
+
+  return new Error(`Invalid Strapi config "${namespace}":\n${details}`);
+};
+
+const parseConfigValue = <TSchema extends z.ZodType>(
+  namespace: string,
+  schema: TSchema,
+  value: unknown
+): z.infer<TSchema> => {
+  const result = schema.safeParse(value);
+
+  if (!result.success) {
+    throw formatConfigValidationError(namespace, result.error);
+  }
+
+  return result.data;
+};
+
+/**
+ * Opt-in config factory: TypeScript inference today, Zod validation at load for
+ * JS and TS. Validation runs when the factory is used — plain config exports
+ * are unchanged (non-breaking).
+ *
+ * Schemas live under `configuration/schemas` and are candidates for
+ * `@strapi/definitions` (`schemas.config.*`) once that package lands.
+ */
+export function defineConfig<
+  TNamespace extends ConfigSchemaNamespace,
+  TConfig extends z.input<(typeof configSchemas)[TNamespace]>,
+>(
+  namespace: TNamespace,
+  config: TConfig | ((params: ConfigParams) => TConfig)
+): TConfig | ((params: ConfigParams) => TConfig) {
+  const schema = configSchemas[namespace];
+
+  if (!schema) {
+    throw new Error(
+      `Unknown Strapi config namespace "${String(namespace)}". Supported: ${Object.keys(configSchemas).join(', ')}`
+    );
+  }
+
+  if (typeof config === 'function') {
+    const factory = config as (params: ConfigParams) => TConfig;
+    return ((params: ConfigParams) => {
+      return parseConfigValue(namespace, schema, factory(params)) as TConfig;
+    }) as (params: ConfigParams) => TConfig;
+  }
+
+  return parseConfigValue(namespace, schema, config) as TConfig;
+}
+
+export const defineAdminConfig = <TConfig extends z.input<typeof configSchemas.admin>>(
+  config: TConfig | ((params: ConfigParams) => TConfig)
+) => defineConfig('admin', config);
+
+export const defineServerConfig = <TConfig extends z.input<typeof configSchemas.server>>(
+  config: TConfig | ((params: ConfigParams) => TConfig)
+) => defineConfig('server', config);
+
+export const defineApiConfig = <TConfig extends z.input<typeof configSchemas.api>>(
+  config: TConfig | ((params: ConfigParams) => TConfig)
+) => defineConfig('api', config);
+
+export const defineFeaturesConfig = <TConfig extends z.input<typeof configSchemas.features>>(
+  config: TConfig | ((params: ConfigParams) => TConfig)
+) => defineConfig('features', config);
+
+export const defineTypescriptConfig = <TConfig extends z.input<typeof configSchemas.typescript>>(
+  config: TConfig | ((params: ConfigParams) => TConfig)
+) => defineConfig('typescript', config);
+
+export const defineDatabaseConfig = <TConfig extends z.input<typeof configSchemas.database>>(
+  config: TConfig | ((params: ConfigParams) => TConfig)
+) => defineConfig('database', config);

--- a/packages/core/core/src/configuration/schemas/index.ts
+++ b/packages/core/core/src/configuration/schemas/index.ts
@@ -115,6 +115,7 @@ export const adminConfigSchema = z
         emailTemplate: z.union([z.string(), unknownRecord]).optional(),
         from: z.string().optional(),
         replyTo: z.string().optional(),
+        expiresIn: z.union([z.string(), z.number()]).optional(),
       })
       .passthrough()
       .optional(),
@@ -139,7 +140,17 @@ export const adminConfigSchema = z
       })
       .passthrough()
       .optional(),
+    /**
+     * @deprecated Use `features.future.experimental_firstPublishedAt` instead.
+     */
+    firstPublishedAtField: z
+      .object({
+        enabled: z.boolean(),
+      })
+      .passthrough()
+      .optional(),
     url: z.string().optional(),
+    absoluteUrl: z.string().optional(),
     path: z.string().optional(),
     serveAdminPanel: z.boolean().optional(),
     autoOpen: z.boolean().optional(),
@@ -166,9 +177,28 @@ export const serverConfigSchema = z
             https: z.string().optional(),
             fetch: z.string().optional(),
             koa: z.boolean().optional(),
+            ipHeader: z.string().optional(),
+            maxIpsCount: z.number().optional(),
           })
           .passthrough(),
       ])
+      .optional(),
+    /**
+     * @deprecated Use `server.proxy.global` instead.
+     */
+    globalProxy: z.string().optional(),
+    /**
+     * @deprecated Not read by Strapi.
+     */
+    emitErrors: z.boolean().optional(),
+    /**
+     * @deprecated Use `admin.autoOpen` instead.
+     */
+    admin: z
+      .object({
+        autoOpen: z.boolean().optional(),
+      })
+      .passthrough()
       .optional(),
     app: z
       .object({
@@ -235,6 +265,7 @@ export const serverConfigSchema = z
       .passthrough()
       .optional(),
     openapi: unknownRecord.optional(),
+    absoluteUrl: z.string().optional(),
   })
   .passthrough();
 

--- a/packages/core/core/src/configuration/schemas/index.ts
+++ b/packages/core/core/src/configuration/schemas/index.ts
@@ -1,0 +1,319 @@
+import * as z from 'zod/v4';
+
+/**
+ * User-authored config schemas (partial / passthrough).
+ *
+ * These validate known fields when present without requiring a fully resolved
+ * config (defaults are merged later). Unknown keys pass through so this remains
+ * non-breaking until stricter base-namespace validation lands.
+ *
+ * Intended to move to `@strapi/definitions` (`schemas.config.*`) once that
+ * package exists — keep this module dependency-free aside from zod.
+ */
+
+const unknownRecord = z.record(z.string(), z.unknown());
+
+export const adminConfigSchema = z
+  .object({
+    apiToken: z
+      .object({
+        salt: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    auth: z
+      .object({
+        secret: z.string().optional(),
+        domain: z.string().optional(),
+        cookie: z
+          .object({
+            name: z.string().optional(),
+            secure: z.boolean().optional(),
+            domain: z.string().optional(),
+            path: z.string().optional(),
+            sameSite: z
+              .union([z.enum(['strict', 'lax', 'none']), z.boolean(), z.null()])
+              .optional(),
+          })
+          .passthrough()
+          .optional(),
+        sessions: z
+          .object({
+            accessTokenLifespan: z.number().optional(),
+            maxRefreshTokenLifespan: z.number().optional(),
+            idleRefreshTokenLifespan: z.number().optional(),
+            maxSessionLifespan: z.number().optional(),
+            idleSessionLifespan: z.number().optional(),
+            options: unknownRecord.optional(),
+          })
+          .passthrough()
+          .optional(),
+        events: z
+          .object({
+            onConnectionSuccess: z.any().optional(),
+            onConnectionError: z.any().optional(),
+          })
+          .passthrough()
+          .optional(),
+        providers: z.array(unknownRecord).optional(),
+        options: unknownRecord.optional(),
+      })
+      .passthrough()
+      .optional(),
+    transfer: z
+      .object({
+        token: z
+          .object({
+            salt: z.string().optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    secrets: z
+      .object({
+        encryptionKey: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    auditLogs: z
+      .object({
+        enabled: z.boolean().optional(),
+        retentionDays: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    history: z
+      .object({
+        retentionDays: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    preview: z
+      .object({
+        enabled: z.boolean().optional(),
+        config: z
+          .object({
+            allowedOrigins: z.array(z.string()).optional(),
+            handler: z.any().optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    ai: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    forgotPassword: z
+      .object({
+        // Runtime expects a template object; keep string for transitional typing drift (#26918).
+        emailTemplate: z.union([z.string(), unknownRecord]).optional(),
+        from: z.string().optional(),
+        replyTo: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    rateLimit: z
+      .object({
+        enabled: z.boolean().optional(),
+        interval: z.number().optional(),
+        max: z.number().optional(),
+        delayAfter: z.number().optional(),
+        timeWait: z.number().optional(),
+        prefixKey: z.string().optional(),
+        whitelist: z.string().optional(),
+        store: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    flags: z
+      .object({
+        nps: z.boolean().optional(),
+        promoteEE: z.boolean().optional(),
+        docLinks: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    url: z.string().optional(),
+    path: z.string().optional(),
+    serveAdminPanel: z.boolean().optional(),
+    autoOpen: z.boolean().optional(),
+    watchIgnoreFiles: z.array(z.string()).optional(),
+    host: z.string().optional(),
+    port: z.number().optional(),
+    layout: unknownRecord.optional(),
+  })
+  .passthrough();
+
+export const serverConfigSchema = z
+  .object({
+    host: z.string().optional(),
+    port: z.number().optional(),
+    socket: z.union([z.string(), z.number()]).optional(),
+    url: z.string().optional(),
+    proxy: z
+      .union([
+        z.boolean(),
+        z
+          .object({
+            global: z.string().optional(),
+            http: z.string().optional(),
+            https: z.string().optional(),
+            fetch: z.string().optional(),
+            koa: z.boolean().optional(),
+          })
+          .passthrough(),
+      ])
+      .optional(),
+    app: z
+      .object({
+        keys: z.array(z.string()).optional(),
+      })
+      .passthrough()
+      .optional(),
+    cron: z
+      .object({
+        enabled: z.boolean().optional(),
+        tasks: unknownRecord.optional(),
+      })
+      .passthrough()
+      .optional(),
+    dirs: z
+      .object({
+        public: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    logger: z
+      .object({
+        config: unknownRecord.optional(),
+        updates: z
+          .object({
+            enabled: z.boolean().optional(),
+          })
+          .passthrough()
+          .optional(),
+        startup: z
+          .object({
+            enabled: z.boolean().optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    transfer: z
+      .object({
+        remote: z
+          .object({
+            enabled: z.boolean().optional(),
+            assetIdleTimeoutMs: z.number().optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    webhooks: z
+      .object({
+        populateRelations: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    http: unknownRecord.optional(),
+    mcp: z
+      .object({
+        enabled: z.boolean().optional(),
+        connectTimeoutMs: z.number().optional(),
+        requestTimeoutMs: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    openapi: unknownRecord.optional(),
+  })
+  .passthrough();
+
+export const apiConfigSchema = z
+  .object({
+    responses: z
+      .object({
+        privateAttributes: z.array(z.string()).optional(),
+      })
+      .passthrough()
+      .optional(),
+    rest: z
+      .object({
+        prefix: z.string().optional(),
+        port: z.number().optional(),
+        defaultLimit: z.number().optional(),
+        maxLimit: z.number().optional(),
+        withCount: z.boolean().optional(),
+        strictParams: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    documents: z
+      .object({
+        strictParams: z.boolean().optional(),
+        strictRelations: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export const featuresConfigSchema = z
+  .object({
+    future: z.record(z.string(), z.boolean().optional()).optional(),
+  })
+  .passthrough();
+
+export const typescriptConfigSchema = z
+  .object({
+    autogenerate: z.boolean().optional(),
+  })
+  .passthrough();
+
+/**
+ * Database user config is client-discriminated and often includes knex extras.
+ * Validate the common envelope loosely; tighten when schemas move to definitions.
+ */
+export const databaseConfigSchema = z
+  .object({
+    connection: z
+      .object({
+        client: z.enum(['mysql', 'postgres', 'sqlite']).optional(),
+        connection: z.union([unknownRecord, z.any()]).optional(),
+        debug: z.boolean().optional(),
+        pool: unknownRecord.optional(),
+        acquireConnectionTimeout: z.number().optional(),
+        useNullAsDefault: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    settings: z
+      .object({
+        forceMigration: z.boolean().optional(),
+        runMigrations: z.boolean().optional(),
+        useTypescriptMigrations: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export const configSchemas = {
+  admin: adminConfigSchema,
+  server: serverConfigSchema,
+  api: apiConfigSchema,
+  features: featuresConfigSchema,
+  typescript: typescriptConfigSchema,
+  database: databaseConfigSchema,
+} as const;
+
+export type ConfigSchemaNamespace = keyof typeof configSchemas;

--- a/packages/core/core/src/factories.ts
+++ b/packages/core/core/src/factories.ts
@@ -5,6 +5,16 @@ import { createController } from './core-api/controller';
 import { CoreContentTypeRouteValidator } from './core-api/routes/validation';
 import { createService } from './core-api/service';
 import { createRoutes } from './core-api/routes';
+import {
+  configSchemas,
+  defineConfig,
+  defineAdminConfig,
+  defineServerConfig,
+  defineApiConfig,
+  defineFeaturesConfig,
+  defineTypescriptConfig,
+  defineDatabaseConfig,
+} from './configuration/define-config';
 
 const symbols = {
   CustomController: Symbol('StrapiCustomCoreController'),
@@ -131,4 +141,13 @@ export {
   createCoreRouter,
   createCoreValidator,
   isCustomController,
+  // Config factories (opt-in Zod validation + TS inference)
+  configSchemas,
+  defineConfig,
+  defineAdminConfig,
+  defineServerConfig,
+  defineApiConfig,
+  defineFeaturesConfig,
+  defineTypescriptConfig,
+  defineDatabaseConfig,
 };


### PR DESCRIPTION
### What does it do?

Adds opt-in config factories on `@strapi/strapi` / `@strapi/core` `factories`:

- `defineConfig(namespace, config)`
- `defineAdminConfig` / `defineServerConfig` / `defineApiConfig` / `defineFeaturesConfig` / `defineTypescriptConfig` / `defineDatabaseConfig`

Each factory is an identity helper with Zod runtime validation (passthrough for unknown keys). Function-form configs are wrapped and validated after `({ env }) => …` runs. Plain config exports without factories are unchanged.

New apps from `create-strapi-app` use the factories for `admin` / `server` / `api`. Schemas live in `@strapi/core` (`configuration/schemas`) and are exported as `factories.configSchemas` so they can move to `@strapi/definitions` later.

### Why is it needed?

Config types are hand-maintained and drift from runtime; JavaScript projects get no checks. This gives TS inference and JS/TS runtime validation without forcing a breaking load-time validation pass for existing apps.

### How to test it?

1. `yarn nx test:unit @strapi/core --testPathPattern=define-config`
2. In a TS or JS app:

```js
const { factories } = require('@strapi/strapi');
module.exports = factories.defineAdminConfig(({ env }) => ({
  auth: { secret: env('ADMIN_JWT_SECRET') },
  apiToken: { salt: 123 }, // should throw on load
}));
```

3. Confirm existing projects that do not use factories still boot unchanged.

### Related issue(s)/PR(s)

Fixes CMS-393

Related direction: https://github.com/strapi/strapi/pull/25992#issuecomment-4923701182 (Zod + identity helpers)
Related future home: CMS-1238 / https://github.com/strapi/strapi/pull/26783 (`@strapi/definitions`)