### PR TITLE
chore(tsconfig): enable exactOptionalPropertyTypes across server workspaces

### DIFF
--- a/packages/admin-test-utils/tsconfig.json
+++ b/packages/admin-test-utils/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/client.json",
   "include": ["src", "./custom.d.ts"],
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
+    "types": ["@testing-library/jest-dom"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -50,6 +50,7 @@
     "test:unit:vitest:watch": "vitest --watch"
   },
   "dependencies": {
+    "@strapi/types": "5.51.2",
     "@strapi/utils": "5.51.2",
     "axios": "1.19.0",
     "boxen": "5.1.2",

--- a/packages/cli/cloud/src/create-project/utils/project-questions.utils.ts
+++ b/packages/cli/cloud/src/create-project/utils/project-questions.utils.ts
@@ -1,4 +1,5 @@
 import type { DistinctQuestion } from 'inquirer';
+import type { Utils } from '@strapi/types';
 import type { ProjectAnswers } from '../../types';
 
 /**
@@ -47,7 +48,7 @@ export function questionDefaultValuesMapper(
  */
 export function getDefaultsFromQuestions(
   questions: ReadonlyArray<DistinctQuestion<ProjectAnswers>>
-): Partial<ProjectAnswers> {
+): Utils.Object.PartialWithUndefined<ProjectAnswers> {
   return questions.reduce((acc, question) => {
     if (question.default && question.name) {
       return { ...acc, [question.name]: question.default };

--- a/packages/cli/cloud/src/services/strapi-info-save.ts
+++ b/packages/cli/cloud/src/services/strapi-info-save.ts
@@ -30,7 +30,7 @@ export async function save(data: LocalSave, { directoryPath }: { directoryPath?:
 
 export async function retrieve({
   directoryPath,
-}: { directoryPath?: string } = {}): Promise<LocalSave> {
+}: { directoryPath?: string | undefined } = {}): Promise<LocalSave> {
   const pathToFile = getFilePath(directoryPath);
   const pathExists = await fse.pathExists(pathToFile);
   if (!pathExists) {

--- a/packages/cli/cloud/tsconfig.json
+++ b/packages/cli/cloud/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/cli/create-strapi-app/src/types.ts
+++ b/packages/cli/create-strapi-app/src/types.ts
@@ -30,12 +30,12 @@ export type DBClient = 'mysql' | 'postgres' | 'sqlite';
 export type DBConfig = {
   client: DBClient;
   connection: {
-    host?: string;
-    port?: string;
-    database?: string;
-    username?: string;
-    password?: string;
-    filename?: string;
+    host?: string | undefined;
+    port?: string | undefined;
+    database?: string | undefined;
+    username?: string | undefined;
+    password?: string | undefined;
+    filename?: string | undefined;
     ssl?: boolean;
   };
 };
@@ -45,9 +45,9 @@ export type PackageManager = 'npm' | 'yarn' | 'pnpm';
 export interface Scope {
   name: string;
   rootPath: string;
-  template?: string;
-  templateBranch?: string;
-  templatePath?: string;
+  template?: string | undefined;
+  templateBranch?: string | undefined;
+  templatePath?: string | undefined;
   strapiVersion?: string;
   installDependencies?: boolean;
   devDependencies?: Record<string, string>;
@@ -55,7 +55,7 @@ export interface Scope {
   docker?: boolean;
   packageManager: PackageManager;
   runApp?: boolean;
-  isQuickstart?: boolean;
+  isQuickstart?: boolean | undefined;
   uuid?: string;
   installId?: string;
   database: DatabaseInfo;
@@ -74,12 +74,12 @@ export type ClientName = 'mysql' | 'postgres' | 'sqlite';
 export interface DatabaseInfo {
   client: ClientName;
   connection?: {
-    host?: string;
-    port?: string;
-    database?: string;
-    username?: string;
-    password?: string;
-    filename?: string;
+    host?: string | undefined;
+    port?: string | undefined;
+    database?: string | undefined;
+    username?: string | undefined;
+    password?: string | undefined;
+    filename?: string | undefined;
     ssl?: boolean;
   };
 }

--- a/packages/cli/create-strapi-app/src/utils/template.ts
+++ b/packages/cli/create-strapi-app/src/utils/template.ts
@@ -119,8 +119,8 @@ export async function copyTemplate(scope: Scope, rootPath: string) {
 type RepoInfo = {
   owner: string;
   repo: string;
-  branch?: string;
-  subPath?: string | null;
+  branch?: string | undefined;
+  subPath?: string | null | undefined;
 };
 
 async function downloadGithubRepo(rootPath: string, { owner, repo, branch, subPath }: RepoInfo) {

--- a/packages/cli/create-strapi-app/tsconfig.json
+++ b/packages/cli/create-strapi-app/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src"]
 }

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -1,5 +1,5 @@
 import * as qs from 'qs';
-import type { Core } from '@strapi/types';
+import type { Core, Utils } from '@strapi/types';
 
 import Strapi, { type StrapiOptions } from './Strapi';
 import { destroyOnSignal, resolveWorkingDirectories, createUpdateNotifier } from './utils';
@@ -8,7 +8,9 @@ export { default as compileStrapi } from './compile';
 export * as factories from './factories';
 export * as ai from './ai';
 
-export const createStrapi = (options: Partial<StrapiOptions> = {}): Core.Strapi => {
+export const createStrapi = (
+  options: Utils.Object.PartialWithUndefined<StrapiOptions> = {}
+): Core.Strapi => {
   const strapi = new Strapi({
     ...options,
     ...resolveWorkingDirectories(options),

--- a/packages/core/data-transfer/src/directory/providers/destination/index.ts
+++ b/packages/core/data-transfer/src/directory/providers/destination/index.ts
@@ -22,7 +22,7 @@ export interface ILocalDirectoryDestinationProviderOptions {
     path: string;
   };
   file: {
-    maxSizeJsonl?: number;
+    maxSizeJsonl?: number | undefined;
   };
 }
 

--- a/packages/core/data-transfer/src/file/providers/destination/index.ts
+++ b/packages/core/data-transfer/src/file/providers/destination/index.ts
@@ -22,7 +22,7 @@ import { ProviderTransferError } from '../../../errors/providers';
 export interface ILocalFileDestinationProviderOptions {
   encryption: {
     enabled: boolean; // if the file should be encrypted
-    key?: string; // the key to use when encryption.enabled is true
+    key?: string | undefined; // the key to use when encryption.enabled is true
   };
 
   compression: {
@@ -31,8 +31,8 @@ export interface ILocalFileDestinationProviderOptions {
 
   file: {
     path: string; // the filename to create
-    maxSize?: number; // the max size of a single backup file
-    maxSizeJsonl?: number; // the max lines of each jsonl file before creating the next file
+    maxSize?: number | undefined; // the max size of a single backup file
+    maxSizeJsonl?: number | undefined; // the max lines of each jsonl file before creating the next file
   };
 }
 

--- a/packages/core/data-transfer/src/file/providers/source/index.ts
+++ b/packages/core/data-transfer/src/file/providers/source/index.ts
@@ -36,7 +36,7 @@ export interface ILocalFileSourceProviderOptions {
 
   encryption: {
     enabled: boolean; // if the file is encrypted (and should be decrypted)
-    key?: string; // the key to decrypt the file
+    key?: string | undefined; // the key to decrypt the file
   };
 
   compression: {

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/index.ts
@@ -10,7 +10,7 @@ export interface IRestoreOptions {
     coreStore?: boolean; // delete core store before transfer
   };
   entities?: {
-    include?: string[]; // only delete these stage entities before transfer
+    include?: string[] | undefined; // only delete these stage entities before transfer
     exclude?: string[]; // exclude these stage entities from deletion
     filters?: ((contentType: Struct.ContentTypeSchema) => boolean)[]; // custom filters to exclude a content type from deletion
     params?: { [uid: string]: unknown }; // params object passed to deleteMany before transfer for custom deletions

--- a/packages/core/data-transfer/src/types/providers.ts
+++ b/packages/core/data-transfer/src/types/providers.ts
@@ -32,7 +32,7 @@ export interface IProvider {
 }
 
 export interface ISourceProvider extends IProvider {
-  results?: ISourceProviderTransferResults;
+  results?: ISourceProviderTransferResults | undefined;
 
   /**
    * Optional totals for a stage. Called by the engine after the stage read stream is created and before `stage::start`.
@@ -48,7 +48,7 @@ export interface ISourceProvider extends IProvider {
 }
 
 export interface IDestinationProvider extends IProvider {
-  results?: IDestinationProviderTransferResults;
+  results?: IDestinationProviderTransferResults | undefined;
 
   /**
    * Optional rollback implementation
@@ -57,7 +57,7 @@ export interface IDestinationProvider extends IProvider {
   rollback?<T extends Error = Error>(e: T): MaybePromise<void>;
 
   setMetadata?(target: ProviderType, metadata: IMetadata): IDestinationProvider;
-  onWarning?: (message: string) => void;
+  onWarning?: ((message: string) => void) | undefined;
 
   createEntitiesWriteStream?(): MaybePromise<Writable>;
   createLinksWriteStream?(): MaybePromise<Writable>;

--- a/packages/core/data-transfer/src/types/transfer-engine.ts
+++ b/packages/core/data-transfer/src/types/transfer-engine.ts
@@ -170,9 +170,9 @@ export interface ITransferEngineOptions {
   transforms?: TransferTransforms;
 
   // List of TransferTransformList preset options to exclude/include
-  exclude?: TransferFilterPreset[];
-  only?: TransferFilterPreset[];
+  exclude?: TransferFilterPreset[] | undefined;
+  only?: TransferFilterPreset[] | undefined;
 
   // delay after each record
-  throttle?: number;
+  throttle?: number | undefined;
 }

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -59,6 +59,7 @@
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",
     "test:front:watch:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js --watchAll",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
+    "test:ts:back": "run -T tsc -p server/tsconfig.json",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {

--- a/packages/core/email/server/src/bootstrap.ts
+++ b/packages/core/email/server/src/bootstrap.ts
@@ -44,6 +44,7 @@ const createProvider = (emailConfig: EmailConfig) => {
   } catch (err) {
     const newError = new Error(`Could not load email provider "${providerName}".`);
     if (err instanceof Error) {
+      // @ts-expect-error - es5 Error.stack missing undefined
       newError.stack = err.stack;
     }
     throw newError;

--- a/packages/core/email/server/tsconfig.json
+++ b/packages/core/email/server/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "tsconfig/base.json",
   "include": ["./src", "../shared"],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "types": ["node"],
     "exactOptionalPropertyTypes": true

--- a/packages/core/email/server/tsconfig.json
+++ b/packages/core/email/server/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["./src", "../shared"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/core/permissions/src/types.ts
+++ b/packages/core/permissions/src/types.ts
@@ -11,9 +11,11 @@ export interface ParametrizedAction {
 }
 export interface PermissionRule {
   action: string | ParametrizedAction;
-  subject?: Subject | null;
-  properties?: {
-    fields?: string[];
-  };
+  subject?: Subject | null | undefined;
+  properties?:
+    | {
+        fields?: string[];
+      }
+    | undefined;
   condition?: Record<string, unknown>;
 }

--- a/packages/core/permissions/tsconfig.json
+++ b/packages/core/permissions/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src", "vitest.config.ts"],
   "exclude": ["**/__tests__/**"]

--- a/packages/core/strapi/src/cli/commands/admin/active-user.ts
+++ b/packages/core/strapi/src/cli/commands/admin/active-user.ts
@@ -8,8 +8,8 @@ import { runAction } from '../../utils/helpers';
 import { getInquirer } from '../../utils/get-inquirer';
 
 interface CmdOptions {
-  email?: string;
-  active?: string;
+  email: string | undefined;
+  active: string | undefined;
 }
 
 interface Answers {
@@ -59,7 +59,7 @@ async function setActive({ email, active }: CmdOptions) {
 /**
  * Change a user's active status
  */
-const action = async (cmdOptions: CmdOptions = {}) => {
+const action = async (cmdOptions: CmdOptions) => {
   const { email, active } = cmdOptions;
 
   if (_.isEmpty(email) && _.isEmpty(active) && process.stdin.isTTY) {

--- a/packages/core/strapi/src/cli/commands/admin/block-user.ts
+++ b/packages/core/strapi/src/cli/commands/admin/block-user.ts
@@ -8,8 +8,8 @@ import { runAction } from '../../utils/helpers';
 import { getInquirer } from '../../utils/get-inquirer';
 
 interface CmdOptions {
-  email?: string;
-  block?: string;
+  email: string | undefined;
+  block: string | undefined;
 }
 
 interface Answers {
@@ -57,7 +57,7 @@ async function setBlock({ email, block }: CmdOptions) {
 /**
  * Change a user's block status
  */
-const action = async (cmdOptions: CmdOptions = {}) => {
+const action = async (cmdOptions: CmdOptions) => {
   const { email, block } = cmdOptions;
 
   if (_.isEmpty(email) && _.isEmpty(block) && process.stdin.isTTY) {

--- a/packages/core/strapi/src/cli/commands/admin/create-user.ts
+++ b/packages/core/strapi/src/cli/commands/admin/create-user.ts
@@ -9,10 +9,10 @@ import { getInquirer } from '../../utils/get-inquirer';
 import type { StrapiCommand } from '../../types';
 
 interface CmdOptions {
-  email?: string;
-  password?: string;
-  firstname?: string;
-  lastname?: string;
+  email: string | undefined;
+  password: string | undefined;
+  firstname: string | undefined;
+  lastname: string | undefined;
 }
 
 const emailValidator = yup.string().email('Invalid email address').lowercase();
@@ -110,7 +110,7 @@ async function createAdmin({ email, password, firstname, lastname }: CmdOptions)
 /**
  * Create new admin user
  */
-const action = async (cmdOptions: CmdOptions = {}) => {
+const action = async (cmdOptions: CmdOptions) => {
   let { email, password, firstname, lastname } = cmdOptions;
 
   if (

--- a/packages/core/strapi/src/cli/commands/admin/delete-user.ts
+++ b/packages/core/strapi/src/cli/commands/admin/delete-user.ts
@@ -9,7 +9,7 @@ import { getInquirer } from '../../utils/get-inquirer';
 import type { StrapiCommand } from '../../types';
 
 interface CmdOptions {
-  email?: string;
+  email: string | undefined;
 }
 
 const emailValidator = yup.string().email('Invalid email address').lowercase();
@@ -69,7 +69,7 @@ async function deleteAdmin({ email }: CmdOptions) {
 /**
  * Delete an admin user
  */
-const action = async (cmdOptions: CmdOptions = {}) => {
+const action = async (cmdOptions: CmdOptions) => {
   let { email } = cmdOptions;
 
   if (_.isEmpty(email) && process.stdin.isTTY) {

--- a/packages/core/strapi/src/cli/commands/admin/reset-user-password.ts
+++ b/packages/core/strapi/src/cli/commands/admin/reset-user-password.ts
@@ -8,8 +8,8 @@ import { runAction } from '../../utils/helpers';
 import { getInquirer } from '../../utils/get-inquirer';
 
 interface CmdOptions {
-  email?: string;
-  password?: string;
+  email: string | undefined;
+  password: string | undefined;
 }
 
 interface Answers {
@@ -41,7 +41,7 @@ async function changePassword({ email, password }: CmdOptions) {
 /**
  * Reset user's password
  */
-const action = async (cmdOptions: CmdOptions = {}) => {
+const action = async (cmdOptions: CmdOptions) => {
   const { email, password } = cmdOptions;
 
   if (_.isEmpty(email) && _.isEmpty(password) && process.stdin.isTTY) {

--- a/packages/core/strapi/src/cli/types.ts
+++ b/packages/core/strapi/src/cli/types.ts
@@ -5,7 +5,7 @@ import { TsConfig } from './utils/tsconfig';
 export interface CLIContext {
   cwd: string;
   logger: Logger;
-  tsconfig?: TsConfig;
+  tsconfig: TsConfig | undefined;
 }
 
 export type StrapiCommand = (params: {

--- a/packages/core/strapi/src/cli/utils/commander.ts
+++ b/packages/core/strapi/src/cli/utils/commander.ts
@@ -118,7 +118,7 @@ const getCommanderConfirmMessage = (
   };
 };
 
-const confirmMessage = async (message: string, { force }: { force?: boolean } = {}) => {
+const confirmMessage = async (message: string, { force }: { force?: boolean | undefined } = {}) => {
   // if we have a force option, respond yes
   if (force === true) {
     // attempt to mimic the inquirer prompt exactly

--- a/packages/core/strapi/src/cli/utils/data-transfer.ts
+++ b/packages/core/strapi/src/cli/utils/data-transfer.ts
@@ -228,8 +228,8 @@ const onlyContentTypesOption = new Option(
 ).argParser(parseList);
 
 type ContentTypeTransferOptions = {
-  excludeContentTypes?: string[];
-  onlyContentTypes?: string[];
+  excludeContentTypes?: string[] | undefined;
+  onlyContentTypes?: string[] | undefined;
 };
 
 type TransferExcludePreset = engineDataTransfer.TransferFilterPreset | typeof MEDIA_LIBRARY_PRESET;
@@ -237,11 +237,11 @@ type TransferExcludePreset = engineDataTransfer.TransferFilterPreset | typeof ME
 type TransferCliFilterOptions = Partial<
   Omit<engineDataTransfer.ITransferEngineOptions, 'exclude' | 'only'>
 > & {
-  exclude?: TransferExcludePreset[];
-  only?: engineDataTransfer.TransferFilterPreset[];
+  exclude?: TransferExcludePreset[] | undefined;
+  only?: engineDataTransfer.TransferFilterPreset[] | undefined;
 } & ContentTypeTransferOptions & {
     /** Set when the files stage is auto-skipped because upload types are out of scope. */
-    filesAutoExcluded?: boolean;
+    filesAutoExcluded?: boolean | undefined;
   };
 
 const validateExcludeOnly = (command: Command) => {
@@ -529,7 +529,7 @@ const getDiffHandler = (
     force,
     action,
   }: {
-    force?: boolean;
+    force?: boolean | undefined;
     action: string;
   }
 ) => {
@@ -612,7 +612,7 @@ const getAssetsBackupHandler = (
     force,
     action,
   }: {
-    force?: boolean;
+    force?: boolean | undefined;
     action: string;
   }
 ) => {

--- a/packages/core/strapi/src/node/core/aliases.ts
+++ b/packages/core/strapi/src/node/core/aliases.ts
@@ -26,7 +26,7 @@ const devAliases: Record<string, string> = {
   '@strapi/review-workflows/strapi-admin': './packages/core/review-workflows/admin/src',
 };
 
-const getMonorepoAliases = ({ monorepo }: { monorepo?: StrapiMonorepo }) => {
+const getMonorepoAliases = ({ monorepo }: { monorepo: StrapiMonorepo | undefined }) => {
   if (!monorepo?.path) {
     return {};
   }

--- a/packages/core/strapi/src/node/create-build-context.ts
+++ b/packages/core/strapi/src/node/create-build-context.ts
@@ -24,7 +24,7 @@ interface BuildContext<TOptions = unknown> extends BaseContext {
   /**
    * The customisations defined by the user in their app.js file
    */
-  customisations?: AppFile;
+  customisations: AppFile | undefined;
   /**
    * Features object with future flags
    */

--- a/packages/core/strapi/src/node/staticFiles.ts
+++ b/packages/core/strapi/src/node/staticFiles.ts
@@ -43,9 +43,7 @@ const getEntryModule = (ctx: BuildContext): string => {
 };
 
 interface GetDocumentHTMLArgs extends Pick<BuildContext, 'logger'> {
-  props?: {
-    entryPath?: string;
-  };
+  props: { entryPath?: string } | undefined;
 }
 
 /**

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -164,7 +164,7 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
 
 const resolveProductionConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
   const {
-    options: { minify, sourcemaps },
+    options: { minify = false, sourcemaps = false },
   } = ctx;
 
   const baseConfig = await resolveBaseConfig(ctx);
@@ -209,7 +209,7 @@ const resolveDevelopmentConfig = async (ctx: BuildContext): Promise<InlineConfig
        */
       allowedHosts: true,
       middlewareMode: true,
-      open: ctx.options.open,
+      open: ctx.options.open ?? false,
       hmr: {
         overlay: false,
         /**

--- a/packages/core/strapi/src/node/webpack/config.ts
+++ b/packages/core/strapi/src/node/webpack/config.ts
@@ -201,7 +201,7 @@ const resolveProductionConfig = async (ctx: BuildContext): Promise<Configuration
       chunkFilename: '[name].[contenthash:8].chunk.js',
     },
     optimization: {
-      minimize: ctx.options.minify,
+      minimize: ctx.options.minify ?? false,
       minimizer: [
         new EsbuildPlugin({
           target,

--- a/packages/core/strapi/tsconfig.json
+++ b/packages/core/strapi/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/core/types/src/utils/object.ts
+++ b/packages/core/types/src/utils/object.ts
@@ -99,6 +99,34 @@ export type PartialBy<TValue, TKeys extends keyof TValue> = Omit<TValue, TKeys> 
   Partial<Pick<TValue, TKeys>>;
 
 /**
+ * Same as the built-in `Partial<TValue>`, but also adds `undefined` to every property type.
+ *
+ * @template TValue The original object type.
+ *
+ * @remark
+ * The built-in `Partial` only adds the `?` modifier; it does not add `undefined` to the property
+ * type. Under `exactOptionalPropertyTypes`, `{ foo?: string }` rejects `{ foo: undefined }`, so
+ * `Partial` alone is not enough to describe an input object whose properties may be explicitly set
+ * to `undefined`.
+ *
+ * Use this helper for **input** types where an absent property and an explicitly `undefined` one are
+ * handled identically at runtime. It is a no-op when `exactOptionalPropertyTypes` is disabled.
+ *
+ * @example
+ * ```typescript
+ * type Person = { name: string; age: number };
+ *
+ * declare const age: number | undefined;
+ *
+ * const a: Partial<Person> = { age };              // error under exactOptionalPropertyTypes
+ * const b: PartialWithUndefined<Person> = { age }; // ok
+ * ```
+ */
+export type PartialWithUndefined<TValue> = {
+  [TKey in keyof TValue]?: TValue[TKey] | undefined;
+};
+
+/**
  * Extracts all unique values from a given object as a union type.
  *
  * @template TObject - An object from which values are to be extracted. It must extend the `object` type.

--- a/packages/core/upload/server/src/register.ts
+++ b/packages/core/upload/server/src/register.ts
@@ -81,6 +81,7 @@ const createProvider = (config: Config) => {
     const newError = new Error(`Could not load upload provider "${providerName}".`);
 
     if (err instanceof Error) {
+      // @ts-expect-error - es5 Error.stack missing undefined
       newError.stack = err.stack;
     }
 

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -30,7 +30,7 @@ type User = {
 type ID = string | number;
 
 type CommonOptions = {
-  user?: User;
+  user?: User | undefined;
 };
 
 type Metas = {
@@ -124,7 +124,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       ref?: string;
       field?: string;
       path?: string;
-      tmpWorkingDirectory?: string;
+      tmpWorkingDirectory?: string | undefined;
     } = {}
   ): Promise<Omit<UploadableFile, 'getStream'>> {
     const fileService = getService('file');

--- a/packages/core/upload/server/src/types.ts
+++ b/packages/core/upload/server/src/types.ts
@@ -14,24 +14,24 @@ export interface FocalPoint {
 export interface File {
   id: number;
   name: string;
-  alternativeText?: string | null;
-  caption?: string | null;
-  focalPoint?: FocalPoint | null;
-  width?: number;
-  height?: number;
+  alternativeText?: string | null | undefined;
+  caption?: string | null | undefined;
+  focalPoint?: FocalPoint | null | undefined;
+  width?: number | undefined;
+  height?: number | undefined;
   formats?: Record<string, unknown>;
   hash: string;
-  ext?: string;
-  mime?: string;
+  ext?: string | undefined;
+  mime?: string | undefined;
   size?: number;
-  sizeInBytes?: number;
+  sizeInBytes?: number | undefined;
   url?: string;
   previewUrl?: string;
   path?: string | null;
   provider?: string;
   provider_metadata?: Record<string, unknown>;
   isUrlSigned?: boolean;
-  folder?: number | null;
+  folder?: number | null | undefined;
   folderPath?: string;
   related?: {
     id: string | number;

--- a/packages/core/upload/server/tsconfig.json
+++ b/packages/core/upload/server/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -144,7 +144,7 @@ type PopulateQuery =
 
 export interface Query {
   orderBy?: OrderByQuery;
-  select?: SelectQuery;
+  select?: SelectQuery | undefined;
   where?: WhereQuery;
   // NOTE: those are internal DB filters do not modify
   filters?: FiltersQuery;
@@ -152,7 +152,7 @@ export interface Query {
   count?: boolean;
   ordering?: unknown;
   _q?: string;
-  limit?: number;
+  limit?: number | undefined;
   offset?: number;
   page?: number;
   pageSize?: number;

--- a/packages/core/utils/src/parse-type.ts
+++ b/packages/core/utils/src/parse-type.ts
@@ -119,7 +119,7 @@ const isBooleanLike = (value: unknown): boolean => {
   return false;
 };
 
-const parseBoolean = (value: unknown, options: { forceCast?: boolean }): boolean => {
+const parseBoolean = (value: unknown, options: { forceCast?: boolean | undefined }): boolean => {
   const { forceCast = false } = options;
 
   if (typeof value === 'boolean') {

--- a/packages/core/utils/src/sanitize/index.ts
+++ b/packages/core/utils/src/sanitize/index.ts
@@ -32,7 +32,7 @@ export interface Options {
    * When set, extra query/input params are derived from the route's request schema (and validated/sanitized with Zod).
    * When absent, no extra params are allowed in strict mode.
    */
-  route?: RouteLike;
+  route?: RouteLike | undefined;
 }
 
 export interface Sanitizer {

--- a/packages/core/utils/src/sessions.ts
+++ b/packages/core/utils/src/sessions.ts
@@ -9,11 +9,11 @@ export interface SessionEntryLike {
 
 export interface SanitizedSessionEntry {
   id: string;
-  deviceId?: string;
-  deviceName?: string;
+  deviceId?: string | undefined;
+  deviceName?: string | undefined;
   current: boolean;
-  loginAt?: string;
-  lastActiveAt?: string;
+  loginAt?: string | undefined;
+  lastActiveAt?: string | undefined;
 }
 
 export interface SessionDisplayEntry {

--- a/packages/core/utils/src/traverse-entity.ts
+++ b/packages/core/utils/src/traverse-entity.ts
@@ -27,12 +27,12 @@ export interface VisitorOptions {
   schema: Model;
   key: string;
   value: Data[keyof Data];
-  attribute?: AnyAttribute;
+  attribute?: AnyAttribute | undefined;
   path: Path;
   getModel(uid: string): Model;
-  parent?: Parent;
+  parent?: Parent | undefined;
   /** Extra root-level keys allowed (e.g. registered input params). Only used when path.attribute === null. */
-  allowedExtraRootKeys?: string[];
+  allowedExtraRootKeys?: string[] | undefined;
 }
 
 export type Visitor = (visitorOptions: VisitorOptions, visitorUtils: VisitorUtils) => void;
@@ -46,14 +46,14 @@ export interface Path {
 export interface TraverseOptions {
   schema: Model;
   path?: Path;
-  parent?: Parent;
+  parent?: Parent | undefined;
   getModel(uid: string): Model;
   /** Extra root-level keys allowed (e.g. registered input params). Only used when path.attribute === null. */
-  allowedExtraRootKeys?: string[];
+  allowedExtraRootKeys?: string[] | undefined;
 }
 
 export interface Parent {
-  attribute?: Attribute;
+  attribute?: Attribute | undefined;
   key: string | null;
   path: Path;
   schema: Model;

--- a/packages/core/utils/src/traverse/factory.ts
+++ b/packages/core/utils/src/traverse/factory.ts
@@ -16,7 +16,7 @@ export interface Path {
 }
 
 export interface Parent {
-  attribute?: Attribute;
+  attribute?: Attribute | undefined;
   key: string | null;
   path: Path;
   schema: Model;
@@ -24,8 +24,8 @@ export interface Parent {
 
 export interface TraverseOptions {
   schema: Model;
-  path?: Path;
-  parent?: Parent;
+  path?: Path | undefined;
+  parent?: Parent | undefined;
   getModel(uid: string): Model;
 }
 
@@ -34,9 +34,9 @@ export interface VisitorOptions {
   value: unknown;
   schema: Model;
   key: string;
-  attribute?: AnyAttribute;
+  attribute?: AnyAttribute | undefined;
   path: Path;
-  parent?: Parent;
+  parent?: Parent | undefined;
   getModel(uid: string): Model;
 }
 
@@ -100,7 +100,7 @@ interface Context<AttributeType = Attribute> {
   path: Path;
   data: unknown;
   visitor: Visitor;
-  parent?: Parent;
+  parent?: Parent | undefined;
   getModel(uid: string): Model;
 }
 

--- a/packages/core/utils/src/user-agent.ts
+++ b/packages/core/utils/src/user-agent.ts
@@ -7,10 +7,10 @@
  */
 
 export interface ParsedUserAgent {
-  browser?: string;
-  os?: string;
+  browser?: string | undefined;
+  os?: string | undefined;
   /** Human-readable label combining browser and OS, e.g. "Chrome on macOS". */
-  deviceName?: string;
+  deviceName?: string | undefined;
 }
 
 /**

--- a/packages/core/utils/tsconfig.json
+++ b/packages/core/utils/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src", "vitest.config.ts"],
   "exclude": ["**/__tests__/**"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/generators/generators/tsconfig.json
+++ b/packages/generators/generators/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["src/templates"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/plugins/cloud/admin/tsconfig.json
+++ b/packages/plugins/cloud/admin/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/client.json",
   "include": ["./src", "*.d.ts"],
   "compilerOptions": {
-    "types": []
+    "types": [],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -58,6 +58,7 @@
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",
     "test:front:watch:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js --watchAll",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
+    "test:ts:back": "run -T tsc -p server/tsconfig.json",
     "test:unit:vitest": "vitest run",
     "test:unit:vitest:watch": "vitest --watch",
     "watch": "run -T rollup -c -w"

--- a/packages/plugins/color-picker/server/tsconfig.json
+++ b/packages/plugins/color-picker/server/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/plugins/documentation/server/src/services/helpers/utils/clean-schema-attributes.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/utils/clean-schema-attributes.ts
@@ -185,7 +185,7 @@ const cleanSchemaAttributes = (
           items: {
             anyOf: components,
           },
-          discriminator,
+          ...(discriminator ? { discriminator } : {}),
         };
         break;
       }

--- a/packages/plugins/documentation/server/tsconfig.json
+++ b/packages/plugins/documentation/server/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/plugins/graphql/admin/tsconfig.json
+++ b/packages/plugins/graphql/admin/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/client.json",
   "include": ["./src"],
   "compilerOptions": {
-    "types": []
+    "types": [],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -55,6 +55,7 @@
     "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
+    "test:ts:back": "run -T tsc -p server/tsconfig.json",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "watch": "run -T rollup -c -w"

--- a/packages/plugins/i18n/server/src/services/__tests__/ai-localizations.test.ts
+++ b/packages/plugins/i18n/server/src/services/__tests__/ai-localizations.test.ts
@@ -48,7 +48,7 @@ describe('ai-localizations service', () => {
         globalId: 'Test',
         info: { displayName: 'Test', singularName: 'test', pluralName: 'tests' },
         attributes,
-      } as Schema.Schema;
+      } as unknown as Schema.Schema;
     };
 
     describe('root-level unsupported fields', () => {

--- a/packages/plugins/i18n/server/src/services/__tests__/localizations.test.ts
+++ b/packages/plugins/i18n/server/src/services/__tests__/localizations.test.ts
@@ -1,3 +1,4 @@
+import { Schema } from '@strapi/types';
 import localizationsService from '../localizations';
 import localesService from '../locales';
 import contentTypesService from '../content-types';
@@ -26,7 +27,7 @@ const model = {
       type: 'integer',
     },
   },
-};
+} as unknown as Schema.ContentType;
 
 const allLocalizedModel = {
   uid: 'test-model',
@@ -53,7 +54,7 @@ const allLocalizedModel = {
       },
     },
   },
-};
+} as unknown as Schema.ContentType;
 
 global.strapi = {
   plugins: {

--- a/packages/plugins/i18n/server/tsconfig.json
+++ b/packages/plugins/i18n/server/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/plugins/sentry/admin/tsconfig.json
+++ b/packages/plugins/sentry/admin/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/client.json",
   "include": ["src"],
   "compilerOptions": {
-    "types": []
+    "types": [],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/plugins/sentry/server/tsconfig.json
+++ b/packages/plugins/sentry/server/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/providers/email-amazon-ses/tsconfig.json
+++ b/packages/providers/email-amazon-ses/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/providers/email-mailgun/tsconfig.json
+++ b/packages/providers/email-mailgun/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/providers/email-nodemailer/src/index.ts
+++ b/packages/providers/email-nodemailer/src/index.ts
@@ -120,15 +120,15 @@ type ProviderOptions = Parameters<typeof nodemailer.createTransport>[0];
 
 interface ProviderCapabilities {
   transport?: {
-    host?: string;
-    port?: number;
-    secure?: boolean;
-    pool?: boolean;
-    maxConnections?: number;
+    host?: string | undefined;
+    port?: number | undefined;
+    secure?: boolean | undefined;
+    pool?: boolean | undefined;
+    maxConnections?: number | undefined;
   };
   auth?: {
-    type?: string;
-    user?: string;
+    type?: string | undefined;
+    user?: string | undefined;
   };
   features?: string[];
 }

--- a/packages/providers/email-nodemailer/tsconfig.json
+++ b/packages/providers/email-nodemailer/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src", "vitest.config.ts"],
   "exclude": ["**/__tests__/**"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/providers/email-sendgrid/tsconfig.json
+++ b/packages/providers/email-sendgrid/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/providers/email-sendmail/src/addressing.ts
+++ b/packages/providers/email-sendmail/src/addressing.ts
@@ -65,9 +65,9 @@ export function groupRecipientsByDomain(recipients: string[]): Record<string, st
 
 /** Collect all recipients from to / cc / bcc (same sources as legacy sendmail). */
 export function collectRecipients(mail: {
-  to?: string | string[];
-  cc?: string | string[];
-  bcc?: string | string[];
+  to?: string | string[] | undefined;
+  cc?: string | string[] | undefined;
+  bcc?: string | string[] | undefined;
 }): string[] {
   return [
     ...parseAddressList(mail.to),

--- a/packages/providers/email-sendmail/tsconfig.json
+++ b/packages/providers/email-sendmail/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["src", "__tests__", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/providers/upload-aws-s3/tsconfig.json
+++ b/packages/providers/upload-aws-s3/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "tsconfig/base.json",
   "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   },
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/providers/upload-cloudinary/tsconfig.json
+++ b/packages/providers/upload-cloudinary/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/providers/upload-local/tsconfig.json
+++ b/packages/providers/upload-local/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/utils/logger/tsconfig.json
+++ b/packages/utils/logger/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/packages/utils/oxlint-config/tsconfig.json
+++ b/packages/utils/oxlint-config/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "tsconfig/base.json",
   "compilerOptions": {
     "noEmit": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "exactOptionalPropertyTypes": true
   },
   "include": ["*.ts"],
   "exclude": ["node_modules"]

--- a/packages/utils/typescript/src/compilers/basic.ts
+++ b/packages/utils/typescript/src/compilers/basic.ts
@@ -16,7 +16,7 @@ export interface ConfigOptions {
 export function run(tsConfigPath: string, configOptions: ConfigOptions = {}) {
   const { ignoreDiagnostics = false } = configOptions;
   // Parse the tsconfig.json file & resolve the configuration options
-  const { fileNames, options, projectReferences } = resolveConfigOptions(tsConfigPath);
+  const { fileNames, options, projectReferences = [] } = resolveConfigOptions(tsConfigPath);
 
   const compilerOptions = merge(options, configOptions.options);
 

--- a/packages/utils/typescript/src/generators/common/models/attributes.ts
+++ b/packages/utils/typescript/src/generators/common/models/attributes.ts
@@ -14,7 +14,7 @@ const { factory } = ts;
 export const getAttributeType = (
   attributeName: string,
   attribute: Attribute,
-  uid?: string
+  uid: string | undefined
 ): ts.TypeReferenceNode | null => {
   if (!Object.keys(mappers).includes(attribute.type)) {
     console.warn(

--- a/packages/utils/typescript/src/generators/common/models/mappers.ts
+++ b/packages/utils/typescript/src/generators/common/models/mappers.ts
@@ -7,7 +7,7 @@ import type { Attribute } from './utils';
 const { factory } = ts;
 
 export interface MapperContext {
-  uid?: string;
+  uid: string | undefined;
   attribute: Attribute;
   attributeName?: string;
 }

--- a/packages/utils/typescript/src/generators/index.ts
+++ b/packages/utils/typescript/src/generators/index.ts
@@ -14,7 +14,7 @@ const GENERATORS = {
 export interface GenerateConfig {
   strapi: any;
   pwd: string;
-  rootDir?: string;
+  rootDir: string | undefined;
   artifacts?: {
     contentTypes?: boolean;
     components?: boolean;

--- a/packages/utils/typescript/src/utils/get-config-path.ts
+++ b/packages/utils/typescript/src/utils/get-config-path.ts
@@ -4,7 +4,7 @@ import * as ts from 'typescript';
 const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
 
 interface GetConfigPathOptions {
-  filename?: string;
+  filename?: string | undefined;
   ancestorsLookup?: boolean;
 }
 

--- a/packages/utils/typescript/tsconfig.json
+++ b/packages/utils/typescript/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/**"]
+  "exclude": ["node_modules", "**/__tests__/**"],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  }
 }

--- a/packages/utils/upgrade/src/modules/npm/package.ts
+++ b/packages/utils/upgrade/src/modules/npm/package.ts
@@ -141,6 +141,7 @@ export class Package implements PackageInterface {
     const packageURL = `${await this.determineRegistryUrl()}/${this.name}`;
 
     const response = await fetch(packageURL, {
+      // @ts-expect-error - undici-types does not support yet exactOptionalPropertyTypes
       dispatcher: agent,
     });
 

--- a/packages/utils/upgrade/src/tasks/codemods/types.ts
+++ b/packages/utils/upgrade/src/tasks/codemods/types.ts
@@ -7,14 +7,14 @@ export interface RunCodemodsOptions {
   logger: Logger;
   confirm?: ConfirmationCallback;
   selectCodemods: SelectCodemodsCallback;
-  cwd?: string;
+  cwd: string | undefined;
   dry?: boolean;
   target: Version.ReleaseType | Version.LiteralSemVer | Version.Range;
-  uid?: string;
+  uid: string | undefined;
 }
 
 export interface ListCodemodsOptions {
   logger: Logger;
-  cwd?: string;
+  cwd: string | undefined;
   target: Version.ReleaseType | Version.LiteralSemVer | Version.Range;
 }

--- a/packages/utils/upgrade/src/tasks/upgrade/types.ts
+++ b/packages/utils/upgrade/src/tasks/upgrade/types.ts
@@ -6,8 +6,8 @@ import type { ConfirmationCallback } from '../../modules/common/types';
 export interface UpgradeOptions {
   logger: Logger;
   confirm?: ConfirmationCallback;
-  cwd?: string;
+  cwd: string | undefined;
   dry?: boolean;
   target: Version.ReleaseType | Version.SemVer;
-  codemodsTarget?: Version.SemVer;
+  codemodsTarget: Version.SemVer | undefined;
 }

--- a/packages/utils/upgrade/tsconfig.json
+++ b/packages/utils/upgrade/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/utils/vitest-config/tsconfig.json
+++ b/packages/utils/vitest-config/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig/base.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8722,6 +8722,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/cloud-cli@workspace:packages/cli/cloud"
   dependencies:
+    "@strapi/types": "npm:5.51.2"
     "@strapi/utils": "npm:5.51.2"
     "@types/cli-progress": "npm:3.11.5"
     "@types/eventsource": "npm:1.1.15"


### PR DESCRIPTION
### What does it do?

Turns `exactOptionalPropertyTypes` on in 29 workspaces and fixes every call site it flags.

Enabled in: `admin-test-utils`, `cloud-cli`, `create-strapi-app`, `@strapi/strapi`, `email` server, `permissions`, `upload` server, `utils`, `generators`, the `color-picker` / `documentation` / `i18n` / `sentry` server plugins, the `cloud` / `graphql` / `sentry` admin plugins, all five email providers, all three upload providers, `logger`, `oxlint-config`, `typescript-utils`, `upgrade` and `vitest-config`.

`@strapi/admin` and everything built on top of the design system are deliberately **not** included — the design system has to accept the flag first, otherwise every consumer inherits its optional-property mismatches. That is a separate piece of work.

Two supporting changes outside the flagged packages:

- **`@strapi/types`** — adds `Utils.Object.PartialWithUndefined<T>`. The built-in `Partial<T>` only adds the `?` modifier; it does not add `undefined` to the property type. Under the flag, `{ foo?: string }` rejects `{ foo: undefined }`, so `Partial<T>` alone cannot describe an input object whose properties may be explicitly set to `undefined`. The helper is a no-op when the flag is disabled.
- **`@strapi/core`** — `createStrapi` accepts `PartialWithUndefined<StrapiOptions>` instead of `Partial<StrapiOptions>`, so callers can forward optional values straight through.

### Why is it needed?

`exactOptionalPropertyTypes` distinguishes "property absent" from "property present and `undefined`". Without it, a value typed `string | undefined` can be assigned to a `foo?: string` property, which silently produces objects whose keys exist with an `undefined` value — a real source of bugs when the consumer does `'foo' in obj`, spreads over defaults, or serialises the object.

This was split out of #27300, where threading a tsconfig path through the CLI surfaced exactly this class of mismatch in the build context and CLI option types.

### How the call sites were fixed

Three patterns, applied by what the caller actually does. They are not interchangeable:

```ts
interface Args {
  a?: T | undefined; // key optional AND value may be undefined
  b: T | undefined;  // key always present, value may be undefined
  c?: T;             // key optional, value may NOT be undefined
}
```

1. **`prop?: T | undefined`** — the default, for option bags where the caller may omit the key entirely and an absent property behaves identically to an explicitly `undefined` one at runtime. `PartialWithUndefined<T>` is the whole-object equivalent.
2. **`prop: T | undefined`** — where the key is always present but the value may not be. The `admin:*` CLI commands are this case: Commander always passes an options object, so the `= {}` action defaults were unreachable and are dropped.
3. **Conditional spread** — where the target type is third-party and cannot be widened. `plugin-documentation` builds an OpenAPI `ArraySchemaObject` whose `discriminator` is only set for component unions, and `openapi-types` declares it as `discriminator?: DiscriminatorObject`; it is now omitted rather than set to `undefined`.

Runtime behaviour is unchanged throughout — every edit is a type-level widening, a conditional spread that omits a key the consumer already treated as absent, or an explicit default matching what the code already did with `undefined`.

### Also in here

- `@strapi/cloud-cli` gains an explicit `@strapi/types` dependency it was already importing transitively.
- `color-picker`, `i18n` and `email` gain the `test:ts:back` script their server `tsconfig.json` needs in order to be checked at all — no script pointed at those three configs, so that server code was never type-checked by `yarn test:ts`. `email`'s config also excludes `**/*.test.ts`: its `types` list has no test globals, and the test files are covered by the vitest/jest setup instead.

### How to test it?

```bash
yarn test:ts       # 37 projects, all green
yarn version:check # aligned at 5.51.2
```

Both pass on this branch. `lint` and `prettier` ran via the pre-commit hook.

### Related issue(s)/PR(s)

- Split out of #27300
- Related to #23480
- Follows the same approach as #27288

