### PR TITLE
fix(admin): previous user's cached permissions after login without a page reload

### DIFF
--- a/packages/core/admin/admin/src/features/Auth.tsx
+++ b/packages/core/admin/admin/src/features/Auth.tsx
@@ -8,13 +8,7 @@ import { useTypedDispatch, useTypedSelector } from '../core/store/hooks';
 import { useStrapiApp } from '../features/StrapiApp';
 import { useIdleSessionLogout } from '../hooks/useIdleSessionLogout';
 import { useQueryParams } from '../hooks/useQueryParams';
-import {
-  getStoredToken,
-  login as loginAction,
-  logout as logoutAction,
-  setLocale,
-  setToken,
-} from '../reducer';
+import { getStoredToken, logout as logoutAction, setLocale, setToken } from '../reducer';
 import { adminApi } from '../services/api';
 import {
   useGetMeQuery,
@@ -25,6 +19,7 @@ import {
 } from '../services/auth';
 import { normalizeAdminLocale } from '../translations/normalizeAdminLocale';
 import { getOrCreateDeviceId } from '../utils/deviceId';
+import { establishAdminSession } from '../utils/establishAdminSession';
 import {
   attemptTokenRefresh,
   setOnSessionExpired,
@@ -296,12 +291,10 @@ const AuthProvider = ({
       if ('data' in res) {
         const { token } = res.data;
 
-        dispatch(
-          loginAction({
-            token,
-            persist: rememberMe,
-          })
-        );
+        establishAdminSession(dispatch, {
+          token,
+          persist: rememberMe,
+        });
       }
 
       return res;

--- a/packages/core/admin/admin/src/features/tests/Auth.test.tsx
+++ b/packages/core/admin/admin/src/features/tests/Auth.test.tsx
@@ -166,5 +166,6 @@ describe('AuthProvider session identity', () => {
     await user.click(screen.getByRole('button', { name: 'establish-session-b' }));
 
     await waitForUserB();
+    expect(window.localStorage.getItem('jwtToken')).toBe(null);
   });
 });

--- a/packages/core/admin/admin/src/features/tests/Auth.test.tsx
+++ b/packages/core/admin/admin/src/features/tests/Auth.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, server, waitFor } from '@tests/utils';
+import { http, HttpResponse } from 'msw';
+
+import { useTypedDispatch } from '../../core/store/hooks';
+import { establishAdminSession } from '../../utils/establishAdminSession';
+import { useAuth } from '../Auth';
+
+const TOKEN_A = 'token-user-a';
+const TOKEN_B = 'token-user-b';
+
+const USER_A = {
+  id: 1,
+  email: 'role-a@example.com',
+  firstname: 'Role',
+  lastname: 'A',
+  username: 'role-a',
+  preferedLanguage: 'en',
+  roles: [{ id: 1 }],
+};
+
+const USER_B = {
+  id: 2,
+  email: 'role-b@example.com',
+  firstname: 'Role',
+  lastname: 'B',
+  username: 'role-b',
+  preferedLanguage: 'en',
+  roles: [{ id: 2 }],
+};
+
+const PERMISSION_A = {
+  action: 'plugin::content-manager.explorer.read',
+  subject: 'api::featured.featured',
+};
+
+const PERMISSION_B = {
+  action: 'admin::marketplace.read',
+  subject: null,
+};
+
+let currentUser: 'a' | 'b' = 'a';
+
+const mockIdentityHandlers = () => {
+  server.use(
+    http.get('/admin/users/me', () =>
+      HttpResponse.json({
+        data: currentUser === 'a' ? USER_A : USER_B,
+      })
+    ),
+    http.get('/admin/users/me/permissions', () =>
+      HttpResponse.json({
+        data: currentUser === 'a' ? [PERMISSION_A] : [PERMISSION_B],
+      })
+    )
+  );
+};
+
+const IdentityProbe = () => {
+  const permissions = useAuth('IdentityProbe', (state) => state.permissions);
+  const user = useAuth('IdentityProbe', (state) => state.user);
+  const login = useAuth('IdentityProbe', (state) => state.login);
+  const isLoading = useAuth('IdentityProbe', (state) => state.isLoading);
+
+  return (
+    <div>
+      <div data-testid="identity-loading">{String(isLoading)}</div>
+      <div data-testid="identity-email">{user?.email ?? ''}</div>
+      <div data-testid="identity-actions">
+        {permissions.map((permission) => permission.action).join(',')}
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          void login({
+            email: USER_B.email,
+            password: 'Testing123!',
+            rememberMe: true,
+          });
+        }}
+      >
+        login-as-b
+      </button>
+    </div>
+  );
+};
+
+const EstablishSessionProbe = () => {
+  const dispatch = useTypedDispatch();
+
+  return (
+    <>
+      <IdentityProbe />
+      <button
+        type="button"
+        onClick={() => {
+          currentUser = 'b';
+          establishAdminSession(dispatch, { token: TOKEN_B });
+        }}
+      >
+        establish-session-b
+      </button>
+    </>
+  );
+};
+
+const waitForUserA = async () => {
+  await waitFor(() => expect(screen.getByTestId('identity-loading')).toHaveTextContent('false'));
+  expect(screen.getByTestId('identity-email')).toHaveTextContent(USER_A.email);
+  expect(screen.getByTestId('identity-actions')).toHaveTextContent(PERMISSION_A.action);
+  expect(screen.getByTestId('identity-actions')).not.toHaveTextContent(PERMISSION_B.action);
+};
+
+const waitForUserB = async () => {
+  await waitFor(() => expect(screen.getByTestId('identity-email')).toHaveTextContent(USER_B.email));
+  expect(screen.getByTestId('identity-actions')).toHaveTextContent(PERMISSION_B.action);
+  expect(screen.getByTestId('identity-actions')).not.toHaveTextContent(PERMISSION_A.action);
+};
+
+describe('AuthProvider session identity', () => {
+  beforeEach(() => {
+    currentUser = 'a';
+    window.localStorage.setItem('jwtToken', JSON.stringify(TOKEN_A));
+    window.localStorage.setItem('isLoggedIn', 'true');
+    mockIdentityHandlers();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('refetches the current user and permissions after login without a page reload', async () => {
+    server.use(
+      http.post('/admin/login', () => {
+        currentUser = 'b';
+        return HttpResponse.json({
+          data: {
+            token: TOKEN_B,
+            user: USER_B,
+          },
+        });
+      })
+    );
+
+    const { user } = render(<IdentityProbe />, {
+      providerOptions: {
+        permissions: () => [],
+      },
+    });
+
+    await waitForUserA();
+
+    await user.click(screen.getByRole('button', { name: 'login-as-b' }));
+
+    await waitForUserB();
+  });
+
+  it('refetches the current user and permissions after a new session is established without persist', async () => {
+    const { user } = render(<EstablishSessionProbe />, {
+      providerOptions: {
+        permissions: () => [],
+      },
+    });
+
+    await waitForUserA();
+
+    await user.click(screen.getByRole('button', { name: 'establish-session-b' }));
+
+    await waitForUserB();
+  });
+});

--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -21,7 +21,6 @@ import { useNotification } from '../../../features/Notifications';
 import { useTracking } from '../../../features/Tracking';
 import { useAPIErrorHandler } from '../../../hooks/useAPIErrorHandler';
 import { LayoutContent, UnauthenticatedLayout } from '../../../layouts/UnauthenticatedLayout';
-import { login } from '../../../reducer';
 import {
   useGetRegistrationInfoQuery,
   useRegisterAdminMutation,
@@ -29,6 +28,7 @@ import {
 } from '../../../services/auth';
 import { isBaseQueryError } from '../../../utils/baseQuery';
 import { getOrCreateDeviceId } from '../../../utils/deviceId';
+import { establishAdminSession } from '../../../utils/establishAdminSession';
 import { getByteSize } from '../../../utils/strings';
 import { translatedErrors } from '../../../utils/translatedErrors';
 
@@ -334,7 +334,7 @@ const Register = ({ hasAdmin }: RegisterProps) => {
     const res = await registerAdmin({ ...body, deviceId: getOrCreateDeviceId() });
 
     if ('data' in res) {
-      dispatch(login({ token: res.data.token }));
+      establishAdminSession(dispatch, { token: res.data.token });
 
       if (news) {
         // Only enable EE survey if user accepted the newsletter
@@ -368,7 +368,7 @@ const Register = ({ hasAdmin }: RegisterProps) => {
     const res = await registerUser({ ...body, deviceId: getOrCreateDeviceId() });
 
     if ('data' in res) {
-      dispatch(login({ token: res.data.token }));
+      establishAdminSession(dispatch, { token: res.data.token });
 
       if (news) {
         // Only enable EE survey if user accepted the newsletter

--- a/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
@@ -16,9 +16,9 @@ import {
   LayoutContent,
   UnauthenticatedLayout,
 } from '../../../layouts/UnauthenticatedLayout';
-import { login } from '../../../reducer';
 import { useResetPasswordMutation } from '../../../services/auth';
 import { isBaseQueryError } from '../../../utils/baseQuery';
+import { establishAdminSession } from '../../../utils/establishAdminSession';
 import { getByteSize } from '../../../utils/strings';
 import { translatedErrors } from '../../../utils/translatedErrors';
 
@@ -115,7 +115,7 @@ const ResetPassword = () => {
     const res = await resetPassword(body);
 
     if ('data' in res) {
-      dispatch(login({ token: res.data.token }));
+      establishAdminSession(dispatch, { token: res.data.token });
       navigate('/');
     }
   };

--- a/packages/core/admin/admin/src/reducer.ts
+++ b/packages/core/admin/admin/src/reducer.ts
@@ -76,8 +76,12 @@ const adminSlice = createSlice({
 
       if (!persist) {
         setCookie(AUTH_COOKIE_NAME, token);
+        // Drop a previous "remember me" token so getToken() cannot keep
+        // authenticating as the last persisted user after a new session.
+        window.localStorage.removeItem(STORAGE_KEYS.TOKEN);
       } else {
         window.localStorage.setItem(STORAGE_KEYS.TOKEN, JSON.stringify(token));
+        deleteCookie(AUTH_COOKIE_NAME);
       }
       window.localStorage.setItem(STORAGE_KEYS.STATUS, 'true');
       state.token = token;

--- a/packages/core/admin/admin/src/services/api.ts
+++ b/packages/core/admin/admin/src/services/api.ts
@@ -7,14 +7,14 @@ import { fetchBaseQuery } from '../utils/baseQuery';
  * @description This is the redux toolkit api for the admin panel, users
  * should use a combination of `enhanceEndpoints` to add their TagTypes
  * to utilise in their `injectEndpoints` construction for automatic cache
- * re-validation. We specifically do not store any tagTypes by default leaving
- * the API surface as small as possible. None of the data-fetching looks for the
- * StrapiApp are stored here either.
+ * re-validation. Keep the base tag list small; `'Me'` is included so session
+ * helpers can invalidate identity queries without casting. None of the
+ * data-fetching looks for the StrapiApp are stored here either.
  */
 const adminApi = createApi({
   reducerPath: 'adminApi',
   baseQuery: fetchBaseQuery(),
-  tagTypes: ['GuidedTourMeta', 'HomepageKeyStatistics', 'AiUsage', 'AiFeatureConfig'],
+  tagTypes: ['GuidedTourMeta', 'HomepageKeyStatistics', 'AiUsage', 'AiFeatureConfig', 'Me'],
   endpoints: () => ({}),
 });
 

--- a/packages/core/admin/admin/src/services/auth.ts
+++ b/packages/core/admin/admin/src/services/auth.ts
@@ -46,6 +46,7 @@ const authService = adminApi
         transformResponse(res: GetOwnPermissions.Response) {
           return res.data;
         },
+        providesTags: ['Me'],
       }),
       updateMe: builder.mutation<UpdateMe.Response['data'], UpdateMe.Request['body']>({
         query: (body) => ({

--- a/packages/core/admin/admin/src/tests/reducer.test.ts
+++ b/packages/core/admin/admin/src/tests/reducer.test.ts
@@ -135,5 +135,21 @@ describe('admin_app reducer', () => {
       reducer(undefined, login({ token: 'abcd', persist: false }));
       expect(localStorage.getItem('jwtToken')).toBe(null);
     });
+
+    it('login persist=false should clear a previously persisted token', () => {
+      localStorage.setItem('jwtToken', JSON.stringify('old-token'));
+
+      const result = reducer(undefined, login({ token: 'abcd', persist: false }));
+
+      expect(result.token).toBe('abcd');
+      expect(localStorage.getItem('jwtToken')).toBe(null);
+      expect(setCookie).toHaveBeenCalledWith('jwtToken', 'abcd');
+    });
+
+    it('login persist=true should clear a previous session cookie', () => {
+      reducer(undefined, login({ token: 'abcd', persist: true }));
+
+      expect(deleteCookie).toHaveBeenCalledWith('jwtToken');
+    });
   });
 });

--- a/packages/core/admin/admin/src/tests/reducer.test.ts
+++ b/packages/core/admin/admin/src/tests/reducer.test.ts
@@ -131,7 +131,7 @@ describe('admin_app reducer', () => {
       expect(deleteCookie).toHaveBeenCalledWith('jwtToken');
     });
 
-    it('login persist=false should not touch localStorage token', () => {
+    it('login persist=false should not persist a token in localStorage', () => {
       reducer(undefined, login({ token: 'abcd', persist: false }));
       expect(localStorage.getItem('jwtToken')).toBe(null);
     });

--- a/packages/core/admin/admin/src/utils/establishAdminSession.ts
+++ b/packages/core/admin/admin/src/utils/establishAdminSession.ts
@@ -4,11 +4,15 @@ import { adminApi } from '../services/api';
 import type { Dispatch } from '../core/store/configure';
 
 /**
- * Establish a new admin session and drop any cached API state from the
- * previous identity. Logout already calls `resetApiState`; login/register/
- * reset-password/SSO previously swapped the token without invalidating
- * `getMe` / `getMyPermissions`, so the panel kept rendering the prior
- * user's menus until a full reload.
+ * Establish a new admin session and refetch identity queries. `getMe` /
+ * `getMyPermissions` are keyed only by endpoint, not by token, so swapping
+ * the token without invalidating them keeps the previous user's menus until
+ * a full reload (see #27367).
+ *
+ * Do not call `resetApiState` here. That wipes `/admin/init` as well, so
+ * first-admin signup refetches `hasAdmin: true` while AuthPage is still
+ * mounted and redirects to Home instead of `/usecase`. Logout already resets
+ * the full API cache.
  *
  * @see https://github.com/strapi/strapi/issues/27367
  */
@@ -17,7 +21,7 @@ const establishAdminSession = (
   payload: { token: string; persist?: boolean }
 ): void => {
   dispatch(login(payload));
-  dispatch(adminApi.util.resetApiState());
+  dispatch(adminApi.util.invalidateTags(['Me']));
 };
 
 export { establishAdminSession };

--- a/packages/core/admin/admin/src/utils/establishAdminSession.ts
+++ b/packages/core/admin/admin/src/utils/establishAdminSession.ts
@@ -1,0 +1,23 @@
+import { login } from '../reducer';
+import { adminApi } from '../services/api';
+
+import type { Dispatch } from '../core/store/configure';
+
+/**
+ * Establish a new admin session and drop any cached API state from the
+ * previous identity. Logout already calls `resetApiState`; login/register/
+ * reset-password/SSO previously swapped the token without invalidating
+ * `getMe` / `getMyPermissions`, so the panel kept rendering the prior
+ * user's menus until a full reload.
+ *
+ * @see https://github.com/strapi/strapi/issues/27367
+ */
+const establishAdminSession = (
+  dispatch: Dispatch,
+  payload: { token: string; persist?: boolean }
+): void => {
+  dispatch(login(payload));
+  dispatch(adminApi.util.resetApiState());
+};
+
+export { establishAdminSession };

--- a/packages/core/admin/ee/admin/src/pages/AuthResponse.tsx
+++ b/packages/core/admin/ee/admin/src/pages/AuthResponse.tsx
@@ -5,8 +5,8 @@ import { useNavigate, useMatch } from 'react-router-dom';
 
 import { Page } from '../../../../admin/src/components/PageHelpers';
 import { useTypedDispatch } from '../../../../admin/src/core/store/hooks';
-import { login } from '../../../../admin/src/reducer';
 import { AUTH_COOKIE_NAME, getCookieValue } from '../../../../admin/src/utils/cookies';
+import { establishAdminSession } from '../../../../admin/src/utils/establishAdminSession';
 
 const AuthResponse = () => {
   const match = useMatch('/auth/login/:authResponse');
@@ -35,11 +35,9 @@ const AuthResponse = () => {
       const jwtToken = getCookieValue(AUTH_COOKIE_NAME);
 
       if (jwtToken) {
-        dispatch(
-          login({
-            token: jwtToken,
-          })
-        );
+        establishAdminSession(dispatch, {
+          token: jwtToken,
+        });
 
         navigate('/auth/login');
       } else {

--- a/packages/core/admin/ee/admin/src/pages/tests/AuthResponse.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/tests/AuthResponse.test.tsx
@@ -65,7 +65,7 @@ describe('<AuthResponse />', () => {
     );
   });
 
-  it('dispatches login and redirects on success with token', () => {
+  it('establishes an admin session and redirects on success with token', () => {
     (useMatch as jest.Mock).mockReturnValue({ params: { authResponse: 'success' } });
     (useNavigate as jest.Mock).mockReturnValue(navigateMock);
     (getCookieValue as jest.Mock).mockReturnValue('fake-token');

--- a/packages/core/admin/ee/admin/src/pages/tests/AuthResponse.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/tests/AuthResponse.test.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { useMatch, useNavigate } from 'react-router-dom';
 
-import { login } from '../../../../../admin/src/reducer';
 import { getCookieValue } from '../../../../../admin/src/utils/cookies';
+import { establishAdminSession } from '../../../../../admin/src/utils/establishAdminSession';
 import { AuthResponse } from '../AuthResponse';
 
 jest.mock('react-router-dom', () => ({
@@ -29,8 +29,8 @@ jest.mock('../../../../../admin/src/features/Auth', () => ({
   AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-jest.mock('../../../../../admin/src/reducer', () => ({
-  login: jest.fn(),
+jest.mock('../../../../../admin/src/utils/establishAdminSession', () => ({
+  establishAdminSession: jest.fn(),
 }));
 
 jest.mock('../../../../../admin/src/utils/cookies', () => ({
@@ -72,11 +72,9 @@ describe('<AuthResponse />', () => {
 
     render(<AuthResponse />);
 
-    expect(dispatchMock).toHaveBeenCalledWith(
-      login({
-        token: 'fake-token',
-      })
-    );
+    expect(establishAdminSession).toHaveBeenCalledWith(dispatchMock, {
+      token: 'fake-token',
+    });
     expect(navigateMock).toHaveBeenCalledWith('/auth/login');
   });
 


### PR DESCRIPTION
### What does it do?

After a new admin session is established (login, invite registration, reset password, or SSO), store the token and reset the admin RTK Query cache so `getMe` and `getMyPermissions` refetch as the new user. Session-cookie login also drops a leftover remember-me token so `getToken()` cannot keep authenticating as the previous user.

### Why is it needed?

The admin panel cached the previous user's profile and permissions for the lifetime of the page. A new authentication without a full reload left menus, avatar, and routes from the old user, while the server correctly returned 403.

### How to test it?

1. Create two roles with different Content Manager permissions (Role A can read a given single type; Role B cannot).
2. Log in as a Role A user and confirm the single type is listed.
3. In the same tab, without a full page reload, complete invite registration as a Role B user (or log in as Role B).
4. The Content Manager sidebar and avatar should match Role B. Clicking a type Role B cannot access should not be offered; a hard reload should not change the menu.

Frontend coverage: `packages/core/admin/admin/src/features/tests/Auth.test.tsx`.

### Related issue(s)/PR(s)

Fixes #27367