### PR TITLE
feat(core): add defineMiddlewaresConfig factory

### DIFF
--- a/docs/docs/docs/01-core/configuration/00-intro.md
+++ b/docs/docs/docs/01-core/configuration/00-intro.md
@@ -106,7 +106,7 @@ In Strapi v5, they will be used for:
 
 ### Config factories (opt-in)
 
-Prefer `factories.defineAdminConfig` / `defineServerConfig` / `defineConfig('admin', …)` from `@strapi/strapi` when authoring `config/*` files. These are identity helpers with Zod runtime validation:
+Prefer `factories.defineAdminConfig` / `defineServerConfig` / `defineMiddlewaresConfig` / `defineConfig('admin', …)` from `@strapi/strapi` when authoring `config/*` files. These are identity helpers with Zod runtime validation:
 
 - TypeScript users get inference without manual `: Core.Config.*` annotations
 - JavaScript users get the same runtime checks when the config loads

--- a/packages/cli/create-strapi-app/templates/example-js/config/middlewares.js
+++ b/packages/cli/create-strapi-app/templates/example-js/config/middlewares.js
@@ -1,4 +1,8 @@
-module.exports = [
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
+module.exports = factories.defineMiddlewaresConfig([
   'strapi::logger',
   'strapi::errors',
   'strapi::security',
@@ -9,4 +13,4 @@ module.exports = [
   'strapi::session',
   'strapi::favicon',
   'strapi::public',
-];
+]);

--- a/packages/cli/create-strapi-app/templates/example/config/middlewares.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/middlewares.ts
@@ -1,6 +1,6 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
-const config: Core.Config.Middlewares = [
+export default factories.defineMiddlewaresConfig([
   'strapi::logger',
   'strapi::errors',
   'strapi::security',
@@ -11,6 +11,4 @@ const config: Core.Config.Middlewares = [
   'strapi::session',
   'strapi::favicon',
   'strapi::public',
-];
-
-export default config;
+]);

--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/middlewares.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/middlewares.js
@@ -1,4 +1,8 @@
-module.exports = [
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
+module.exports = factories.defineMiddlewaresConfig([
   'strapi::logger',
   'strapi::errors',
   'strapi::security',
@@ -9,4 +13,4 @@ module.exports = [
   'strapi::session',
   'strapi::favicon',
   'strapi::public',
-];
+]);

--- a/packages/cli/create-strapi-app/templates/vanilla/config/middlewares.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/middlewares.ts
@@ -1,6 +1,6 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
-const config: Core.Config.Middlewares = [
+export default factories.defineMiddlewaresConfig([
   'strapi::logger',
   'strapi::errors',
   'strapi::security',
@@ -11,6 +11,4 @@ const config: Core.Config.Middlewares = [
   'strapi::session',
   'strapi::favicon',
   'strapi::public',
-];
-
-export default config;
+]);

--- a/packages/core/core/src/configuration/__tests__/define-config.test.ts
+++ b/packages/core/core/src/configuration/__tests__/define-config.test.ts
@@ -2,6 +2,7 @@ import {
   defineAdminConfig,
   defineApiConfig,
   defineConfig,
+  defineMiddlewaresConfig,
   defineServerConfig,
 } from '../define-config';
 
@@ -111,5 +112,21 @@ describe('defineConfig factories', () => {
         env: (key, fallback) => fallback ?? '',
       })
     ).toThrow(/Invalid Strapi config "server"/);
+  });
+
+  it('validates middlewares as an array of names or config objects', () => {
+    const config = defineMiddlewaresConfig([
+      'strapi::logger',
+      { name: 'strapi::cors', config: { origin: ['*'] } },
+    ]);
+
+    expect(config).toHaveLength(2);
+  });
+
+  it('rejects a non-array middlewares config', () => {
+    expect(() =>
+      // @ts-expect-error intentional invalid runtime shape
+      defineMiddlewaresConfig({ name: 'strapi::logger' })
+    ).toThrow(/Invalid Strapi config "middlewares"/);
   });
 });

--- a/packages/core/core/src/configuration/define-config.ts
+++ b/packages/core/core/src/configuration/define-config.ts
@@ -88,3 +88,7 @@ export const defineTypescriptConfig = <TConfig extends z.input<typeof configSche
 export const defineDatabaseConfig = <TConfig extends z.input<typeof configSchemas.database>>(
   config: TConfig | ((params: ConfigParams) => TConfig)
 ) => defineConfig('database', config);
+
+export const defineMiddlewaresConfig = <TConfig extends z.input<typeof configSchemas.middlewares>>(
+  config: TConfig | ((params: ConfigParams) => TConfig)
+) => defineConfig('middlewares', config);

--- a/packages/core/core/src/configuration/schemas/index.ts
+++ b/packages/core/core/src/configuration/schemas/index.ts
@@ -338,6 +338,24 @@ export const databaseConfigSchema = z
   })
   .passthrough();
 
+/**
+ * Middleware config is an array of names, `{ name, config, resolve }` objects, or handlers.
+ * Per-middleware config shapes are not validated here yet (follow-up / definitions).
+ */
+export const middlewaresConfigSchema = z.array(
+  z.union([
+    z.string(),
+    z
+      .object({
+        name: z.string().optional(),
+        resolve: z.string().optional(),
+        config: z.unknown().optional(),
+      })
+      .passthrough(),
+    z.any(),
+  ])
+);
+
 export const configSchemas = {
   admin: adminConfigSchema,
   server: serverConfigSchema,
@@ -345,6 +363,7 @@ export const configSchemas = {
   features: featuresConfigSchema,
   typescript: typescriptConfigSchema,
   database: databaseConfigSchema,
+  middlewares: middlewaresConfigSchema,
 } as const;
 
 export type ConfigSchemaNamespace = keyof typeof configSchemas;

--- a/packages/core/core/src/factories.ts
+++ b/packages/core/core/src/factories.ts
@@ -14,6 +14,7 @@ import {
   defineFeaturesConfig,
   defineTypescriptConfig,
   defineDatabaseConfig,
+  defineMiddlewaresConfig,
 } from './configuration/define-config';
 
 const symbols = {
@@ -150,4 +151,5 @@ export {
   defineFeaturesConfig,
   defineTypescriptConfig,
   defineDatabaseConfig,
+  defineMiddlewaresConfig,
 };


### PR DESCRIPTION
### What does it do?

Adds `factories.defineMiddlewaresConfig` (and `defineConfig('middlewares', …)`) with a Zod schema for the middleware array: string names, `{ name, config, resolve }` objects, or handlers.

Updates create-strapi-app middleware templates to use the factory.

Stacked on #27304 (config factories base).

### Why is it needed?

Extends the opt-in config factory work to `config/middlewares` so JS/TS apps get runtime shape checks. Per-middleware config payloads stay loosely typed until dedicated schemas exist.

### How to test it?

1. `yarn nx test:unit @strapi/core --testPathPattern=define-config`
2. Confirm middleware templates export `defineMiddlewaresConfig([...])`
3. Invalid non-array export should throw on load when using the factory

### Related issue(s)/PR(s)

Fixes CMS-393 (stacked follow-up)
Depends on #27304