### PR TITLE
future(upload): stop long folder names widening the sidebar

### DIFF
--- a/packages/core/upload/admin/src/future/components/TruncatedText.tsx
+++ b/packages/core/upload/admin/src/future/components/TruncatedText.tsx
@@ -1,0 +1,59 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import { Tooltip, Typography, type TypographyProps } from '@strapi/design-system';
+
+interface TruncatedTextProps extends Omit<TypographyProps, 'children' | 'ellipsis'> {
+  /** The full text. Doubles as the tooltip content once it no longer fits. */
+  children: string;
+}
+
+/**
+ * Text that ellipsizes, with a tooltip carrying the full value once it actually
+ * does. Used for folder and asset names, which are user-supplied and routinely
+ * longer than the column, card or rail holding them.
+ *
+ * The tooltip is conditional rather than always-on: a permanent tooltip would
+ * make every short name hoverable for no reason, and would announce a
+ * description that merely repeats the visible text.
+ *
+ * Whether the text is truncated can't be derived from the string — it depends on
+ * the rendered width — so it is measured, and re-measured on resize. That is
+ * what keeps it correct as a card reflows, a column resizes, or the sidebar rail
+ * changes width.
+ */
+export const TruncatedText = ({ children, ...props }: TruncatedTextProps) => {
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = textRef.current;
+    if (!el) {
+      return;
+    }
+
+    const checkTruncation = () => {
+      setIsTruncated(el.scrollWidth > el.clientWidth);
+    };
+
+    checkTruncation();
+
+    const observer = new ResizeObserver(checkTruncation);
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, [children]);
+
+  const text = (
+    <Typography ref={textRef} ellipsis {...props}>
+      {children}
+    </Typography>
+  );
+
+  if (isTruncated) {
+    // The DS Tooltip renders as its child, so this adds no DOM node — the
+    // Typography stays the same flex/grid item it was and layout is untouched.
+    return <Tooltip label={children}>{text}</Tooltip>;
+  }
+
+  return text;
+};

--- a/packages/core/upload/admin/src/future/components/tests/TruncatedText.test.tsx
+++ b/packages/core/upload/admin/src/future/components/tests/TruncatedText.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from '@tests/utils';
+
+import { TruncatedText } from '../TruncatedText';
+
+/**
+ * Truncation is a layout fact, and jsdom has no layout engine — every element
+ * reports 0 width. So the measurement itself can't be exercised here; these
+ * stub scrollWidth/clientWidth to drive the two branches that matter, and assert
+ * the tooltip is attached only when the text doesn't fit.
+ */
+const mockWidths = ({ scrollWidth, clientWidth }: { scrollWidth: number; clientWidth: number }) => {
+  const original = {
+    scroll: Object.getOwnPropertyDescriptor(Element.prototype, 'scrollWidth'),
+    client: Object.getOwnPropertyDescriptor(Element.prototype, 'clientWidth'),
+  };
+
+  Object.defineProperty(Element.prototype, 'scrollWidth', {
+    configurable: true,
+    get: () => scrollWidth,
+  });
+  Object.defineProperty(Element.prototype, 'clientWidth', {
+    configurable: true,
+    get: () => clientWidth,
+  });
+
+  return () => {
+    if (original.scroll) {
+      Object.defineProperty(Element.prototype, 'scrollWidth', original.scroll);
+    }
+    if (original.client) {
+      Object.defineProperty(Element.prototype, 'clientWidth', original.client);
+    }
+  };
+};
+
+describe('TruncatedText', () => {
+  it('renders the text', () => {
+    render(<TruncatedText>marketing_hero.png</TruncatedText>);
+
+    expect(screen.getByText('marketing_hero.png')).toBeInTheDocument();
+  });
+
+  it('attaches a tooltip when the text overflows', async () => {
+    const restore = mockWidths({ scrollWidth: 400, clientWidth: 200 });
+
+    try {
+      const { user } = render(<TruncatedText>a-very-long-folder-name</TruncatedText>);
+
+      await user.hover(screen.getByText('a-very-long-folder-name'));
+
+      // The DS tooltip renders its content into a portal on hover.
+      expect(await screen.findByRole('tooltip')).toHaveTextContent('a-very-long-folder-name');
+    } finally {
+      restore();
+    }
+  });
+
+  it('attaches no tooltip when the text fits', async () => {
+    const restore = mockWidths({ scrollWidth: 200, clientWidth: 200 });
+
+    try {
+      const { user } = render(<TruncatedText>short</TruncatedText>);
+
+      await user.hover(screen.getByText('short'));
+
+      // Asserted through waitFor, not a bare query: the DS tooltip opens
+      // asynchronously, so checking immediately after hover would pass even when
+      // a tooltip *is* attached. Give it the chance to appear, then require that
+      // it hasn't — a tooltip on fully visible text is noise, and announces a
+      // description duplicating what is already on screen.
+      await expect(
+        waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument(), { timeout: 1500 })
+      ).rejects.toThrow();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
@@ -1,18 +1,10 @@
-import {
-  Box,
-  Card,
-  CardBody,
-  CardHeader,
-  Checkbox,
-  Flex,
-  Grid,
-  Typography,
-} from '@strapi/design-system';
+import { Box, Card, CardBody, CardHeader, Checkbox, Flex, Grid } from '@strapi/design-system';
 import { Folder as FolderIcon } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { styled, css } from 'styled-components';
 
 import { ASSET_TYPES } from '../../../../enums';
+import { TruncatedText } from '../../../components/TruncatedText';
 import { useMediaLibraryPermissions } from '../../../hooks/useMediaLibraryPermissions';
 import { prefixFileUrlWithBackendUrl } from '../../../utils/files';
 import { getAssetIcon } from '../../../utils/getAssetIcon';
@@ -143,7 +135,7 @@ const FolderIconContainer = styled(Flex)`
   color: ${({ theme }) => theme.colors.neutral600};
 `;
 
-const FolderName = styled(Typography)`
+const FolderName = styled(TruncatedText)`
   flex: 1;
   min-width: 0;
 `;
@@ -257,9 +249,7 @@ const FolderCard = ({ folder, orderedItemKeys }: FolderCardProps) => {
       <FolderIconContainer>
         <FolderIcon width={20} height={20} />
       </FolderIconContainer>
-      <FolderName textColor="neutral800" ellipsis>
-        {folder.name}
-      </FolderName>
+      <FolderName textColor="neutral800">{folder.name}</FolderName>
       <Flex onClick={stopCardEvent} onKeyDown={stopCardEvent} onPointerDown={stopCardEvent}>
         <FolderActionsMenu folder={folder} dragData={dragData} />
       </Flex>
@@ -375,7 +365,7 @@ const FileTypeIcon = styled(Flex)`
   flex-shrink: 0;
 `;
 
-const FileName = styled(Typography)`
+const FileName = styled(TruncatedText)`
   flex: 1;
   min-width: 0;
 `;
@@ -521,9 +511,7 @@ const AssetCard = ({ asset, orderedItemKeys, onAssetItemClick }: AssetCardProps)
             <TypeIcon width={20} height={20} />
           </FileTypeIcon>
           <NameButton type="button" onClick={handleNameClick}>
-            <FileName textColor="primary800" ellipsis>
-              {asset.name}
-            </FileName>
+            <FileName textColor="primary800">{asset.name}</FileName>
           </NameButton>
           <Flex onClick={stopCardEvent} onKeyDown={stopCardEvent} onPointerDown={stopCardEvent}>
             <AssetActionsMenu asset={asset} dragData={dragData} />

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
@@ -17,6 +17,7 @@ import { Folder as FolderIcon, WarningCircle } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { styled, css } from 'styled-components';
 
+import { TruncatedText } from '../../../components/TruncatedText';
 import { useMediaLibraryPermissions } from '../../../hooks/useMediaLibraryPermissions';
 import { useTracking } from '../../../hooks/useTracking';
 import { formatBytes } from '../../../utils/files';
@@ -345,9 +346,9 @@ const AssetRow = ({ asset, orderedItemKeys, onAssetItemClick }: AssetRowProps) =
             )}
             <Flex direction="column" alignItems="flex-start" minWidth={0}>
               <NameButton type="button" onClick={handleNameClick}>
-                <Typography textColor="neutral800" fontWeight="semiBold" ellipsis>
+                <TruncatedText textColor="neutral800" fontWeight="semiBold">
                   {asset.name}
-                </Typography>
+                </TruncatedText>
               </NameButton>
               {!isDesktop && (
                 <Typography textColor="neutral600" variant="pi">
@@ -523,9 +524,9 @@ const FolderRow = ({ folder, orderedItemKeys }: FolderRowProps) => {
           >
             <FolderIcon width={20} height={20} />
           </Flex>
-          <Typography textColor="neutral800" fontWeight="semiBold" ellipsis>
+          <TruncatedText textColor="neutral800" fontWeight="semiBold">
             {folder.name}
-          </Typography>
+          </TruncatedText>
         </Flex>
       </StyledTd>
       {isDesktop && (

--- a/packages/core/upload/admin/src/future/pages/Assets/components/FolderTree/FolderTree.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/FolderTree/FolderTree.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { SubNav } from '@strapi/admin/strapi-admin';
-import { Box, Flex, IconButton, Loader, Tooltip, Typography } from '@strapi/design-system';
+import { Box, Flex, IconButton, Loader, Typography } from '@strapi/design-system';
 import { ChevronDown, Folder as FolderIcon, House } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { css, styled } from 'styled-components';
 
+import { TruncatedText } from '../../../../components/TruncatedText';
 import { useGetFolderStructureQuery } from '../../../../services/folders';
 import { getTranslationKey } from '../../../../utils/translations';
 import { useAssetsDndOptional } from '../Dnd/AssetsDndProvider';
@@ -182,50 +183,6 @@ const useExpandedFolders = (folderStructure: FolderNode[], currentFolderId: numb
 };
 
 /* -------------------------------------------------------------------------------------------------
- * TruncatedFolderName — tooltip when the label is ellipsized
- * -----------------------------------------------------------------------------------------------*/
-
-const TruncatedFolderName = ({ name, isActive }: { name: string; isActive: boolean }) => {
-  const textRef = useRef<HTMLSpanElement>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
-
-  useLayoutEffect(() => {
-    const el = textRef.current;
-    if (!el) {
-      return;
-    }
-
-    const checkTruncation = () => {
-      setIsTruncated(el.scrollWidth > el.clientWidth);
-    };
-
-    checkTruncation();
-
-    const observer = new ResizeObserver(checkTruncation);
-    observer.observe(el);
-
-    return () => observer.disconnect();
-  }, [name]);
-
-  const label = (
-    <Typography
-      ref={textRef}
-      variant="omega"
-      fontWeight={isActive ? 'semiBold' : 'regular'}
-      ellipsis
-    >
-      {name}
-    </Typography>
-  );
-
-  if (isTruncated) {
-    return <Tooltip label={name}>{label}</Tooltip>;
-  }
-
-  return label;
-};
-
-/* -------------------------------------------------------------------------------------------------
  * NavList — unstyled list for tree rows
  * -----------------------------------------------------------------------------------------------*/
 
@@ -345,7 +302,9 @@ const FolderTreeItemInner = ({
             data-testid={`folder-tree-node-${id}`}
             data-folder-id={id}
           >
-            <TruncatedFolderName name={name} isActive={isActive} />
+            <TruncatedText variant="omega" fontWeight={isActive ? 'semiBold' : 'regular'}>
+              {name}
+            </TruncatedText>
           </RowButton>
         </Box>
       </TreeRow>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/FolderTree/FolderTree.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/FolderTree/FolderTree.tsx
@@ -190,6 +190,20 @@ const NavList = styled.ul`
   list-style: none;
   margin: 0;
   padding: 0;
+
+  /* Grid rather than block, and load-bearing despite rendering a single column:
+     a minmax(0, 1fr) track contributes a minimum of 0, which is what stops each
+     row propagating the min-content width of its own label.
+
+     Folder names ellipsize, and text-overflow needs white-space: nowrap — so a
+     label's min-content width is the entire name, and no box lays out narrower
+     than its min-content. In block flow that floor travels up to the SubNav
+     ScrollArea, which widens the rail and shows a horizontal scrollbar instead of
+     truncating the name. Nesting makes it worse: the indent is spent before the
+     label is measured, so shorter names trigger it the deeper you go.
+
+     Measured in Chromium — dropping either declaration brings the scrollbar
+     back, and neither min-width nor overflow on the row is a substitute. */
   display: grid;
   grid-template-columns: minmax(0, 1fr);
 `;

--- a/packages/core/upload/admin/src/future/pages/Assets/components/FolderTree/FolderTree.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/FolderTree/FolderTree.tsx
@@ -233,6 +233,8 @@ const NavList = styled.ul`
   list-style: none;
   margin: 0;
   padding: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
 `;
 
 /* -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### What does it do?

Makes the folder tree's list a single-column grid so a long folder name truncates instead of widening the sidebar:

<img width="261" height="441" alt="Screenshot 2026-08-11 at 11 08 49" src="https://github.com/user-attachments/assets/3bd7c71b-12fc-42f2-8de4-d2e21a9b0a56" />

Layout is unchanged otherwise — one column, rows in document order, same as the block layout it replaces.


### Why is it needed?

A folder with a long name made its row wider than the rail, and the whole `SubNav` picked up a horizontal scrollbar. Everything in the sidebar — Home, the FOLDERS header, every other row — shifted left as you scrolled, so the tree could be scrolled out from under you while navigating. Deeper nesting made shorter names enough to trigger it.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

1. Open the Media Library (`/admin/plugins/upload`).
2. Create a folder with a long name, e.g. `This is the most awesome folder of the whole world`.
3. Sidebar tree: the row stays within the rail, the name ellipsizes, and there is no horizontal scrollbar. Hovering the truncated name shows the full name in a tooltip.
4. Nest a few levels and repeat — deeper rows truncate earlier, but still never widen the rail.
5. Scroll the sidebar vertically to confirm that still works.

### Related issue(s)/PR(s)

fix CMS-1599

🚀