### PR TITLE
fix(plugins): admin build fails to resolve @strapi/admin under isolated node_modules

### DIFF
--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -79,6 +79,7 @@
     "pluralize": "8.0.0"
   },
   "devDependencies": {
+    "@strapi/admin": "5.52.0",
     "@strapi/strapi": "5.52.0",
     "@strapi/types": "5.52.0",
     "@types/graphql-depth-limit": "1.1.5",
@@ -98,6 +99,7 @@
     "typescript": "5.9.3"
   },
   "peerDependencies": {
+    "@strapi/admin": "^5.0.0",
     "@strapi/strapi": "^5.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -64,6 +64,7 @@
     "@strapi/icons": "2.2.4"
   },
   "devDependencies": {
+    "@strapi/admin": "5.52.0",
     "@strapi/strapi": "5.52.0",
     "@types/node": "20.19.41",
     "react": "18.3.1",
@@ -74,6 +75,7 @@
     "vitest-config": "5.52.0"
   },
   "peerDependencies": {
+    "@strapi/admin": "^5.0.0",
     "@strapi/strapi": "^5.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -72,6 +72,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@strapi/admin": "5.52.0",
     "@strapi/strapi": "5.52.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
@@ -86,6 +87,7 @@
     "styled-components": "6.4.1"
   },
   "peerDependencies": {
+    "@strapi/admin": "^5.0.0",
     "@strapi/strapi": "^5.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9447,6 +9447,7 @@ __metadata:
     "@graphql-tools/schema": "npm:10.0.3"
     "@graphql-tools/utils": "npm:^10.1.3"
     "@koa/cors": "npm:5.0.0"
+    "@strapi/admin": "npm:5.52.0"
     "@strapi/design-system": "npm:2.2.4"
     "@strapi/icons": "npm:2.2.4"
     "@strapi/strapi": "npm:5.52.0"
@@ -9477,6 +9478,7 @@ __metadata:
     tsconfig: "npm:5.52.0"
     typescript: "npm:5.9.3"
   peerDependencies:
+    "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -9490,6 +9492,7 @@ __metadata:
   resolution: "@strapi/plugin-sentry@workspace:packages/plugins/sentry"
   dependencies:
     "@sentry/node": "npm:7.112.2"
+    "@strapi/admin": "npm:5.52.0"
     "@strapi/design-system": "npm:2.2.4"
     "@strapi/icons": "npm:2.2.4"
     "@strapi/strapi": "npm:5.52.0"
@@ -9501,6 +9504,7 @@ __metadata:
     vitest: "catalog:"
     vitest-config: "npm:5.52.0"
   peerDependencies:
+    "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -9513,6 +9517,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-users-permissions@workspace:packages/plugins/users-permissions"
   dependencies:
+    "@strapi/admin": "npm:5.52.0"
     "@strapi/design-system": "npm:2.2.4"
     "@strapi/icons": "npm:2.2.4"
     "@strapi/strapi": "npm:5.52.0"
@@ -9543,6 +9548,7 @@ __metadata:
     yup: "npm:0.32.9"
     zod: "npm:3.25.76"
   peerDependencies:
+    "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0


### PR DESCRIPTION
### What does it do?

Declares `@strapi/admin` as a peer dependency (`^5.0.0`) plus a dev dependency (`5.51.2`) in three plugins that reference it but never declared it:

- `@strapi/plugin-users-permissions` — real runtime imports in `admin/src/pages/Providers/index.jsx` and `admin/src/pages/EmailTemplates/index.jsx`
- `@strapi/plugin-graphql` — `import type { StrapiApp }` in `admin/src/index.ts`
- `@strapi/plugin-sentry` — `import type { StrapiApp }` in `admin/src/index.ts`

This matches what `i18n`, `cloud`, `content-manager`, `upload`, `content-releases`, `review-workflows`, `content-type-builder` and `email` already do. `yarn.lock` workspace entries updated accordingly.

### Why is it needed?

With a hoisted `node_modules` layout the missing declaration resolves by accident. With an isolated layout — pnpm with `enableGlobalVirtualStore` / `node-linker=isolated` — it does not, and starting a Strapi app crashes Vite's dependency pre-bundling:

```
✘ [ERROR] Could not resolve "@strapi/admin/strapi-admin"

    node_modules/@strapi/plugin-users-permissions/dist/admin/pages/Providers/index.mjs:3:37:
      3 │ import { useTracking, Layouts } from '@strapi/admin/strapi-admin';

vite error while updating dependencies:
Error: Build failed with 2 errors
```

`@strapi/strapi` does not depend on `@strapi/plugin-users-permissions`, so nothing else pulls `@strapi/admin` into the plugin's resolution scope.

For `graphql` and `sentry` the imports are type-only and erased at build time, so there is no runtime failure — but both ship `dist/admin/src/index.d.ts` referencing `@strapi/admin/strapi-admin`, which is unresolvable for consumers type-checking under the same isolated layout.

Using a peer dependency rather than a plain dependency keeps a single `@strapi/admin` instance, so React contexts such as `useTracking` are not duplicated.

### How to test it?

1. Create a Strapi app in a pnpm workspace with `node-linker=isolated` (or pnpm's `enableGlobalVirtualStore`) and `strict-peer-dependencies=true`.
2. `pnpm develop` and open `http://localhost:1337/admin`.

Before: Vite fails to pre-bundle with `Could not resolve "@strapi/admin/strapi-admin"`. After: the admin panel builds and the Users & Permissions Providers / Email Templates settings pages load.

### Related issue(s)/PR(s)

Subset of #27249 ("chore(deps): declare per-workspace dependencies previously resolved by hoisting"), which makes the same three declarations as part of a much larger sweep of undeclared workspace dependencies.

This PR is split out because these three are the only ones that break a *user-facing* runtime path — a plain `pnpm develop` on a released 5.51.2 app crashes the admin dev server, no monorepo build involved. Merging it standalone gets that fix out without waiting on review of the full sweep; if #27249 lands first, this one can simply be closed.

Reported while running Strapi 5.51.2 inside a pnpm monorepo with `enableGlobalVirtualStore` and `strict-peer-dependencies`.
