### PR TITLE
fix(upload): keep provider rejections handled while image manipulation runs

### DIFF
--- a/packages/core/upload/server/src/services/__tests__/resources/fast-provider-rejection.ts
+++ b/packages/core/upload/server/src/services/__tests__/resources/fast-provider-rejection.ts
@@ -1,0 +1,63 @@
+// Child script for upload/unhandled-rejection.test.ts: the thumbnail upload rejects while responsive
+// format generation still spans an event loop turn.
+import _ from 'lodash';
+import createUploadService from '../../upload';
+
+const defaultConfig = {
+  'plugin::upload': {
+    provider: 'local',
+  },
+};
+
+const nextTurn = () =>
+  new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+
+const providerMethods = {
+  async upload(file: { hash: string }) {
+    if (file.hash === 'thumbnail_image_d9b4f84424') {
+      throw new Error('provider rejected');
+    }
+  },
+};
+
+const imageManipulationMock = {
+  getDimensions: async () => ({ width: 1500, height: 1000 }),
+  isResizableImage: async () => true,
+  generateThumbnail: async () => ({ hash: 'thumbnail_image_d9b4f84424', ext: '.png' }),
+  async generateResponsiveFormats() {
+    await nextTurn();
+    return [];
+  },
+};
+
+const services: Record<string, any> = {
+  provider: providerMethods,
+  'image-manipulation': imageManipulationMock,
+};
+
+global.strapi = {
+  config: {
+    get: (configPath: any, defaultValue: any) => _.get(defaultConfig, configPath, defaultValue),
+  },
+  plugins: {
+    upload: {
+      services,
+      provider: providerMethods,
+      service: (name: string) => services[name],
+    },
+  },
+  plugin: (name: string) => global.strapi.plugins[name],
+} as any;
+
+const uploadService = createUploadService({ strapi: global.strapi } as any);
+
+uploadService
+  ._uploadImage({ hash: 'image_d9b4f84424', ext: '.png' } as any)
+  .then(() => {
+    console.log('upload resolved');
+  })
+  .catch((error: Error) => {
+    console.log(error.message);
+  });

--- a/packages/core/upload/server/src/services/__tests__/upload/unhandled-rejection.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/unhandled-rejection.test.ts
@@ -1,0 +1,20 @@
+// A provider that rejects faster than image manipulation used to take down the process
+// (github.com/strapi/strapi#27374). Jest evaluates tests in a vm context where `unhandledRejection`
+// never reaches `process`, so the check runs in a real node process.
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../../../../..');
+const scriptPath = path.join(__dirname, '../resources/fast-provider-rejection.ts');
+
+describe('Upload image with a failing provider', () => {
+  test('rejects the upload instead of terminating the process', () => {
+    const output = execFileSync(
+      process.execPath,
+      ['--unhandled-rejections=strict', '--import', 'tsx', scriptPath],
+      { cwd: repoRoot, encoding: 'utf8' }
+    );
+
+    expect(output.trim()).toBe('provider rejected');
+  }, 60000);
+});

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -47,6 +47,13 @@ const { MEDIA_CREATE, MEDIA_UPDATE, MEDIA_DELETE } = ALLOWED_WEBHOOK_EVENTS;
 const { ApplicationError, NotFoundError } = errors;
 const { bytesToKbytes } = fileUtils;
 
+// A rejection handler has to be attached in the same tick the operation starts, otherwise a fast
+// provider failure is an unhandled rejection until the awaited image manipulation gets to Promise.all.
+const queueOperation = <T>(queue: Promise<T>[], operation: Promise<T>) => {
+  Promise.resolve(operation).catch(() => {});
+  queue.push(operation);
+};
+
 export default ({ strapi }: { strapi: Core.Strapi }) => {
   const fileService = getService('file');
 
@@ -315,13 +322,13 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     const uploadPromises: Promise<void>[] = [];
 
     // Upload image
-    uploadPromises.push(getService('provider').upload(fileData));
+    queueOperation(uploadPromises, getService('provider').upload(fileData));
 
     // Generate & Upload thumbnail and responsive formats
     if (await isResizableImage(fileData)) {
       const thumbnailFile = await generateThumbnail(fileData);
       if (thumbnailFile) {
-        uploadPromises.push(uploadThumbnail(thumbnailFile));
+        queueOperation(uploadPromises, uploadThumbnail(thumbnailFile));
       }
 
       const formats = await generateResponsiveFormats(fileData);
@@ -329,7 +336,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         for (const format of formats) {
           // eslint-disable-next-line no-continue
           if (!format) continue;
-          uploadPromises.push(uploadResponsiveFormat(format));
+          queueOperation(uploadPromises, uploadResponsiveFormat(format));
         }
       }
     }
@@ -367,7 +374,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     const promises: Promise<unknown>[] = [];
 
     // Replace the main file
-    promises.push(getService('provider').replace(fileData, oldFile));
+    queueOperation(promises, getService('provider').replace(fileData, oldFile));
 
     const newFormatKeys = new Set<string>();
 
@@ -375,7 +382,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       const thumbnailFile = await generateThumbnail(fileData);
       if (thumbnailFile) {
         newFormatKeys.add('thumbnail');
-        promises.push(replaceFormat('thumbnail', thumbnailFile));
+        queueOperation(promises, replaceFormat('thumbnail', thumbnailFile));
       }
 
       const formats = await generateResponsiveFormats(fileData);
@@ -384,7 +391,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
           // eslint-disable-next-line no-continue
           if (!format) continue;
           newFormatKeys.add(format.key);
-          promises.push(replaceFormat(format.key, format.file));
+          queueOperation(promises, replaceFormat(format.key, format.file));
         }
       }
     }
@@ -397,7 +404,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       for (const oldKey of Object.keys(oldFile.formats)) {
         if (!newFormatKeys.has(oldKey)) {
           const oldFormat = oldFile.formats[oldKey] as File;
-          promises.push(strapi.plugin('upload').provider.delete(oldFormat));
+          queueOperation(promises, strapi.plugin('upload').provider.delete(oldFormat));
         }
       }
     }


### PR DESCRIPTION
### What does it do?

`uploadImage` and `replaceImage` collect provider operations in a list and only await that list at the end. Each operation now gets a no-op rejection handler attached in the tick it starts, through a small `queueOperation` helper. The promise stored in the list keeps its rejection, so the final `Promise.all` still surfaces the failure exactly as before.

### Why is it needed?

The main upload starts at the top of `uploadImage`, then `isResizableImage`, `generateThumbnail` and `generateResponsiveFormats` are awaited before `Promise.all` runs. A provider that fails fast, an S3 endpoint answering 403 for instance, rejects during one of those awaits with nothing listening. Node treats that as an unhandled rejection and, on its default setting, takes the whole Strapi process down instead of letting the request fail with a 5xx.

Attaching a handler inside the provider service is not enough. The `uploadThumbnail`, `uploadResponsiveFormat` and `replaceFormat` wrappers are async functions, so the promise sitting in the queue is the wrapper's own, and the delete calls in `replaceImage` are queued the same way. Each one needs its own handler.

### How to test it?

```bash
npx jest --config packages/core/upload/jest.config.js --rootDir packages/core/upload unhandled-rejection
```

The check runs in a real node process under `--unhandled-rejections=strict`, because jest evaluates tests in a vm context where the event never reaches `process`. On develop it fails with `Error: provider rejected` and the node crash banner. With this change the upload rejects and the process survives.

For a manual run, use `examples/getstarted` with `@strapi/provider-upload-aws-s3` pointed at credentials the endpoint rejects, then upload a resizable image. The request fails and the server keeps running.

### Related issue(s)/PR(s)

Fixes #27374
