### PR TITLE
fix(upload): show tooltip on truncated names in the media library

### DIFF
--- a/packages/core/upload/admin/src/future/components/TruncatedText.tsx
+++ b/packages/core/upload/admin/src/future/components/TruncatedText.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { Tooltip, Typography, type TypographyProps } from '@strapi/design-system';
 
@@ -17,43 +17,68 @@ interface TruncatedTextProps extends Omit<TypographyProps, 'children' | 'ellipsi
  * description that merely repeats the visible text.
  *
  * Whether the text is truncated can't be derived from the string — it depends on
- * the rendered width — so it is measured, and re-measured on resize. That is
- * what keeps it correct as a card reflows, a column resizes, or the sidebar rail
- * changes width.
+ * the rendered width — so it has to be measured. That measurement happens when
+ * the pointer or focus arrives, not at mount.
+ *
+ * Measuring at mount is the obvious approach and it does not work here. The
+ * reading is only correct once the row's width constraint has reached this span,
+ * and the tree remounts its rows during first render: the instance that survives
+ * can take its one measurement while still unconstrained, conclude it fits, and
+ * be stuck there. Nothing corrects it afterwards, because a ResizeObserver on
+ * this span never fires again — an ancestor clamps the row, so the text
+ * overflows inside a box whose own size stops changing.
+ *
+ * Reading on hover sidesteps all of that. It is the only moment the answer is
+ * needed, the layout is settled by then, and nothing is cached across remounts
+ * or resizes that could go stale.
  */
 export const TruncatedText = ({ children, ...props }: TruncatedTextProps) => {
-  const textRef = useRef<HTMLSpanElement>(null);
+  const textRef = useRef<HTMLSpanElement | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
 
-  useLayoutEffect(() => {
+  const checkTruncation = () => {
     const el = textRef.current;
-    if (!el) {
-      return;
-    }
 
-    const checkTruncation = () => {
+    if (el) {
       setIsTruncated(el.scrollWidth > el.clientWidth);
-    };
+    }
+  };
 
-    checkTruncation();
+  // A ref callback rather than useRef alone, so the first measurement happens
+  // when the node attaches and again whenever it is replaced. The tree remounts
+  // its rows during first render, and a value measured against the discarded
+  // node would never be revisited — this re-runs against the node that survives.
+  const attachRef = (el: HTMLSpanElement | null) => {
+    textRef.current = el;
 
-    const observer = new ResizeObserver(checkTruncation);
-    observer.observe(el);
+    if (el) {
+      checkTruncation();
+    }
+  };
 
-    return () => observer.disconnect();
-  }, [children]);
-
-  const text = (
-    <Typography ref={textRef} ellipsis {...props}>
-      {children}
-    </Typography>
+  // The Tooltip stays mounted and the *label* is what's conditional, rather than
+  // swapping between a wrapped and unwrapped span. Swapping loses the first
+  // hover: the measurement that decides to show a tooltip is itself triggered by
+  // the pointer arriving, so the trigger would mount underneath a pointer that
+  // has already entered, and Radix — which starts watching at mount — sees no
+  // enter event and stays closed until the pointer leaves and returns.
+  //
+  // With `label` empty the DS Tooltip renders its child as-is and attaches
+  // nothing, so untruncated text still costs no DOM node and announces no
+  // description duplicating what is already on screen.
+  return (
+    <Tooltip label={isTruncated ? children : undefined}>
+      <Typography
+        ref={attachRef}
+        ellipsis
+        // Focus is covered as well as hover: the tooltip has to be reachable by
+        // keyboard, and these rows are buttons.
+        onPointerEnter={checkTruncation}
+        onFocus={checkTruncation}
+        {...props}
+      >
+        {children}
+      </Typography>
+    </Tooltip>
   );
-
-  if (isTruncated) {
-    // The DS Tooltip renders as its child, so this adds no DOM node — the
-    // Typography stays the same flex/grid item it was and layout is untouched.
-    return <Tooltip label={children}>{text}</Tooltip>;
-  }
-
-  return text;
 };


### PR DESCRIPTION
### What does it do?

`TruncatedText` decides whether to show a tooltip by measuring `scrollWidth > clientWidth`. That measurement used to happen once in a layout effect, and the result did not survive: the folder tree replaces a row's DOM node on the frame after mount, leaving the component holding the answer it computed against the discarded node.

Nothing corrected it afterwards. The `ResizeObserver` watched the span itself, and once laid out that box stops changing — an ancestor clamps the row, so the text overflows inside a fixed-width box. The observer never fired again and the "it fits" verdict became permanent.

Changes:

* Measure from a ref callback, so the reading happens when the node attaches and again whenever it is replaced.
* Re-measure on pointer enter and focus, so it stays correct as the rail, column or card resizes.
* Keep the `Tooltip` always mounted and make the `label` conditional, instead of wrapping the span only once truncated. Wrapping on demand lost the first hover: the measurement is triggered by the pointer arriving, so the trigger mounted underneath a pointer that had already entered, and Radix stayed closed until the pointer left and came back.

With an empty `label` the design-sysogtem `Tooltip` renders its child as-is, so text that fits still adds no DOM node and announces no description.og

### Why is it needed?

Long folder and asset names are visibly clipped with an ellipsis but show no tooltip on hover, so there is no way to read the full name. This affects the folder tree in the sidebar, the cards in grid view, and the name column in table view.

Resizing the browser window made the tooltips appear, because that finally changed the observed box. That made the bug look intermittent and easy to miss when testing.

### How to test it?

Run `examples/getstarted` with the new media library enabled:

```bash
cd examples/getstarted
BETA_MEDIA_LIBRARY=true yarn develop
```

Create a folder with a name long enough to be clipped in the sidebar (around 100 characters), then:

1. Open the Media Library and let the page settle. **Do not resize the window** — resizing hides the bug.
2. Hover the clipped folder name in the sidebar tree. The tooltip should appear on the **first** hover and show the full name.
3. Switch to grid view and hover a clipped folder or asset card name. Same result.
4. Switch to table view and hover a clipped name in the name column. Same result.
5. Hover a short name that is not clipped anywhere. No tooltip should appear.
6. Tab to a clipped folder row in the sidebar. The tooltip should appear on focus.

Automated tests:

```bash
npx jest --config packages/core/upload/jest.config.front.js TruncatedText
```

Note these pass either way. `TruncatedText.test.tsx` stubs `scrollWidth`/`clientWidth` on `Element.prototype`, so the real measurement path is never exercised and the suite also passes against the broken code. The manual steps above are what actually verify this fix.

### Related issue(s)/PR(s)

fix [CMS-1607](https://linear.app/strapi/issue/CMS-1607/tooltip-on-truncated-names-never-appears-in-the-new-media-library)

Follow-up to strapi/strapi#27334, which introduced `TruncatedText`.