### PR TITLE
fix(upgrade): json codemods cannot import shared typescript utilities

### DIFF
--- a/packages/utils/upgrade/resources/examples/smoke-shared-util-import.json.ts
+++ b/packages/utils/upgrade/resources/examples/smoke-shared-util-import.json.ts
@@ -1,0 +1,13 @@
+import type { modules } from '../../dist';
+import { JSON_SMOKE_MARKER } from '../utils/json-smoke';
+
+/** Smoke JSON transform that imports a shared util under resources/utils. Not a production codemod. */
+const transform: modules.runner.json.JSONTransform = (file) => {
+  if (JSON_SMOKE_MARKER !== 'json-codemod-utils-ok') {
+    throw new Error('Unexpected smoke marker');
+  }
+
+  return file.json;
+};
+
+export default transform;

--- a/packages/utils/upgrade/resources/utils/json-smoke.ts
+++ b/packages/utils/upgrade/resources/utils/json-smoke.ts
@@ -1,0 +1,9 @@
+/**
+ * Smoke helper for the JSON-codemod util-import CLI test.
+ * Uses an `enum` so Node strip-types cannot load it without esbuild-register.
+ */
+export enum JsonSmokeKind {
+  Ok = 'json-codemod-utils-ok',
+}
+
+export const JSON_SMOKE_MARKER = JsonSmokeKind.Ok;

--- a/packages/utils/upgrade/src/modules/codemod-repository/constants.ts
+++ b/packages/utils/upgrade/src/modules/codemod-repository/constants.ts
@@ -1,11 +1,15 @@
 import path from 'node:path';
 
-export const INTERNAL_CODEMODS_DIRECTORY = path.join(
+export const INTERNAL_RESOURCES_DIRECTORY = path.join(
   __dirname, // upgrade/dist/src/modules/codemod-repository
   '..', // upgrade/dist/src/modules
   '..', // upgrade/dist/src
   '..', // upgrade/dist
   '..', // upgrade
-  'resources', // resources
+  'resources' // resources
+);
+
+export const INTERNAL_CODEMODS_DIRECTORY = path.join(
+  INTERNAL_RESOURCES_DIRECTORY,
   'codemods' // resources/codemods
 );

--- a/packages/utils/upgrade/src/modules/runner/__tests__/json-transform.test.ts
+++ b/packages/utils/upgrade/src/modules/runner/__tests__/json-transform.test.ts
@@ -53,6 +53,9 @@ for (const filepath of paths) {
 
 const configuration: JSONRunnerConfiguration = { dry: true, cwd };
 
+import { register } from 'esbuild-register/dist/node';
+
+import { INTERNAL_RESOURCES_DIRECTORY } from '../../codemod-repository/constants';
 import { transformJSON } from '../json/transform';
 
 import type { JSONRunnerConfiguration, JSONTransform } from '../json';
@@ -65,6 +68,20 @@ describe('JSON Transform', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  test('hookMatcher allows shared TypeScript under resources/', async () => {
+    const codemodPath = codemodFullPath(codemodNoUpdate.path);
+
+    await transformJSON(codemodPath, paths, configuration);
+
+    const [{ hookMatcher }] = (register as jest.Mock).mock.calls[0];
+
+    expect(hookMatcher(codemodPath)).toBe(true);
+    expect(hookMatcher(path.join(INTERNAL_RESOURCES_DIRECTORY, 'utils', 'json-smoke.ts'))).toBe(
+      true
+    );
+    expect(hookMatcher(path.join('/tmp', 'unrelated-outside-resources.ts'))).toBe(false);
   });
 
   test('Codemods that return nothing are considered as "errored" state', async () => {

--- a/packages/utils/upgrade/src/modules/runner/json/transform.ts
+++ b/packages/utils/upgrade/src/modules/runner/json/transform.ts
@@ -1,14 +1,23 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import assert from 'node:assert';
+import path from 'node:path';
 import { isEqual } from 'lodash/fp';
 import { register } from 'esbuild-register/dist/node';
 
+import { INTERNAL_RESOURCES_DIRECTORY } from '../../codemod-repository/constants';
 import { createJSONTransformAPI, readJSON, saveJSON } from '../../json';
 
 import type { Report } from '../../report';
 
 import type { JSONRunnerConfiguration, JSONSourceFile, JSONTransformParams } from './types';
+
+const isPathInsideResources = (filename: string) => {
+  const resolved = path.resolve(filename);
+  const resourcesRoot = path.resolve(INTERNAL_RESOURCES_DIRECTORY);
+
+  return resolved === resourcesRoot || resolved.startsWith(resourcesRoot + path.sep);
+};
 
 export const transformJSON = async (
   codemodPath: string,
@@ -42,12 +51,13 @@ export const transformJSON = async (
    * Due to this, if hookIgnoreNodeModules is set to true or left unspecified,
    * esbuild-register won't try to compile them upon require.
    *
-   * hookMatcher is added to make sure we're not matching anything else than our codemod in external directories.
+   * hookMatcher scopes transpilation to the codemod itself (including out-of-tree paths) and to shared helpers
+   * under the package resources/ directory (e.g. resources/utils), without compiling arbitrary node_modules.
    */
   const esbuildOptions = {
     extensions: ['.js', '.mjs', '.ts'],
     hookIgnoreNodeModules: false,
-    hookMatcher: isEqual(codemodPath),
+    hookMatcher: (filename: string) => isEqual(codemodPath, filename) || isPathInsideResources(filename),
   };
   const { unregister } = register(esbuildOptions);
 

--- a/packages/utils/upgrade/src/modules/runner/json/transform.ts
+++ b/packages/utils/upgrade/src/modules/runner/json/transform.ts
@@ -57,7 +57,8 @@ export const transformJSON = async (
   const esbuildOptions = {
     extensions: ['.js', '.mjs', '.ts'],
     hookIgnoreNodeModules: false,
-    hookMatcher: (filename: string) => isEqual(codemodPath, filename) || isPathInsideResources(filename),
+    hookMatcher: (filename: string) =>
+      isEqual(codemodPath, filename) || isPathInsideResources(filename),
   };
   const { unregister } = register(esbuildOptions);
 

--- a/tests/cli/tests/upgrade/config.js
+++ b/tests/cli/tests/upgrade/config.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = () => {
+  return {
+    /** Spawns @strapi/upgrade loader directly; no shared test-app from app-template. */
+    testApps: 0,
+  };
+};

--- a/tests/cli/tests/upgrade/json-codemod-utils.test.cli.js
+++ b/tests/cli/tests/upgrade/json-codemod-utils.test.cli.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const coffee = require('coffee');
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+const upgradeRoot = path.join(repoRoot, 'packages/utils/upgrade');
+const transformJs = path.join(
+  upgradeRoot,
+  'dist/src/modules/runner/json/transform.js'
+);
+const smokeCodemod = path.join(
+  upgradeRoot,
+  'resources/examples/smoke-shared-util-import.json.ts'
+);
+
+/** Spawns plain Node so Jest does not transpile the codemod / util import graph. */
+function spawnSmoke(projectDir) {
+  const script = `
+    const path = require('path');
+    const { transformJSON } = require(${JSON.stringify(transformJs)});
+
+    (async () => {
+      const projectDir = process.argv[1];
+      const packageJsonPath = path.join(projectDir, 'package.json');
+      const report = await transformJSON(
+        ${JSON.stringify(smokeCodemod)},
+        [packageJsonPath],
+        { cwd: projectDir, dry: true }
+      );
+
+      if (report.error !== 0) {
+        console.error(JSON.stringify(report));
+        process.exit(1);
+      }
+
+      console.log('ok');
+    })().catch((err) => {
+      console.error(err && err.stack ? err.stack : err);
+      process.exit(1);
+    });
+  `;
+
+  return coffee.spawn(process.execPath, ['-e', script, projectDir], {
+    cwd: repoRoot,
+  });
+}
+
+describe('upgrade JSON codemod shared utils', () => {
+  beforeAll(() => {
+    if (!fs.existsSync(transformJs)) {
+      throw new Error(
+        `Missing ${transformJs}; build @strapi/upgrade first (yarn nx build @strapi/upgrade)`
+      );
+    }
+    if (!fs.existsSync(smokeCodemod)) {
+      throw new Error(`Missing smoke codemod at ${smokeCodemod}`);
+    }
+  });
+
+  it('loads a JSON codemod that imports a TypeScript util under resources/utils', async () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strapi-upgrade-cli-smoke-'));
+    try {
+      fs.writeFileSync(path.join(projectDir, 'package.json'), JSON.stringify({ name: 'smoke' }));
+
+      await spawnSmoke(projectDir).expect('code', 0).expect('stdout', /ok/).end();
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli/tests/upgrade/json-codemod-utils.test.cli.js
+++ b/tests/cli/tests/upgrade/json-codemod-utils.test.cli.js
@@ -7,14 +7,8 @@ const coffee = require('coffee');
 
 const repoRoot = path.resolve(__dirname, '../../../..');
 const upgradeRoot = path.join(repoRoot, 'packages/utils/upgrade');
-const transformJs = path.join(
-  upgradeRoot,
-  'dist/src/modules/runner/json/transform.js'
-);
-const smokeCodemod = path.join(
-  upgradeRoot,
-  'resources/examples/smoke-shared-util-import.json.ts'
-);
+const transformJs = path.join(upgradeRoot, 'dist/src/modules/runner/json/transform.js');
+const smokeCodemod = path.join(upgradeRoot, 'resources/examples/smoke-shared-util-import.json.ts');
 
 /** Spawns plain Node so Jest does not transpile the codemod / util import graph. */
 function spawnSmoke(projectDir) {


### PR DESCRIPTION
### What does it do?

Widens the `@strapi/upgrade` JSON runner `esbuild-register` `hookMatcher` so TypeScript files under the package `resources/` directory (not only the single codemod path) are transpiled. Adds a CLI smoke test that loads a JSON codemod importing a shared util from `resources/utils`.

### Why is it needed?

JSON codemods could not import shared helpers under `resources/utils/` because only the exact codemod file was hooked for transpilation. That forced helpers to be inlined (see the TODO on the better-sqlite3 JSON codemod). Code transforms already share utils via jscodeshift; this aligns JSON transforms.

### How to test it?

1. Build upgrade: `yarn nx build @strapi/upgrade`
2. Run the smoke: `yarn test:cli -d upgrade --testPathPattern=json-codemod-utils`
3. Optionally run package unit tests: `cd packages/utils/upgrade && yarn test:unit`

### Related issue(s)/PR(s)

- Fixes CMS-1604