### PR TITLE
future(upload): keep the multi-selection when acting on one row

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetActionsMenu.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetActionsMenu.tsx
@@ -21,6 +21,7 @@ import { prefixFileUrlWithBackendUrl } from '../../../utils/files';
 import { getTranslationKey } from '../../../utils/translations';
 import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useBusyAssetsOptional } from '../hooks/useBusyAssets';
+import { assetKey } from '../utils/selection';
 
 import { ActionsMenuContent } from './ActionsMenuContent';
 import { BulkMoveDialog } from './BulkMoveDialog';
@@ -46,15 +47,17 @@ interface AssetActionsMenuProps {
  * drawer versions render as `IconButton`s and report through its in-drawer toast
  * slot, neither of which fits a menu item on a row.
  *
- * Any successful move or delete clears the whole selection: a delete only
- * invalidates RTK tags, so without it an `asset:<id>` key for a file that no
- * longer exists would linger in the selection.
+ * A successful move or delete deselects this one asset and leaves the rest of
+ * the selection intact: the mutations only invalidate RTK tags, so without it an
+ * `asset:<id>` key for a file that has been deleted — or has moved out of this
+ * list — would linger. The other selected rows are untouched, which is the whole
+ * point of the menu being a single-item affordance.
  */
 export const AssetActionsMenu = ({ asset, dragData }: AssetActionsMenuProps) => {
   const { formatMessage } = useIntl();
   const { copy } = useClipboard();
   const { toggleNotification } = useNotification();
-  const { clear } = useAssetSelection();
+  const { deselect } = useAssetSelection();
   // Absent in the asset picker and in unit tests: the replace still runs, it
   // just renders no row-level overlay.
   const markBusy = useBusyAssetsOptional()?.markBusy ?? (() => () => {});
@@ -330,7 +333,7 @@ export const AssetActionsMenu = ({ asset, dragData }: AssetActionsMenuProps) => 
           open
           onClose={() => setIsMoveOpen(false)}
           items={moveItems}
-          onSuccess={clear}
+          onSuccess={() => deselect(assetKey(asset.id))}
         />
       )}
       {/* Both dialogs live inside the row, so a background refetch that drops the
@@ -342,7 +345,7 @@ export const AssetActionsMenu = ({ asset, dragData }: AssetActionsMenuProps) => 
           open
           onClose={() => setIsDeleteOpen(false)}
           target={{ fileIds: [asset.id], folderIds: [] }}
-          onSuccess={clear}
+          onSuccess={() => deselect(assetKey(asset.id))}
         />
       )}
     </>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/FolderActionsMenu.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/FolderActionsMenu.tsx
@@ -7,6 +7,7 @@ import { useIntl } from 'react-intl';
 
 import { getTranslationKey } from '../../../utils/translations';
 import { useAssetSelection } from '../hooks/useAssetSelection';
+import { folderKey } from '../utils/selection';
 
 import { ActionsMenuContent } from './ActionsMenuContent';
 import { BulkMoveDialog } from './BulkMoveDialog';
@@ -28,16 +29,17 @@ interface FolderActionsMenuProps {
  * affordance). It reuses the shared move and delete dialogs, which mount only
  * while open.
  *
- * A successful move or delete clears the whole selection: they only invalidate
- * RTK tags, so without it a `folder:<id>` key for a folder that no longer lives
- * where the selection thinks it does would linger. A rename leaves the id
- * valid, so it deliberately keeps the selection.
+ * A successful move or delete deselects this one folder and leaves the rest of
+ * the selection intact: they only invalidate RTK tags, so without it a
+ * `folder:<id>` key for a folder that no longer lives where the selection thinks
+ * it does would linger. A rename leaves the id valid and the folder in place, so
+ * it touches the selection not at all.
  */
 export const FolderActionsMenu = ({ folder, dragData }: FolderActionsMenuProps) => {
   const { formatMessage } = useIntl();
   const { copy } = useClipboard();
   const { toggleNotification } = useNotification();
-  const { clear } = useAssetSelection();
+  const { deselect } = useAssetSelection();
   const [isRenameOpen, setIsRenameOpen] = useState(false);
   const [isMoveOpen, setIsMoveOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
@@ -133,7 +135,7 @@ export const FolderActionsMenu = ({ folder, dragData }: FolderActionsMenuProps) 
           open
           onClose={() => setIsMoveOpen(false)}
           items={moveItems}
-          onSuccess={clear}
+          onSuccess={() => deselect(folderKey(folder.id))}
         />
       )}
       {isDeleteOpen && (
@@ -141,7 +143,7 @@ export const FolderActionsMenu = ({ folder, dragData }: FolderActionsMenuProps) 
           open
           onClose={() => setIsDeleteOpen(false)}
           target={{ fileIds: [], folderIds: [folder.id] }}
-          onSuccess={clear}
+          onSuccess={() => deselect(folderKey(folder.id))}
         />
       )}
     </>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/AssetActionsMenu.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/AssetActionsMenu.test.tsx
@@ -8,7 +8,7 @@ import type { DragFileData } from '../../../../types/dnd';
 
 const mockToggleNotification = jest.fn();
 const mockCopy = jest.fn();
-const mockClear = jest.fn();
+const mockDeselect = jest.fn();
 const mockDownloadFile = jest.fn();
 const mockAIAvailability = jest.fn(() => true);
 
@@ -25,7 +25,7 @@ jest.mock('@strapi/admin/strapi-admin', () => ({
 
 jest.mock('../../hooks/useAssetSelection', () => ({
   useAssetSelection: () => ({
-    clear: mockClear,
+    deselect: mockDeselect,
     selectedIds: new Set<number>([9, 10]),
     selectedFolderIds: new Set<number>([8]),
   }),
@@ -414,7 +414,7 @@ describe('AssetActionsMenu', () => {
   });
 
   describe('Move to folder', () => {
-    it('moves only this asset, whatever else is selected, then clears the selection', async () => {
+    it('moves only this asset, whatever else is selected, then deselects only this asset', async () => {
       let requestBody: unknown;
       server.use(
         http.post(
@@ -442,7 +442,7 @@ describe('AssetActionsMenu', () => {
         // The menu never carries the selected assets (9, 10) or folder (8).
         expect(requestBody).toEqual({ fileIds: [5], folderIds: [], destinationFolderId: 1 })
       );
-      expect(mockClear).toHaveBeenCalledTimes(1);
+      expect(mockDeselect).toHaveBeenCalledWith('asset:5');
       await waitFor(() => expect(screen.queryByText('Move elements to')).not.toBeInTheDocument());
     });
 
@@ -456,12 +456,12 @@ describe('AssetActionsMenu', () => {
       await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(screen.queryByText('Move elements to')).not.toBeInTheDocument();
-      expect(mockClear).not.toHaveBeenCalled();
+      expect(mockDeselect).not.toHaveBeenCalled();
     });
   });
 
   describe('Delete', () => {
-    it('deletes only this asset on confirm, toasts, and clears the selection', async () => {
+    it('deletes only this asset on confirm, toasts, and deselects only this asset', async () => {
       let requestBody: unknown;
       server.use(
         http.post(
@@ -489,7 +489,7 @@ describe('AssetActionsMenu', () => {
         type: 'success',
         message: '1 item has been deleted',
       });
-      expect(mockClear).toHaveBeenCalledTimes(1);
+      expect(mockDeselect).toHaveBeenCalledWith('asset:5');
     });
 
     it('closes the confirm on cancel without deleting anything', async () => {
@@ -503,7 +503,7 @@ describe('AssetActionsMenu', () => {
 
       expect(screen.queryByText('Delete 1 item?')).not.toBeInTheDocument();
       expect(mockToggleNotification).not.toHaveBeenCalled();
-      expect(mockClear).not.toHaveBeenCalled();
+      expect(mockDeselect).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/FolderActionsMenu.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/FolderActionsMenu.test.tsx
@@ -8,7 +8,7 @@ import type { DragFolderData } from '../../../../types/dnd';
 
 const mockToggleNotification = jest.fn();
 const mockCopy = jest.fn();
-const mockClear = jest.fn();
+const mockDeselect = jest.fn();
 
 jest.mock('@strapi/admin/strapi-admin', () => ({
   ...jest.requireActual('@strapi/admin/strapi-admin'),
@@ -18,7 +18,7 @@ jest.mock('@strapi/admin/strapi-admin', () => ({
 
 jest.mock('../../hooks/useAssetSelection', () => ({
   useAssetSelection: () => ({
-    clear: mockClear,
+    deselect: mockDeselect,
     selectedIds: new Set<number>([9, 10]),
     selectedFolderIds: new Set<number>([8]),
   }),
@@ -202,7 +202,7 @@ describe('FolderActionsMenu', () => {
           message: 'Folder has been renamed',
         })
       );
-      expect(mockClear).not.toHaveBeenCalled();
+      expect(mockDeselect).not.toHaveBeenCalled();
     });
 
     it('closes the dialog on cancel without renaming anything', async () => {
@@ -220,7 +220,7 @@ describe('FolderActionsMenu', () => {
   });
 
   describe('Move to folder', () => {
-    it('moves only this folder, whatever else is selected, then clears the selection', async () => {
+    it('moves only this folder, whatever else is selected, then deselects only this folder', async () => {
       let requestBody: unknown;
       server.use(
         http.post(
@@ -248,7 +248,7 @@ describe('FolderActionsMenu', () => {
         // The menu never carries the selected assets (9, 10) or folder (8).
         expect(requestBody).toEqual({ fileIds: [], folderIds: [5], destinationFolderId: 1 })
       );
-      expect(mockClear).toHaveBeenCalledTimes(1);
+      expect(mockDeselect).toHaveBeenCalledWith('folder:5');
       await waitFor(() => expect(screen.queryByText('Move elements to')).not.toBeInTheDocument());
     });
 
@@ -319,12 +319,12 @@ describe('FolderActionsMenu', () => {
       await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(screen.queryByText('Move elements to')).not.toBeInTheDocument();
-      expect(mockClear).not.toHaveBeenCalled();
+      expect(mockDeselect).not.toHaveBeenCalled();
     });
   });
 
   describe('Delete folder', () => {
-    it('deletes only this folder on confirm, toasts, and clears the selection', async () => {
+    it('deletes only this folder on confirm, toasts, and deselects only this folder', async () => {
       let requestBody: unknown;
       server.use(
         http.post(
@@ -352,7 +352,7 @@ describe('FolderActionsMenu', () => {
         type: 'success',
         message: '1 item has been deleted',
       });
-      expect(mockClear).toHaveBeenCalledTimes(1);
+      expect(mockDeselect).toHaveBeenCalledWith('folder:5');
     });
 
     it('closes the confirm on cancel without deleting anything', async () => {
@@ -366,7 +366,7 @@ describe('FolderActionsMenu', () => {
 
       expect(screen.queryByText('Delete 1 item?')).not.toBeInTheDocument();
       expect(mockToggleNotification).not.toHaveBeenCalled();
-      expect(mockClear).not.toHaveBeenCalled();
+      expect(mockDeselect).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useAssetSelection.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useAssetSelection.ts
@@ -11,6 +11,7 @@ import {
 import {
   clearSelection,
   createEmptySelection,
+  deselect as deselectState,
   getIdsOfKind,
   selectAll as selectAllState,
   selectRange as selectRangeState,
@@ -46,6 +47,8 @@ export interface AssetSelection {
   selectRange: (orderedKeys: ItemKey[], targetKey: ItemKey) => void;
   /** Header checkbox — selects every rendered item (folders and assets). */
   selectAll: (orderedKeys: ItemKey[]) => void;
+  /** Row-level "..." menu — drops one key when its item leaves the list (move, delete). */
+  deselect: (key: ItemKey) => void;
   /** Close button / folder navigation / list-identity changes. */
   clear: () => void;
 }
@@ -98,6 +101,10 @@ export const AssetSelectionProvider = ({
     [disabled]
   );
 
+  // No `disabled` guard, like `clear`: this only ever shrinks the selection, and a
+  // disabled provider has nothing in it (every additive path is guarded).
+  const deselect = useCallback((key: ItemKey) => setState((prev) => deselectState(prev, key)), []);
+
   const clear = useCallback(() => setState(clearSelection()), []);
 
   const selectedIds = useMemo(
@@ -119,6 +126,7 @@ export const AssetSelectionProvider = ({
       toggle,
       selectRange,
       selectAll,
+      deselect,
       clear,
     }),
     [
@@ -130,6 +138,7 @@ export const AssetSelectionProvider = ({
       toggle,
       selectRange,
       selectAll,
+      deselect,
       clear,
     ]
   );

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
@@ -582,6 +582,66 @@ describe('AssetsTable', () => {
       expect(await screen.findByRole('checkbox', { name: 'Select image3.png' })).not.toBeChecked();
       expect(screen.getByText('3 items selected')).toBeInTheDocument();
     });
+
+    it("keeps the selection when an unselected asset's row menu deletes it", async () => {
+      let requestBody: unknown;
+      server.use(
+        http.post(
+          '*/upload/actions/bulk-delete',
+          async ({ request }) => {
+            requestBody = await request.json();
+            return HttpResponse.json({ data: { files: [], folders: [] } });
+          },
+          { once: true }
+        )
+      );
+
+      const { user } = setup();
+
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
+      expect(screen.getByText('2 items selected')).toBeInTheDocument();
+
+      // The third row's own menu — image1 and image2 stay selected around it.
+      await user.click(screen.getAllByRole('button', { name: 'More actions' })[2]);
+      await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+      await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => expect(requestBody).toEqual({ fileIds: [3], folderIds: [] }));
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
+      expect(screen.getByText('2 items selected')).toBeInTheDocument();
+    });
+
+    it("keeps the selection when an unselected folder's row menu deletes it", async () => {
+      let requestBody: unknown;
+      server.use(
+        http.post(
+          '*/upload/actions/bulk-delete',
+          async ({ request }) => {
+            requestBody = await request.json();
+            return HttpResponse.json({ data: { files: [], folders: [] } });
+          },
+          { once: true }
+        )
+      );
+
+      const { user } = setup({ folders: [createMockFolder(1, 'Photos')] });
+
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image1.png' }));
+      await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
+      expect(screen.getByText('2 items selected')).toBeInTheDocument();
+
+      // Folders render before assets, so the folder's trigger is the first one.
+      await user.click(screen.getAllByRole('button', { name: 'More actions' })[0]);
+      await user.click(screen.getByRole('menuitem', { name: 'Delete folder' }));
+      await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => expect(requestBody).toEqual({ fileIds: [], folderIds: [1] }));
+      expect(await screen.findByRole('checkbox', { name: 'Select image1.png' })).toBeChecked();
+      expect(await screen.findByRole('checkbox', { name: 'Select image2.png' })).toBeChecked();
+      expect(screen.getByText('2 items selected')).toBeInTheDocument();
+    });
   });
 
   describe('BulkActionsBar', () => {

--- a/packages/core/upload/admin/src/future/pages/Assets/utils/selection.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/utils/selection.ts
@@ -59,6 +59,25 @@ export const toggleSelection = (state: SelectionState, key: ItemKey): SelectionS
 };
 
 /**
+ * Subtractive counterpart to {@link toggleSelection} — removes a key without the
+ * add-if-absent ambiguity, leaving the rest of the selection alone. Used when a
+ * single-item affordance (a row's "..." menu) makes exactly one key stale.
+ *
+ * Idempotent: removing a key that was never selected is a no-op. The anchor is
+ * dropped only when it is the removed key, so a Shift+click range built around
+ * other rows survives.
+ */
+export const deselect = (state: SelectionState, key: ItemKey): SelectionState => {
+  const selectedKeys = new Set(state.selectedKeys);
+  selectedKeys.delete(key);
+
+  return {
+    selectedKeys,
+    anchorKey: state.anchorKey === key ? null : state.anchorKey,
+  };
+};
+
+/**
  * Shift+click — selects the contiguous range between the current anchor and the
  * target in render order, replacing the current selection. The anchor stays put.
  *

--- a/packages/core/upload/admin/src/future/pages/Assets/utils/tests/selection.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/utils/tests/selection.test.ts
@@ -2,6 +2,7 @@ import {
   assetKey,
   clearSelection,
   createEmptySelection,
+  deselect,
   folderKey,
   getIdsOfKind,
   getSelectAllState,
@@ -61,6 +62,62 @@ describe('selection logic', () => {
       toggleSelection(prev, assetKey(20));
 
       expect([...prev.selectedKeys]).toEqual([assetKey(10)]);
+    });
+  });
+
+  describe('deselect', () => {
+    it('removes only the given key, leaving the rest of the selection', () => {
+      const next = deselect(
+        stateFrom([folderKey(1), assetKey(10), assetKey(20)], assetKey(20)),
+        assetKey(10)
+      );
+
+      expect([...next.selectedKeys]).toEqual([folderKey(1), assetKey(20)]);
+    });
+
+    it('is a no-op when the key was never selected', () => {
+      const next = deselect(stateFrom([folderKey(1), assetKey(10)], folderKey(1)), assetKey(999));
+
+      expect([...next.selectedKeys]).toEqual([folderKey(1), assetKey(10)]);
+      expect(next.anchorKey).toBe(folderKey(1));
+    });
+
+    it('keeps an anchor pointing at another key, so a later range still works', () => {
+      const next = deselect(
+        stateFrom([folderKey(1), assetKey(10), assetKey(20)], folderKey(1)),
+        assetKey(20)
+      );
+
+      expect(next.anchorKey).toBe(folderKey(1));
+      expect([...selectRange(next, ORDER, assetKey(10)).selectedKeys]).toEqual([
+        folderKey(1),
+        folderKey(2),
+        assetKey(10),
+      ]);
+    });
+
+    it('nulls the anchor when the removed key is the anchor', () => {
+      const next = deselect(stateFrom([folderKey(1), assetKey(10)], assetKey(10)), assetKey(10));
+
+      expect([...next.selectedKeys]).toEqual([folderKey(1)]);
+      expect(next.anchorKey).toBeNull();
+    });
+
+    // `toggleSelection` anchors on the key it removes, so the anchor can already
+    // point at an unselected row before anything is deselected.
+    it('nulls the anchor pointing at the removed key even when it was not selected', () => {
+      const next = deselect(stateFrom([folderKey(1)], assetKey(10)), assetKey(10));
+
+      expect([...next.selectedKeys]).toEqual([folderKey(1)]);
+      expect(next.anchorKey).toBeNull();
+    });
+
+    it('does not mutate the input state', () => {
+      const prev = stateFrom([assetKey(10), assetKey(20)], assetKey(20));
+      deselect(prev, assetKey(20));
+
+      expect([...prev.selectedKeys]).toEqual([assetKey(10), assetKey(20)]);
+      expect(prev.anchorKey).toBe(assetKey(20));
     });
   });
 


### PR DESCRIPTION
### What does it do?

A row's "..." menu no longer wipes the whole multi-selection when its move or delete succeeds — it now drops just that one item's key.

- Adds `deselect(state, key)` to `utils/selection.ts`, the subtractive counterpart to `toggleSelection` (no add-if-absent ambiguity). It is idempotent, does not mutate the input, and only nulls `anchorKey` when the anchor *is* the removed key, so a Shift+click range built around other rows still works afterwards.
- Exposes `deselect` from `useAssetSelection`. Like `clear`, it has no `disabled` guard: it can only shrink the selection, and a disabled provider is empty anyway since every additive path is already guarded.
- `AssetActionsMenu` and `FolderActionsMenu` swap `onSuccess={clear}` for `onSuccess={() => deselect(assetKey(asset.id))}` / `folderKey(folder.id)`. Rename still touches the selection not at all — the id stays valid and the folder stays put.

### Why is it needed?

The row menu is a single-item affordance: it acts on the row it was opened from, whatever else is selected. But on success it called `clear()`, so deleting or moving one unrelated row threw away a multi-selection the user had just built up — and if the deleted row was not part of that selection, nothing about it was stale.

The key still has to be removed, though. Both mutations only invalidate RTK tags, so an `asset:<id>` / `folder:<id>` key for an item that has been deleted, or has moved out of the current list, would otherwise linger in the selection and keep inflating the bulk bar count.

### How to test it?

`cd examples/getstarted && UNSTABLE_MEDIA_LIBRARY=true yarn develop`, then open the future Media Library with a few folders and assets.

1. Select two assets, then open a **third, unselected** row's menu and delete it. The first two stay checked and the bar still reads "2 items selected".
2. Same with an unselected folder, and with **Move to folder** instead of Delete.
3. Now select three assets and use the menu on **one of the selected** rows: only that row leaves the selection, the other two remain.
4. Cancel a move or delete dialog — the selection is untouched.
5. Rename a folder from its menu — the selection is untouched.
6. Shift+click a range, delete an unrelated row from its menu, then Shift+click again: the range still extends from the original anchor.

Automated: `yarn test:front --testPathPattern "future/pages/Assets"` — new `deselect` unit tests plus `AssetsTable` integration tests covering the unselected-row case end to end.

### Related issue(s)/PR(s)

- CMS-1597