### PR TITLE
fix(admin): unrelated permission conditions no longer block page access

### DIFF
--- a/packages/core/admin/admin/src/components/PageHelpers.tsx
+++ b/packages/core/admin/admin/src/components/PageHelpers.tsx
@@ -174,9 +174,9 @@ export interface ProtectProps {
 /**
  * @public
  * @description A wrapper component that should be used to protect a page. It will check the permissions
- * you pass to it and render the children if the user has the required permissions. If a user does not have ALL
- * the required permissions, it will redirect the user to the home page. Whilst these checks happen it will render
- * the loading component and should the check fail it will render the error component with a notification.
+ * you pass to it and render the children if any of the user's matching permissions grants access. If none do,
+ * it renders the NoPermissions component. Whilst these checks happen it will render the loading component
+ * and should the check fail it will render the error component with a notification.
  */
 const Protect = ({ permissions = [], children }: ProtectProps) => {
   const userPermissions = useAuth('Protect', (state) => state.permissions);
@@ -190,9 +190,10 @@ const Protect = ({ permissions = [], children }: ProtectProps) => {
       ) >= 0
   );
 
-  const shouldCheckConditions = matchingPermissions.some(
-    (perm) => Array.isArray(perm.conditions) && perm.conditions.length > 0
-  );
+  const hasConditions = (permission: Permission) =>
+    Array.isArray(permission.conditions) && permission.conditions.length > 0;
+
+  const shouldCheckConditions = matchingPermissions.some(hasConditions);
 
   const { isLoading, error, data } = useCheckPermissionsQuery(
     {
@@ -225,10 +226,12 @@ const Protect = ({ permissions = [], children }: ProtectProps) => {
 
   const { data: permissionsData } = data || {};
 
+  const hasUnconditionedPermission = matchingPermissions.some(
+    (permission) => !hasConditions(permission)
+  );
+
   const canAccess =
-    shouldCheckConditions && permissionsData
-      ? !permissionsData.includes(false)
-      : matchingPermissions.length > 0;
+    hasUnconditionedPermission || (permissionsData ?? []).some((perm) => perm === true);
 
   if (!canAccess) {
     return <NoPermissions />;

--- a/packages/core/admin/admin/src/components/tests/PageHelpers.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/PageHelpers.test.tsx
@@ -1,5 +1,6 @@
 import { fixtures } from '@strapi/admin-test-utils';
-import { render, screen } from '@tests/utils';
+import { render, screen, server } from '@tests/utils';
+import { http, HttpResponse } from 'msw';
 
 import { Page } from '../PageHelpers';
 
@@ -83,6 +84,129 @@ describe('PageHelpers', () => {
       expect(
         screen.getByText("You don't have the permissions to access that content")
       ).toBeInTheDocument();
+    });
+
+    it("should render the children when an unconditioned permission is granted even if another requested permission's condition fails", async () => {
+      server.use(
+        http.post<Record<string, never>, { permissions: Array<{ action: string }> }>(
+          '/admin/permissions/check',
+          async ({ request }) => {
+            const body = await request.json();
+
+            return HttpResponse.json({
+              data: body.permissions.map(({ action }) => action !== 'admin::roles.update'),
+            });
+          }
+        )
+      );
+
+      render(
+        <Page.Protect
+          permissions={[
+            { action: 'admin::roles.read', subject: null },
+            { action: 'admin::roles.update', subject: null },
+          ]}
+        >
+          <div>Content</div>
+        </Page.Protect>,
+        {
+          providerOptions: {
+            permissions: () => [
+              {
+                id: 1,
+                actionParameters: {},
+                action: 'admin::roles.read',
+                subject: null,
+                conditions: [],
+                properties: {},
+              },
+              {
+                id: 2,
+                actionParameters: {},
+                action: 'admin::roles.update',
+                subject: null,
+                conditions: ['willFail'],
+                properties: {},
+              },
+            ],
+          },
+        }
+      );
+
+      await screen.findByText('Content');
+
+      server.restoreHandlers();
+    });
+
+    it('should render the NoPermissions component when every matching permission has a condition that fails', async () => {
+      server.use(http.post('/admin/permissions/check', () => HttpResponse.json({ data: [false] })));
+
+      render(
+        <Page.Protect permissions={[{ action: 'admin::roles.update', subject: null }]}>
+          <div>Content</div>
+        </Page.Protect>,
+        {
+          providerOptions: {
+            permissions: () => [
+              {
+                id: 1,
+                actionParameters: {},
+                action: 'admin::roles.update',
+                subject: null,
+                conditions: ['willFail'],
+                properties: {},
+              },
+            ],
+          },
+        }
+      );
+
+      await screen.findByText("You don't have the permissions to access that content");
+
+      server.restoreHandlers();
+    });
+
+    it('should render the children when only one of several conditioned permissions passes', async () => {
+      server.use(
+        http.post('/admin/permissions/check', () => HttpResponse.json({ data: [true, false] }))
+      );
+
+      render(
+        <Page.Protect
+          permissions={[
+            { action: 'admin::roles.read', subject: null },
+            { action: 'admin::roles.update', subject: null },
+          ]}
+        >
+          <div>Content</div>
+        </Page.Protect>,
+        {
+          providerOptions: {
+            permissions: () => [
+              {
+                id: 1,
+                actionParameters: {},
+                action: 'admin::roles.read',
+                subject: null,
+                conditions: ['willPass'],
+                properties: {},
+              },
+              {
+                id: 2,
+                actionParameters: {},
+                action: 'admin::roles.update',
+                subject: null,
+                conditions: ['willFail'],
+                properties: {},
+              },
+            ],
+          },
+        }
+      );
+
+      await screen.findByText('Content');
+
+      server.restoreHandlers();
     });
   });
 });


### PR DESCRIPTION
### What does it do?

`Page.Protect` resolves `canAccess` per permission instead of aggregating the whole condition check into a single verdict.

Also adds two tests in `PageHelpers.test.tsx`: one asserting the children render when an unconditioned `read` is granted while a conditioned `update` fails, and one asserting `NoPermissions` still renders when every matching permission has a failing condition.

### Why is it needed?

A role with an unconditional `read` on a collection type lost access to it entirely as soon as a second, condition-gated permission (e.g. `update` behind a custom condition) was added on the same collection type and that condition evaluated to `false`. The user was shown the full-page "You don't have the permission to access that content" screen despite `read` still being granted unconditionally.

### How to test it?

1. Log in as a super admin.
2. Create a user with the `Editor` role.
3. In `Settings > Roles > Editor`, enable only `Read` on a collection type (e.g. `Country`), with no condition. Save.
4. Log in as the editor user and open that collection type in the Content Manager — entries are listed. ✅
5. As super admin, additionally enable `Update` on the same collection type, gated by a custom condition that evaluates to `false` for the editor user (e.g. one checking the acting user's email). Save.
6. Log back in as the editor user and open the same collection type.

Expected: entries are still listed. Before this change, step 6 showed the "You don't have the permission to access that content" screen.

Automated coverage:

```bash
yarn test:front packages/core/admin/admin/src/components/tests/PageHelpers.test.tsx
```

### Related issue(s)/PR(s)

Linear: [EE-135 — Content Manager blocks read access when a conditional permission on another action evaluates to false](https://linear.app/strapi/issue/EE-135/content-manager-blocks-read-access-when-a-conditional-permission-on)
