### PR TITLE
fix(content-manager): redirect to accessible locale when default locale is not authorised

### DIFF
--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -100,6 +100,23 @@ const Layout = () => {
 
         return <NavigateWithLocaleWarning to={{ pathname, search }} />;
       }
+    } else if (accessibleLocales.length > 0) {
+      /**
+       * No locale was specified in the URL, but the user has locale-scoped
+       * permissions. The default-locale resolution fails because the user's
+       * role cannot access the content type's default locale. Redirect to the
+       * first accessible locale with a warning instead of showing a generic
+       * 403 error page.
+       */
+      const search = stringify({
+        ...query,
+        plugins: {
+          ...query.plugins,
+          i18n: { ...query.plugins?.i18n, locale: accessibleLocales[0] },
+        },
+      });
+
+      return <NavigateWithLocaleWarning to={{ pathname, search }} />;
     } else {
       return <Navigate to="/content-manager/403" replace />;
     }

--- a/packages/core/content-manager/admin/src/tests/layout.test.tsx
+++ b/packages/core/content-manager/admin/src/tests/layout.test.tsx
@@ -247,4 +247,30 @@ describe('Content Manager | Layout', () => {
     expect(await screen.findByText('No permissions page')).toBeInTheDocument();
     expect(screen.queryByText('List page')).not.toBeInTheDocument();
   });
+
+  it('redirects to an accessible locale when no locale is specified in the URL and the default locale is not authorised', async () => {
+    // When a user's role has locale-scoped permissions that exclude the content
+    // type's default locale, landing on the page with no locale in the URL must
+    // redirect to the first accessible locale with a warning instead of showing
+    // a generic 403 error page.
+    const FR_ONLY_READ_PERMISSION = {
+      ...EN_ONLY_READ_PERMISSION,
+      properties: { locales: ['fr'] },
+    };
+
+    mockInitData({ models: [ARTICLE_MODEL] });
+
+    renderLayout('/content-manager/collection-types/api::article.article/1', [
+      FR_ONLY_READ_PERMISSION,
+    ]);
+
+    expect(await screen.findByText('Edit page')).toBeInTheDocument();
+    expect(screen.getByTestId('search')).toHaveTextContent('plugins[i18n][locale]=fr');
+    expect(
+      screen.getByText(
+        "You don't have the permissions to access this content for the requested locale"
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No permissions page')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## What

When a user's role has **locale-scoped permissions that exclude the content type's default locale**, simply landing on that content type with **no locale specified in the URL** (e.g. clicking it in the Content Manager sidebar) crashed with a raw `403 Forbidden` and a generic "Whoops! Something went wrong." error screen.

By contrast, the explicit-locale-switch path (`?plugins[i18n][locale]=en`) already showed the friendly "You don't have the permissions to access this content for the requested locale" message and redirected to an accessible locale.

This PR closes that gap: when the URL carries **no locale** but the user has access to **at least one locale**, we now redirect to the first accessible locale with the same warning — instead of throwing a generic 403 error page.

## Why

The `Layout` component in `content-manager/admin/src/layout.tsx` only handled the locale-not-allowed case when `requestedLocale` was a **string** (i.e. explicitly present in the query string). The default-locale-resolution code path (landing on the page with no locale param) fell through to the `else` branch and hard-redirected to `/content-manager/403`.

## How

In `packages/core/content-manager/admin/src/layout.tsx`, added an `else if (accessibleLocales.length > 0)` branch that mirrors the existing explicit-locale handling: build a new search string pointing at `accessibleLocales[0]` and return `<NavigateWithLocaleWarning>` (which shows the friendly warning toast and redirects), instead of the generic 403 redirect.

## Test plan

Added a unit test in `layout.test.tsx` covering the scenario: user has `fr`-only read permission, navigates to a collection type with no locale in the URL → expects redirect to `fr` with the locale warning, and no generic "No permissions page".

## Related

Fixes #27247