### PR TITLE
enhancement(database): log internal migrations at info level

### DIFF
--- a/packages/core/database/src/migrations/__tests__/providers.test.ts
+++ b/packages/core/database/src/migrations/__tests__/providers.test.ts
@@ -216,7 +216,7 @@ describe('migration providers', () => {
 
   describe('createInternalMigrationProvider', () => {
     it('runs registered migrations through the internal storage table', async () => {
-      const { db, sqlite } = createTestDatabase();
+      const { db, sqlite, logger } = createTestDatabase();
       const provider = createInternalMigrationProvider(db);
 
       await provider.register({
@@ -237,12 +237,25 @@ describe('migration providers', () => {
       expect(await sqlite('strapi_migrations_internal').select('name')).toEqual([
         { name: 'test-internal' },
       ]);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: 'info',
+          message: '[internal migration]: migrating test-internal',
+        })
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: 'info',
+          message: '[internal migration]: migrated test-internal',
+        })
+      );
+      expect(logger.debug).not.toHaveBeenCalled();
 
       await sqlite.destroy();
     });
 
     it('skips registered internal migrations already recorded in storage', async () => {
-      const { db, sqlite } = createTestDatabase();
+      const { db, sqlite, logger } = createTestDatabase();
       const up = jest.fn(async (knex: knex.Knex) => {
         await knex.schema.createTable('should_not_exist', (table) => {
           table.increments('id');
@@ -270,6 +283,8 @@ describe('migration providers', () => {
       expect(await sqlite('strapi_migrations_internal').select('name')).toEqual([
         { name: 'already-applied' },
       ]);
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.debug).not.toHaveBeenCalled();
 
       await sqlite.destroy();
     });

--- a/packages/core/database/src/migrations/internal.ts
+++ b/packages/core/database/src/migrations/internal.ts
@@ -15,8 +15,7 @@ export const createInternalMigrationProvider = (db: Database): InternalMigration
     storage: createStorage({ db, tableName: 'strapi_migrations_internal' }),
     logger: {
       info(message) {
-        // NOTE: only log internal migration in debug mode
-        db.logger.debug(transformLogMessage('info', message));
+        db.logger.info(transformLogMessage('info', message));
       },
     },
     getMigrations: async () =>


### PR DESCRIPTION
### What does it do?

Logs internal database migration lifecycle events (`migrating` / `migrated`) at **info** instead of **debug**, matching user migrations.

### Why is it needed?

Internal v4→v5 migrations can run for a long time with no visible feedback at the default log level, so users often assume the process is stuck. User migrations already log at info; this aligns internal migrations with that behavior.

### How to test it?

1. Start an app that still has pending internal migrations (or temporarily clear `strapi_migrations_internal` for a known migration in a throwaway DB).
2. Boot with the default log level (no debug).
3. Confirm lines like `[internal migration]: migrating …` / `migrated …` appear.
4. Warm start with no pending migrations should stay quiet.

### Related issue(s)/PR(s)

- Fixes CMS-220