### PR TITLE
fix(create-strapi-app): pin a better-sqlite3 release that supports Node 26

### DIFF
--- a/packages/cli/create-strapi-app/src/utils/database.ts
+++ b/packages/cli/create-strapi-app/src/utils/database.ts
@@ -107,7 +107,7 @@ export async function getDatabaseInfos(options: Options): Promise<DBConfig> {
 const sqlClientModule = {
   mysql: { mysql2: '3.20.0' },
   postgres: { pg: '8.20.0' },
-  sqlite: { 'better-sqlite3': '12.8.0' },
+  sqlite: { 'better-sqlite3': '12.11.1' },
 };
 
 export function addDatabaseDependencies(scope: Scope) {


### PR DESCRIPTION
### What does it do?

Moves the `better-sqlite3` version that `create-strapi-app` writes into a scaffolded SQLite app from `12.8.0` to `12.11.1`.

### Why is it needed?

`better-sqlite3@12.8.0` declares `engines.node` as `20.x || 22.x || 23.x || 24.x || 25.x`, and it has no Node 26 prebuild. A fresh SQLite app therefore fails the engine check on Node 26.

Strapi declares `>=20.0.0 <=26.x.x` and CI runs on 22, 24 and 26, so the default scaffold cannot install on a Node version the project advertises.

`12.11.1` is the last 12.x release. It adds `26.x` to its engines range and ships a Node 26 prebuild, so it covers the declared range without a major bump.

### How to test it?

On Node 26, scaffold an app with this branch's `create-strapi-app` and pick SQLite. The generated `package.json` should carry `"better-sqlite3": "12.11.1"`, and both the install and `strapi develop` should succeed.

### Related issue(s)/PR(s)

Fixes #27354

#27310 does the same bump to 13.0.3 across the whole repo, but it is blocked on raising `engines.node` to `>=22`. This one stays inside the current range, so it can land first if that wait turns out to be long.
