### PR TITLE
chore(strapi): own compileStrapi in @strapi/strapi

### DIFF
--- a/packages/core/strapi/src/cli/commands/admin/active-user.ts
+++ b/packages/core/strapi/src/cli/commands/admin/active-user.ts
@@ -1,11 +1,12 @@
 import _ from 'lodash';
 import type { DistinctQuestion } from 'inquirer';
 import { createCommand } from 'commander';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
 import { getInquirer } from '../../utils/get-inquirer';
+import { compileStrapi } from '../../../compile';
 
 interface CmdOptions {
   email?: string;

--- a/packages/core/strapi/src/cli/commands/admin/block-user.ts
+++ b/packages/core/strapi/src/cli/commands/admin/block-user.ts
@@ -1,11 +1,12 @@
 import _ from 'lodash';
 import type { DistinctQuestion } from 'inquirer';
 import { createCommand } from 'commander';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
 import { getInquirer } from '../../utils/get-inquirer';
+import { compileStrapi } from '../../../compile';
 
 interface CmdOptions {
   email?: string;

--- a/packages/core/strapi/src/cli/commands/admin/create-user.ts
+++ b/packages/core/strapi/src/cli/commands/admin/create-user.ts
@@ -2,11 +2,12 @@ import { createCommand } from 'commander';
 import { yup } from '@strapi/utils';
 import _ from 'lodash';
 import type { QuestionCollection } from 'inquirer';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import { runAction } from '../../utils/helpers';
 import { getInquirer } from '../../utils/get-inquirer';
 import type { StrapiCommand } from '../../types';
+import { compileStrapi } from '../../../compile';
 
 interface CmdOptions {
   email?: string;

--- a/packages/core/strapi/src/cli/commands/admin/delete-user.ts
+++ b/packages/core/strapi/src/cli/commands/admin/delete-user.ts
@@ -2,11 +2,12 @@ import { createCommand } from 'commander';
 import { yup } from '@strapi/utils';
 import _ from 'lodash';
 import type { QuestionCollection } from 'inquirer';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import { runAction } from '../../utils/helpers';
 import { getInquirer } from '../../utils/get-inquirer';
 import type { StrapiCommand } from '../../types';
+import { compileStrapi } from '../../../compile';
 
 interface CmdOptions {
   email?: string;

--- a/packages/core/strapi/src/cli/commands/admin/list-users.ts
+++ b/packages/core/strapi/src/cli/commands/admin/list-users.ts
@@ -1,10 +1,11 @@
 import { createCommand } from 'commander';
 import CLITable from 'cli-table3';
 import chalk from 'chalk';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import { runAction } from '../../utils/helpers';
 import type { StrapiCommand } from '../../types';
+import { compileStrapi } from '../../../compile';
 
 /**
  * List admin users

--- a/packages/core/strapi/src/cli/commands/admin/reset-user-password.ts
+++ b/packages/core/strapi/src/cli/commands/admin/reset-user-password.ts
@@ -1,11 +1,12 @@
 import _ from 'lodash';
 import type { DistinctQuestion } from 'inquirer';
 import { createCommand } from 'commander';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
 import { getInquirer } from '../../utils/get-inquirer';
+import { compileStrapi } from '../../../compile';
 
 interface CmdOptions {
   email?: string;

--- a/packages/core/strapi/src/cli/commands/components/list.ts
+++ b/packages/core/strapi/src/cli/commands/components/list.ts
@@ -1,10 +1,11 @@
 import { createCommand } from 'commander';
 import CLITable from 'cli-table3';
 import chalk from 'chalk';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 const action = async () => {
   const appContext = await compileStrapi();

--- a/packages/core/strapi/src/cli/commands/configuration/dump.ts
+++ b/packages/core/strapi/src/cli/commands/configuration/dump.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import { createCommand } from 'commander';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 interface CmdOptions {
   file?: string;

--- a/packages/core/strapi/src/cli/commands/configuration/restore.ts
+++ b/packages/core/strapi/src/cli/commands/configuration/restore.ts
@@ -1,11 +1,12 @@
 import { createCommand } from 'commander';
 import fs from 'fs';
 import _ from 'lodash';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 import type { Database } from '@strapi/database';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 type Strategy = 'replace' | 'merge' | 'keep';
 

--- a/packages/core/strapi/src/cli/commands/console.ts
+++ b/packages/core/strapi/src/cli/commands/console.ts
@@ -1,9 +1,10 @@
 import REPL from 'repl';
 import { createCommand } from 'commander';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../types';
 import { runAction } from '../utils/helpers';
+import { compileStrapi } from '../../compile';
 
 const action = async () => {
   const appContext = await compileStrapi();

--- a/packages/core/strapi/src/cli/commands/content-types/list.ts
+++ b/packages/core/strapi/src/cli/commands/content-types/list.ts
@@ -2,10 +2,11 @@ import { createCommand } from 'commander';
 import CLITable from 'cli-table3';
 import chalk from 'chalk';
 
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 const action = async () => {
   const appContext = await compileStrapi();

--- a/packages/core/strapi/src/cli/commands/controllers/list.ts
+++ b/packages/core/strapi/src/cli/commands/controllers/list.ts
@@ -2,10 +2,11 @@ import { createCommand } from 'commander';
 import CLITable from 'cli-table3';
 import chalk from 'chalk';
 
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 const action = async () => {
   const appContext = await compileStrapi();

--- a/packages/core/strapi/src/cli/commands/hooks/list.ts
+++ b/packages/core/strapi/src/cli/commands/hooks/list.ts
@@ -1,10 +1,11 @@
 import { createCommand } from 'commander';
 import CLITable from 'cli-table3';
 import chalk from 'chalk';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 const action = async () => {
   const appContext = await compileStrapi();

--- a/packages/core/strapi/src/cli/commands/middlewares/list.ts
+++ b/packages/core/strapi/src/cli/commands/middlewares/list.ts
@@ -1,10 +1,11 @@
 import { createCommand } from 'commander';
 import CLITable from 'cli-table3';
 import chalk from 'chalk';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 const action = async () => {
   const appContext = await compileStrapi();

--- a/packages/core/strapi/src/cli/commands/openapi/generate.ts
+++ b/packages/core/strapi/src/cli/commands/openapi/generate.ts
@@ -1,4 +1,4 @@
-import { compileStrapi, createStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 import * as openapi from '@strapi/openapi';
 
 import type { Core } from '@strapi/types';
@@ -6,6 +6,7 @@ import type { Core } from '@strapi/types';
 import chalk from 'chalk';
 import fse from 'fs-extra';
 import path from 'path';
+import { compileStrapi } from '../../../compile';
 
 const DEFAULT_OUTPUT = path.join(process.cwd(), 'specification.json');
 

--- a/packages/core/strapi/src/cli/commands/policies/list.ts
+++ b/packages/core/strapi/src/cli/commands/policies/list.ts
@@ -1,10 +1,11 @@
 import { createCommand } from 'commander';
 import CLITable from 'cli-table3';
 import chalk from 'chalk';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 const action = async () => {
   const appContext = await compileStrapi();

--- a/packages/core/strapi/src/cli/commands/report.ts
+++ b/packages/core/strapi/src/cli/commands/report.ts
@@ -1,8 +1,9 @@
 import { createCommand } from 'commander';
 import { EOL } from 'os';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 import type { StrapiCommand } from '../types';
 import { runAction } from '../utils/helpers';
+import { compileStrapi } from '../../compile';
 
 interface CmdOptions {
   uuid: boolean;

--- a/packages/core/strapi/src/cli/commands/routes/list.ts
+++ b/packages/core/strapi/src/cli/commands/routes/list.ts
@@ -3,10 +3,11 @@ import CLITable from 'cli-table3';
 import chalk from 'chalk';
 import { toUpper } from 'lodash/fp';
 
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 const action = async () => {
   const appContext = await compileStrapi();

--- a/packages/core/strapi/src/cli/commands/services/list.ts
+++ b/packages/core/strapi/src/cli/commands/services/list.ts
@@ -1,10 +1,11 @@
 import { createCommand } from 'commander';
 import CLITable from 'cli-table3';
 import chalk from 'chalk';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 const action = async () => {
   const appContext = await compileStrapi();

--- a/packages/core/strapi/src/cli/commands/ts/generate-types.ts
+++ b/packages/core/strapi/src/cli/commands/ts/generate-types.ts
@@ -2,6 +2,7 @@ import { createCommand } from 'commander';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
+import { compileStrapi } from '../../../compile';
 
 interface CmdOptions {
   debug?: boolean;
@@ -20,7 +21,7 @@ const action = async ({ debug, silent, verbose, outDir }: CmdOptions) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const tsUtils = require('@strapi/typescript-utils');
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { createStrapi, compileStrapi } = require('@strapi/core');
+  const { createStrapi } = require('@strapi/core');
 
   const appContext = await compileStrapi({ ignoreDiagnostics: true });
   const app = await createStrapi(appContext).register();

--- a/packages/core/strapi/src/cli/utils/data-transfer.ts
+++ b/packages/core/strapi/src/cli/utils/data-transfer.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import Table from 'cli-table3';
 import { Command, Option } from 'commander';
 import { configs, createLogger, type winston, formats } from '@strapi/logger';
-import { createStrapi, compileStrapi } from '@strapi/core';
+import { createStrapi } from '@strapi/core';
 import ora from 'ora';
 import { merge } from 'lodash/fp';
 import type { Core } from '@strapi/types';
@@ -16,6 +16,7 @@ import {
   exitWith,
 } from './helpers';
 import { getParseListWithChoices, parseInteger, parseList, confirmMessage } from './commander';
+import { compileStrapi } from '../../compile';
 
 const {
   errors: { TransferEngineInitializationError },

--- a/packages/core/strapi/src/compile.ts
+++ b/packages/core/strapi/src/compile.ts
@@ -13,10 +13,7 @@ interface Options {
   ignoreDiagnostics?: boolean;
 }
 
-/**
- * @deprecated use `compileStrapi` from `@strapi/strapi`
- */
-export default async function compile(options?: Options) {
+export async function compileStrapi(options?: Options) {
   const { appDir = process.cwd(), ignoreDiagnostics = false } = options ?? {};
   const isTSProject = await tsUtils().isUsingTypeScript(appDir);
   const outDir = await tsUtils().resolveOutDir(appDir);

--- a/packages/core/strapi/src/index.ts
+++ b/packages/core/strapi/src/index.ts
@@ -1,4 +1,7 @@
 export * from '@strapi/core';
 
+// This overrides `compileStrapi` from `@strapi/core` which is deprecated
+export { compileStrapi } from './compile';
+
 export type * from '@strapi/types';
 export type * from './cli/types';


### PR DESCRIPTION
### What does it do?

Moves the `compileStrapi` implementation from `@strapi/core` into `@strapi/strapi`.

- Adds `packages/core/strapi/src/compile.ts` (same implementation, lazy `require` of `@strapi/typescript-utils`).
- `@strapi/strapi` re-exports it from its index, shadowing the `@strapi/core` re-export — so the public `require('@strapi/strapi').compileStrapi` entry point used by `create-strapi-app` templates, `tests/migration`, and `examples/complex` is unchanged.
- All 22 CLI commands and `cli/utils/data-transfer.ts` now import the local `compileStrapi` instead of pulling it from `@strapi/core`.
- The `@strapi/core` export is kept and marked `@deprecated`, so nothing breaks for anyone importing it directly.

### Why is it needed?

Compiling a project is a CLI/tooling concern, not a runtime one. Keeping `compileStrapi` in `@strapi/core` is what forces the runtime package to depend on `@strapi/typescript-utils`.

This is the first step towards dropping that dependency from `@strapi/core`. It can't be removed yet — `Strapi.ts` and `services/metrics/sender.ts` still use it — but those are separate, smaller surfaces that can follow in their own PRs.

### How to test it?

```sh
yarn build
yarn test:unit
yarn test:ts
```

Then, from a generated app, confirm the CLI commands that compile still work and that the public export is intact:

```sh
yarn strapi ts:generate-types
yarn strapi routes:list
node -e "console.log(typeof require('@strapi/strapi').compileStrapi)"  # -> function
```

### Related issue(s)/PR(s)

Groundwork for #27300 (custom tsconfig path across the CLI) — a CLI-owned `compileStrapi` is where those options belong.