### PR TITLE
feat(content-manager): preview add tablet viewport + configurable sizes

### DIFF
--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -31,12 +31,14 @@ import { type EditLayout, useDocumentLayout } from '../../hooks/useDocumentLayou
 import { Blocker } from '../../pages/EditView/components/Blocker';
 import { FormLayout } from '../../pages/EditView/components/FormLayout';
 import { handleInvisibleAttributes } from '../../pages/EditView/utils/data';
+import { useGetInitialDataQuery } from '../../services/init';
 import { buildValidParams } from '../../utils/api';
 import { createYupSchema } from '../../utils/validation';
 import { InputPopover } from '../components/InputPopover';
 import { PreviewHeader } from '../components/PreviewHeader';
 import { useGetPreviewUrlQuery } from '../services/preview';
 import { INTERNAL_EVENTS, PUBLIC_EVENTS } from '../utils/constants';
+import { getPreviewDevices } from '../utils/devices';
 import { getSendMessage } from '../utils/getSendMessage';
 
 import type { Schema, UID } from '@strapi/types';
@@ -54,6 +56,15 @@ const DEVICES = [
     },
     width: '100%',
     height: '100%',
+  },
+  {
+    name: 'tablet',
+    label: {
+      id: 'content-manager.preview.device.tablet',
+      defaultMessage: 'Tablet',
+    },
+    width: '768px',
+    height: '1024px',
   },
   {
     name: 'mobile',
@@ -158,10 +169,16 @@ const PreviewPage = () => {
 
   const params = React.useMemo(() => buildValidParams(query), [query]);
 
+  const { data: initialData } = useGetInitialDataQuery(undefined);
+  const devices = React.useMemo(
+    () => getPreviewDevices(DEVICES, initialData?.previewViewports),
+    [initialData?.previewViewports]
+  );
+
   const [deviceName, setDeviceName] = React.useState<(typeof DEVICES)[number]['name']>(
     DEVICES[0].name
   );
-  const device = DEVICES.find((d) => d.name === deviceName) ?? DEVICES[0];
+  const device = devices.find((d) => d.name === deviceName) ?? devices[0];
 
   const previewHighlightColors: PreviewHighlightColors = {
     highlightHoverColor: theme.colors.primary500,
@@ -418,7 +435,7 @@ const PreviewPage = () => {
                         defaultMessage: 'Select device type',
                       })}
                     >
-                      {DEVICES.map((deviceOption) => (
+                      {devices.map((deviceOption) => (
                         <SingleSelectOption key={deviceOption.name} value={deviceOption.name}>
                           {formatMessage(deviceOption.label)}
                         </SingleSelectOption>

--- a/packages/core/content-manager/admin/src/preview/utils/devices.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/devices.ts
@@ -1,0 +1,34 @@
+import type { MessageDescriptor } from 'react-intl';
+
+interface Device {
+  name: string;
+  label: MessageDescriptor;
+  width: string;
+  height: string;
+}
+
+interface ViewportOverride {
+  width: number;
+  height: number;
+}
+
+type ViewportOverrides = Partial<Record<string, ViewportOverride>>;
+
+const getPreviewDevices = (devices: Device[], overrides: ViewportOverrides = {}): Device[] => {
+  return devices.map((device) => {
+    const override = overrides[device.name];
+
+    if (!override) {
+      return device;
+    }
+
+    return {
+      ...device,
+      width: `${override.width}px`,
+      height: `${override.height}px`,
+    };
+  });
+};
+
+export { getPreviewDevices };
+export type { Device, ViewportOverrides };

--- a/packages/core/content-manager/admin/src/preview/utils/tests/devices.test.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/tests/devices.test.ts
@@ -1,0 +1,64 @@
+import { getPreviewDevices, type Device } from '../devices';
+
+const DEVICES: Device[] = [
+  {
+    name: 'desktop',
+    label: { id: 'device.desktop', defaultMessage: 'Desktop' },
+    width: '100%',
+    height: '100%',
+  },
+  {
+    name: 'tablet',
+    label: { id: 'device.tablet', defaultMessage: 'Tablet' },
+    width: '768px',
+    height: '1024px',
+  },
+  {
+    name: 'mobile',
+    label: { id: 'device.mobile', defaultMessage: 'Mobile' },
+    width: '375px',
+    height: '667px',
+  },
+];
+
+describe('getPreviewDevices', () => {
+  test('returns the default devices unchanged when no overrides are provided', () => {
+    expect(getPreviewDevices(DEVICES)).toEqual(DEVICES);
+  });
+
+  test('returns the default devices unchanged when overrides is an empty object', () => {
+    expect(getPreviewDevices(DEVICES, {})).toEqual(DEVICES);
+  });
+
+  test('only overrides the device with a matching override, leaving others untouched', () => {
+    const result = getPreviewDevices(DEVICES, { tablet: { width: 800, height: 1280 } });
+
+    expect(result.find((d) => d.name === 'desktop')).toEqual(DEVICES[0]);
+    expect(result.find((d) => d.name === 'mobile')).toEqual(DEVICES[2]);
+    expect(result.find((d) => d.name === 'tablet')).toEqual({
+      ...DEVICES[1],
+      width: '800px',
+      height: '1280px',
+    });
+  });
+
+  test('applies overrides to every device when all are configured', () => {
+    const result = getPreviewDevices(DEVICES, {
+      desktop: { width: 1440, height: 900 },
+      tablet: { width: 768, height: 1024 },
+      mobile: { width: 390, height: 844 },
+    });
+
+    expect(result).toEqual([
+      { ...DEVICES[0], width: '1440px', height: '900px' },
+      { ...DEVICES[1], width: '768px', height: '1024px' },
+      { ...DEVICES[2], width: '390px', height: '844px' },
+    ]);
+  });
+
+  test('ignores overrides for unknown device names', () => {
+    const result = getPreviewDevices(DEVICES, { watch: { width: 200, height: 200 } });
+
+    expect(result).toEqual(DEVICES);
+  });
+});

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -274,6 +274,7 @@
   "preview.content.open-editor": "Open editor",
   "preview.device.select": "Select device type",
   "preview.device.desktop": "Desktop",
+  "preview.device.tablet": "Tablet",
   "preview.device.mobile": "Mobile",
   "preview.info.single-click-hint": "Double click to edit",
   "preview.error.invalid-field-path": "Could not locate this field in the current document",

--- a/packages/core/content-manager/server/src/controllers/init.ts
+++ b/packages/core/content-manager/server/src/controllers/init.ts
@@ -6,12 +6,14 @@ export default {
     const { findAllComponents } = getService('components');
     const { getAllFieldSizes } = getService('field-sizes');
     const { findAllContentTypes } = getService('content-types');
+    const { getViewports } = getService('preview-config');
 
     ctx.body = {
       data: {
         fieldSizes: getAllFieldSizes(),
         components: findAllComponents().map(toDto),
         contentTypes: findAllContentTypes().map(toDto),
+        previewViewports: getViewports(),
       },
     };
   },

--- a/packages/core/content-manager/server/src/preview/services/__tests__/preview-config.test.ts
+++ b/packages/core/content-manager/server/src/preview/services/__tests__/preview-config.test.ts
@@ -1,10 +1,11 @@
 import { createPreviewConfigService } from '../preview-config';
 
-const getConfig = (enabled: boolean, handler: () => void) => {
+const getConfig = (enabled: boolean, handler: () => void, viewports?: object) => {
   return {
     enabled,
     config: {
       handler,
+      ...(viewports ? { viewports } : {}),
     },
   };
 };
@@ -92,6 +93,74 @@ describe('Preview Config', () => {
       } as any;
 
       expect(() => createPreviewConfigService({ strapi }).validate()).toThrowError();
+    });
+
+    test('Passes with valid viewports', () => {
+      const strapi = {
+        config: {
+          get: () =>
+            getConfig(true, () => {}, {
+              desktop: { width: 1440, height: 900 },
+              tablet: { width: 768, height: 1024 },
+              mobile: { width: 390, height: 844 },
+            }),
+        },
+      } as any;
+
+      createPreviewConfigService({ strapi }).validate();
+    });
+
+    test('Fails on non-numeric viewport width/height', () => {
+      const strapi = {
+        config: {
+          get: () => getConfig(true, () => {}, { tablet: { width: '768', height: 1024 } }),
+        },
+      } as any;
+
+      expect(() => createPreviewConfigService({ strapi }).validate()).toThrowError();
+    });
+
+    test('Fails on negative viewport width/height', () => {
+      const strapi = {
+        config: {
+          get: () => getConfig(true, () => {}, { mobile: { width: 390, height: -1 } }),
+        },
+      } as any;
+
+      expect(() => createPreviewConfigService({ strapi }).validate()).toThrowError();
+    });
+  });
+
+  describe('getViewports', () => {
+    test('Returns an empty object when preview is disabled', () => {
+      const strapi = {
+        config: {
+          get: () => undefined,
+        },
+      } as any;
+
+      expect(createPreviewConfigService({ strapi }).getViewports()).toEqual({});
+    });
+
+    test('Returns an empty object when no viewports are configured', () => {
+      const strapi = {
+        config: {
+          get: () => getConfig(true, () => {}),
+        },
+      } as any;
+
+      expect(createPreviewConfigService({ strapi }).getViewports()).toEqual({});
+    });
+
+    test('Returns the configured viewports', () => {
+      const viewports = { tablet: { width: 768, height: 1024 } };
+      const strapi = {
+        config: {
+          get: () => getConfig(true, () => {}, viewports),
+        },
+      } as any;
+
+      expect(createPreviewConfigService({ strapi }).getViewports()).toEqual(viewports);
     });
   });
 });

--- a/packages/core/content-manager/server/src/preview/services/preview-config.ts
+++ b/packages/core/content-manager/server/src/preview/services/preview-config.ts
@@ -80,6 +80,31 @@ const createPreviewConfigService = ({ strapi }: { strapi: Core.Strapi }) => {
           'Preview configuration is invalid. Handler must be a function'
         );
       }
+
+      const viewports = this.getViewports();
+
+      const isPositiveNumber = (value: unknown) => typeof value === 'number' && value > 0;
+
+      Object.entries(viewports).forEach(([device, viewport]) => {
+        if (!isPositiveNumber(viewport?.width) || !isPositiveNumber(viewport?.height)) {
+          throw new errors.ValidationError(
+            `Preview configuration is invalid. Viewport for "${device}" must have a positive width and height`
+          );
+        }
+      });
+    },
+
+    /**
+     * Utility to get the configured viewport overrides, keyed by device name
+     */
+    getViewports(): NonNullable<NonNullable<Core.Config.Admin['preview']>['config']['viewports']> {
+      if (!this.isEnabled()) {
+        return {};
+      }
+
+      const config = strapi.config.get('admin.preview') as PreviewConfig;
+
+      return config?.config?.viewports ?? {};
     },
 
     /**

--- a/packages/core/content-manager/shared/contracts/init.ts
+++ b/packages/core/content-manager/shared/contracts/init.ts
@@ -1,6 +1,11 @@
+import type { Core } from '@strapi/types';
 import { errors } from '@strapi/utils';
 import { Component } from './components';
 import { ContentType } from './content-types';
+
+type PreviewViewport = NonNullable<
+  NonNullable<NonNullable<Core.Config.Admin['preview']>['config']['viewports']>['desktop']
+>;
 
 /**
  * GET /init
@@ -16,6 +21,7 @@ export declare namespace GetInitData {
       fieldSizes: Record<string, { default: number; isResizable: boolean }>;
       components: Component[];
       contentTypes: ContentType[];
+      previewViewports: Partial<Record<'desktop' | 'tablet' | 'mobile', PreviewViewport>>;
     };
     error?: errors.ApplicationError;
   }

--- a/packages/core/types/src/core/config/admin.ts
+++ b/packages/core/types/src/core/config/admin.ts
@@ -115,8 +115,20 @@ export interface PreviewHandlerParams {
   [key: string]: unknown;
 }
 
+export interface PreviewViewportConfig {
+  width: number;
+  height: number;
+}
+
+export interface PreviewViewports {
+  desktop?: PreviewViewportConfig;
+  tablet?: PreviewViewportConfig;
+  mobile?: PreviewViewportConfig;
+}
+
 export interface PreviewConfig {
   allowedOrigins?: string[];
+  viewports?: PreviewViewports;
   handler: (
     uid: string,
     params: PreviewHandlerParams

--- a/tests/e2e/tests/content-manager/preview.spec.ts
+++ b/tests/e2e/tests/content-manager/preview.spec.ts
@@ -139,6 +139,27 @@ test.describe('Preview', () => {
     );
   });
 
+  test('Selecting the Tablet device should resize the preview iframe', async ({ page }) => {
+    // Open an edit view for a content type that has preview
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: /west ham post match/i }));
+
+    // Check that preview opens in its own page
+    await openPreview(page);
+
+    const deviceSelect = page.getByRole('combobox', { name: /select device type/i });
+    await expect(deviceSelect).toBeVisible();
+
+    const iframe = page.getByTitle('Preview');
+
+    await clickAndWait(page, deviceSelect);
+    await clickAndWait(page, page.getByRole('option', { name: 'Tablet' }));
+
+    await expect(iframe).toHaveCSS('width', '768px');
+    await expect(iframe).toHaveCSS('height', '1024px');
+  });
+
   test('Publishing from preview with conditional fields should not trigger validation errors', async ({
     page,
   }) => {


### PR DESCRIPTION
### What does it do?

Adds a "Tablet" option (768×1024 default) to the Preview device selector,
alongside the existing Desktop and Mobile options. Also makes each device's
width/height configurable per project via `config/admin.ts`:

```js
preview: {
  config: {
    viewports: {
      desktop: { width: 1440, height: 900 },
      tablet: { width: 768, height: 1024 },
      mobile: { width: 390, height: 844 },
    },
  },
}
```

All three keys are optional — Desktop keeps filling the preview panel (width/height: 100%) by default unless a project explicitly overrides it.

The override flows through the existing admin.preview config namespace (validated in `preview-config.ts`, same place as the current `allowedOrigins/handler` options) and reaches the client via `/content-manager/init`, which the Preview page already fetches indirectly through useDocument — no extra network round trip.

Describe the technical changes you did.

### Why is it needed?

The Preview feature only supported Desktop and Mobile viewports with fixed, non-configurable dimensions. Content editors and teams with tablet-first or custom-breakpoint designs had no way to preview at those sizes.

### How to test it?

1. `yarn develop` in `examples/getstarted` (or any Strapi v5 project with preview configured in `config/admin.ts`).
2. Open a document with preview enabled, click Open preview. Confirm Tablet appears in the device selector and resizes the iframe to 768×1024.
3. Add a `preview.config.viewports` override to `config/admin.ts` (see snippet above), restart, and confirm the override takes effect — and that Desktop still fills the panel when left unconfigured.

Automated coverage:
`preview-config.test.ts` — validates getViewports() and the new width/height validation in validate().
`devices.test.ts` — unit tests the client-side merge helper (getPreviewDevices).
`tests/e2e/tests/content-manager/preview.spec.ts` — new Playwright test selecting Tablet and asserting the iframe resizes.

