### PR TITLE
fix(review-workflows): guard release-action service call when cms-content-releases is disabled

### DIFF
--- a/packages/core/review-workflows/server/src/services/__tests__/workflows.test.ts
+++ b/packages/core/review-workflows/server/src/services/__tests__/workflows.test.ts
@@ -1,0 +1,130 @@
+import workflowsFactory from '../workflows';
+
+const validateActionsByContentTypes = jest.fn();
+const migrate = jest.fn();
+const deleteMany = jest.fn();
+const sendDidEditWorkflow = jest.fn();
+const validateWorkflowCount = jest.fn();
+
+jest.mock('../../utils', () => ({
+  getService: jest.fn((name: string) => {
+    if (name === 'validation') {
+      return {
+        validateWorkflowStages: jest.fn(),
+        validateWorkflowCount,
+      };
+    }
+    if (name === 'workflow-metrics') {
+      return {
+        sendDidCreateWorkflow: jest.fn(),
+        sendDidEditWorkflow,
+      };
+    }
+    if (name === 'stages') {
+      return {
+        createMany: jest.fn(),
+        replaceStages: jest.fn(),
+        deleteMany,
+      };
+    }
+    return {};
+  }),
+}));
+
+jest.mock('../workflow-content-types', () => () => ({
+  migrate,
+}));
+
+const workflow = {
+  id: 1,
+  name: 'Default',
+  contentTypes: ['api::article.article'],
+  stages: [{ id: 10, name: 'Todo' }],
+};
+
+const createStrapiMock = ({ releaseActionService }: { releaseActionService?: unknown }) => {
+  const dbQuery = {
+    update: jest.fn().mockResolvedValue(workflow),
+    delete: jest.fn().mockResolvedValue(workflow),
+    count: jest.fn().mockResolvedValue(2),
+    create: jest.fn().mockResolvedValue(workflow),
+  };
+
+  return {
+    db: {
+      transaction: jest.fn((fn: (args: unknown) => unknown) => fn({})),
+      query: jest.fn(() => dbQuery),
+    },
+    get: jest.fn((name: string) => {
+      if (name === 'query-params') {
+        return { transform: jest.fn((_uid: string, opts: unknown) => opts) };
+      }
+      return undefined;
+    }),
+    plugin: jest.fn((name: string) => {
+      if (name === 'content-releases') {
+        return {
+          service: jest.fn((serviceName: string) => {
+            if (serviceName === 'release-action') {
+              return releaseActionService;
+            }
+            return undefined;
+          }),
+        };
+      }
+      return { service: jest.fn() };
+    }),
+  };
+};
+
+describe('review-workflows workflows service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    validateWorkflowCount.mockResolvedValue(undefined);
+    migrate.mockResolvedValue(undefined);
+    deleteMany.mockResolvedValue(undefined);
+    validateActionsByContentTypes.mockResolvedValue(undefined);
+  });
+
+  describe('when release-action service is missing', () => {
+    it('update should not throw', async () => {
+      const strapi = createStrapiMock({ releaseActionService: undefined });
+      const service = workflowsFactory({ strapi: strapi as any });
+
+      await expect(service.update(workflow, { data: {} })).resolves.toEqual(workflow);
+      expect(validateActionsByContentTypes).not.toHaveBeenCalled();
+    });
+
+    it('delete should not throw', async () => {
+      const strapi = createStrapiMock({ releaseActionService: undefined });
+      const service = workflowsFactory({ strapi: strapi as any });
+
+      await expect(service.delete(workflow, {})).resolves.toEqual(workflow);
+      expect(validateActionsByContentTypes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when release-action service is present', () => {
+    it('update should still call validateActionsByContentTypes', async () => {
+      const strapi = createStrapiMock({
+        releaseActionService: { validateActionsByContentTypes },
+      });
+      const service = workflowsFactory({ strapi: strapi as any });
+
+      await service.update(workflow, { data: {} });
+
+      expect(validateActionsByContentTypes).toHaveBeenCalledWith(workflow.contentTypes);
+    });
+
+    it('delete should still call validateActionsByContentTypes', async () => {
+      const strapi = createStrapiMock({
+        releaseActionService: { validateActionsByContentTypes },
+      });
+      const service = workflowsFactory({ strapi: strapi as any });
+
+      await service.delete(workflow, {});
+
+      expect(validateActionsByContentTypes).toHaveBeenCalledWith(workflow.contentTypes);
+    });
+  });
+});

--- a/packages/core/review-workflows/server/src/services/workflows.ts
+++ b/packages/core/review-workflows/server/src/services/workflows.ts
@@ -117,7 +117,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
           await strapi
             .plugin('content-releases')
             .service('release-action')
-            .validateActionsByContentTypes(opts.data.contentTypes);
+            ?.validateActionsByContentTypes(opts.data.contentTypes);
         }
 
         return createdWorkflow;
@@ -197,7 +197,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         await strapi
           .plugin('content-releases')
           .service('release-action')
-          .validateActionsByContentTypes([
+          ?.validateActionsByContentTypes([
             ...workflow.contentTypes,
             ...(opts.data.contentTypes || []),
           ]);
@@ -243,7 +243,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         await strapi
           .plugin('content-releases')
           .service('release-action')
-          .validateActionsByContentTypes(workflow.contentTypes);
+          ?.validateActionsByContentTypes(workflow.contentTypes);
 
         return deletedWorkflow;
       });


### PR DESCRIPTION
Fixes #27245. When the enterprise feature cms-content-releases is disabled, the `release-action` service is undefined, causing a TypeError when validating content types in Review Workflows update/delete. This PR adds optional chaining to safely guard the method calls.