### PR TITLE
fix(types): support exactOptionalPropertyTypes on Document Service inputs

### DIFF
--- a/packages/core/core/src/services/document-service/attributes/index.ts
+++ b/packages/core/core/src/services/document-service/attributes/index.ts
@@ -8,6 +8,11 @@ import transforms from './transforms';
 type Data = Modules.Documents.Params.Data.Input<UID.Schema>;
 
 const applyTransforms = curry((schema: Schema.Schema, data: Data) => {
+  // NOTE: this iterates the *data* keys, so unlike the rest of the write path it does visit keys
+  // that were passed explicitly as `undefined`. The input types deliberately allow that
+  // (`{ foo: undefined }` must behave like `{}` — see `processData` in `@strapi/database`), so
+  // every transform registered below has to leave a non-matching value untouched rather than
+  // assume a present key holds a value.
   const attributeNames = Object.keys(data) as Array<keyof typeof data & string>;
 
   for (const attributeName of attributeNames) {

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -52,7 +52,7 @@
     "doc:ts": "typedoc",
     "doc:ts:watch": "typedoc --watch",
     "lint": "run -T eslint . --max-warnings=0",
-    "test:ts": "run -T tsc -p tsconfig.json",
+    "test:ts": "run -T tsc -p tsconfig.json && run -T tsc -p tests/tsconfig.json",
     "watch": "run -T tsc -p tsconfig.build.json -w"
   },
   "dependencies": {

--- a/packages/core/types/src/modules/documents/params/attributes/index.ts
+++ b/packages/core/types/src/modules/documents/params/attributes/index.ts
@@ -74,16 +74,27 @@ export type ScalarValues = GetValue<
 
 /**
  * Attribute.GetValues override with extended values
+ *
+ * @remark
+ * Optional properties explicitly allow `undefined` so that the type stays usable under
+ * `exactOptionalPropertyTypes`. This mirrors the runtime, which does not distinguish an absent key
+ * from an explicitly `undefined` one: the database layer iterates the schema attributes and skips
+ * any value failing `isUndefined` (see `processData` in `@strapi/database`), so `{}` and
+ * `{ foo: undefined }` produce the exact same query.
+ *
+ * Note that `null` is *not* equivalent: it means "write NULL" and must keep being spelled out.
+ *
+ * The required branch below (`-?`) is intentionally left alone.
  */
 export type GetValues<TSchemaUID extends UID.Schema> = {
-  id?: ID;
-  documentId?: DocumentID;
+  id?: ID | undefined;
+  documentId?: DocumentID | undefined;
 } & OmitRelationsWithoutTarget<
   TSchemaUID,
   {
-    [TKey in Schema.OptionalAttributeNames<TSchemaUID>]?: GetValue<
-      Schema.AttributeByName<TSchemaUID, TKey>
-    >;
+    [TKey in Schema.OptionalAttributeNames<TSchemaUID>]?:
+      | GetValue<Schema.AttributeByName<TSchemaUID, TKey>>
+      | undefined;
   } & {
     [TKey in Schema.RequiredAttributeNames<TSchemaUID>]-?: GetValue<
       Schema.AttributeByName<TSchemaUID, TKey>

--- a/packages/core/types/src/modules/documents/params/attributes/relations.ts
+++ b/packages/core/types/src/modules/documents/params/attributes/relations.ts
@@ -1,30 +1,30 @@
 import type * as Schema from '../../../../schema';
 
 import type * as UID from '../../../../uid';
-import type { If } from '../../../../utils';
+import type { If, Object } from '../../../../utils';
 
 import type { ID, DocumentID } from './id';
 
 type ShortHand = ID;
 type LongHandEntity = { id: ID };
-type LongHandDocument = { documentId: DocumentID; locale?: string };
+type LongHandDocument = { documentId: DocumentID; locale?: string | undefined };
 type LongHand = LongHandEntity | LongHandDocument;
 
 interface PositionalArguments {
-  before?: ID;
-  after?: ID;
-  start?: boolean;
-  end?: boolean;
+  before?: ID | undefined;
+  after?: ID | undefined;
+  start?: boolean | undefined;
+  end?: boolean | undefined;
 }
 
-type WithPositionArguments<T> = T & { position?: PositionalArguments };
+type WithPositionArguments<T> = T & { position?: PositionalArguments | undefined };
 
 type Set = { set: ShortHand[] | LongHand[] | null };
 type Connect = { connect: ShortHand[] | WithPositionArguments<LongHand>[] };
 type Disconnect = { disconnect: ShortHand[] | LongHand[] };
 
 type FullUpdate = Set;
-type PartialUpdate = Partial<Connect & Disconnect>;
+type PartialUpdate = Object.PartialWithUndefined<Connect & Disconnect>;
 
 type XOneInput = ShortHand | LongHand | null;
 type XManyInput = ShortHand[] | LongHand[] | null | PartialUpdate | FullUpdate;

--- a/packages/core/types/src/modules/documents/params/data.ts
+++ b/packages/core/types/src/modules/documents/params/data.ts
@@ -67,6 +67,6 @@ export type Input<TSchemaUID extends UID.Schema> = AttributeUtils.GetValues<TSch
  */
 export type PartialInput<TSchemaUID extends UID.Schema> = Utils.If<
   Utils.Constants.AreSchemaRegistriesExtended,
-  Partial<Input<TSchemaUID>>,
+  Utils.Object.PartialWithUndefined<Input<TSchemaUID>>,
   Input<TSchemaUID>
 >;

--- a/packages/core/types/src/modules/documents/params/index.ts
+++ b/packages/core/types/src/modules/documents/params/index.ts
@@ -1,5 +1,5 @@
 import type * as UID from '../../../uid';
-import { Extends, MatchAllIntersect } from '../../../utils';
+import { Extends, MatchAllIntersect, Object } from '../../../utils';
 
 import type { GetPluginParams } from '..';
 
@@ -17,24 +17,39 @@ import type * as Locale from './locale';
 // Utils
 import type * as Attribute from './attributes';
 
+/**
+ * @remark
+ * Every optional param below explicitly allows `undefined` so that callers compiling with
+ * `exactOptionalPropertyTypes` can forward their own optional values (`{ populate: maybePopulate }`)
+ * without having to conditionally spread each key. This is a no-op when the flag is off.
+ */
 export type Pick<TSchemaUID extends UID.Schema, TKind extends Kind> = MatchAllIntersect<
   [
     // Sort
-    [HasMember<TKind, 'sort'>, { sort?: Sort.Any<TSchemaUID> }],
-    [HasMember<TKind, 'sort:string'>, { sort?: Sort.StringNotation<TSchemaUID> }],
-    [HasMember<TKind, 'sort:array'>, { sort?: Sort.ArrayNotation<TSchemaUID> }],
-    [HasMember<TKind, 'sort:object'>, { sort?: Sort.ObjectNotation<TSchemaUID> }],
+    [HasMember<TKind, 'sort'>, { sort?: Sort.Any<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'sort:string'>, { sort?: Sort.StringNotation<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'sort:array'>, { sort?: Sort.ArrayNotation<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'sort:object'>, { sort?: Sort.ObjectNotation<TSchemaUID> | undefined }],
     // Fields
-    [HasMember<TKind, 'fields'>, { fields?: Fields.Any<TSchemaUID> }],
-    [HasMember<TKind, 'fields:string'>, { fields?: Fields.StringNotation<TSchemaUID> }],
-    [HasMember<TKind, 'fields:array'>, { fields?: Fields.ArrayNotation<TSchemaUID> }],
+    [HasMember<TKind, 'fields'>, { fields?: Fields.Any<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'fields:string'>, { fields?: Fields.StringNotation<TSchemaUID> | undefined }],
+    [HasMember<TKind, 'fields:array'>, { fields?: Fields.ArrayNotation<TSchemaUID> | undefined }],
     // Filters
-    [HasMember<TKind, 'filters'>, { filters?: Filters.Any<TSchemaUID> }],
+    [HasMember<TKind, 'filters'>, { filters?: Filters.Any<TSchemaUID> | undefined }],
     // Populate
-    [HasMember<TKind, 'populate'>, { populate?: Populate.Any<TSchemaUID> }],
-    [HasMember<TKind, 'populate:string'>, { populate?: Populate.StringNotation<TSchemaUID> }],
-    [HasMember<TKind, 'populate:array'>, { populate?: Populate.ArrayNotation<TSchemaUID> }],
-    [HasMember<TKind, 'populate:object'>, { populate?: Populate.ObjectNotation<TSchemaUID> }],
+    [HasMember<TKind, 'populate'>, { populate?: Populate.Any<TSchemaUID> | undefined }],
+    [
+      HasMember<TKind, 'populate:string'>,
+      { populate?: Populate.StringNotation<TSchemaUID> | undefined },
+    ],
+    [
+      HasMember<TKind, 'populate:array'>,
+      { populate?: Populate.ArrayNotation<TSchemaUID> | undefined },
+    ],
+    [
+      HasMember<TKind, 'populate:object'>,
+      { populate?: Populate.ObjectNotation<TSchemaUID> | undefined },
+    ],
     // Pagination
     [HasMember<TKind, 'pagination'>, Pagination.Any],
     [HasMember<TKind, 'pagination:offset'>, Pagination.OffsetNotation],
@@ -45,18 +60,21 @@ export type Pick<TSchemaUID extends UID.Schema, TKind extends Kind> = MatchAllIn
     [HasMember<TKind, 'hasPublishedVersion'>, PublicationStatus.Param],
     [HasMember<TKind, 'publicationFilter'>, PublicationStatus.PublicationFilterParam],
     // Locale
-    [HasMember<TKind, 'locale'>, { locale?: Locale.Any }],
-    [HasMember<TKind, 'locale:string'>, { locale?: Locale.StringNotation }],
-    [HasMember<TKind, 'locale:array'>, { locale?: Locale.ArrayNotation }],
+    [HasMember<TKind, 'locale'>, { locale?: Locale.Any | undefined }],
+    [HasMember<TKind, 'locale:string'>, { locale?: Locale.StringNotation | undefined }],
+    [HasMember<TKind, 'locale:array'>, { locale?: Locale.ArrayNotation | undefined }],
     // Plugin
     [HasMember<TKind, 'plugin'>, GetPluginParams<TSchemaUID>],
     // Data
-    [HasMember<TKind, 'data'>, { data?: Data.Input<TSchemaUID> }],
-    [HasMember<TKind, 'data:partial'>, { data?: Partial<Data.Input<TSchemaUID>> }],
+    [HasMember<TKind, 'data'>, { data?: Data.Input<TSchemaUID> | undefined }],
+    [
+      HasMember<TKind, 'data:partial'>,
+      { data?: Object.PartialWithUndefined<Data.Input<TSchemaUID>> | undefined },
+    ],
     // Search
-    [HasMember<TKind, '_q'>, { _q?: Search.Q }],
+    [HasMember<TKind, '_q'>, { _q?: Search.Q | undefined }],
     // Look Up - For internal use only
-    [HasMember<TKind, 'lookup'>, { lookup?: Record<string, unknown> }],
+    [HasMember<TKind, 'lookup'>, { lookup?: Record<string, unknown> | undefined }],
   ]
 >;
 

--- a/packages/core/types/src/modules/documents/params/pagination.ts
+++ b/packages/core/types/src/modules/documents/params/pagination.ts
@@ -1,13 +1,13 @@
 import type { XOR } from '../../../utils';
 
 export type PageNotation = {
-  page?: number;
-  pageSize?: number;
+  page?: number | undefined;
+  pageSize?: number | undefined;
 };
 
 export type OffsetNotation = {
-  start?: number;
-  limit?: number;
+  start?: number | undefined;
+  limit?: number | undefined;
 };
 
 export type Any = XOR<PageNotation, OffsetNotation>;

--- a/packages/core/types/src/modules/documents/params/status.ts
+++ b/packages/core/types/src/modules/documents/params/status.ts
@@ -5,9 +5,9 @@ export type Kind = 'draft' | 'published';
 export type { PublicationFilterMode };
 
 export type Param = {
-  status?: Kind;
+  status?: Kind | undefined;
   /** @deprecated Use `publicationFilter` instead (`never-published`, `has-published-version`, …). */
-  hasPublishedVersion?: boolean;
+  hasPublishedVersion?: boolean | undefined;
 };
 
-export type PublicationFilterParam = { publicationFilter?: PublicationFilterMode };
+export type PublicationFilterParam = { publicationFilter?: PublicationFilterMode | undefined };

--- a/packages/core/types/src/utils/object.ts
+++ b/packages/core/types/src/utils/object.ts
@@ -99,6 +99,34 @@ export type PartialBy<TValue, TKeys extends keyof TValue> = Omit<TValue, TKeys> 
   Partial<Pick<TValue, TKeys>>;
 
 /**
+ * Same as the built-in `Partial<TValue>`, but also adds `undefined` to every property type.
+ *
+ * @template TValue The original object type.
+ *
+ * @remark
+ * The built-in `Partial` only adds the `?` modifier; it does not add `undefined` to the property
+ * type. Under `exactOptionalPropertyTypes`, `{ foo?: string }` rejects `{ foo: undefined }`, so
+ * `Partial` alone is not enough to describe an input object whose properties may be explicitly set
+ * to `undefined`.
+ *
+ * Use this helper for **input** types where an absent property and an explicitly `undefined` one are
+ * handled identically at runtime. It is a no-op when `exactOptionalPropertyTypes` is disabled.
+ *
+ * @example
+ * ```typescript
+ * type Person = { name: string; age: number };
+ *
+ * declare const age: number | undefined;
+ *
+ * const a: Partial<Person> = { age };              // error under exactOptionalPropertyTypes
+ * const b: PartialWithUndefined<Person> = { age }; // ok
+ * ```
+ */
+export type PartialWithUndefined<TValue> = {
+  [TKey in keyof TValue]?: TValue[TKey] | undefined;
+};
+
+/**
  * Extracts all unique values from a given object as a union type.
  *
  * @template TObject - An object from which values are to be extracted. It must extend the `object` type.

--- a/packages/core/types/tests/exact-optional-property-types.ts
+++ b/packages/core/types/tests/exact-optional-property-types.ts
@@ -1,0 +1,250 @@
+/**
+ * Type-level fixture compiled with `exactOptionalPropertyTypes: true`.
+ *
+ * The repository default is `exactOptionalPropertyTypes: false`, under which `p?: T` and
+ * `p?: T | undefined` are indistinguishable — meaning the regression this file guards against is
+ * invisible in the regular `test:ts` program. It therefore has its own tsconfig
+ * (`tests/tsconfig.json`) that turns the flag on.
+ *
+ * What it asserts:
+ *
+ *  - optional **input** properties accept an explicit `undefined` (an absent key and an explicitly
+ *    `undefined` one are handled identically by the runtime — `processData` in `@strapi/database`
+ *    iterates the schema attributes and skips anything failing `isUndefined`);
+ *  - `null` keeps meaning "write NULL" and is still rejected where the schema does not allow it;
+ *  - required attributes are still required, and still reject `undefined`.
+ *
+ * This file is type-checked only; nothing is executed.
+ */
+
+/* eslint-disable no-void -- `void` marks the calls as type-checked-only, never awaited */
+
+import type { Modules, Schema, Struct } from '../src';
+
+/* -------------------------------------------------------------------------------------------------
+ * Fixture schemas
+ * ---------------------------------------------------------------------------------------------- */
+
+interface AddressComponent extends Struct.ComponentSchema {
+  collectionName: 'components_default_addresses';
+  category: 'default';
+  info: { displayName: 'Address' };
+  attributes: {
+    street: Schema.Attribute.String & Schema.Attribute.Required;
+    zipCode: Schema.Attribute.String;
+  };
+}
+
+interface Organization extends Struct.CollectionTypeSchema {
+  collectionName: 'organizations';
+  info: { singularName: 'organization'; pluralName: 'organizations'; displayName: 'Organization' };
+  attributes: {
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
+interface Invoice extends Struct.CollectionTypeSchema {
+  collectionName: 'invoices';
+  info: { singularName: 'invoice'; pluralName: 'invoices'; displayName: 'Invoice' };
+  attributes: {
+    // Required scalar
+    amount: Schema.Attribute.Decimal & Schema.Attribute.Required;
+    // Optional scalars
+    description: Schema.Attribute.Text;
+    issuedByUserId: Schema.Attribute.Integer;
+    // Optional xToOne relation
+    organization: Schema.Attribute.Relation<'oneToOne', 'api::organization.organization'>;
+    // Optional component
+    billingAddress: Schema.Attribute.Component<'default.address', false>;
+    // Optional JSON column
+    metadata: Schema.Attribute.JSON;
+  };
+}
+
+declare module '../src/public/registries' {
+  export interface ContentTypeSchemas {
+    'api::invoice.invoice': Invoice;
+    'api::organization.organization': Organization;
+  }
+
+  export interface ComponentSchemas {
+    'default.address': AddressComponent;
+  }
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * The caller's own domain type — the shape that triggered the bug
+ * ---------------------------------------------------------------------------------------------- */
+
+type IssueInvoiceCommand = {
+  organizationDocumentId: string;
+  amount: number;
+  description?: string;
+  issuedByUserId?: number;
+  metadata?: Record<string, string>;
+};
+
+declare const command: IssueInvoiceCommand;
+declare const documents: Modules.Documents.ServiceInstance<'api::invoice.invoice'>;
+
+/* -------------------------------------------------------------------------------------------------
+ * create() — explicit `undefined` on optional properties
+ * ---------------------------------------------------------------------------------------------- */
+
+// Every optional field is forwarded as `T | undefined` straight from the caller's own optional
+// properties, without conditional spreads or an undefined-stripping helper.
+void documents.create({
+  data: {
+    amount: command.amount,
+    description: command.description,
+    issuedByUserId: command.issuedByUserId,
+    metadata: command.metadata,
+    organization: { documentId: command.organizationDocumentId },
+    billingAddress: undefined,
+  },
+});
+
+// Explicit `undefined` on the relation and the component too.
+void documents.create({
+  data: {
+    amount: 1,
+    organization: undefined,
+    billingAddress: undefined,
+    description: undefined,
+    metadata: undefined,
+  },
+});
+
+// `id` / `documentId` are optional input properties as well.
+void documents.create({
+  data: {
+    amount: 1,
+    id: undefined,
+    documentId: undefined,
+  },
+});
+
+// Optional properties of the relation long-hand notation.
+void documents.create({
+  data: {
+    amount: 1,
+    organization: { documentId: 'abc', locale: undefined },
+  },
+});
+
+// Component input reuses the same machinery: optional member accepts `undefined`, required does not.
+void documents.create({
+  data: {
+    amount: 1,
+    billingAddress: { street: 'Main street', zipCode: undefined },
+  },
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * `null` still means "write NULL" and is not interchangeable with `undefined`
+ * ---------------------------------------------------------------------------------------------- */
+
+// Relations explicitly accept `null` (clear the relation).
+void documents.create({
+  data: {
+    amount: 1,
+    organization: null,
+  },
+});
+
+// A nullable JSON column accepts `null`.
+void documents.create({
+  data: {
+    amount: 1,
+    metadata: null,
+  },
+});
+
+// A non-nullable scalar does not silently gain `null` from this change.
+void documents.create({
+  data: {
+    amount: 1,
+    // @ts-expect-error `null` is not a valid value for a text attribute
+    description: null,
+  },
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * Required attributes stay required — the `-?` branch of GetValues is untouched
+ * ---------------------------------------------------------------------------------------------- */
+
+// @ts-expect-error `amount` is required and missing
+void documents.create({ data: { description: 'no amount' } });
+
+void documents.create({
+  data: {
+    // @ts-expect-error `amount` is required and cannot be explicitly undefined
+    amount: undefined,
+  },
+});
+
+void documents.create({
+  data: {
+    amount: 1,
+    // @ts-expect-error `street` is required on the component and cannot be explicitly undefined
+    billingAddress: { street: undefined },
+  },
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * update() — the `data:partial` fragment goes through PartialWithUndefined
+ * ---------------------------------------------------------------------------------------------- */
+
+void documents.update({
+  documentId: 'abc',
+  data: {
+    amount: command.amount,
+    description: command.description,
+    issuedByUserId: command.issuedByUserId,
+    organization: undefined,
+  },
+});
+
+// Every property is optional on update, including the ones that are required on create.
+void documents.update({
+  documentId: 'abc',
+  data: { amount: undefined },
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * Top-level method params — `{ data, populate: maybePopulate }` hits the same wall
+ * ---------------------------------------------------------------------------------------------- */
+
+declare const maybeLocale: string | undefined;
+declare const maybeStatus: 'draft' | 'published' | undefined;
+declare const maybeFields: ['description'] | undefined;
+declare const maybePopulate: ['organization'] | undefined;
+declare const maybeSearch: string | undefined;
+declare const maybeLimit: number | undefined;
+
+void documents.create({
+  data: { amount: 1 },
+  locale: maybeLocale,
+  status: maybeStatus,
+  fields: maybeFields,
+  populate: maybePopulate,
+});
+
+void documents.findMany({
+  locale: maybeLocale,
+  status: maybeStatus,
+  fields: maybeFields,
+  populate: maybePopulate,
+  _q: maybeSearch,
+  limit: maybeLimit,
+  sort: undefined,
+  filters: undefined,
+});
+
+void documents.findOne({
+  documentId: 'abc',
+  locale: maybeLocale,
+  status: maybeStatus,
+  fields: maybeFields,
+  populate: maybePopulate,
+});

--- a/packages/core/types/tests/tsconfig.json
+++ b/packages/core/types/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    // The repository default is `false`. These fixtures exist specifically to guarantee the
+    // published input types stay usable for consumers who turn the flag on.
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["."],
+  "exclude": ["node_modules"]
+}

--- a/packages/core/types/tsconfig.eslint.json
+++ b/packages/core/types/tsconfig.eslint.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## What does it do?

Widens Document Service **input** types so optional properties accept explicit `undefined` under TypeScript's `exactOptionalPropertyTypes`.

- Adds `Object.PartialWithUndefined<T>` for input/`Partial` shapes where absent and `undefined` are equivalent at runtime
- Updates Document Service params (`data`, relations, pagination, status, top-level method options) to `?: T | undefined`
- Adds a dedicated EOPT type fixture (`packages/core/types/tests/`) wired into `@strapi/types` `test:ts`
- Documents that `applyTransforms` may see explicit `undefined` keys (same as `{}` after DB `processData`)

Required attributes (`-?`) and `null` (“write NULL”) are unchanged.

## Why is it needed?

With `exactOptionalPropertyTypes`, `{ foo?: string }` rejects `{ foo: undefined }` and forwarding optional caller fields (`description: command.description`) fails type-checking even though the runtime treats missing and `undefined` the same (`processData` skips `isUndefined` values).

Fixes #27336 (Document Service input slice). Does **not** enable EOPT repo-wide (#27314) or rewrite Content API / client result types.

## How to test it?

```bash
# Fixture fails on develop without these changes; passes with them
yarn workspace @strapi/types exec tsc -p tests/tsconfig.json

# Full types package check (includes EOPT fixture)
yarn workspace @strapi/types test:ts
```

Confirm:
- optional create/update fields accept `undefined`
- required fields still reject missing / `undefined`
- non-nullable scalars still reject `null`

## Related issue(s)/PR(s)

- Closes #27336 (scoped Document Service inputs)
- Related: #27288 (same approach — coordinate to avoid duplicate PRs)
- Follow-up: #27314 (enable EOPT across server workspaces)