### PR TITLE
chore(deps): upgrade commander from 8.3.0 to 14.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "chalk": "4.1.2",
     "chokidar": "3.6.0",
     "coffee": "5.5.1",
-    "commander": "8.3.0",
     "core-js": "3.36.0",
     "create-strapi-app": "workspace:*",
     "cross-env": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,6 @@
     "chalk": "4.1.2",
     "chokidar": "3.6.0",
     "coffee": "5.5.1",
-    "commander": "8.3.0",
     "core-js": "3.36.0",
     "create-strapi-app": "workspace:*",
     "cross-env": "7.0.3",

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -55,7 +55,7 @@
     "boxen": "5.1.2",
     "chalk": "4.1.2",
     "cli-progress": "3.12.0",
-    "commander": "8.3.0",
+    "commander": "14.0.3",
     "eventsource": "2.0.2",
     "fast-safe-stringify": "2.1.1",
     "fs-extra": "11.3.4",

--- a/packages/cli/cloud/src/bin.ts
+++ b/packages/cli/cloud/src/bin.ts
@@ -6,11 +6,11 @@ import { buildStrapiCloudCommands } from './index';
 
 function loadStrapiCloudCommand(argv = process.argv, command = new Command()) {
   // Initial program setup
-  command.storeOptionsAsProperties(false).allowUnknownOption(true);
+  command.allowUnknownOption(true);
 
   // Help command
   command.helpOption('-h, --help', 'Display help for command');
-  command.addHelpCommand('help [command]', 'Display help for command');
+  command.helpCommand('help [command]', 'Display help for command');
 
   const cwd = process.cwd();
 

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -55,7 +55,7 @@
     "@strapi/cloud-cli": "5.51.2",
     "async-retry": "1.3.3",
     "chalk": "4.1.2",
-    "commander": "8.3.0",
+    "commander": "14.0.3",
     "execa": "5.1.1",
     "fs-extra": "11.3.4",
     "inquirer": "9.3.8",

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -55,7 +55,7 @@
     "@strapi/cloud-cli": "5.52.3",
     "async-retry": "1.3.3",
     "chalk": "4.1.2",
-    "commander": "8.3.0",
+    "commander": "14.0.3",
     "execa": "5.1.1",
     "fs-extra": "11.3.4",
     "inquirer": "9.3.8",

--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -1,7 +1,7 @@
 import { join, basename } from 'node:path';
 import os from 'node:os';
 import chalk from 'chalk';
-import commander from 'commander';
+import { Command, Option } from 'commander';
 import crypto from 'crypto';
 import fse from 'fs-extra';
 
@@ -19,7 +19,7 @@ import { logger } from './utils/logger';
 
 const { version } = fse.readJSONSync(join(__dirname, '..', 'package.json'));
 
-const command = new commander.Command('create-strapi-app')
+const command = new Command('create-strapi-app')
   .version(version)
   .arguments('[directory]')
   .usage('[directory] [options]')
@@ -51,8 +51,8 @@ const command = new commander.Command('create-strapi-app')
   .option('--no-git-init', 'Do no initialize a git repository')
 
   // Legacy no-ops (hidden from --help): accept old flags so existing CI/scripts keep working
-  .addOption(new commander.Option('--enable-ab-tests', 'ignored').hideHelp())
-  .addOption(new commander.Option('--no-enable-ab-tests', 'ignored').hideHelp())
+  .addOption(new Option('--enable-ab-tests', 'ignored').hideHelp())
+  .addOption(new Option('--no-enable-ab-tests', 'ignored').hideHelp())
 
   // Automation
   .option('--non-interactive', 'Skip all interactive prompts and use defaults')

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -77,7 +77,6 @@
     "chalk": "4.1.2",
     "ci-info": "4.0.0",
     "cli-table3": "0.6.5",
-    "commander": "8.3.0",
     "configstore": "5.0.1",
     "debug": "4.3.4",
     "delegates": "1.0.0",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -78,7 +78,6 @@
     "chalk": "4.1.2",
     "ci-info": "4.0.0",
     "cli-table3": "0.6.5",
-    "commander": "8.3.0",
     "configstore": "5.0.1",
     "debug": "4.3.4",
     "delegates": "1.0.0",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -59,7 +59,6 @@
     "@strapi/utils": "5.51.2",
     "chalk": "4.1.2",
     "cli-table3": "0.6.5",
-    "commander": "8.3.0",
     "fs-extra": "11.3.4",
     "inquirer": "9.3.8",
     "lodash": "4.18.1",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -59,7 +59,6 @@
     "@strapi/utils": "5.52.3",
     "chalk": "4.1.2",
     "cli-table3": "0.6.5",
-    "commander": "8.3.0",
     "fs-extra": "11.3.4",
     "inquirer": "9.3.8",
     "lodash": "4.18.1",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -139,7 +139,7 @@
     "ci-info": "4.0.0",
     "cli-progress": "3.12.0",
     "cli-table3": "0.6.5",
-    "commander": "8.3.0",
+    "commander": "14.0.3",
     "concurrently": "8.2.2",
     "css-loader": "6.11.0",
     "dotenv": "16.6.1",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -138,7 +138,7 @@
     "ci-info": "4.0.0",
     "cli-progress": "3.12.0",
     "cli-table3": "0.6.5",
-    "commander": "8.3.0",
+    "commander": "14.0.3",
     "concurrently": "8.2.2",
     "css-loader": "6.11.0",
     "dotenv": "16.6.1",

--- a/packages/core/strapi/src/cli/commands/generate.ts
+++ b/packages/core/strapi/src/cli/commands/generate.ts
@@ -6,15 +6,20 @@ import type { StrapiCommand } from '../types';
  * `$ strapi generate`
  */
 const command: StrapiCommand = ({ argv }) => {
-  return createCommand('generate')
-    .description('Launch the interactive API generator')
-    .action(() => {
-      assertCwdContainsStrapiProject('generate');
-      argv.splice(2, 1);
+  return (
+    createCommand('generate')
+      .description('Launch the interactive API generator')
+      // Arguments are forwarded as-is to the plop CLI (e.g. `strapi generate api my-api`),
+      // so commander must not reject them as excess arguments.
+      .allowExcessArguments(true)
+      .action(() => {
+        assertCwdContainsStrapiProject('generate');
+        argv.splice(2, 1);
 
-      // NOTE: this needs to be lazy loaded in order for plop to work correctly
-      import('@strapi/generators').then((gen) => gen.runCLI());
-    });
+        // NOTE: this needs to be lazy loaded in order for plop to work correctly
+        import('@strapi/generators').then((gen) => gen.runCLI());
+      })
+  );
 };
 
 export { command };

--- a/packages/core/strapi/src/cli/index.ts
+++ b/packages/core/strapi/src/cli/index.ts
@@ -9,11 +9,11 @@ import { version } from '../../package.json';
 
 const createCLI = async (argv: string[], command = new Command()) => {
   // Initial program setup
-  command.storeOptionsAsProperties(false).allowUnknownOption(true);
+  command.allowUnknownOption(true);
 
   // Help command
   command.helpOption('-h, --help', 'Display help for command');
-  command.addHelpCommand('help [command]', 'Display help for command');
+  command.helpCommand('help [command]', 'Display help for command');
 
   command.version(version, '-v, --version', 'Output the version number');
 

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -64,7 +64,7 @@
     "@strapi/logger": "5.51.2",
     "@strapi/permissions": "5.51.2",
     "@strapi/utils": "5.51.2",
-    "commander": "8.3.0",
+    "commander": "14.0.3",
     "json-logic-js": "2.0.5",
     "koa": "2.16.4",
     "koa-body": "6.0.1",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -63,7 +63,7 @@
     "@strapi/logger": "5.52.3",
     "@strapi/permissions": "5.52.3",
     "@strapi/utils": "5.52.3",
-    "commander": "8.3.0",
+    "commander": "14.0.3",
     "json-logic-js": "2.0.5",
     "koa": "2.16.4",
     "koa-body": "6.0.1",

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -68,7 +68,7 @@
     "@strapi/utils": "5.51.2",
     "chalk": "4.1.2",
     "cli-table3": "0.6.5",
-    "commander": "8.3.0",
+    "commander": "14.0.3",
     "esbuild-register": "3.6.0",
     "execa": "5.1.1",
     "fast-glob": "3.3.2",

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -68,7 +68,7 @@
     "@strapi/utils": "5.52.3",
     "chalk": "4.1.2",
     "cli-table3": "0.6.5",
-    "commander": "8.3.0",
+    "commander": "14.0.3",
     "esbuild-register": "3.6.0",
     "execa": "5.1.1",
     "fast-glob": "3.3.2",

--- a/packages/utils/upgrade/src/cli/index.ts
+++ b/packages/utils/upgrade/src/cli/index.ts
@@ -22,6 +22,6 @@ program
     process.exit(1);
   })
   .helpOption('-h, --help', 'Print command line options')
-  .addHelpCommand('help [command]', 'Print options for a specific command')
+  .helpCommand('help [command]', 'Print options for a specific command')
   .version(packageJSONVersion)
   .parse(process.argv);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8731,7 +8731,7 @@ __metadata:
     boxen: "npm:5.1.2"
     chalk: "npm:4.1.2"
     cli-progress: "npm:3.12.0"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     eslint-config-custom: "npm:5.51.2"
     eventsource: "npm:2.0.2"
     fast-safe-stringify: "npm:2.1.1"
@@ -8976,7 +8976,6 @@ __metadata:
     chalk: "npm:4.1.2"
     ci-info: "npm:4.0.0"
     cli-table3: "npm:0.6.5"
-    commander: "npm:8.3.0"
     configstore: "npm:5.0.1"
     debug: "npm:4.3.4"
     delegates: "npm:1.0.0"
@@ -9044,7 +9043,6 @@ __metadata:
     "@types/ws": "npm:^8.5.4"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
-    commander: "npm:8.3.0"
     fs-extra: "npm:11.3.4"
     inquirer: "npm:9.3.8"
     jest: "npm:29.6.0"
@@ -9752,7 +9750,7 @@ __metadata:
     ci-info: "npm:4.0.0"
     cli-progress: "npm:3.12.0"
     cli-table3: "npm:0.6.5"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     concurrently: "npm:8.2.2"
     css-loader: "npm:6.11.0"
     dotenv: "npm:16.6.1"
@@ -9818,7 +9816,7 @@ __metadata:
     "@types/koa__router": "npm:12.0.0"
     "@types/node": "npm:20.19.41"
     "@types/node-schedule": "npm:2.1.7"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     eslint-config-custom: "npm:5.51.2"
     json-logic-js: "npm:2.0.5"
     koa: "npm:2.16.4"
@@ -9898,7 +9896,7 @@ __metadata:
     "@types/node": "npm:20.19.41"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     esbuild-register: "npm:3.6.0"
     eslint-config-custom: "npm:5.51.2"
     execa: "npm:5.1.1"
@@ -14597,17 +14595,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:14.0.3, commander@npm:^14.0.2, commander@npm:^14.0.3":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
+  languageName: node
+  linkType: hard
+
 "commander@npm:2.17.x":
   version: 2.17.1
   resolution: "commander@npm:2.17.1"
   checksum: 10c0/b10453ca205d5a794c5e639dbc54bf4eaec61a204d56693b8082e9000744df13a47840f7d10ae2fc6fc046e2d71bb7c67987dff5b77f862064e187cf88beac3f
-  languageName: node
-  linkType: hard
-
-"commander@npm:8.3.0, commander@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "commander@npm:8.3.0"
-  checksum: 10c0/8b043bb8322ea1c39664a1598a95e0495bfe4ca2fad0d84a92d7d1d8d213e2a155b441d2470c8e08de7c4a28cf2bc6e169211c49e1b21d9f7edc6ae4d9356060
   languageName: node
   linkType: hard
 
@@ -14622,13 +14620,6 @@ __metadata:
   version: 13.1.0
   resolution: "commander@npm:13.1.0"
   checksum: 10c0/7b8c5544bba704fbe84b7cab2e043df8586d5c114a4c5b607f83ae5060708940ed0b5bd5838cf8ce27539cde265c1cbd59ce3c8c6b017ed3eec8943e3a415164
-  languageName: node
-  linkType: hard
-
-"commander@npm:^14.0.2, commander@npm:^14.0.3":
-  version: 14.0.3
-  resolution: "commander@npm:14.0.3"
-  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
   languageName: node
   linkType: hard
 
@@ -14650,6 +14641,13 @@ __metadata:
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: 10c0/85748abd9d18c8bc88febed58b98f66b7c591d9b5017cad459565761d7b29ca13b7783ea2ee5ce84bf235897333706c4ce29adf1ce15c8252780e7000e2ce9ea
+  languageName: node
+  linkType: hard
+
+"commander@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "commander@npm:8.3.0"
+  checksum: 10c0/8b043bb8322ea1c39664a1598a95e0495bfe4ca2fad0d84a92d7d1d8d213e2a155b441d2470c8e08de7c4a28cf2bc6e169211c49e1b21d9f7edc6ae4d9356060
   languageName: node
   linkType: hard
 
@@ -15063,7 +15061,7 @@ __metadata:
     "@types/node": "npm:20.19.41"
     async-retry: "npm:1.3.3"
     chalk: "npm:4.1.2"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     eslint-config-custom: "npm:5.51.2"
     execa: "npm:5.1.1"
     fs-extra: "npm:11.3.4"
@@ -27936,7 +27934,6 @@ __metadata:
     chalk: "npm:4.1.2"
     chokidar: "npm:3.6.0"
     coffee: "npm:5.5.1"
-    commander: "npm:8.3.0"
     core-js: "npm:3.36.0"
     create-strapi-app: "workspace:*"
     cross-env: "npm:7.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8988,7 +8988,7 @@ __metadata:
     boxen: "npm:5.1.2"
     chalk: "npm:4.1.2"
     cli-progress: "npm:3.12.0"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     eslint-config-custom: "npm:5.52.3"
     eventsource: "npm:2.0.2"
     fast-safe-stringify: "npm:2.1.1"
@@ -9237,7 +9237,6 @@ __metadata:
     chalk: "npm:4.1.2"
     ci-info: "npm:4.0.0"
     cli-table3: "npm:0.6.5"
-    commander: "npm:8.3.0"
     configstore: "npm:5.0.1"
     debug: "npm:4.3.4"
     delegates: "npm:1.0.0"
@@ -9305,7 +9304,6 @@ __metadata:
     "@types/ws": "npm:^8.5.4"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
-    commander: "npm:8.3.0"
     fs-extra: "npm:11.3.4"
     inquirer: "npm:9.3.8"
     jest: "npm:29.6.0"
@@ -10018,7 +10016,7 @@ __metadata:
     ci-info: "npm:4.0.0"
     cli-progress: "npm:3.12.0"
     cli-table3: "npm:0.6.5"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     concurrently: "npm:8.2.2"
     css-loader: "npm:6.11.0"
     dotenv: "npm:16.6.1"
@@ -10082,7 +10080,7 @@ __metadata:
     "@types/koa__router": "npm:12.0.0"
     "@types/node": "npm:20.19.41"
     "@types/node-schedule": "npm:2.1.7"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     eslint-config-custom: "npm:5.52.3"
     json-logic-js: "npm:2.0.5"
     koa: "npm:2.16.4"
@@ -10162,7 +10160,7 @@ __metadata:
     "@types/node": "npm:20.19.41"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     esbuild-register: "npm:3.6.0"
     eslint-config-custom: "npm:5.52.3"
     execa: "npm:5.1.1"
@@ -14811,17 +14809,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:14.0.3, commander@npm:^14.0.2, commander@npm:^14.0.3":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
+  languageName: node
+  linkType: hard
+
 "commander@npm:2.17.x":
   version: 2.17.1
   resolution: "commander@npm:2.17.1"
   checksum: 10c0/b10453ca205d5a794c5e639dbc54bf4eaec61a204d56693b8082e9000744df13a47840f7d10ae2fc6fc046e2d71bb7c67987dff5b77f862064e187cf88beac3f
-  languageName: node
-  linkType: hard
-
-"commander@npm:8.3.0, commander@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "commander@npm:8.3.0"
-  checksum: 10c0/8b043bb8322ea1c39664a1598a95e0495bfe4ca2fad0d84a92d7d1d8d213e2a155b441d2470c8e08de7c4a28cf2bc6e169211c49e1b21d9f7edc6ae4d9356060
   languageName: node
   linkType: hard
 
@@ -14836,13 +14834,6 @@ __metadata:
   version: 13.1.0
   resolution: "commander@npm:13.1.0"
   checksum: 10c0/7b8c5544bba704fbe84b7cab2e043df8586d5c114a4c5b607f83ae5060708940ed0b5bd5838cf8ce27539cde265c1cbd59ce3c8c6b017ed3eec8943e3a415164
-  languageName: node
-  linkType: hard
-
-"commander@npm:^14.0.2, commander@npm:^14.0.3":
-  version: 14.0.3
-  resolution: "commander@npm:14.0.3"
-  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
   languageName: node
   linkType: hard
 
@@ -14864,6 +14855,13 @@ __metadata:
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: 10c0/85748abd9d18c8bc88febed58b98f66b7c591d9b5017cad459565761d7b29ca13b7783ea2ee5ce84bf235897333706c4ce29adf1ce15c8252780e7000e2ce9ea
+  languageName: node
+  linkType: hard
+
+"commander@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "commander@npm:8.3.0"
+  checksum: 10c0/8b043bb8322ea1c39664a1598a95e0495bfe4ca2fad0d84a92d7d1d8d213e2a155b441d2470c8e08de7c4a28cf2bc6e169211c49e1b21d9f7edc6ae4d9356060
   languageName: node
   linkType: hard
 
@@ -15270,7 +15268,7 @@ __metadata:
     "@types/node": "npm:20.19.41"
     async-retry: "npm:1.3.3"
     chalk: "npm:4.1.2"
-    commander: "npm:8.3.0"
+    commander: "npm:14.0.3"
     eslint-config-custom: "npm:5.52.3"
     execa: "npm:5.1.1"
     fs-extra: "npm:11.3.4"
@@ -27935,7 +27933,6 @@ __metadata:
     chalk: "npm:4.1.2"
     chokidar: "npm:3.6.0"
     coffee: "npm:5.5.1"
-    commander: "npm:8.3.0"
     core-js: "npm:3.36.0"
     create-strapi-app: "workspace:*"
     cross-env: "npm:7.0.3"


### PR DESCRIPTION
### What does it do?

Upgrades `commander` from `8.3.0` to `14.0.3` across the 8 workspaces that depend on it, and adapts the CLIs to the breaking changes released between those versions.

**Why 14 and not 15:** Commander 15 is ESM-only (`"type": "module"`) and requires Node.js `>=22.12.0`. This repo declares `>=20.0.0 <=26.x.x` and ships CommonJS, so 15 is not viable yet. 14.0.3 is the newest release that stays CommonJS and matches the Node.js `>=20` constraint; per Commander's release policy it receives security updates until May 2027.

Breaking changes that required code changes:

- **v12 removed the default CommonJS export.** `create-strapi-app` used `import commander from 'commander'`, which failed typecheck with `TS1192: Module ... has no default export`. Switched to the named `Command` / `Option` imports.
- **v13 made excess command-arguments an error by default** (`allowExcessArguments` flipped to `false`). `strapi generate` declares no positional arguments of its own — it forwards argv to the plop CLI, so `strapi generate api my-api` would have failed with `error: too many arguments`. The command now opts back in with `.allowExcessArguments(true)`.
- **v12 deprecated `.addHelpCommand(string, string)`** in favour of `.helpCommand()`. Updated in the strapi, cloud and upgrade CLIs.

Also removes the `storeOptionsAsProperties(false)` calls from the strapi and cloud CLI setup. `false` has been the constructor default since Commander 7, so these were no-ops carried over from Commander 6 and earlier.

Breaking changes reviewed with no change required: v13's stricter option-flag parsing (no multi-character short flags exist in the repo; `--ts, --typescript` are dual *long* flags, supported since 13.1), v12's duplicate option-flag and duplicate command-name errors, v9's boolean-option default semantics, v13's removal of `Help.wrap()`, v12's `passThroughOptions` constraint, and v14's negative-number auto-detection.

**User-visible behaviour change:** commands other than `generate` now reject extra positional arguments with `error: too many arguments` instead of silently ignoring them. This is Commander's intended new default and makes CLI misuse explicit.

Finally, a second commit drops three stale `commander` declarations. `@strapi/core` and `@strapi/data-transfer` declared it as a runtime dependency and the root workspace as a devDependency, but none of the three reference it anywhere in their source, tests, configs or build output — the CLI entry points they once had now live in `@strapi/strapi/src/cli`. That leaves five declarations, all genuine: `@strapi/strapi`, `@strapi/cloud-cli`, `@strapi/upgrade` and `create-strapi-app` use it directly, and `@strapi/types` exposes `Command` in its public type surface.

### Why is it needed?

`commander@8.3.0` was released in October 2021 and is six majors behind. Staying on it means no upstream fixes and a progressively harder migration. Doing the jump now, while stopping deliberately at 14, keeps us on a supported line without forcing an ESM-only dependency into a CommonJS codebase.

### How to test it?

```bash
yarn install && yarn build
yarn test:ts
yarn lint
yarn test:unit
yarn test:cli
```

All green locally: build 37 projects, `test:ts` 37 projects, lint + prettier clean, 219 unit tests across `@strapi/strapi` / `@strapi/cloud-cli` / `@strapi/upgrade` / `@strapi/data-transfer`, and `test:cli` at 20 suites / 43 tests / 9 snapshots.

Manual checks worth repeating in a generated app:

- `strapi generate api my-api` — must reach the plop prompts rather than erroring on arguments
- `strapi --help`, `strapi help develop`, `strapi -v` — help command and version still wired up
- `strapi develop --no-watch-admin --no-build-admin` — negated boolean flags still resolve as before
- `npx create-strapi-app@… my-app --ts --no-install` — positional directory plus flags still parse

### Related issue(s)/PR(s)

Spawned out of #27300 (`feat(strapi): support a custom tsconfig path across the CLI`). Adding a new `--tsconfig` option to the root CLI command there is what surfaced how far behind `commander@8.3.0` has fallen, so the upgrade is split into this PR to keep #27300 scoped to the tsconfig change.

---

### Note for reviewers: pre-existing issue surfaced by this upgrade

While testing I found that `initializeEnvironmentCommand` in `packages/cli/cloud/src/environment/command.ts` caches the `cloud environment` command in module scope. The cache is keyed on nothing, so it outlives the root `Command` it was built against. Calling `createCLI()` twice in one process hands out a command wired into the *previous* CLI tree:

This is **not caused by this PR**, which I confirmed by running the real built `packages/cli/cloud/dist/environment/{link,list}/command.js` against both versions, redirecting `require('commander')` per run:

```
=== real cloud dist on 8.3.0 ===
  1st createCLI -> cloud: present | environment x1 | subcommands: [["link","list"]]
  2nd createCLI -> cloud: MISSING

=== real cloud dist on 14.0.3 ===
  1st createCLI -> cloud: present | environment x1 | subcommands: [["link","list"]]
      [swallowed] Failed to load command: cannot add command 'link' as already have command 'link'
      [swallowed] Failed to load command: cannot add command 'list' as already have command 'list'
  2nd createCLI -> cloud: MISSING
```

The second CLI already lost its `cloud` namespace on Commander 8, silently and with no error. What changed is that Commander 12+ throws on duplicate command names, so both re-registrations — `link` and `list` — now raise `cannot add command '<name>' as already have command '<name>'`, which `buildStrapiCloudCommands` swallows into a `console.error`. The end state is identical on both versions.

`runCLI` (strapi) and `runStrapiCloudCommand` (cloud bin) each build the CLI once per process, so the stale cache is never consulted and there is no user impact. It is reachable only from tests or embedders that construct the CLI twice. Left alone here to keep this PR scoped to the dependency upgrade.

The fix, if someone wants to pick it up separately, is to derive the parent from `parent.commands` instead of caching it — Commander already stores what the cache is remembering:

```ts
export const initializeEnvironmentCommand = (command: Command, ctx: unknown): Command => {
  const cloud = defineCloudNamespace(command, ctx);
  return (
    cloud.commands.find((c) => c.name() === 'environment') ??
    cloud.command('environment').description('Manage environments')
  );
};
```

`defineCloudNamespace` needs the same treatment — it is not cached, so calling it twice would register `cloud` and its `environments` alias twice.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

