### PR TITLE
future(upload): dismiss the bulk-actions bar while the asset drawer is open

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -61,6 +61,7 @@ import {
 import { getAssetIcon } from '../../../../utils/getAssetIcon';
 import { getTranslationKey } from '../../../../utils/translations';
 import { useFolderInfo } from '../../hooks/useFolderInfo';
+import { ASSET_DETAILS_URL_PARAM, parseAssetDetailsId } from '../../hooks/useIsAssetDetailsOpen';
 import { BusyOverlay } from '../BusyOverlay';
 
 import { AssetCropEditor } from './AssetCropEditor';
@@ -70,9 +71,6 @@ import type {
   AssetWithPopulatedCreatedBy,
   FocalPoint,
 } from '../../../../../../../shared/contracts/files';
-
-// Name of the parameter to look for in the URL to open the drawer
-const URL_PARAM = 'assetId';
 
 interface DrawerToast {
   type: 'success' | 'danger';
@@ -120,15 +118,14 @@ const useAssetOperation = () => {
 };
 
 /* -------------------------------------------------------------------------------------------------
- * useAssetDetailsParam - sync drawer visibility with URL ?{URL_PARAM}={id}
+ * useAssetDetailsParam - sync drawer visibility with URL ?{ASSET_DETAILS_URL_PARAM}={id}
  * -----------------------------------------------------------------------------------------------*/
 
 export const useAssetDetailsParam = () => {
-  const [{ query }, setQuery] = useQueryParams<{ [URL_PARAM]?: string }>();
+  const [{ query }, setQuery] = useQueryParams<{ [ASSET_DETAILS_URL_PARAM]?: string }>();
 
-  const detailsId = query?.[URL_PARAM];
-  const assetId = detailsId ? parseInt(detailsId, 10) : null;
-  const hasValidId = assetId !== null && !Number.isNaN(assetId);
+  const assetId = parseAssetDetailsId(query?.[ASSET_DETAILS_URL_PARAM]);
+  const hasValidId = assetId !== null;
 
   // Closing is driven by removing the URL param (a navigation), so navigation
   // guards like <Blocker> can intercept it. `isMounted` keeps the drawer in the
@@ -157,13 +154,13 @@ export const useAssetDetailsParam = () => {
 
   const openDetails = React.useCallback(
     (id: number) => {
-      setQuery({ [URL_PARAM]: String(id) }, 'push', true);
+      setQuery({ [ASSET_DETAILS_URL_PARAM]: String(id) }, 'push', true);
     },
     [setQuery]
   );
 
   const closeDetails = React.useCallback(() => {
-    setQuery({ [URL_PARAM]: undefined }, 'remove', true);
+    setQuery({ [ASSET_DETAILS_URL_PARAM]: undefined }, 'remove', true);
   }, [setQuery]);
 
   return {

--- a/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
@@ -18,6 +18,7 @@ import { emptyItemLocations, type ItemLocations } from '../../../utils/itemLocat
 import { getTranslationKey } from '../../../utils/translations';
 import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useFolderNavigation } from '../hooks/useFolderNavigation';
+import { useIsAssetDetailsOpen } from '../hooks/useIsAssetDetailsOpen';
 
 import { BulkMoveDialog } from './BulkMoveDialog';
 import { DeleteItemsDialog } from './DeleteItemsDialog';
@@ -100,6 +101,7 @@ export const BulkActionsBar = ({
   const { canUpdate } = useMediaLibraryPermissions();
   const { selectedIds, selectedFolderIds, clear } = useAssetSelection();
   const { currentFolderId } = useFolderNavigation();
+  const isDetailsDrawerOpen = useIsAssetDetailsOpen();
   const [generateAiMetadata, { isLoading: isGeneratingMetadata }] = useGenerateAiMetadataMutation();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
@@ -245,7 +247,14 @@ export const BulkActionsBar = ({
   // without the permission, the bar has nothing to offer — drop it entirely
   // rather than show a count + "Clear selection" over no actions (mirrors the
   // drawer footer, which hides when no permitted action survives).
-  if (count === 0 || !canUpdate) {
+  //
+  // The details drawer owns the bottom of the screen while it is open. It is
+  // fixed to `bottom: 0` too, and its z-index of 200 is pinned below the
+  // overlay token on purpose, so the bar (popover, 500) covers the drawer's own
+  // footer actions — and, because the drawer is non-modal, keeps taking clicks
+  // through it. The selection itself is untouched: the bar returns unchanged
+  // when the drawer closes.
+  if (count === 0 || !canUpdate || isDetailsDrawerOpen) {
     return null;
   }
 

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/BulkActionsBar.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/BulkActionsBar.test.tsx
@@ -1,0 +1,126 @@
+import { useQueryParams } from '@strapi/admin/strapi-admin';
+import { render, screen, waitFor } from '@tests/utils';
+
+import { AssetSelectionProvider, useAssetSelection } from '../../hooks/useAssetSelection';
+import { BulkActionsBar } from '../BulkActionsBar';
+
+import type { File } from '../../../../../../../shared/contracts/files';
+
+const mockToggleNotification = jest.fn();
+const mockAIAvailability = jest.fn(() => false);
+
+jest.mock('@strapi/admin/strapi-admin', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin'),
+  useNotification: () => ({ toggleNotification: mockToggleNotification }),
+}));
+
+jest.mock('@strapi/admin/strapi-admin/ee', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin/ee'),
+  useAIAvailability: () => mockAIAvailability(),
+}));
+
+jest.mock('../../hooks/useFolderNavigation', () => ({
+  useFolderNavigation: () => ({ currentFolderId: null }),
+}));
+
+const mockAssets: File[] = [
+  { id: 1, name: 'image1.png', mime: 'image/png', ext: '.png', url: '/image1.png' } as File,
+  { id: 2, name: 'image2.png', mime: 'image/png', ext: '.png', url: '/image2.png' } as File,
+];
+
+/**
+ * Drives the real `AssetSelectionProvider` and the real URL query params, so
+ * "the selection survives" is genuinely asserted rather than faked by a
+ * static mock.
+ */
+const Harness = () => {
+  const { toggle } = useAssetSelection();
+  const [, setQuery] = useQueryParams<{ assetId?: string }>();
+
+  return (
+    <>
+      <button onClick={() => toggle('asset:1')}>Toggle asset 1</button>
+      <button onClick={() => toggle('asset:2')}>Toggle asset 2</button>
+      <button onClick={() => setQuery({ assetId: '1' }, 'push', true)}>Open drawer</button>
+      <button onClick={() => setQuery({ assetId: undefined }, 'remove', true)}>Close drawer</button>
+      <BulkActionsBar assets={mockAssets} />
+    </>
+  );
+};
+
+const setup = (initialEntries?: string[]) =>
+  render(
+    <AssetSelectionProvider>
+      <Harness />
+    </AssetSelectionProvider>,
+    { initialEntries }
+  );
+
+describe('BulkActionsBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('is visible with a selection and no details param', async () => {
+    const { user } = setup();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+    await user.click(screen.getByRole('button', { name: 'Toggle asset 2' }));
+
+    expect(await screen.findByRole('region', { name: 'Bulk actions' })).toBeInTheDocument();
+    expect(screen.getByText('2 items selected')).toBeInTheDocument();
+  });
+
+  it('is hidden while the details drawer is open', async () => {
+    const { user } = setup();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+    await user.click(screen.getByRole('button', { name: 'Toggle asset 2' }));
+    await screen.findByRole('region', { name: 'Bulk actions' });
+
+    await user.click(screen.getByRole('button', { name: 'Open drawer' }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole('region', { name: 'Bulk actions' })).not.toBeInTheDocument()
+    );
+  });
+
+  it('returns with the selection intact once the drawer closes', async () => {
+    const { user } = setup();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+    await user.click(screen.getByRole('button', { name: 'Toggle asset 2' }));
+    await screen.findByRole('region', { name: 'Bulk actions' });
+
+    await user.click(screen.getByRole('button', { name: 'Open drawer' }));
+    await waitFor(() =>
+      expect(screen.queryByRole('region', { name: 'Bulk actions' })).not.toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close drawer' }));
+
+    expect(await screen.findByRole('region', { name: 'Bulk actions' })).toBeInTheDocument();
+    expect(screen.getByText('2 items selected')).toBeInTheDocument();
+  });
+
+  // Covers deep links and reloads, which take a different path from the case
+  // above: the param is already in the URL on mount rather than added later.
+  // Selecting after render (rather than asserting on an empty selection)
+  // proves the bar is hidden because the drawer is open, not merely because
+  // nothing is selected yet.
+  it('stays hidden from the first render when the URL already carries the param', async () => {
+    const { user } = setup(['/?assetId=1']);
+
+    await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+
+    expect(screen.queryByRole('region', { name: 'Bulk actions' })).not.toBeInTheDocument();
+  });
+
+  it('does not hide the bar for an unparseable param', async () => {
+    const { user } = setup(['/?assetId=abc']);
+
+    await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+
+    expect(await screen.findByRole('region', { name: 'Bulk actions' })).toBeInTheDocument();
+  });
+});

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useIsAssetDetailsOpen.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useIsAssetDetailsOpen.ts
@@ -1,0 +1,30 @@
+import { useQueryParams } from '@strapi/admin/strapi-admin';
+
+/** Name of the parameter to look for in the URL to open the asset details drawer. */
+export const ASSET_DETAILS_URL_PARAM = 'assetId';
+
+/**
+ * The asset id in the URL, or `null` when the param is absent or unparseable.
+ *
+ * One definition shared by the drawer (which needs the id) and the "is it open?"
+ * hook below, so the two can never disagree about what counts as open.
+ */
+export const parseAssetDetailsId = (raw: string | undefined): number | null => {
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+/**
+ * Whether the asset details drawer is open, derived purely from the URL.
+ *
+ * Deliberately separate from `useAssetDetailsParam`, which additionally owns the
+ * drawer's mount lifecycle: its `shouldRenderDrawer` only stays correct in the
+ * component wired to the close animation, so a second caller would strand it at
+ * `true`. Anything that just needs the answer reads this instead.
+ */
+export const useIsAssetDetailsOpen = (): boolean => {
+  const [{ query }] = useQueryParams<{ [ASSET_DETAILS_URL_PARAM]?: string }>();
+
+  return parseAssetDetailsId(query?.[ASSET_DETAILS_URL_PARAM]) !== null;
+};


### PR DESCRIPTION
### What does it do?

The bulk-actions bar no longer renders while the asset details drawer is open. The
selection is left completely untouched, so the bar returns with the same count and
the same items the moment the drawer closes.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

1. Multi-select several assets (grid and table view), then open one asset's drawer. The bar
   is gone and Delete / Copy link / Download / Save changes are all reachable and clickable.
2. Close the drawer — the bar returns with the same count.
3. Repeat at mobile width and desktop width; the behaviour is not viewport-conditional.
4. Deep-link `/admin/plugins/upload?assetId=<id>` and confirm nothing is odd on load.
5. With the drawer open, confirm the drawer's own delete-confirm alert dialog still renders
   above the drawer.

Automated:

```bash
yarn workspace @strapi/upload test:front --testPathPattern="BulkActionsBar|AssetsTable|AssetsGrid|AssetDetailsDrawer"
```


### Related issue(s)/PR(s)

- CMS-1614
