### PR TITLE
fix(upload): shorten the media library add assets label so it fits on one line

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/AssetDialog.tsx
+++ b/packages/core/upload/admin/src/components/AssetDialog/AssetDialog.tsx
@@ -166,7 +166,7 @@ export const AssetContent = ({
           <Modal.Title>
             {formatMessage({
               id: getTrad('header.actions.add-assets'),
-              defaultMessage: 'Add new assets',
+              defaultMessage: 'Add assets',
             })}
           </Modal.Title>
         </Modal.Header>
@@ -190,7 +190,7 @@ export const AssetContent = ({
           <Modal.Title>
             {formatMessage({
               id: getTrad('header.actions.add-assets'),
-              defaultMessage: 'Add new assets',
+              defaultMessage: 'Add assets',
             })}
           </Modal.Title>
         </Modal.Header>
@@ -207,7 +207,7 @@ export const AssetContent = ({
           <Modal.Title>
             {formatMessage({
               id: getTrad('header.actions.add-assets'),
-              defaultMessage: 'Add new assets',
+              defaultMessage: 'Add assets',
             })}
           </Modal.Title>
         </Modal.Header>
@@ -261,7 +261,7 @@ export const AssetContent = ({
         <Modal.Title>
           {formatMessage({
             id: getTrad('header.actions.add-assets'),
-            defaultMessage: 'Add new assets',
+            defaultMessage: 'Add assets',
           })}
         </Modal.Title>
       </Modal.Header>

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/BrowseStep.tsx
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/BrowseStep.tsx
@@ -284,7 +284,7 @@ export const BrowseStep = ({
                 <Button variant="secondary" startIcon={<Plus />} onClick={onAddAsset}>
                   {formatMessage({
                     id: getTrad('header.actions.add-assets'),
-                    defaultMessage: 'Add new assets',
+                    defaultMessage: 'Add assets',
                   })}
                 </Button>
               )

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/BrowseStep.test.tsx
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/BrowseStep.test.tsx
@@ -174,7 +174,7 @@ describe('BrowseStep', () => {
   it('calls onAddAsset callback', () => {
     const spy = jest.fn();
     const { getByText } = setup({ onAddAsset: spy, folders: [] });
-    fireEvent.click(getByText('Add new assets'));
+    fireEvent.click(getByText('Add assets'));
     expect(spy).toHaveBeenCalled();
   });
 

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/AddAssetStep.tsx
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/AddAssetStep.tsx
@@ -29,7 +29,7 @@ export const AddAssetStep = ({ onClose, onAddAsset, trackedLocation }: AddAssetS
         <Modal.Title>
           {formatMessage({
             id: getTrad('header.actions.add-assets'),
-            defaultMessage: 'Add new assets',
+            defaultMessage: 'Add assets',
           })}
         </Modal.Title>
       </Modal.Header>

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.tsx
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.tsx
@@ -109,7 +109,7 @@ export const PendingAssetStep = ({
         <Modal.Title>
           {formatMessage({
             id: getTrad('header.actions.add-assets'),
-            defaultMessage: 'Add new assets',
+            defaultMessage: 'Add assets',
           })}
         </Modal.Title>
       </Modal.Header>
@@ -138,7 +138,7 @@ export const PendingAssetStep = ({
             <Button size="S" onClick={onClickAddAsset}>
               {formatMessage({
                 id: getTrad('header.actions.add-assets'),
-                defaultMessage: 'Add new assets',
+                defaultMessage: 'Add assets',
               })}
             </Button>
           </Flex>

--- a/packages/core/upload/admin/src/pages/App/components/EmptyOrNoPermissions.tsx
+++ b/packages/core/upload/admin/src/pages/App/components/EmptyOrNoPermissions.tsx
@@ -63,7 +63,7 @@ export const EmptyOrNoPermissions = ({
           <Button variant="secondary" startIcon={<Plus />} onClick={onActionClick}>
             {formatMessage({
               id: getTrad('header.actions.add-assets'),
-              defaultMessage: 'Add new assets',
+              defaultMessage: 'Add assets',
             })}
           </Button>
         )

--- a/packages/core/upload/admin/src/pages/App/components/Header.tsx
+++ b/packages/core/upload/admin/src/pages/App/components/Header.tsx
@@ -103,7 +103,7 @@ export const Header = ({
             <Button startIcon={<Plus />} onClick={onToggleUploadAssetDialog} fullWidth>
               {formatMessage({
                 id: getTrad('header.actions.add-assets'),
-                defaultMessage: 'Add new assets',
+                defaultMessage: 'Add assets',
               })}
             </Button>
           </Flex>

--- a/packages/core/upload/admin/src/pages/App/components/tests/EmptyOrNoPermissions.test.tsx
+++ b/packages/core/upload/admin/src/pages/App/components/tests/EmptyOrNoPermissions.test.tsx
@@ -31,13 +31,13 @@ describe('EmptyOrNoPermissions', () => {
   test('canCreate', () => {
     const { getByText } = setup({});
 
-    expect(getByText('Add new assets')).toBeInTheDocument();
+    expect(getByText('Add assets')).toBeInTheDocument();
   });
 
   test('isFiltering and canCreate', () => {
     const { queryByText } = setup({ isFiltering: true });
 
-    expect(queryByText('Add new assets')).not.toBeInTheDocument();
+    expect(queryByText('Add assets')).not.toBeInTheDocument();
   });
 
   test('canRead and not canCreate', () => {

--- a/packages/core/upload/admin/src/pages/App/components/tests/__snapshots__/Header.test.tsx.snap
+++ b/packages/core/upload/admin/src/pages/App/components/tests/__snapshots__/Header.test.tsx.snap
@@ -368,7 +368,7 @@ exports[`Header renders 1`] = `
                 <span
                   class="c14"
                 >
-                  Add new assets
+                  Add assets
                 </span>
               </button>
             </div>

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -132,7 +132,7 @@
   "form.input.label.file-name": "File name",
   "form.upload-url.error.url.invalid": "One URL is invalid",
   "form.upload-url.error.url.invalids": "{number} URLs are invalids",
-  "header.actions.add-assets": "Add new assets",
+  "header.actions.add-assets": "Add assets",
   "header.actions.add-folder": "Add new folder",
   "folder.create.title": "New folder",
   "folder.create.title-in": "New folder in {folderName}",

--- a/tests/e2e/tests/admin/home.spec.ts
+++ b/tests/e2e/tests/admin/home.spec.ts
@@ -176,7 +176,7 @@ test.describe('Home as super admin', () => {
 
       // Upload an asset
       await navToHeader(page, ['Media Library'], 'Media Library');
-      await page.getByRole('button', { name: 'Add new assets' }).first().click();
+      await page.getByRole('button', { name: 'Add assets' }).first().click();
       await page
         .getByLabel('Drag & Drop here or')
         .setInputFiles('public/assets/administration_panel.png');

--- a/tests/e2e/tests/media-library/cancel-deletion.spec.ts
+++ b/tests/e2e/tests/media-library/cancel-deletion.spec.ts
@@ -25,9 +25,9 @@ describeOnCondition(process.env.BETA_MEDIA_LIBRARY !== 'true')('Media Library', 
       await navToHeader(page, ['Media Library'], 'Media Library');
 
       // Upload one asset so we have something to open and attempt to delete
-      await page.getByRole('button', { name: 'Add new assets' }).first().click();
+      await page.getByRole('button', { name: 'Add assets' }).first().click();
       await expect(
-        page.getByRole('dialog').getByRole('heading', { name: 'Add new assets' })
+        page.getByRole('dialog').getByRole('heading', { name: 'Add assets' })
       ).toBeVisible();
 
       const fileInput = page.getByRole('dialog').locator('input[type="file"]');
@@ -41,7 +41,7 @@ describeOnCondition(process.env.BETA_MEDIA_LIBRARY !== 'true')('Media Library', 
 
       // Stable media library does not show a toast on upload success; the dialog just closes
       await expect(
-        page.getByRole('dialog').getByRole('heading', { name: 'Add new assets' })
+        page.getByRole('dialog').getByRole('heading', { name: 'Add assets' })
       ).not.toBeVisible({ timeout: 15000 });
 
       // Open the first asset (the one we just uploaded) by clicking its card


### PR DESCRIPTION
### What does it do?

Changes the `header.actions.add-assets` label from "Add new assets" to "Add assets", along with the `defaultMessage` call sites and the tests that assert on it.

### Why is it needed?

The two header buttons in the Media Library share the width left by the title and the doc link, and at that width "Add new assets" wraps onto a second line. "Add new folder" still fits, so it is left alone. Dropping "new" keeps the asset label on one line, and it is also the wording the new media library already uses for the same action.

### How to test it?

Run the sandbox:

```bash
cd examples/getstarted
yarn develop
```

Open the Media Library. The primary button in the header reads "Add assets" on a single line, and the upload dialog it opens carries the same title.

### Related issue(s)/PR(s)

Fixes #27369