### PR TITLE
chore(cli): keep CLI options separate from the CLI context

### DIFF
--- a/packages/cli/cloud/src/bin.ts
+++ b/packages/cli/cloud/src/bin.ts
@@ -30,9 +30,9 @@ function loadStrapiCloudCommand(argv = process.argv, command = new Command()) {
   buildStrapiCloudCommands({ command, ctx, argv });
 }
 
-function runStrapiCloudCommand(argv = process.argv, command = new Command()) {
+async function runStrapiCloudCommand(argv = process.argv, command = new Command()) {
   loadStrapiCloudCommand(argv, command);
-  command.parse(argv);
+  await command.parseAsync(argv);
 }
 
 export { runStrapiCloudCommand };

--- a/packages/cli/cloud/src/index.ts
+++ b/packages/cli/cloud/src/index.ts
@@ -9,7 +9,7 @@ import { createGrowthSsoTrial } from './create-growth-sso-trial';
 import listProjects from './list-projects';
 import listEnvironments from './environment/list';
 import linkEnvironment from './environment/link';
-import { CLIContext } from './types';
+import type { CLIContext, StrapiCloudCommandInfo } from './types';
 import { getLocalConfig, saveLocalConfig } from './config/local';
 
 export const cli = {
@@ -25,7 +25,7 @@ export const cli = {
 
 export { createGrowthSsoTrial };
 
-const cloudCommands = [
+const cloudCommands: StrapiCloudCommandInfo[] = [
   deployProject,
   link,
   login,

--- a/packages/cli/cloud/src/utils/helpers.ts
+++ b/packages/cli/cloud/src/utils/helpers.ts
@@ -27,19 +27,18 @@ const assertCwdContainsStrapiProject = (name: string) => {
   }
 };
 
-const runAction =
-  (name: string, action: (...args: any[]) => Promise<unknown>) =>
-  (...args: unknown[]) => {
+const runAction = (name: string, action: (...args: any[]) => Promise<unknown>) => {
+  // NOTE: Commander binds the Command to the action handler. Keep it a regular function.
+  return function handler(...args: unknown[]) {
     assertCwdContainsStrapiProject(name);
 
     Promise.resolve()
-      .then(() => {
-        return action(...args);
-      })
+      .then(() => action(...args))
       .catch((error) => {
         console.error(error);
         process.exit(1);
       });
   };
+};
 
 export { runAction };

--- a/packages/core/strapi/src/cli/commands/build.ts
+++ b/packages/core/strapi/src/cli/commands/build.ts
@@ -1,20 +1,20 @@
 import { createCommand } from 'commander';
-import type { StrapiCommand } from '../types';
+import type { CLIContext, StrapiCommand } from '../types';
 
 import { build as nodeBuild, BuildOptions } from '../../node/build';
 import { handleUnexpectedError } from '../../node/core/errors';
 
 type BuildCLIOptions = BuildOptions;
 
-const action = async (options: BuildCLIOptions) => {
+const action = async (options: BuildCLIOptions, ctx: CLIContext) => {
   try {
     if (options.bundler === 'webpack') {
-      options.logger.warn(
+      ctx.logger.warn(
         '[@strapi/strapi]: Using webpack as a bundler is deprecated. You should migrate to vite.'
       );
     }
 
-    await nodeBuild(options);
+    await nodeBuild(options, ctx);
   } catch (err) {
     handleUnexpectedError(err);
   }
@@ -33,9 +33,7 @@ const command: StrapiCommand = ({ ctx }) => {
     .option('--stats', 'Print build statistics to the console', false)
     .option('--install-deps', 'Auto-install missing admin dependencies', false)
     .description('Build the strapi admin app')
-    .action(async (options: BuildCLIOptions) => {
-      return action({ ...options, ...ctx });
-    });
+    .action((options) => action(options, ctx));
 };
 
 export { command };

--- a/packages/core/strapi/src/cli/commands/develop.ts
+++ b/packages/core/strapi/src/cli/commands/develop.ts
@@ -1,22 +1,22 @@
 import { createCommand } from 'commander';
 import cluster from 'node:cluster';
-import type { StrapiCommand } from '../types';
+import type { CLIContext, StrapiCommand } from '../types';
 import { develop as nodeDevelop, DevelopOptions } from '../../node/develop';
 import { handleUnexpectedError } from '../../node/core/errors';
 
 type DevelopCLIOptions = DevelopOptions;
 
-const action = async (options: DevelopCLIOptions) => {
+const action = async (options: DevelopCLIOptions, ctx: CLIContext) => {
   try {
     if (cluster.isPrimary) {
       if (options.bundler === 'webpack') {
-        options.logger.warn(
+        ctx.logger.warn(
           '[@strapi/strapi]: Using webpack as a bundler is deprecated. You should migrate to vite.'
         );
       }
     }
 
-    await nodeDevelop(options);
+    await nodeDevelop(options, ctx);
   } catch (err) {
     handleUnexpectedError(err);
   }
@@ -40,9 +40,7 @@ const command: StrapiCommand = ({ ctx }) => {
     .option('--install-deps', 'Auto-install missing admin dependencies', true)
     .option('--no-install-deps', 'Do not auto-install missing admin dependencies')
     .description('Start your Strapi application in development mode')
-    .action(async (options: DevelopCLIOptions) => {
-      return action({ ...options, ...ctx });
-    });
+    .action((options) => action(options, ctx));
 };
 
 export { command };

--- a/packages/core/strapi/src/cli/index.ts
+++ b/packages/core/strapi/src/cli/index.ts
@@ -27,7 +27,7 @@ const createCLI = async (argv: string[], command = new Command()) => {
   // Lazy: defer `loadTsConfig` (which loads `typescript`) until first read
   let tsconfig: TsConfig | undefined;
   let loaded = false;
-  const ctx = { cwd, logger } as CLIContext;
+  const ctx: CLIContext = { cwd, logger };
   Object.defineProperty(ctx, 'tsconfig', {
     enumerable: true,
     get() {

--- a/packages/core/strapi/src/cli/utils/helpers.ts
+++ b/packages/core/strapi/src/cli/utils/helpers.ts
@@ -177,20 +177,19 @@ const assertCwdContainsStrapiProject = (name: string) => {
   }
 };
 
-const runAction =
-  (name: string, action: (...args: any[]) => Promise<void>) =>
-  (...args: unknown[]) => {
+const runAction = (name: string, action: (this: Command, ...args: any[]) => Promise<void>) => {
+  // NOTE: Commander binds the Command to the action handler. Keep it a regular function.
+  return function handler(this: Command, ...args: unknown[]) {
     assertCwdContainsStrapiProject(name);
 
     Promise.resolve()
-      .then(() => {
-        return action(...args);
-      })
+      .then(() => action.apply(this, args))
       .catch((error) => {
         console.error(error);
         process.exit(1);
       });
   };
+};
 
 /**
  * @description Notify users this is an experimental command and get them to approve first

--- a/packages/core/strapi/src/node/build.ts
+++ b/packages/core/strapi/src/node/build.ts
@@ -5,7 +5,7 @@ import { getTimer, prettyTime } from './core/timer';
 import { createBuildContext } from './create-build-context';
 import { writeStaticClientFiles } from './staticFiles';
 
-interface BuildOptions extends CLIContext {
+interface BuildOptions {
   /**
    * Which bundler to use for building.
    *
@@ -39,7 +39,10 @@ interface BuildOptions extends CLIContext {
  *
  * @description Builds the admin panel of the strapi application.
  */
-const build = async ({ logger, cwd, tsconfig, installDeps = false, ...options }: BuildOptions) => {
+const build = async (
+  { installDeps = false, ...options }: BuildOptions,
+  { logger, cwd, tsconfig }: CLIContext
+) => {
   const timer = getTimer();
 
   const shouldContinue = await handleAdminDependencies({

--- a/packages/core/strapi/src/node/develop.ts
+++ b/packages/core/strapi/src/node/develop.ts
@@ -29,7 +29,7 @@ const core = lazy<typeof import('@strapi/core')>('@strapi/core');
 const buildCtx = lazy<typeof import('./create-build-context')>('./create-build-context');
 const staticFs = lazy<typeof import('./staticFiles')>('./staticFiles');
 
-interface DevelopOptions extends CLIContext {
+interface DevelopOptions {
   /**
    * Which bundler to use for building.
    *
@@ -53,7 +53,7 @@ const cleanupDistDirectory = async ({
   tsconfig,
   logger,
   timer,
-}: Pick<DevelopOptions, 'tsconfig' | 'logger'> & { timer: TimeMeasurer }) => {
+}: Pick<CLIContext, 'tsconfig' | 'logger'> & { timer: TimeMeasurer }) => {
   const distDir = tsconfig?.config?.options?.outDir;
 
   if (
@@ -90,16 +90,10 @@ const cleanupDistDirectory = async ({
   cleaningSpinner?.succeed();
 };
 
-const develop = async ({
-  cwd,
-  polling,
-  logger,
-  tsconfig,
-  watchAdmin,
-  buildAdmin,
-  installDeps = true,
-  ...options
-}: DevelopOptions) => {
+const develop = async (
+  { polling, watchAdmin, buildAdmin, installDeps = true, ...options }: DevelopOptions,
+  { cwd, logger, tsconfig }: CLIContext
+) => {
   const timer = getTimer();
 
   if (cluster.isPrimary) {


### PR DESCRIPTION
### What does it do?

**1. `build` and `develop` take the CLI context as a separate argument**

The Commander action handlers merged the parsed options and the CLI context into a single object before calling into `node/`:

```diff
// packages/core/strapi/src/cli/commands/build.ts
-    .action(async (options: BuildCLIOptions) => {
-      return action({ ...options, ...ctx });
-    });
+    .action((options) => action(options, ctx));
```

`BuildOptions` and `DevelopOptions` no longer `extends CLIContext`; `build` and `develop` receive the context as a second parameter:

```diff
// packages/core/strapi/src/node/build.ts
-const build = async ({ logger, cwd, tsconfig, installDeps = false, ...options }: BuildOptions) => {
+const build = async (
+  { installDeps = false, ...options }: BuildOptions,
+  { logger, cwd, tsconfig }: CLIContext
+) => {
```

`cleanupDistDirectory` in `node/develop.ts` now picks `tsconfig`/`logger` off `CLIContext` rather than off `DevelopOptions`, since those keys no longer live there. The `options.logger.warn` deprecation notices in the two command files read `ctx.logger` instead.

**2. `runStrapiCloudCommand` awaits the parse**

```diff
// packages/cli/cloud/src/bin.ts
-function runStrapiCloudCommand(argv = process.argv, command = new Command()) {
+async function runStrapiCloudCommand(argv = process.argv, command = new Command()) {
   loadStrapiCloudCommand(argv, command);
-  command.parse(argv);
+  await command.parseAsync(argv);
 }
```

`@strapi/strapi`'s own `runCLI` already uses `parseAsync`; the cloud entry point used the synchronous `parse`, which returns before any async action settles.

**3. `runAction` no longer drops Commander's `this`**

Both copies of `runAction` (there are two — `packages/core/strapi/src/cli/utils/helpers.ts` and `packages/cli/cloud/src/utils/helpers.ts`, flagged as duplicated in an existing `TODO`) returned an arrow function. Commander invokes an action handler with the `Command` instance bound as `this`, and an arrow function discards it, so an action can never reach `this.opts()` / `this.optsWithGlobals()`. They now return a regular `function` and forward `this`:

```diff
-const runAction =
-  (name: string, action: (...args: any[]) => Promise<void>) =>
-  (...args: unknown[]) => {
+const runAction = (name: string, action: (this: Command, ...args: any[]) => Promise<void>) => {
+  // NOTE: Commander binds the Command to the action handler. Keep it a regular function.
+  return function handler(this: Command, ...args: unknown[]) {
```

No action currently reads `this`, so this changes no behaviour today — it removes the trap.

**4. Two typing tidy-ups**

- `cloudCommands` is annotated `StrapiCloudCommandInfo[]` (the type already existed in `packages/cli/cloud/src/types.ts`, it just wasn't applied), so a malformed command entry fails at the declaration rather than at use.
- `const ctx = { cwd, logger } as CLIContext` becomes `const ctx: CLIContext = { cwd, logger }` in `packages/core/strapi/src/cli/index.ts`. The `as` cast was there to satisfy the `tsconfig` property that `Object.defineProperty` installs on the next line, but `tsconfig` is already optional on `CLIContext`, so the cast only suppressed checking of the two properties actually written.

### Why is it needed?

`{ ...options, ...ctx }` merges two things with different provenance: `options` is whatever the user typed on the command line, `ctx` is constructed in `cli/index.ts`. Any option named `cwd`, `logger`, or `tsconfig` collides, and because the spread order puts `ctx` last, the context silently wins — the value a user passed is dropped with no error. Reverse the spread order and the opposite happens.

Nothing collides today, so this is not a live bug: `strapi build`/`strapi develop` declare no such option. But the shape invites one — adding a `--logger` or `--cwd` flag would produce a silent, type-clean failure, since `BuildOptions extends CLIContext` makes both halves the same type and the compiler sees nothing wrong. Passing the context as its own parameter makes the two sources distinct in the signature, and a colliding option name would then be a visible conflict.

It also unblocks the flag that collides most obviously. `cwd` is currently fixed to `process.cwd()` in `cli/index.ts` and reaches `build`/`develop` only through the context, so a `--cwd <path>` option — run `strapi build` against a project directory other than the shell's — could not be added while the two were merged: the option would land in the same object as the context value and one would quietly overwrite the other. With the two separated, the command layer can resolve `--cwd` and hand the context an explicit directory, and the `node/` functions keep taking a single unambiguous `cwd`. That option isn't part of this PR — this only clears the way for it.

The `parse` → `parseAsync` and `runAction` changes are in the same area and the same spirit: both are places where the CLI plumbing silently discards something (a pending promise, the bound `Command`).

### How to test it?

```bash
yarn nx run-many -t test:ts --projects @strapi/strapi,@strapi/cloud-cli
yarn nx run-many -t test:unit --projects @strapi/strapi,@strapi/cloud-cli
```

Both pass on this branch, along with `yarn lint` and `yarn prettier:check` via the pre-commit hook.

Behaviour is unchanged, so the manual check is that it stays that way — in a sandbox app:

1. `yarn strapi build` and `yarn strapi build --stats --silent` behave as before.
2. `yarn strapi develop` and `yarn strapi develop --watch-admin` behave as before, including the webpack deprecation warning when `--bundler webpack` is passed.
3. `yarn strapi cloud:login` (or any `cloud:*` command) still completes — this exercises the `parseAsync` change.

### Related issue(s)/PR(s)

Split out of #27300, which threads a `--tsconfig` path through the same call chain. Independent of it — the two touch adjacent lines in `node/build.ts` and `node/develop.ts` and will need a trivial rebase whichever merges second, but neither depends on the other.
