### PR TITLE
feat(core): add definePluginsConfig envelope factory

### DIFF
--- a/docs/docs/docs/01-core/configuration/00-intro.md
+++ b/docs/docs/docs/01-core/configuration/00-intro.md
@@ -106,11 +106,12 @@ In Strapi v5, they will be used for:
 
 ### Config factories (opt-in)
 
-Prefer `factories.defineAdminConfig` / `defineServerConfig` / `defineMiddlewaresConfig` / `defineConfig('admin', …)` from `@strapi/strapi` when authoring `config/*` files. These are identity helpers with Zod runtime validation:
+Prefer `factories.defineAdminConfig` / `defineServerConfig` / `defineMiddlewaresConfig` / `definePluginsConfig` / `defineConfig('admin', …)` from `@strapi/strapi` when authoring `config/*` files. These are identity helpers with Zod runtime validation:
 
 - TypeScript users get inference without manual `: Core.Config.*` annotations
 - JavaScript users get the same runtime checks when the config loads
 - Existing plain object / function exports remain supported (non-breaking)
+- `definePluginsConfig` validates the plugin envelope (`enabled` / `resolve` / `config`) only; deep per-plugin payload checks remain on each plugin's `config.validator`
 
 Schemas currently live in `@strapi/core` (`configuration/schemas`) and are intended to move to `@strapi/definitions` (`schemas.config.*`) once that package lands. Load-time validation of _all_ configs (without opting into factories) and strict unknown-key rejection are follow-ups.
 

--- a/packages/cli/create-strapi-app/templates/example-js/config/plugins.js
+++ b/packages/cli/create-strapi-app/templates/example-js/config/plugins.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
 const allowedMediaTypes = [
   'image/*',
   'video/*',
@@ -20,7 +24,7 @@ const deniedExecutableTypes = [
   'application/x-mach-binary',
 ];
 
-module.exports = () => ({
+module.exports = factories.definePluginsConfig(() => ({
   'users-permissions': {
     config: {
       jwtManagement: 'refresh',
@@ -37,4 +41,4 @@ module.exports = () => ({
       },
     },
   },
-});
+}));

--- a/packages/cli/create-strapi-app/templates/example/config/plugins.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/plugins.ts
@@ -1,4 +1,4 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
 const allowedMediaTypes = [
   'image/*',
@@ -22,7 +22,7 @@ const deniedExecutableTypes = [
   'application/x-mach-binary',
 ];
 
-const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Plugin => ({
+export default factories.definePluginsConfig(() => ({
   'users-permissions': {
     config: {
       jwtManagement: 'refresh',
@@ -39,6 +39,4 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Plugin =>
       },
     },
   },
-});
-
-export default config;
+}));

--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/plugins.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/plugins.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const { factories } = require('@strapi/strapi');
+
 const allowedMediaTypes = [
   'image/*',
   'video/*',
@@ -20,7 +24,7 @@ const deniedExecutableTypes = [
   'application/x-mach-binary',
 ];
 
-module.exports = () => ({
+module.exports = factories.definePluginsConfig(() => ({
   'users-permissions': {
     config: {
       jwtManagement: 'refresh',
@@ -37,4 +41,4 @@ module.exports = () => ({
       },
     },
   },
-});
+}));

--- a/packages/cli/create-strapi-app/templates/vanilla/config/plugins.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/plugins.ts
@@ -1,4 +1,4 @@
-import type { Core } from '@strapi/strapi';
+import { factories } from '@strapi/strapi';
 
 const allowedMediaTypes = [
   'image/*',
@@ -22,7 +22,7 @@ const deniedExecutableTypes = [
   'application/x-mach-binary',
 ];
 
-const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Plugin => ({
+export default factories.definePluginsConfig(() => ({
   'users-permissions': {
     config: {
       jwtManagement: 'refresh',
@@ -39,6 +39,4 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Plugin =>
       },
     },
   },
-});
-
-export default config;
+}));

--- a/packages/core/core/src/configuration/__tests__/define-config.test.ts
+++ b/packages/core/core/src/configuration/__tests__/define-config.test.ts
@@ -3,6 +3,7 @@ import {
   defineApiConfig,
   defineConfig,
   defineMiddlewaresConfig,
+  definePluginsConfig,
   defineServerConfig,
 } from '../define-config';
 
@@ -128,5 +129,26 @@ describe('defineConfig factories', () => {
       // @ts-expect-error intentional invalid runtime shape
       defineMiddlewaresConfig({ name: 'strapi::logger' })
     ).toThrow(/Invalid Strapi config "middlewares"/);
+  });
+
+  it('validates the plugins config envelope without deep plugin payloads', () => {
+    const config = definePluginsConfig({
+      graphql: { enabled: true, config: { endpoint: '/graphql' } },
+      upload: false,
+    });
+
+    expect(config).toEqual({
+      graphql: { enabled: true, config: { endpoint: '/graphql' } },
+      upload: false,
+    });
+  });
+
+  it('rejects an invalid plugins entry shape', () => {
+    expect(() =>
+      definePluginsConfig({
+        // @ts-expect-error intentional invalid runtime shape
+        graphql: 'yes',
+      })
+    ).toThrow(/Invalid Strapi config "plugins"/);
   });
 });

--- a/packages/core/core/src/configuration/define-config.ts
+++ b/packages/core/core/src/configuration/define-config.ts
@@ -92,3 +92,7 @@ export const defineDatabaseConfig = <TConfig extends z.input<typeof configSchema
 export const defineMiddlewaresConfig = <TConfig extends z.input<typeof configSchemas.middlewares>>(
   config: TConfig | ((params: ConfigParams) => TConfig)
 ) => defineConfig('middlewares', config);
+
+export const definePluginsConfig = <TConfig extends z.input<typeof configSchemas.plugins>>(
+  config: TConfig | ((params: ConfigParams) => TConfig)
+) => defineConfig('plugins', config);

--- a/packages/core/core/src/configuration/schemas/index.ts
+++ b/packages/core/core/src/configuration/schemas/index.ts
@@ -356,6 +356,25 @@ export const middlewaresConfigSchema = z.array(
   ])
 );
 
+/**
+ * Plugins config envelope only (`enabled` / `resolve` / `config`).
+ * Per-plugin `config` payloads stay `unknown` here — deep validation belongs on
+ * each plugin's `config.validator` (and future schema registry / augmentation).
+ */
+export const pluginsConfigSchema = z.record(
+  z.string(),
+  z.union([
+    z.boolean(),
+    z
+      .object({
+        enabled: z.boolean().optional(),
+        resolve: z.string().optional(),
+        config: z.unknown().optional(),
+      })
+      .passthrough(),
+  ])
+);
+
 export const configSchemas = {
   admin: adminConfigSchema,
   server: serverConfigSchema,
@@ -364,6 +383,7 @@ export const configSchemas = {
   typescript: typescriptConfigSchema,
   database: databaseConfigSchema,
   middlewares: middlewaresConfigSchema,
+  plugins: pluginsConfigSchema,
 } as const;
 
 export type ConfigSchemaNamespace = keyof typeof configSchemas;

--- a/packages/core/core/src/factories.ts
+++ b/packages/core/core/src/factories.ts
@@ -15,6 +15,7 @@ import {
   defineTypescriptConfig,
   defineDatabaseConfig,
   defineMiddlewaresConfig,
+  definePluginsConfig,
 } from './configuration/define-config';
 
 const symbols = {
@@ -152,4 +153,5 @@ export {
   defineTypescriptConfig,
   defineDatabaseConfig,
   defineMiddlewaresConfig,
+  definePluginsConfig,
 };


### PR DESCRIPTION
### What does it do?

Adds `factories.definePluginsConfig` (and `defineConfig('plugins', …)`) with a Zod schema for the **plugin envelope** only:

- boolean shortcut, or
- `{ enabled?, resolve?, config? }` (passthrough)

Per-plugin `config` payloads remain `unknown` at this layer. Deep validation stays on each plugin's existing `config.validator` (and a future schema registry / type augmentation).

Updates create-strapi-app plugins templates to use the factory.

Stacked on #27306 (middlewares) → #27304 (base factories).

### Why is it needed?

Gives JS/TS apps runtime checks for malformed `config/plugins` entries without pretending core owns every plugin's payload schema.

### How to test it?

1. `yarn nx test:unit @strapi/core --testPathPattern=define-config`
2. Confirm plugins templates use `definePluginsConfig`
3. Invalid entry like `graphql: 'yes'` should throw when using the factory

### Related issue(s)/PR(s)

Fixes CMS-393 (stacked follow-up)
Depends on #27306 / #27304
Related: CMS-1238 (`@strapi/definitions`) for future schema home + plugin registry