### PR TITLE
docs: fix malformed URL and two dead links

### DIFF
--- a/docs/docs/api/Strapi.mdx
+++ b/docs/docs/api/Strapi.mdx
@@ -127,7 +127,7 @@ strapi.eventHub.emit('user.created', { username: 'johndoe', email: 'johndoe@exam
 
 In this example, we are emitting a `user.created` event with some data attached to it, and then listening for a user.updated event and logging the data. These events can be used to trigger actions within the Strapi application or to communicate with external systems.
 
-For more information on how to use the EventEmitter class and its methods, see the [Node.js documentation](ttps://nodejs.org/docs/latest-v18.x/api/events.html#class-eventemitter).
+For more information on how to use the EventEmitter class and its methods, see the [Node.js documentation](https://nodejs.org/docs/latest-v18.x/api/events.html#class-eventemitter).
 
 ### `strapi.startupLogger`
 

--- a/docs/docs/docs/01-core/admin/01-ee/02-audit-logs.md
+++ b/docs/docs/docs/01-core/admin/01-ee/02-audit-logs.md
@@ -10,7 +10,7 @@ tags:
 
 ## Summary
 
-Audit Logs provide a way to view the history of all user actions at Admin API level. This includes actions related to entries (including publish actions), media (including its folders), users, login & logout of admin users, components, roles, and permissions, you can see the list of all the default events [here](https://github.com/strapi/strapi/blob/main/packages/core/admin/ee/server/services/audit-logs.js#L9).
+Audit Logs provide a way to view the history of all user actions at Admin API level. This includes actions related to entries (including publish actions), media (including its folders), users, login & logout of admin users, components, roles, and permissions, you can see the list of all the default events [here](https://github.com/strapi/strapi/blob/main/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts).
 
 ## Backend design
 
@@ -59,4 +59,4 @@ To understand how we obtain this information, we need to know how we emit an eve
 strapi.eventHub.emit(name: Pick<Event, 'name'>, payload: Pick<Event, 'payload'>);
 ```
 
-First, we check the event is coming from admin requests and it's on our [default events](https://github.com/strapi/strapi/blob/main/packages/core/admin/ee/server/services/audit-logs.js#L9) list, then when creating our Audit Log, we retrieve the action and payload from this emitted event, where the first argument is the action or event name, and the second one is the payload. We obtain the user from the requestContext.
+First, we check the event is coming from admin requests and it's on our [default events](https://github.com/strapi/strapi/blob/main/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts) list, then when creating our Audit Log, we retrieve the action and payload from this emitted event, where the first argument is the action or event name, and the second one is the payload. We obtain the user from the requestContext.

--- a/docs/docs/docs/01-core/content-manager/06-preview.md
+++ b/docs/docs/docs/01-core/content-manager/06-preview.md
@@ -41,7 +41,7 @@ This is why the file has an unusual structure with many functions defined inline
 
 ### Field identification with stega
 
-We use [stega encoding](https://github.com/vercel/stega) to identify which Strapi field each piece of text comes from. Stega embeds invisible metadata into text content using Unicode zero-width characters that are imperceptible to users but can be decoded programmatically.
+We use [stega encoding](https://www.npmjs.com/package/@vercel/stega) to identify which Strapi field each piece of text comes from. Stega embeds invisible metadata into text content using Unicode zero-width characters that are imperceptible to users but can be decoded programmatically.
 
 1. The Document Service encodes field metadata into text values (invisible to users)
 2. The frontend renders the content normally


### PR DESCRIPTION
Three link defects found by a docs audit:

1. **docs/docs/api/Strapi.mdx**: the Node.js events API link is malformed - `(ttps://nodejs.org/...` is missing the leading `h`, so the link is broken. Fixed to `https://nodejs.org/docs/latest-v18.x/api/events.html` (verified 200).

2. **docs/.../admin/01-ee/02-audit-logs.md**: the "default events" link points to `packages/core/admin/ee/server/services/audit-logs.js#L9`, which no longer exists (the EE audit-logs code moved and is TypeScript now). Updated to the current `ee/server/src/audit-logs/services/audit-logs.ts` (verified in the repo tree; the stale `#L9` anchor is dropped).

3. **docs/.../content-manager/06-preview.md**: links to `github.com/vercel/stega`, which returns 404 (repo removed). Strapi depends on `@vercel/stega` (see `packages/core/core/package.json`), so the link now points to its npm package page.