### PR TITLE
fix(admin): clear a field's validation error when its value changes

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -12,6 +12,7 @@ import { WarningCircle } from '@strapi/icons';
 import { generateNKeysBetween } from 'fractional-indexing';
 import { produce, type Draft } from 'immer';
 import isEqual from 'lodash/isEqual';
+import toPath from 'lodash/toPath';
 import { useIntl, type MessageDescriptor, type PrimitiveType } from 'react-intl';
 import { useBlocker } from 'react-router-dom';
 
@@ -602,6 +603,35 @@ const setDraftValues = <TFormValues extends FormValues>(
   draft.values = values as Draft<TFormValues>;
 };
 
+/**
+ * Removes the error message a field is holding onto once its value changes, so a message left
+ * behind by a rejected submission (e.g. the server-side `<field> must be defined.` of a required
+ * field) does not survive the user fixing the field.
+ *
+ * Errors are keyed at the field path whilst the value can be updated at a path nested within it —
+ * relations write their value to `<field>.connect` / `<field>.disconnect` — so the ancestors of the
+ * changed path are cleared too. Only actual messages (a string or a `MessageDescriptor`) are
+ * removed: nested error structures are left alone so that changing one row of a repeatable
+ * component or a dynamic zone does not wipe the errors of its siblings.
+ */
+const clearErrorsForField = <TFormValues extends FormValues>(
+  errors: FormErrors<TFormValues>,
+  field: string
+): FormErrors<TFormValues> => {
+  const path = toPath(field);
+
+  return path.reduceRight<FormErrors<TFormValues>>((acc, _, index) => {
+    const currentPath = path.slice(0, index + 1).join('.');
+    const error = getIn(acc, currentPath);
+
+    if (typeof error === 'string' || isErrorMessageDescriptor(error)) {
+      return setIn(acc, currentPath, undefined);
+    }
+
+    return acc;
+  }, errors);
+};
+
 type FormActions<TFormValues extends FormValues = FormValues> =
   | { type: 'SUBMIT_ATTEMPT' }
   | { type: 'SUBMIT_FAILURE' }
@@ -640,9 +670,18 @@ const reducer = <TFormValues extends FormValues = FormValues>(
       case 'SUBMIT_SUCCESS':
         draft.isSubmitting = false;
         break;
-      case 'SET_FIELD_VALUE':
+      case 'SET_FIELD_VALUE': {
         setDraftValues(draft, setIn(state.values, action.payload.field, action.payload.value));
+
+        const errors = clearErrorsForField(state.errors, action.payload.field);
+
+        if (errors !== state.errors) {
+          // @ts-expect-error – TODO: figure out why this fails a TS check.
+          draft.errors = errors;
+        }
+
         break;
+      }
       case 'ADD_FIELD_ROW': {
         /**
          * TODO: add check for if the field is an array?

--- a/packages/core/admin/admin/src/components/tests/FormRelationStaleError.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/FormRelationStaleError.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Reproduction for https://github.com/strapi/strapi/issues/27248 — mechanism level.
+ *
+ * A required relation's server-side validation error is stored at the field path (`author`),
+ * while connecting a relation writes to `author.connect`. The Form reducer's `SET_FIELD_VALUE`
+ * only replaces values, so the error at `author` survives the change and `useField('author').error`
+ * keeps returning the stale message until the next `validate()`/`resetForm()`.
+ */
+import { act } from '@testing-library/react';
+import { renderHook } from '@tests/utils';
+
+import { Form, useField, useForm } from '../Form';
+
+const REQUIRED_ERROR = 'author must be defined.';
+
+const createFormWrapper = () =>
+  function ({ children }: { children: React.ReactNode }) {
+    return (
+      <Form method="PUT" initialValues={{}} initialErrors={{ author: REQUIRED_ERROR }}>
+        {children}
+      </Form>
+    );
+  };
+
+describe('required relation error is not cleared when the relation is connected (issue #27248)', () => {
+  it('clears the error at `author` once `author.connect` receives a relation', () => {
+    const { result } = renderHook(
+      () => ({
+        field: useField('author'),
+        onChange: useForm('test', (state) => state.onChange),
+        values: useForm('test', (state) => state.values),
+      }),
+      { wrapper: createFormWrapper() }
+    );
+
+    // the state left behind by a rejected publish
+    expect(result.current.field.error).toBe(REQUIRED_ERROR);
+
+    // the user connects a relation, exactly like RelationsField.handleConnect does
+    act(() => {
+      result.current.onChange('author.connect', [{ id: 7, documentId: 'david-doe' }]);
+    });
+
+    // the value really changed
+    expect(result.current.values).toEqual({
+      author: { connect: [{ id: 7, documentId: 'david-doe' }] },
+    });
+
+    // reported expectation: the error should be gone
+    expect(result.current.field.error).toBeUndefined();
+  });
+});

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/RequiredRelationStaleError.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/RequiredRelationStaleError.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Reproduction for https://github.com/strapi/strapi/issues/27248
+ *
+ * A required relation keeps its "<field> must be defined." validation error — the error the
+ * server returns and `DocumentActions` writes into form state with
+ * `setErrors(formatValidationErrors(res.error))` after a rejected save/publish — even after the
+ * user connects a relation, because the value change lands on `<field>.connect` while the error
+ * lives at `<field>`, and the shared Form reducer never clears errors on `SET_FIELD_VALUE`.
+ */
+import { Form } from '@strapi/admin/strapi-admin';
+import { render as renderRTL, screen, server, waitFor } from '@tests/utils';
+import { http, HttpResponse } from 'msw';
+import { Route, Routes } from 'react-router-dom';
+
+import { RelationsInput } from '../Relations';
+
+const REQUIRED_ERROR = 'relations must be defined.';
+
+const render = () =>
+  renderRTL(
+    // `initialErrors` reproduces the state left behind by a rejected publish: the server-side
+    // validation error keyed at the relation field path.
+    <Form method="PUT" initialValues={{}} initialErrors={{ relations: REQUIRED_ERROR }}>
+      {({ values }) => (
+        <>
+          <RelationsInput
+            attribute={{
+              type: 'relation',
+              relation: 'manyToOne',
+              target: 'api::category.category',
+              inversedBy: 'relation_locales',
+              // @ts-expect-error – this is what the API returns
+              targetModel: 'api::category.category',
+              relationType: 'manyToOne',
+            }}
+            label="relations"
+            mainField={{ name: 'name', type: 'string' }}
+            name="relations"
+            type="relation"
+            required
+            id="12345"
+            model="api::address.address"
+            isRelatedToCurrentDocument
+          />
+          <div data-testid="form-values">{JSON.stringify(values)}</div>
+        </>
+      )}
+    </Form>,
+    {
+      renderOptions: {
+        wrapper: ({ children }) => (
+          <Routes>
+            <Route path="/content-manager/:collectionType/:slug/:id" element={children} />
+          </Routes>
+        ),
+      },
+      initialEntries: ['/content-manager/collection-types/api::address.address/12345'],
+    }
+  );
+
+describe('Relations – required relation keeps a stale validation error (issue #27248)', () => {
+  beforeEach(() => {
+    // The relation is empty, so only one entry is available to connect.
+    server.use(
+      http.get('/content-manager/relations/:model/:fieldName', () =>
+        HttpResponse.json({
+          results: [
+            {
+              id: 7,
+              documentId: 'david-doe',
+              locale: 'en',
+              status: 'draft',
+              name: 'David Doe',
+            },
+          ],
+          pagination: { page: 1, pageCount: 1, total: 1 },
+        })
+      )
+    );
+  });
+
+  it('clears the required-relation error as soon as a relation is connected', async () => {
+    const { user } = render();
+
+    // Pre-condition: the error left behind by the rejected publish is on screen.
+    expect(await screen.findByText(REQUIRED_ERROR)).toBeInTheDocument();
+
+    // The user fills the relation the normal way.
+    await user.click(await screen.findByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: /David Doe/ }));
+
+    // The change really landed in form state, at `relations.connect`.
+    await waitFor(() => {
+      expect(screen.getByTestId('form-values')).toHaveTextContent('"connect"');
+    });
+    // eslint-disable-next-line no-console
+    console.log('form values after connect:', screen.getByTestId('form-values').textContent);
+
+    // Reported expectation: the error should be gone now, without another save/publish.
+    expect(screen.queryByText(REQUIRED_ERROR)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### What does it do?

SET_FIELD_VALUE now drops the message stored for the changed path and for its ancestors (relations write to `<field>.connect`/`<field>.disconnect`). Only plain messages are removed, so editing one row of a repeatable component or dynamic zone leaves its siblings' errors untouched.

### Why is it needed?

A required relation kept its server-side " must be defined." error after the user connected a relation: the error is stored in Form state at the field path by DocumentActions' setErrors(formatValidationErrors(res.error)) when a save/publish is rejected, while connecting writes the value to `<field>.connect`, and the reducer's SET_FIELD_VALUE never touched errors — so the message only disappeared on the next validate()/resetForm(), i.e. after another save or publish.

### How to test it?

* Follow reproduction of strapi/strapi#27248

### Related issue(s)/PR(s)

* Fixes strapi/strapi#27248