### PR TITLE
fix(content-manager): deduplicate MCP tool names when an api has multiple content types

### DIFF
--- a/docs/docs/docs/01-core/strapi/mcp-server.md
+++ b/docs/docs/docs/01-core/strapi/mcp-server.md
@@ -169,6 +169,7 @@ Content-manager derives one MCP tool set per **displayed** content type at boots
 `slugifyUidForMcpToolName` (`packages/core/content-manager/server/src/mcp/utils.ts`) turns a content-type UID into a tool-name segment:
 
 - `api::article.article` → `article`
+- `api::writer.editor` → `writer_editor` (api name and content-type name differ, so both are kept)
 - `plugin::i18n.locale` → `plugin-i18n_locale`
 
 ### Collection types

--- a/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
+++ b/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
@@ -304,6 +304,11 @@ describe('slugifyUidForMcpToolName', () => {
     expect(slugifyUidForMcpToolName('api::article.article')).toBe('article');
   });
 
+  it('includes the content-type suffix so api models sharing an api name stay unique', () => {
+    expect(slugifyUidForMcpToolName('api::writer.writer')).toBe('writer');
+    expect(slugifyUidForMcpToolName('api::writer.editor')).toBe('writer_editor');
+  });
+
   it('maps plugin UIDs to namespace-model_content-type per documented format', () => {
     expect(slugifyUidForMcpToolName('plugin::i18n.locale')).toBe('plugin-i18n_locale');
   });
@@ -347,6 +352,28 @@ describe('deriveDisplayedContentTypeMcpToolDefinitions', () => {
         'write_plugin-cms-basics_settings',
       ])
     );
+  });
+
+  it('derives unique tool names for api content types that share an api name', () => {
+    const models = [
+      baseModel({
+        uid: 'api::writer.writer',
+        apiID: 'writer',
+        kind: 'collectionType',
+      }),
+      baseModel({
+        uid: 'api::writer.editor',
+        apiID: 'editor',
+        kind: 'collectionType',
+      }),
+    ];
+
+    const tools = deriveDisplayedContentTypeMcpToolDefinitions(mockStrapi, models);
+    const names = tools.map((tool) => tool.name);
+    const uniqueNames = new Set(names);
+
+    expect(uniqueNames.size).toBe(names.length);
+    expect(names).toEqual(expect.arrayContaining(['list_writer', 'list_writer_editor']));
   });
 
   it('emits list/get with explorer.read for a collection type', () => {

--- a/packages/core/content-manager/server/src/mcp/utils.ts
+++ b/packages/core/content-manager/server/src/mcp/utils.ts
@@ -13,7 +13,7 @@ export const slugifyUidForMcpToolName = (uid: string): string => {
   const parts = modelName.split('.').map((part) => part.toLowerCase());
 
   if (namespace === 'api') {
-    return parts[0];
+    return parts[0] === parts[1] ? parts[0] : parts.join('_');
   }
 
   return `${namespace.toLowerCase()}-${parts.join('_')}`;

--- a/packages/core/content-manager/server/src/mcp/utils.ts
+++ b/packages/core/content-manager/server/src/mcp/utils.ts
@@ -6,7 +6,9 @@ import { shapeRelationsForMcp } from './sanitizers/shape-relations';
 
 /**
  * Converts a Strapi content-type UID into a safe MCP tool-name segment.
- * `api::article.article` → `article`; `plugin::i18n.locale` → `plugin-i18n_locale`.
+ * `api::article.article` → `article`; `api::writer.editor` → `writer_editor` (the api name and the
+ * content-type name differ, so both are kept to stay unique within the api);
+ * `plugin::i18n.locale` → `plugin-i18n_locale`.
  */
 export const slugifyUidForMcpToolName = (uid: string): string => {
   const [namespace, modelName] = uid.split('::');


### PR DESCRIPTION
### What does it do?

`slugifyUidForMcpToolName` now keeps the content-type segment of an `api::` UID when it differs from the api name, so `api::writer.editor` becomes `writer_editor`. `api::article.article` still maps to `article`, so tool names stay the same for the usual one-content-type-per-api layout.

### Why is it needed?

Two content types living in the same api both resolved to the api name, so the same tool name got registered twice and `McpCapabilityDefinitionRegistry` threw during the content-manager bootstrap. The whole application failed to start, and the error named the tool rather than the two UIDs behind it. #26710 fixed this for plugin namespaces but left the `api::` branch as it was.

### How to test it?

Unit tests:

```
yarn test:unit -- packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
```

In `examples/getstarted`, add a second content type under an existing api folder (for example `src/api/writer/content-types/editor`), set `mcp: { enabled: true }` in `config/server.js` and start the app. It boots, and the two content types show up as `list_writer` and `list_writer_editor`.

### Related issue(s)/PR(s)

- Fixes #27353
- Follow-up to #26710