### PR TITLE
fix(database): increment and decrement throw with a relation filter

### DIFF
--- a/packages/core/database/src/query/__tests__/increment-relation-subquery.test.ts
+++ b/packages/core/database/src/query/__tests__/increment-relation-subquery.test.ts
@@ -1,0 +1,135 @@
+import knex from 'knex';
+import { createEntityManager } from '../../entity-manager';
+import { createMetadata } from '../../metadata';
+
+const TEST_UID = 'api::test.test';
+const RELATED_UID = 'api::related.related';
+
+const models = [
+  {
+    uid: RELATED_UID,
+    singularName: 'related',
+    pluralName: 'relateds',
+    tableName: 'relateds',
+    attributes: {
+      id: { type: 'increments' },
+      title: { type: 'string' },
+    },
+  },
+  {
+    uid: TEST_UID,
+    singularName: 'test',
+    pluralName: 'tests',
+    tableName: 'tests',
+    attributes: {
+      id: { type: 'increments' },
+      name: { type: 'string' },
+      views: { type: 'integer' },
+      related: {
+        type: 'relation',
+        relation: 'manyToOne',
+        target: RELATED_UID,
+      },
+    },
+  },
+];
+
+const makeDb = () => {
+  const connection = knex({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+
+  const metadata = createMetadata(models as any);
+
+  const db = {
+    connection,
+    metadata,
+    getConnection: (table?: string) => (table ? connection(table) : connection),
+    dialect: {
+      client: 'sqlite',
+      useReturning: () => false,
+      transformErrors(e: Error) {
+        throw e;
+      },
+    },
+    lifecycles: {
+      run: jest.fn(async () => undefined),
+    },
+  } as any;
+
+  return { db, connection };
+};
+
+const setupTables = async (connection: knex.Knex) => {
+  await connection.schema.createTable('relateds', (t) => {
+    t.increments('id');
+    t.string('title');
+  });
+  await connection.schema.createTable('tests', (t) => {
+    t.increments('id');
+    t.string('name');
+    t.integer('views').defaultTo(0);
+  });
+  await connection.schema.createTable('tests_related_lnk', (t) => {
+    t.increments('id');
+    t.integer('test_id');
+    t.integer('related_id');
+  });
+  await connection('relateds').insert([{ title: 'Category A' }, { title: 'Category B' }]);
+  await connection('tests').insert([
+    { id: 1, name: 'Hugo LLORIS', views: 10 },
+    { id: 2, name: 'Samuel UMTITI', views: 10 },
+    { id: 3, name: 'Lucas HERNANDEZ', views: 10 },
+  ]);
+  await connection('tests_related_lnk').insert([
+    { test_id: 1, related_id: 1 },
+    { test_id: 2, related_id: 2 },
+    { test_id: 3, related_id: 1 },
+  ]);
+};
+
+describe('increment/decrement with relation filter subquery', () => {
+  it('increments only rows matching a nested relation where', async () => {
+    const { db, connection } = makeDb();
+    await setupTables(connection);
+    const em = createEntityManager(db);
+
+    await em
+      .createQueryBuilder(TEST_UID)
+      .init({ where: { related: { title: 'Category A' } } })
+      .increment('views', 2)
+      .execute();
+
+    const rows = await connection('tests').orderBy('id').select('name', 'views');
+    expect(rows).toEqual([
+      { name: 'Hugo LLORIS', views: 12 },
+      { name: 'Samuel UMTITI', views: 10 },
+      { name: 'Lucas HERNANDEZ', views: 12 },
+    ]);
+
+    await connection.destroy();
+  });
+
+  it('decrements only rows matching a nested relation where', async () => {
+    const { db, connection } = makeDb();
+    await setupTables(connection);
+    const em = createEntityManager(db);
+
+    await em
+      .createQueryBuilder(TEST_UID)
+      .init({ where: { related: { title: 'Category A' } } })
+      .decrement('views', 3)
+      .execute();
+
+    const rows = await connection('tests').orderBy('id').select('name', 'views');
+    expect(rows).toEqual([
+      { name: 'Hugo LLORIS', views: 7 },
+      { name: 'Samuel UMTITI', views: 10 },
+      { name: 'Lucas HERNANDEZ', views: 7 },
+    ]);
+
+    await connection.destroy();
+  });
+});

--- a/packages/core/database/src/query/query-builder.ts
+++ b/packages/core/database/src/query/query-builder.ts
@@ -437,6 +437,13 @@ const createQueryBuilder = (
 
     runSubQuery() {
       const originalType = state.type;
+      const data = state.data;
+      // Inner SELECT must not inherit increment/decrement SET clauses (getKnexQuery
+      // applies them after the type switch). Apply them on the outer write instead.
+      const increments = state.increments;
+      const decrements = state.decrements;
+      state.increments = [];
+      state.decrements = [];
 
       // Build the inner SELECT from a clone that stays `select`, so the outer write
       // state is never mutated. clone() shallow-merges state (shared where/joins,
@@ -447,13 +454,25 @@ const createQueryBuilder = (
       const subQB = sub.select('id').getKnexQuery();
 
       const nestedSubQuery = db.getConnection().select('id').from(subQB.as('subQuery'));
-      const qb = db.getConnection(tableName);
+      const qb = db.getConnection(tableName).whereIn('id', nestedSubQuery);
 
-      if (originalType === 'update') {
-        return qb.update(state.data).whereIn('id', nestedSubQuery);
+      if (originalType === 'delete') {
+        return qb.delete();
       }
 
-      return qb.delete().whereIn('id', nestedSubQuery);
+      if (data) {
+        qb.update(data);
+      }
+
+      if (!_.isEmpty(increments)) {
+        increments.forEach((incr) => qb.increment(incr.column, incr.amount));
+      }
+
+      if (!_.isEmpty(decrements)) {
+        decrements.forEach((decr) => qb.decrement(decr.column, decr.amount));
+      }
+
+      return qb;
     },
 
     processState() {


### PR DESCRIPTION
### What does it do?

`increment()` / `decrement()` with a relation filter now run through the joined-write subquery path: the inner query (cloned so it stays `select`) finds matching ids, and the outer query applies the increment/decrement SET clauses without calling knex `.update(null)`.

Stacked on #26909 so this uses the clone-based `runSubQuery` (outer type stays `update`/`delete`).

### Why is it needed?

This is a pre-existing bug on `develop` (flagged on #26909 as out of scope). `increment()` / `decrement()` set `type` to `update` with `data` still null, so the subquery write throws `Cannot convert undefined or null to object`. The increment clauses were also applied on the inner builder and dropped.

### How to test it?

```
yarn workspace @strapi/database test:unit src/query/__tests__/increment-relation-subquery.test.ts src/query/__tests__/relation-subquery.test.ts --forceExit
```

### Related issue(s)/PR(s)

Stacked on #26909 ([comment](https://github.com/strapi/strapi/pull/26909#discussion_r3768805884)). Related: CMS-1459.
