### PR TITLE
fix(upload): support object breakpoints for width/height-only resize

### DIFF
--- a/packages/core/upload/server/src/services/__tests__/upload/responsive-parallelism.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/responsive-parallelism.test.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 jest.mock('sharp', () => {
   const toFileState = { inFlight: 0, maxInFlight: 0 };
+  const resizeCalls: unknown[] = [];
   // `__setNextMetadata` — per-test image dimensions
   const nextMetadata: {
     value: { width: number | null; height: number | null; format: string };
@@ -19,12 +20,20 @@ jest.mock('sharp', () => {
     return { width: 100, height: 100, size: 1000 };
   });
 
-  const makeChain = () => ({
-    metadata: jest.fn().mockImplementation(() => Promise.resolve({ ...nextMetadata.value })),
-    resize: jest.fn().mockReturnThis(),
-    toFile,
-    on: jest.fn().mockReturnThis(),
-  });
+  const makeChain = () => {
+    const chain: Record<string, any> = {
+      metadata: jest.fn().mockImplementation(() => Promise.resolve({ ...nextMetadata.value })),
+      toFile,
+    };
+
+    chain.resize = jest.fn().mockImplementation((options: unknown) => {
+      resizeCalls.push(options);
+      return chain;
+    });
+    chain.on = jest.fn().mockReturnValue(chain);
+
+    return chain;
+  };
 
   return {
     __esModule: true,
@@ -35,6 +44,10 @@ jest.mock('sharp', () => {
         concurrency: jest.fn(),
         __getToFile: () => toFile,
         __getToFileState: () => toFileState,
+        __getResizeCalls: () => resizeCalls,
+        __clearResizeCalls() {
+          resizeCalls.length = 0;
+        },
         __setNextMetadata(m: { width: number | null; height: number | null; format: string }) {
           nextMetadata.value = m;
         },
@@ -90,16 +103,21 @@ const testFile: Parameters<typeof imageManipulation.generateResponsiveFormats>[0
 
 beforeEach(() => {
   uploadSettings.responsiveDimensions = true;
+  defaultConfig['plugin::upload'] = {
+    breakpoints: { large: 1000, medium: 750, small: 500 },
+  };
   const s = sharp as any;
   s.__setNextMetadata({ width: 2000, height: 2000, format: 'jpeg' });
   resetStrapi();
   s.__getToFile().mockClear();
   s.__getToFileState().inFlight = 0;
   s.__getToFileState().maxInFlight = 0;
+  s.__clearResizeCalls();
 });
 
 const getToFile = () => (sharp as any).__getToFile() as jest.Mock;
 const getToFileState = () => (sharp as any).__getToFileState() as { maxInFlight: number };
+const getResizeCalls = () => (sharp as any).__getResizeCalls() as unknown[];
 
 describe('generateResponsiveFormats (sequential resizes)', () => {
   test('never runs more than one toFile at a time for all breakpoints', async () => {
@@ -134,5 +152,70 @@ describe('generateResponsiveFormats (no toFile when nothing to resize)', () => {
     await imageManipulation.generateResponsiveFormats(testFile);
 
     expect(getToFile()).not.toHaveBeenCalled();
+  });
+});
+
+describe('generateResponsiveFormats (breakpoint shapes — #24221)', () => {
+  test('numeric breakpoints keep square inside fit (backward compatible)', async () => {
+    (defaultConfig['plugin::upload'] as { breakpoints: Record<string, unknown> }).breakpoints = {
+      large: 1000,
+    };
+    resetStrapi();
+
+    await imageManipulation.generateResponsiveFormats(testFile);
+
+    expect(getResizeCalls()).toEqual([{ width: 1000, height: 1000, fit: 'inside' }]);
+  });
+
+  test('object breakpoints can constrain width only for portrait-friendly scaling', async () => {
+    (defaultConfig['plugin::upload'] as { breakpoints: Record<string, unknown> }).breakpoints = {
+      large: { width: 1000 },
+    };
+    // Portrait source: height exceeds 1000, width does not — width-only config must still resize
+    // when width is larger, and skip when only height is larger.
+    (sharp as any).__setNextMetadata({ width: 1200, height: 500, format: 'jpeg' });
+    resetStrapi();
+
+    await imageManipulation.generateResponsiveFormats(testFile);
+
+    expect(getToFile()).toHaveBeenCalledTimes(1);
+    expect(getResizeCalls()).toEqual([{ fit: 'inside', width: 1000 }]);
+  });
+
+  test('width-only object breakpoint skips portrait images whose width already fits', async () => {
+    (defaultConfig['plugin::upload'] as { breakpoints: Record<string, unknown> }).breakpoints = {
+      large: { width: 1000 },
+    };
+    (sharp as any).__setNextMetadata({ width: 500, height: 1200, format: 'jpeg' });
+    resetStrapi();
+
+    await imageManipulation.generateResponsiveFormats(testFile);
+
+    expect(getToFile()).not.toHaveBeenCalled();
+    expect(getResizeCalls()).toEqual([]);
+  });
+
+  test('object breakpoints can constrain height only', async () => {
+    (defaultConfig['plugin::upload'] as { breakpoints: Record<string, unknown> }).breakpoints = {
+      large: { height: 1000, fit: 'inside' },
+    };
+    (sharp as any).__setNextMetadata({ width: 500, height: 1200, format: 'jpeg' });
+    resetStrapi();
+
+    await imageManipulation.generateResponsiveFormats(testFile);
+
+    expect(getToFile()).toHaveBeenCalledTimes(1);
+    expect(getResizeCalls()).toEqual([{ fit: 'inside', height: 1000 }]);
+  });
+
+  test('object breakpoints pass through custom fit', async () => {
+    (defaultConfig['plugin::upload'] as { breakpoints: Record<string, unknown> }).breakpoints = {
+      cover: { width: 800, height: 800, fit: 'cover' },
+    };
+    resetStrapi();
+
+    await imageManipulation.generateResponsiveFormats(testFile);
+
+    expect(getResizeCalls()).toEqual([{ fit: 'cover', width: 800, height: 800 }]);
   });
 });

--- a/packages/core/upload/server/src/services/image-manipulation.ts
+++ b/packages/core/upload/server/src/services/image-manipulation.ts
@@ -194,8 +194,35 @@ const DEFAULT_BREAKPOINTS = {
   small: 500,
 };
 
+/**
+ * Breakpoint config entry: a number keeps the historical square `inside` box, or a sharp
+ * `ResizeOptions` object for width/height/fit control (#24221).
+ */
+type BreakpointValue = number | ResizeOptions;
+
+const isBreakpointObject = (value: unknown): value is ResizeOptions =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const resolveBreakpointResizeOptions = (breakpoint: BreakpointValue): ResizeOptions => {
+  if (typeof breakpoint === 'number') {
+    return {
+      width: breakpoint,
+      height: breakpoint,
+      fit: 'inside',
+    };
+  }
+
+  return {
+    fit: 'inside',
+    ...breakpoint,
+  };
+};
+
 const getBreakpoints = () =>
-  strapi.config.get<Record<string, number>>('plugin::upload.breakpoints', DEFAULT_BREAKPOINTS);
+  strapi.config.get<Record<string, BreakpointValue>>(
+    'plugin::upload.breakpoints',
+    DEFAULT_BREAKPOINTS
+  );
 
 const generateResponsiveFormats = async (file: UploadableFile) => {
   const { responsiveDimensions = false } = (await getService('upload').getSettings()) ?? {};
@@ -210,7 +237,11 @@ const generateResponsiveFormats = async (file: UploadableFile) => {
   for (const key of Object.keys(breakpoints)) {
     const breakpoint = breakpoints[key];
 
-    if (breakpointSmallerThan(breakpoint, originalDimensions)) {
+    if (typeof breakpoint !== 'number' && !isBreakpointObject(breakpoint)) {
+      continue;
+    }
+
+    if (shouldGenerateBreakpoint(breakpoint, originalDimensions)) {
       results.push(await generateBreakpoint(key, { file, breakpoint }));
     }
   }
@@ -220,28 +251,43 @@ const generateResponsiveFormats = async (file: UploadableFile) => {
 
 const generateBreakpoint = async (
   key: string,
-  { file, breakpoint }: { file: UploadableFile; breakpoint: number }
+  { file, breakpoint }: { file: UploadableFile; breakpoint: BreakpointValue }
 ) => {
-  const newFile = await resizeFileTo(
-    file,
-    {
-      width: breakpoint,
-      height: breakpoint,
-      fit: 'inside',
-    },
-    {
-      name: `${key}_${file.name}`,
-      hash: `${key}_${file.hash}`,
-    }
-  );
+  const newFile = await resizeFileTo(file, resolveBreakpointResizeOptions(breakpoint), {
+    name: `${key}_${file.name}`,
+    hash: `${key}_${file.hash}`,
+  });
   return {
     key,
     file: newFile,
   };
 };
 
-const breakpointSmallerThan = (breakpoint: number, { width, height }: Dimensions) => {
-  return breakpoint < (width ?? 0) || breakpoint < (height ?? 0);
+/**
+ * Decide whether a responsive variant is needed for the given breakpoint and source size.
+ *
+ * - Numeric breakpoints (and objects with both width & height): generate when either side
+ *   exceeds the corresponding limit — same as the historical square-box behaviour.
+ * - Width-only / height-only objects: only compare that axis, so portrait images are not
+ *   forced through a max-height constraint when the user asked for max-width (#24221).
+ */
+const shouldGenerateBreakpoint = (breakpoint: BreakpointValue, dimensions: Dimensions): boolean => {
+  const { width, height } = dimensions;
+  const options = resolveBreakpointResizeOptions(breakpoint);
+
+  const exceedsWidth = typeof options.width === 'number' && width != null && options.width < width;
+  const exceedsHeight =
+    typeof options.height === 'number' && height != null && options.height < height;
+
+  if (typeof options.width === 'number' && options.height == null) {
+    return exceedsWidth;
+  }
+
+  if (typeof options.height === 'number' && options.width == null) {
+    return exceedsHeight;
+  }
+
+  return exceedsWidth || exceedsHeight;
 };
 
 /**


### PR DESCRIPTION
## What does it do?

Extends `plugin::upload.breakpoints` so each entry can be either:

- a **number** — existing behaviour (`width` + `height` = value, `fit: 'inside'`)
- a **Sharp `ResizeOptions` object** — e.g. `{ width: 1000 }` or `{ height: 1000, fit: 'inside' }`

Generation skips a breakpoint when the source already fits the constrained axis (width-only objects no longer resize portrait images solely because height exceeds the number).

## Why is it needed?

With numeric breakpoints, Sharp always gets a square box, so the **largest side** is clamped. Landscape `1200×500` → `1000×416` (expected); portrait `500×1200` → `416×1000` (often unwanted). Callers need width- or height-only control.

Fixes #24221

## How to test it?

```bash
yarn workspace @strapi/upload test:unit --testPathPattern='responsive-parallelism|image-manipulation|upload/uploadImage'
```

Manual: enable responsive dimensions, set `breakpoints: { large: { width: 1000 } }`, upload landscape and portrait images, confirm formats.

## Related issue(s)/PR(s)

- Fixes #24221