### PR TITLE
enhancement(database): add migration progress heartbeats

### DIFF
--- a/packages/core/database/src/migrations/__tests__/heartbeat-logger.test.ts
+++ b/packages/core/database/src/migrations/__tests__/heartbeat-logger.test.ts
@@ -1,0 +1,70 @@
+import { createHeartbeatLogger } from '../heartbeat';
+import { transformLogMessage } from '../logger';
+
+describe('createHeartbeatLogger', () => {
+  it('does not emit before the interval elapses', () => {
+    let now = 0;
+    const log = jest.fn();
+    const heartbeat = createHeartbeatLogger(log, {
+      intervalMs: 60_000,
+      now: () => now,
+    });
+
+    heartbeat.tick((elapsed) => `t=${elapsed}`);
+    now = 59_999;
+    heartbeat.tick((elapsed) => `t=${elapsed}`);
+
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('emits at most once per interval with elapsed seconds', () => {
+    let now = 0;
+    const log = jest.fn();
+    const heartbeat = createHeartbeatLogger(log, {
+      intervalMs: 60_000,
+      now: () => now,
+    });
+
+    now = 60_000;
+    heartbeat.tick((elapsed) => `still running (${elapsed}s)`);
+    heartbeat.tick((elapsed) => `duplicate (${elapsed}s)`);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith('still running (60s)');
+
+    now = 120_000;
+    heartbeat.tick((elapsed) => `still running (${elapsed}s)`);
+
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenLastCalledWith('still running (120s)');
+  });
+});
+
+describe('transformLogMessage', () => {
+  it('includes durationSeconds when present', () => {
+    expect(
+      transformLogMessage('info', {
+        event: 'migrated',
+        name: '5.0.0-02-created-document-id',
+        durationSeconds: 12.4,
+      })
+    ).toEqual({
+      level: 'info',
+      message: '[internal migration]: migrated 5.0.0-02-created-document-id (12.400s)',
+      timestamp: expect.any(Number),
+    });
+  });
+
+  it('omits duration when not a finite number', () => {
+    expect(
+      transformLogMessage('info', {
+        event: 'migrating',
+        name: '5.0.0-02-created-document-id',
+      })
+    ).toEqual({
+      level: 'info',
+      message: '[internal migration]: migrating 5.0.0-02-created-document-id',
+      timestamp: expect.any(Number),
+    });
+  });
+});

--- a/packages/core/database/src/migrations/__tests__/providers.test.ts
+++ b/packages/core/database/src/migrations/__tests__/providers.test.ts
@@ -246,7 +246,9 @@ describe('migration providers', () => {
       expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({
           level: 'info',
-          message: '[internal migration]: migrated test-internal',
+          message: expect.stringMatching(
+            /^\[internal migration\]: migrated test-internal \(\d+\.\d{3}s\)$/
+          ),
         })
       );
       expect(logger.debug).not.toHaveBeenCalled();

--- a/packages/core/database/src/migrations/heartbeat.ts
+++ b/packages/core/database/src/migrations/heartbeat.ts
@@ -1,0 +1,39 @@
+export interface HeartbeatLoggerOptions {
+  /** Minimum time between heartbeat log lines. Defaults to 60s. */
+  intervalMs?: number;
+  /** Injectable clock for tests. */
+  now?: () => number;
+}
+
+export interface HeartbeatLogger {
+  /**
+   * Emit `buildMessage(elapsedSeconds)` at most once per interval.
+   * Safe to call on every batch — no-ops until the interval elapses.
+   */
+  tick(buildMessage: (elapsedSeconds: number) => string): void;
+}
+
+/**
+ * Append-only, time-throttled progress logger for long-running migrations.
+ * Never rewrites terminal lines — one complete Winston info line per tick.
+ */
+export const createHeartbeatLogger = (
+  log: (message: string) => void,
+  { intervalMs = 60_000, now = () => Date.now() }: HeartbeatLoggerOptions = {}
+): HeartbeatLogger => {
+  const startedAt = now();
+  let lastEmittedAt = startedAt;
+
+  return {
+    tick(buildMessage) {
+      const current = now();
+      if (current - lastEmittedAt < intervalMs) {
+        return;
+      }
+
+      const elapsedSeconds = Math.floor((current - startedAt) / 1000);
+      log(buildMessage(elapsedSeconds));
+      lastEmittedAt = current;
+    },
+  };
+};

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -16,6 +16,7 @@ import { snakeCase } from 'lodash/fp';
 import type { Knex } from 'knex';
 
 import type { Migration } from '../common';
+import { createHeartbeatLogger, type HeartbeatLogger } from '../heartbeat';
 import type { Database } from '../..';
 import type { Meta } from '../../metadata';
 
@@ -114,11 +115,17 @@ const getNextIdsToCreateDocumentId = async (
 };
 
 // Migrate document ids for tables that have localizations
-const migrateDocumentIdsWithLocalizations = async (db: Database, knex: Knex, meta: Meta) => {
+const migrateDocumentIdsWithLocalizations = async (
+  db: Database,
+  knex: Knex,
+  meta: Meta,
+  heartbeat: HeartbeatLogger
+) => {
   const singularName = meta.singularName.toLowerCase();
   const joinColumn = snakeCase(`${singularName}_id`);
   const inverseJoinColumn = snakeCase(`inv_${singularName}_id`);
   let ids: number[];
+  let processed = 0;
 
   do {
     ids = await getNextIdsToCreateDocumentId(db, knex, {
@@ -130,16 +137,27 @@ const migrateDocumentIdsWithLocalizations = async (db: Database, knex: Knex, met
 
     if (ids.length > 0) {
       await knex(meta.tableName).update({ document_id: createId() }).whereIn('id', ids);
+      processed += ids.length;
+      heartbeat.tick(
+        (elapsedSeconds) =>
+          `[document-id] still running (${elapsedSeconds}s) · ${meta.tableName} ${processed} rows processed`
+      );
     }
   } while (ids.length > 0);
 };
 
 // Migrate document ids for tables that don't have localizations
-const migrationDocumentIds = async (db: Database, knex: Knex, meta: Meta) => {
+const migrationDocumentIds = async (
+  db: Database,
+  knex: Knex,
+  meta: Meta,
+  heartbeat: HeartbeatLogger
+) => {
   const batchSize = getBatchSize(knex);
-  let recordsLeft = +(
+  const total = +(
     await knex(meta.tableName).count('* as recordsLeft').whereNull('document_id')
   )[0].recordsLeft;
+  let recordsLeft = total;
   while (recordsLeft > 0) {
     const currentBatchSize = recordsLeft < batchSize ? recordsLeft : batchSize;
     const updateRecords = (
@@ -147,6 +165,11 @@ const migrationDocumentIds = async (db: Database, knex: Knex, meta: Meta) => {
     ).map((item) => ({ id: item.id, document_id: createId() }));
     await knex(meta.tableName).insert(updateRecords).onConflict('id').merge();
     recordsLeft -= updateRecords.length;
+    const processed = total - recordsLeft;
+    heartbeat.tick(
+      (elapsedSeconds) =>
+        `[document-id] still running (${elapsedSeconds}s) · ${meta.tableName} ${processed}/${total}`
+    );
   }
 };
 
@@ -179,7 +202,10 @@ const hasLocalizationsJoinTable = async (knex: Knex, tableName: string) => {
 export const createdDocumentId: Migration = {
   name: '5.0.0-02-created-document-id',
   async up(knex, db) {
-    // do sth
+    const heartbeat = createHeartbeatLogger((message) => {
+      db.logger.info(message);
+    });
+
     for (const meta of db.metadata.values()) {
       const hasTable = await knex.schema.hasTable(meta.tableName);
 
@@ -195,9 +221,9 @@ export const createdDocumentId: Migration = {
         }
 
         if (await hasLocalizationsJoinTable(knex, meta.tableName)) {
-          await migrateDocumentIdsWithLocalizations(db, knex, meta);
+          await migrateDocumentIdsWithLocalizations(db, knex, meta, heartbeat);
         } else {
-          await migrationDocumentIds(db, knex, meta);
+          await migrationDocumentIds(db, knex, meta, heartbeat);
         }
       }
     }

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -138,9 +138,10 @@ const migrateDocumentIdsWithLocalizations = async (
     if (ids.length > 0) {
       await knex(meta.tableName).update({ document_id: createId() }).whereIn('id', ids);
       processed += ids.length;
+      const rowsProcessed = processed;
       heartbeat.tick(
         (elapsedSeconds) =>
-          `[document-id] still running (${elapsedSeconds}s) · ${meta.tableName} ${processed} rows processed`
+          `[document-id] still running (${elapsedSeconds}s) · ${meta.tableName} ${rowsProcessed} rows processed`
       );
     }
   } while (ids.length > 0);
@@ -154,9 +155,8 @@ const migrationDocumentIds = async (
   heartbeat: HeartbeatLogger
 ) => {
   const batchSize = getBatchSize(knex);
-  const total = +(
-    await knex(meta.tableName).count('* as recordsLeft').whereNull('document_id')
-  )[0].recordsLeft;
+  const total = +(await knex(meta.tableName).count('* as recordsLeft').whereNull('document_id'))[0]
+    .recordsLeft;
   let recordsLeft = total;
   while (recordsLeft > 0) {
     const currentBatchSize = recordsLeft < batchSize ? recordsLeft : batchSize;

--- a/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
+++ b/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
@@ -100,6 +100,12 @@ const buildHarness = (
 
   const db: any = {
     dialect: { client: 'postgres' },
+    logger: {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
     metadata: {
       values: () => [
         {

--- a/packages/core/database/src/migrations/logger.ts
+++ b/packages/core/database/src/migrations/logger.ts
@@ -1,3 +1,9 @@
+type MigrationLogEvent = {
+  event: unknown;
+  name: unknown;
+  durationSeconds?: unknown;
+};
+
 export const transformLogMessage = (level: string, message: unknown) => {
   if (typeof message === 'string') {
     return { level, message };
@@ -5,9 +11,16 @@ export const transformLogMessage = (level: string, message: unknown) => {
 
   if (typeof message === 'object' && message !== null) {
     if ('event' in message && 'name' in message) {
+      const { event, name, durationSeconds } = message as MigrationLogEvent;
+      let text = `[internal migration]: ${event} ${name}`;
+
+      if (typeof durationSeconds === 'number' && Number.isFinite(durationSeconds)) {
+        text += ` (${durationSeconds.toFixed(3)}s)`;
+      }
+
       return {
         level,
-        message: `[internal migration]: ${message.event} ${message?.name}`,
+        message: text,
         timestamp: Date.now(),
       };
     }


### PR DESCRIPTION
### What does it do?

Stacked on #27324.

- Adds an append-only, time-throttled heartbeat logger (default **60s**) used by `5.0.0-02-created-document-id`, so long backfills report progress like `… still running (120s) · files 12000/450000` without rewriting terminal lines.
- Includes `durationSeconds` on migration lifecycle log lines (`migrated` / `reverted`).

### Why is it needed?

After lifting internal migrations to info, a single long migration can still look hung for minutes/hours between `migrating` and `migrated`. Heartbeats give bounded progress feedback (~1 line/min). Duration on finish lines makes upgrade timing easier to diagnose.

### How to test it?

1. With #27324 applied, run a large `document-id` backfill (or unit tests below).
2. Confirm at most one heartbeat info line per minute, with table + progress counts.
3. Confirm finish lines include duration, e.g. `[internal migration]: migrated … (12.400s)`.
4. `yarn workspace @strapi/database test:unit -- src/migrations/__tests__/heartbeat-logger.test.ts src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts`

### Related issue(s)/PR(s)

- Fixes CMS-220
- Stacked on #27324