### PR TITLE
docs(api): fix internal links to renamed EventHub and StrapiFS pages

### DIFF
--- a/docs/docs/api/Strapi.mdx
+++ b/docs/docs/api/Strapi.mdx
@@ -111,7 +111,7 @@ Wrapper around [FS NodeJS module](https://nodejs.org/docs/latest-v18.x/api/fs.ht
 
 The `strapi.eventHub` object is used to manipulate events within a Strapi project. It is an instance of the built-in EventEmitter class from Node.js, which provides a simple way to emit and listen for events.
 
-The `strapi.eventHub` object is created using the `createEventHub()` function in the [EventHub](EventHub) module of the Strapi core. This function returns a new instance of the EventHub class, which extends the EventEmitter class and adds some additional functionality specific to Strapi.
+The `strapi.eventHub` object is created using the `createEventHub()` function in the [EventHub](event-hub) module of the Strapi core. This function returns a new instance of the EventHub class, which extends the EventEmitter class and adds some additional functionality specific to Strapi.
 
 #### Examples:
 

--- a/docs/docs/api/Strapi.mdx
+++ b/docs/docs/api/Strapi.mdx
@@ -127,7 +127,7 @@ strapi.eventHub.emit('user.created', { username: 'johndoe', email: 'johndoe@exam
 
 In this example, we are emitting a `user.created` event with some data attached to it, and then listening for a user.updated event and logging the data. These events can be used to trigger actions within the Strapi application or to communicate with external systems.
 
-For more information on how to use the EventEmitter class and its methods, see the [Node.js documentation](ttps://nodejs.org/docs/latest-v18.x/api/events.html#class-eventemitter).
+For more information on how to use the EventEmitter class and its methods, see the [Node.js documentation](https://nodejs.org/docs/latest-v18.x/api/events.html#class-eventemitter).
 
 ### `strapi.startupLogger`
 

--- a/docs/docs/api/Strapi.mdx
+++ b/docs/docs/api/Strapi.mdx
@@ -101,13 +101,13 @@ Strapi server object.
 
 ### `strapi.fs`
 
-- [<Type>StrapiFS</Type>](StrapiFS)
+- [<Type>StrapiFS</Type>](strapi-fs)
 
 Wrapper around [FS NodeJS module](https://nodejs.org/docs/latest-v18.x/api/fs.html).
 
 ### `strapi.eventHub`
 
-- [<Type>EventHub</Type>](EventHub)
+- [<Type>EventHub</Type>](event-hub)
 
 The `strapi.eventHub` object is used to manipulate events within a Strapi project. It is an instance of the built-in EventEmitter class from Node.js, which provides a simple way to emit and listen for events.
 

--- a/docs/docs/docs/01-core/admin/01-ee/02-audit-logs.md
+++ b/docs/docs/docs/01-core/admin/01-ee/02-audit-logs.md
@@ -10,7 +10,7 @@ tags:
 
 ## Summary
 
-Audit Logs provide a way to view the history of all user actions at Admin API level. This includes actions related to entries (including publish actions), media (including its folders), users, login & logout of admin users, components, roles, and permissions, you can see the list of all the default events [here](https://github.com/strapi/strapi/blob/main/packages/core/admin/ee/server/services/audit-logs.js#L9).
+Audit Logs provide a way to view the history of all user actions at Admin API level. This includes actions related to entries (including publish actions), media (including its folders), users, login & logout of admin users, components, roles, and permissions, you can see the list of all the default events [here](https://github.com/strapi/strapi/blob/main/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts).
 
 ## Backend design
 
@@ -59,4 +59,4 @@ To understand how we obtain this information, we need to know how we emit an eve
 strapi.eventHub.emit(name: Pick<Event, 'name'>, payload: Pick<Event, 'payload'>);
 ```
 
-First, we check the event is coming from admin requests and it's on our [default events](https://github.com/strapi/strapi/blob/main/packages/core/admin/ee/server/services/audit-logs.js#L9) list, then when creating our Audit Log, we retrieve the action and payload from this emitted event, where the first argument is the action or event name, and the second one is the payload. We obtain the user from the requestContext.
+First, we check the event is coming from admin requests and it's on our [default events](https://github.com/strapi/strapi/blob/main/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts) list, then when creating our Audit Log, we retrieve the action and payload from this emitted event, where the first argument is the action or event name, and the second one is the payload. We obtain the user from the requestContext.

--- a/docs/docs/docs/01-core/content-manager/06-preview.md
+++ b/docs/docs/docs/01-core/content-manager/06-preview.md
@@ -41,7 +41,7 @@ This is why the file has an unusual structure with many functions defined inline
 
 ### Field identification with stega
 
-We use [stega encoding](https://github.com/vercel/stega) to identify which Strapi field each piece of text comes from. Stega embeds invisible metadata into text content using Unicode zero-width characters that are imperceptible to users but can be decoded programmatically.
+We use [stega encoding](https://www.npmjs.com/package/@vercel/stega) to identify which Strapi field each piece of text comes from. Stega embeds invisible metadata into text content using Unicode zero-width characters that are imperceptible to users but can be decoded programmatically.
 
 1. The Document Service encodes field metadata into text values (invisible to users)
 2. The frontend renders the content normally

--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -32,7 +32,7 @@ npm install @strapi/provider-upload-aws-s3 --save
 - `providerOptions.providerConfig` contains extended configuration options (see below).
 - `actionOptions` is passed directly to the parameters to each method respectively. You can find the complete list of [upload/ uploadStream options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) and [delete options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#deleteObject-property)
 
-See the [documentation about using a provider](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#using-a-provider) for information on installing and using a provider. To understand how environment variables are used in Strapi, please refer to the [documentation about environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables).
+See the [documentation about using a provider](https://docs.strapi.io/cms/configurations/media-library-providers/amazon-s3) for information on installing and using a provider. To understand how environment variables are used in Strapi, please refer to the [documentation about environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables).
 
 If you're using the bucket as a CDN and deliver the content on a custom domain, you can get use of the `baseUrl` and `rootPath` properties to configure how your assets' urls will be saved inside Strapi.
 

--- a/packages/providers/upload-cloudinary/README.md
+++ b/packages/providers/upload-cloudinary/README.md
@@ -27,7 +27,7 @@ npm install @strapi/provider-upload-cloudinary --save
 - `providerOptions` is passed down during the construction of the provider. (ex: `cloudinary.config`). [Complete list of options](https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters)
 - `actionOptions` is passed directly to each method respectively allowing for custom options. You can find the complete list of [upload/ uploadStream options](https://cloudinary.com/documentation/image_upload_api_reference#upload_optional_parameters) and [delete options](https://cloudinary.com/documentation/image_upload_api_reference#destroy_optional_parameters)
 
-See the [documentation about using a provider](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#using-a-provider) for information on installing and using a provider. To understand how environment variables are used in Strapi, please refer to the [documentation about environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables).
+See the [documentation about using a provider](https://docs.strapi.io/cms/configurations/media-library-providers/cloudinary) for information on installing and using a provider. To understand how environment variables are used in Strapi, please refer to the [documentation about environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables).
 
 ### Provider Configuration
 

--- a/packages/providers/upload-local/README.md
+++ b/packages/providers/upload-local/README.md
@@ -44,7 +44,7 @@ module.exports = ({ env }) => ({
 });
 ```
 
-The `sizeLimit` parameter must be a number. Be aware that the unit is in bytes, and the default is 1000000. When setting this value high, you should make sure to also configure the body parser middleware `maxFileSize` so the file can be sent and processed. Read more [here](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#configuration)
+The `sizeLimit` parameter must be a number. Be aware that the unit is in bytes, and the default is 1000000. When setting this value high, you should make sure to also configure the body parser middleware `maxFileSize` so the file can be sent and processed. Read more [here](https://docs.strapi.io/cms/configurations/media-library-providers/local-upload)
 
 ### Security Middleware Configuration
 


### PR DESCRIPTION
The API reference pages under `docs/docs/api/` were renamed to kebab-case (`EventHub.mdx` -> `event-hub.mdx`, `StrapiFS.mdx` -> `strapi-fs.mdx`), but `docs/docs/api/Strapi.mdx` still links to the old CamelCase names. The `EventHub` and `StrapiFS` links in the Type table and the `strapi.eventHub` section therefore 404. Updated all three occurrences to the current file names.