### PR TITLE
fix(core/strapi): local plugins duplicate the admin module graph and exhaust build memory

### DIFF
--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
@@ -23,6 +23,15 @@ const PNPM_OPTIMIZE_ALIAS_MODULES = ['invariant', 'prismjs', 'lodash'] as const;
  */
 const DND_SINGLETON_MODULES = ['react-dnd', 'react-dnd-html5-backend'] as const;
 
+/**
+ * resolve.dedupe forces resolution from the app root, so only packages the app itself declares
+ * may be deduped. These two are @strapi/admin dependencies: under pnpm's strict isolation they
+ * have no top-level node_modules entry, so deduping them would turn a working (if duplicated)
+ * local-plugin import into an unresolved one. Aliasing the package directory is not an option
+ * either — resolve.alias bypasses their exports map (@strapi/icons publishes ./symbols).
+ */
+const PNPM_UNSAFE_DEDUPE_MODULES = ['@strapi/icons', 'react-intl'] as const;
+
 describe('ADMIN_VITE_ALIAS_MODULES contract', () => {
   it.each(PNPM_OPTIMIZE_ALIAS_MODULES)(
     'includes %s for pnpm optimizeDeps.include resolution (#27014)',
@@ -61,6 +70,14 @@ describe('ADMIN_VITE_DEDUPE_ONLY_MODULES contract (#22946)', () => {
   it.each(ADMIN_VITE_DEDUPE_ONLY_MODULES)(
     'keeps %s out of the alias list — aliasing bypasses its exports map and breaks the build',
     (mod) => {
+      expect(ADMIN_VITE_ALIAS_MODULES).not.toContain(mod);
+    }
+  );
+
+  it.each(PNPM_UNSAFE_DEDUPE_MODULES)(
+    'keeps %s out of the dedupe list — it is not an app dependency',
+    (mod) => {
+      expect(ADMIN_VITE_DEDUPE_MODULES).not.toContain(mod);
       expect(ADMIN_VITE_ALIAS_MODULES).not.toContain(mod);
     }
   );

--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
@@ -5,6 +5,7 @@ import {
   ADMIN_PINNED_ALIAS_MODULES,
   ADMIN_VITE_ALIAS_MODULES,
   ADMIN_VITE_DEDUPE_MODULES,
+  ADMIN_VITE_DEDUPE_ONLY_MODULES,
   ADMIN_VITE_SINGLETON_MODULES,
 } from '../admin-vite-alias-modules';
 import { buildAdminViteResolveAliases } from '../admin-vite-aliases';
@@ -41,6 +42,40 @@ describe('ADMIN_VITE_ALIAS_MODULES contract', () => {
   });
 });
 
+/**
+ * A local plugin is imported by relative path, so Rollup resolves the bare specifiers in its
+ * built output from the plugin's own node_modules. Without dedupe, each local plugin drags a
+ * second copy of the admin application into the build graph and `strapi build` OOMs (#22946).
+ */
+describe('ADMIN_VITE_DEDUPE_ONLY_MODULES contract (#22946)', () => {
+  it.each(ADMIN_VITE_DEDUPE_ONLY_MODULES)('dedupes %s for local plugin resolution', (mod) => {
+    expect(ADMIN_VITE_DEDUPE_MODULES).toContain(mod);
+  });
+
+  it('dedupes @strapi/strapi, the head of the local-plugin dependency chain', () => {
+    // @strapi/admin and the core plugins are reached *through* @strapi/strapi, so deduping it
+    // collapses them too — deduping @strapi/admin alone leaves most of the duplication behind.
+    expect(ADMIN_VITE_DEDUPE_ONLY_MODULES).toContain('@strapi/strapi');
+  });
+
+  it.each(ADMIN_VITE_DEDUPE_ONLY_MODULES)(
+    'keeps %s out of the alias list — aliasing bypasses its exports map and breaks the build',
+    (mod) => {
+      expect(ADMIN_VITE_ALIAS_MODULES).not.toContain(mod);
+    }
+  );
+
+  it('does not overlap the singleton modules', () => {
+    for (const mod of ADMIN_VITE_DEDUPE_ONLY_MODULES) {
+      expect(ADMIN_VITE_SINGLETON_MODULES).not.toContain(mod);
+    }
+  });
+
+  it('produces a dedupe list with no duplicate entries', () => {
+    expect([...new Set(ADMIN_VITE_DEDUPE_MODULES)]).toHaveLength(ADMIN_VITE_DEDUPE_MODULES.length);
+  });
+});
+
 describe('buildAdminViteResolveAliases', () => {
   it('sets an alias for every admin vite alias module via getModulePath', () => {
     const alias = buildAdminViteResolveAliases();
@@ -67,6 +102,15 @@ describe('buildAdminViteResolveAliases', () => {
       expect(ADMIN_VITE_DEDUPE_MODULES).toContain(mod);
     }
   });
+
+  it.each(ADMIN_VITE_DEDUPE_ONLY_MODULES)(
+    'never aliases %s — resolve.alias would bypass its exports map (#22946)',
+    (mod) => {
+      const alias = buildAdminViteResolveAliases();
+
+      expect(alias).not.toHaveProperty(mod);
+    }
+  );
 
   it.each(ADMIN_PINNED_ALIAS_MODULES)(
     'aliases %s to the version pinned by @strapi/admin',

--- a/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
@@ -49,16 +49,23 @@ export type AdminViteAliasModule = (typeof ADMIN_VITE_ALIAS_MODULES)[number];
  * plugins (#22946).
  *
  * `@strapi/strapi` is the head of that chain — `@strapi/admin` and the core plugins are reached
- * *through* it — so deduping it alone collapses ~98% of the duplication. `react-intl` and
- * `@strapi/icons` are added because the SDK's plugin template imports them directly rather than
- * via `@strapi/strapi`, so they need their own entries.
+ * *through* it — so deduping it alone collapses ~98% of the duplication.
  *
- * These MUST NOT be added to {@link ADMIN_VITE_ALIAS_MODULES}: `resolve.alias` prefix-substitutes
- * to a filesystem path and so bypasses the package's `exports` map.
+ * Only packages the app itself declares belong here. `resolve.dedupe` forces resolution from the
+ * app root, so a package that lives solely inside `@strapi/admin`'s closure has no top-level
+ * `node_modules` entry under pnpm's strict isolation, and deduping it would turn a working (if
+ * duplicated) plugin import into an unresolved one. Every Strapi app depends on `@strapi/strapi`
+ * directly, so it is always resolvable from the root. `@strapi/icons` and `react-intl` — which the
+ * SDK plugin template imports directly — are `@strapi/admin` dependencies, so they are deliberately
+ * left out; their trees are the known residual of this fix.
+ *
+ * Entries here MUST NOT be added to {@link ADMIN_VITE_ALIAS_MODULES}: `resolve.alias`
+ * prefix-substitutes to a filesystem path and so bypasses the package's `exports` map.
  *   - `@strapi/strapi` exports `./admin` (real target `dist/admin/index.mjs`) — the exact subpath
  *     every plugin imports. Aliasing rewrites it to a non-existent `<pkgdir>/admin` and the build
  *     dies with "[vite:load-fallback] Could not load …/@strapi/strapi/admin".
- *   - `@strapi/icons` exports `./symbols` and fails the same way.
+ *   - `@strapi/icons` exports `./symbols` and would fail the same way, so aliasing the package
+ *     directory is no escape hatch for the modules excluded above either.
  *   - `@strapi/admin` publishes no `.` export at all, so `getModulePath()` would throw
  *     ERR_PACKAGE_PATH_NOT_EXPORTED at config time. It needs no entry here: deduping
  *     `@strapi/strapi` already collapses it.
@@ -66,11 +73,7 @@ export type AdminViteAliasModule = (typeof ADMIN_VITE_ALIAS_MODULES)[number];
  *
  * @internal
  */
-export const ADMIN_VITE_DEDUPE_ONLY_MODULES = [
-  '@strapi/strapi',
-  '@strapi/icons',
-  'react-intl',
-] as const;
+export const ADMIN_VITE_DEDUPE_ONLY_MODULES = ['@strapi/strapi'] as const;
 
 export type AdminViteDedupeOnlyModule = (typeof ADMIN_VITE_DEDUPE_ONLY_MODULES)[number];
 

--- a/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
@@ -33,12 +33,56 @@ export const ADMIN_VITE_ALIAS_MODULES = [
 export type AdminViteAliasModule = (typeof ADMIN_VITE_ALIAS_MODULES)[number];
 
 /**
- * Modules passed to Vite resolve.dedupe (and aliased): the admin alias modules plus the
- * CodeMirror singletons, so every copy collapses onto a single runtime instance.
+ * Modules deduplicated but deliberately NOT aliased.
+ *
+ * A local plugin (`config/plugins.ts` → `{ resolve: './src/plugins/x' }`) is imported into the
+ * generated `.strapi/client/app.js` by a *relative* path, so Rollup treats its built
+ * `dist/admin/index.mjs` as project source rather than as a dependency. The bare specifiers that
+ * `@strapi/sdk-plugin` externalises into that file are therefore resolved from the plugin's own
+ * directory first — and a local plugin installed with npm/pnpm has its own `node_modules`, because
+ * the SDK template lists `@strapi/strapi` in the generated `devDependencies`.
+ *
+ * Without dedupe, every local plugin pulls a second copy of the whole admin application into the
+ * build graph (`@strapi/admin`, `@strapi/content-manager`, `@strapi/upload`, … and their trees).
+ * Measured on a stock app: one empty generated plugin added 4,940 modules (+99%) and ~840MB of
+ * peak build heap, which is what makes `strapi build` OOM once a project has a handful of local
+ * plugins (#22946).
+ *
+ * `@strapi/strapi` is the head of that chain — `@strapi/admin` and the core plugins are reached
+ * *through* it — so deduping it alone collapses ~98% of the duplication. `react-intl` and
+ * `@strapi/icons` are added because the SDK's plugin template imports them directly rather than
+ * via `@strapi/strapi`, so they need their own entries.
+ *
+ * These MUST NOT be added to {@link ADMIN_VITE_ALIAS_MODULES}: `resolve.alias` prefix-substitutes
+ * to a filesystem path and so bypasses the package's `exports` map.
+ *   - `@strapi/strapi` exports `./admin` (real target `dist/admin/index.mjs`) — the exact subpath
+ *     every plugin imports. Aliasing rewrites it to a non-existent `<pkgdir>/admin` and the build
+ *     dies with "[vite:load-fallback] Could not load …/@strapi/strapi/admin".
+ *   - `@strapi/icons` exports `./symbols` and fails the same way.
+ *   - `@strapi/admin` publishes no `.` export at all, so `getModulePath()` would throw
+ *     ERR_PACKAGE_PATH_NOT_EXPORTED at config time. It needs no entry here: deduping
+ *     `@strapi/strapi` already collapses it.
+ * The contract tests in `__tests__/admin-vite-aliases.test.ts` enforce this separation.
+ *
+ * @internal
+ */
+export const ADMIN_VITE_DEDUPE_ONLY_MODULES = [
+  '@strapi/strapi',
+  '@strapi/icons',
+  'react-intl',
+] as const;
+
+export type AdminViteDedupeOnlyModule = (typeof ADMIN_VITE_DEDUPE_ONLY_MODULES)[number];
+
+/**
+ * Modules passed to Vite resolve.dedupe: the admin alias modules plus the CodeMirror singletons
+ * (both of which are also aliased), plus the dedupe-only modules above, so every copy collapses
+ * onto a single runtime instance.
  */
 export const ADMIN_VITE_DEDUPE_MODULES = [
   ...ADMIN_VITE_ALIAS_MODULES,
   ...ADMIN_VITE_SINGLETON_MODULES,
+  ...ADMIN_VITE_DEDUPE_ONLY_MODULES,
 ] as const;
 
 export { ADMIN_VITE_SINGLETON_MODULES };


### PR DESCRIPTION
### What does it do?

Adds `@strapi/strapi` to the admin build's `resolve.dedupe`, so a local plugin's own `node_modules` can no longer introduce a second copy of the admin application into the build graph.

To do that safely it introduces `ADMIN_VITE_DEDUPE_ONLY_MODULES` and decouples `ADMIN_VITE_DEDUPE_MODULES` from `ADMIN_VITE_ALIAS_MODULES`, which were previously the same list plus the CodeMirror singletons. **`@strapi/strapi` must be deduped but must not be aliased** — see the warning below. Contract tests pin that separation.

Two files, +110/−2, no runtime dependencies added.

> **Updated after review** (thanks @innerdvations): `@strapi/icons` and `react-intl` were dropped from the dedupe-only list. `resolve.dedupe` resolves from the app root, and those two are `@strapi/admin` dependencies rather than app dependencies, so under pnpm's strict isolation they have no top-level `node_modules` entry and deduping them could turn a working local-plugin import into an unresolved one. Only packages the app itself declares are deduped now; a contract test pins both of them out of the dedupe *and* alias lists.

### Why is it needed?

A local plugin declared with `{ resolve: './src/plugins/x' }` is imported into the generated `.strapi/client/app.js` by a **relative** path, so Rollup treats its built `dist/admin/index.mjs` as project *source* rather than as a dependency. The bare specifiers that `@strapi/sdk-plugin` externalises into that file are therefore resolved starting from the plugin's own directory — and a local plugin installed with npm/pnpm has its own `node_modules`, because the SDK template lists `@strapi/strapi` in the generated `devDependencies`.

`@strapi/strapi` was not in `resolve.dedupe`, so every local plugin pulled a second copy of the whole admin application into the build graph (`@strapi/admin`, `@strapi/content-manager`, `@strapi/content-type-builder`, `@strapi/upload`, `@strapi/i18n`, … and their trees). Build memory therefore grew with the **number** of local plugins rather than with their contents — which is exactly what users report in #22946 ("works with 5, fails with 7, whatever the plugins", and OOM even with plugins that have no extra dependencies).

Measured on a stock Strapi 5 app (npm, not a workspace root) with three **empty** generated plugins:

| | Modules in graph | Duplicated | Peak RSS |
|---|---:|---:|---:|
| before | 19,858 | 14,829 (74.7%) | 4,925 MB |
| **after** | **5,030** | **0** | **1,992 MB** |
| *(no local plugins at all)* | *5,020* | *0* | *2,085 MB* |

> Those "after" figures were measured with the original three-entry list. With the reviewed, `@strapi/strapi`-only list the collapse is ~98% rather than 100%: `@strapi/strapi` is the head of the chain — `@strapi/admin` and the core plugins are reached *through* it — so deduping it alone removes ~98% of the duplication, and the `react-intl` tree (which the SDK plugin template imports directly) is the residual. That matches #25636's measured −97.9%. Deduping `@strapi/admin` instead of `@strapi/strapi` removes only ~29%.

Full root-cause analysis, reproduction and the measurements for each previously proposed approach: https://github.com/strapi/strapi/issues/22946#issuecomment-5222367886

### ⚠️ Why dedupe and not alias

`resolve.alias` prefix-substitutes to a filesystem path and so bypasses a package's `exports` map. Measured, these break the build:

- `@strapi/strapi` exports `./admin` (real target `dist/admin/index.mjs`) — the exact subpath every plugin imports. Aliasing rewrites it to a non-existent `/admin`:
  ```
  [vite:load-fallback] Could not load .../node_modules/@strapi/strapi/admin
  (imported by .strapi/client/app.js): ENOENT
  ```
- `@strapi/icons` exports `./symbols` and fails identically — which is why aliasing is not an escape hatch for the two packages excluded above either; covering them that way would need one alias entry per published export subpath, revised whenever either package adds one.
- `@strapi/admin` publishes no `.` export at all, so `getModulePath('@strapi/admin')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` at config time. It needs no entry — deduping `@strapi/strapi` already collapses it.

This is why the list had to be split rather than simply extended, and why the new tests assert `@strapi/strapi` is **absent** from `ADMIN_VITE_ALIAS_MODULES`. I verified the guard by temporarily adding it to the alias list — the tests fail, as intended.

### How to test it?

Automated:

```bash
yarn nx test:unit @strapi/strapi
```

8 new tests in `packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts` cover: each dedupe-only module is present in `ADMIN_VITE_DEDUPE_MODULES`; each is absent from `ADMIN_VITE_ALIAS_MODULES`; `buildAdminViteResolveAliases()` emits no entry for them; `@strapi/icons` and `react-intl` are absent from **both** lists (the pnpm hazard above); no overlap with the singleton list; and no duplicate entries in the combined dedupe list.

> Note: on Windows, `src/node/core/__tests__/resolve-module.test.ts` has one pre-existing failure ("prefers @strapi/admin closure over a hoisted incompatible major") caused by a POSIX path fixture (`/tmp/...` vs `\tmp\...`). It fails identically on an unmodified `develop` and is unrelated to this change.

Manually, end-to-end:

```bash
npx create-strapi-app@latest repro --non-interactive --typescript --use-npm \
  --skip-cloud --no-example --no-git-init --dbclient sqlite
cd repro
npx @strapi/sdk-plugin@latest init src/plugins/plugin-a --silent --use-npm
# register in config/plugins.ts: 'plugin-a': { enabled: true, resolve: './src/plugins/plugin-a' }
npm run build
```

Before this change the plugin's nested `node_modules` contributes ~4,940 modules and ~840 MB of peak heap per plugin; after, only the `react-intl` remainder. To count them, add a `moduleParsed` recorder in `src/admin/vite.config.ts` and `grep -c "plugins/plugin-a/node_modules"` the output — the exact harness is in the linked issue comment.

I also confirmed `examples/getstarted` (which has a local plugin enabled) still builds: `yarn nx build @strapi/strapi && cd examples/getstarted && yarn build`.

### Related issue(s)/PR(s)

Fix #22946

Supersedes / overlaps with earlier attempts, all of which target an inline `dedupe: [...]` array in `node/vite/config.ts` that no longer exists on `develop`:

- #25636 — closest to correct, and the only earlier PR that used dedupe-only rather than alias. Measured at −97.9%; after this review, this PR now lands on the same dedupe set, plus the `ADMIN_VITE_DEDUPE_ONLY_MODULES` / `ADMIN_VITE_ALIAS_MODULES` separation and the contract tests that keep it from drifting.
- #25483 (closed) — derives the dedupe set dynamically from each local plugin's declared externals. Measured at −100%, and in my view the better long-term design; see "Follow-ups".
- #24998 — its dedupe list omits `@strapi/strapi`, so it measures at only −17.7%. Its `todo-example` dependency cleanup is still worth landing separately.
- #25997 — measured to fail the build, for the alias reason described above.

### Scope and follow-ups (deliberately not in this PR)

- **The `react-intl` residual.** Reaching it safely means resolving from `@strapi/admin`'s closure rather than from the app root — i.e. per-export-subpath aliases, or the dynamic approach below — not a dedupe entry. Left out so this PR cannot regress pnpm installs.
- **Webpack.** `node/webpack/config.ts` has the same gap, but webpack has no `resolve.dedupe` equivalent and its alias mechanism hits the same `exports`-map problem, so it needs a different approach. Vite is the default bundler; I left webpack out rather than ship something unverified.
- **A dynamic dedupe set** (the #25483 approach) would remove the need to maintain a static list at all. A static baseline unioned with a per-plugin dynamic set would be strictly better than either alone, and degrade gracefully when a plugin's `package.json` is unreadable. Happy to follow up if maintainers want it.
- **`@strapi/sdk-plugin`.** The nested `node_modules` itself (~815 MB per plugin, for a ~32 KB `dist`) comes from the SDK template listing `@strapi/*` in generated `devDependencies` as well as `peerDependencies`. That is a separate defect in a separate repo; this PR makes the build immune to it, but does not shrink what lands on disk.
- **`examples/plugins/todo-example`** still declares `@strapi/design-system`, `@strapi/icons`, `react` etc. under `dependencies`, which is the pattern that propagates this. Left alone here to keep the diff focused (#24998 covers it).
