### PR TITLE
fix(content-manager): stop relation fields rendering a full page loader

### DIFF
--- a/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
@@ -55,6 +55,12 @@ interface DocumentRBACProps {
   children: React.ReactNode;
   permissions: Permission[] | null;
   model?: string;
+  /**
+   * @default true
+   * @description Whether to replace the children with a full page loader whilst
+   * the permissions resolve. Set to `false` when the consumer isn't a page.
+   */
+  showLoader?: boolean;
 }
 
 /**
@@ -65,7 +71,7 @@ interface DocumentRBACProps {
  * It then creates an list of `can{Action}` that are passed to the context for consumption
  * within the app to enforce RBAC.
  */
-const DocumentRBAC = ({ children, permissions, model }: DocumentRBACProps) => {
+const DocumentRBAC = ({ children, permissions, model, showLoader = true }: DocumentRBACProps) => {
   const { slug } = useParams<{ slug: string }>();
 
   if (!slug && !model) {
@@ -144,7 +150,7 @@ const DocumentRBAC = ({ children, permissions, model }: DocumentRBACProps) => {
     []
   );
 
-  if (isLoading) {
+  if (isLoading && showLoader) {
     return <Page.Loading />;
   }
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -638,7 +638,7 @@ const RelationsInput = ({
   return (
     <Field.Root error={field.error} hint={hint} name={name} required={required}>
       <Field.Label action={labelAction}>{label}</Field.Label>
-      <DocumentRBAC permissions={permissions} model={relation.model}>
+      <DocumentRBAC permissions={permissions} model={relation.model} showLoader={false}>
         <MemoizedRelationModalWithContext
           relation={relation}
           name={name}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/Relations.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/Relations.test.tsx
@@ -91,6 +91,14 @@ describe('Relations', () => {
     expect(screen.getByRole('button', { name: 'Relation entity 3' })).toBeInTheDocument();
   });
 
+  it('should not render a page loader whilst the permissions are loading', async () => {
+    render({});
+
+    expect(screen.queryByText('Loading content.')).not.toBeInTheDocument();
+
+    await screen.findByRole('combobox');
+  });
+
   it('should be disabled when the prop is passed', async () => {
     render({ disabled: true });
 


### PR DESCRIPTION
### What does it do?

The relation field wraps its input in `DocumentRBAC`, which replaces its children with `Page.Loading` while the permission check is in flight. `Page.Loading` is a page-level element with `height: 100dvh`, so for a moment the field is as tall as the window. `DocumentRBAC` now accepts a `showLoader` prop and the relation field opts out, so the input stays on screen while its permissions resolve. Pages keep the loader.

### Why is it needed?

Expanding a dynamic zone component that contains a relation field made it stretch to roughly the window height, then snap back. The accordion measures its content height on open and animates to it, so it caught the loader.

### How to test it?

Environment: `examples/getstarted`, `yarn develop`. Add a component with a relation field to a dynamic zone, save the entry, then collapse and expand it. It should open straight to its own height, with or without a related entry selected.

The new test fails against the previous code:

```bash
yarn jest --config packages/core/content-manager/jest.config.front.js --rootDir packages/core/content-manager Relations/tests
```

### Related issue(s)/PR(s)

Fixes #27317