### PR TITLE
fix(core/core): koa response helper types missing in consumer projects

### DIFF
--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -3,6 +3,10 @@ import type { Core } from '@strapi/types';
 
 import Strapi, { type StrapiOptions } from './Strapi';
 import { destroyOnSignal, resolveWorkingDirectories, createUpdateNotifier } from './utils';
+import type {
+  ContextDelegatedResponseErrorMethods,
+  ContextDelegatedResponseSuccessMethods,
+} from './services/server/koa-methods';
 
 export { default as compileStrapi } from './compile';
 export * as factories from './factories';
@@ -41,4 +45,11 @@ declare module 'koa' {
     get query(): ParsedQuery;
     set query(obj: any);
   }
+
+  // Keep Koa's context and response types in sync with the helpers registered at runtime in `koa.ts`.
+  // `BaseResponse` and `BaseContext` both extend `DefaultContextDelegatedResponse`, so augmenting it
+  // once covers `ctx.*` and `ctx.response.*`.
+  interface DefaultContextDelegatedResponse
+    extends ContextDelegatedResponseErrorMethods,
+      ContextDelegatedResponseSuccessMethods {}
 }

--- a/packages/core/core/src/services/server/koa-methods.ts
+++ b/packages/core/core/src/services/server/koa-methods.ts
@@ -122,14 +122,3 @@ export interface ContextDelegatedResponseSuccessMethods {
   /** 204 | 200 */
   deleted(response?: unknown): void;
 }
-
-// Keep Koa's context and response types in sync with the helpers registered at runtime in `koa.ts`.
-declare module 'koa' {
-  interface DefaultContextDelegatedResponse
-    extends ContextDelegatedResponseErrorMethods,
-      ContextDelegatedResponseSuccessMethods {}
-
-  interface BaseResponse
-    extends ContextDelegatedResponseErrorMethods,
-      ContextDelegatedResponseSuccessMethods {}
-}


### PR DESCRIPTION
### What does it do?

Moves the `declare module 'koa'` block that augments `DefaultContextDelegatedResponse` with the generated error/success helpers (`ctx.forbidden`, `ctx.notFound`, `ctx.created`, …) from `packages/core/core/src/services/server/koa-methods.ts` back to `packages/core/core/src/index.ts`.

It also drops the separate `BaseResponse` augmentation: Koa declares both `BaseResponse` and `BaseContext` as extending `DefaultContextDelegatedResponse` ([`@types/koa`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/koa/index.d.ts)), so augmenting that single interface already covers `ctx.*` and `ctx.response.*`.

### Why is it needed?

#26923 relocated the augmentation into `koa-methods.ts`. That file is not reachable from the package's public type entry point, so `dist/index.d.ts` no longer carries the augmentation and consumers never load it — effectively reverting the effect of #25424.

Without it, `ctx.forbidden` resolves through Koa's `DefaultContext` index signature instead of the augmented interface. With `noPropertyAccessFromIndexSignature` enabled, that fails:

```
Property 'forbidden' comes from an index signature, so it must be accessed with ['forbidden'].
```

Screen recording of the regression: https://youtu.be/9tvDmrBE1p4
Screen recording of an example: https://youtu.be/pxPc4xcJXY4

### How to test it?

1. `yarn nx build @strapi/core` (or `yarn build:types` inside `packages/core/core`).
2. Confirm `packages/core/core/dist/index.d.ts` contains:

   ```ts
   declare module 'koa' {
       ...
       interface DefaultContextDelegatedResponse extends ContextDelegatedResponseErrorMethods, ContextDelegatedResponseSuccessMethods {
       }
   }
   ```

3. In a TypeScript Strapi project with `noPropertyAccessFromIndexSignature: true`, a controller using `ctx.forbidden('nope')` / `ctx.response.created(entity)` type-checks with no index-signature error.

### Follow-ups (not in this PR)

This fix restores the previous behaviour but keeps the same fragility — the augmentation only works because it happens to sit in a file the entry point pulls in. Two things worth considering separately:

- **Type regression tests.** Nothing in CI caught this move, because the source tree still type-checks fine; only the published `.d.ts` graph changed. A test asserting against the built declarations (or a `tsd`/`expect-type` fixture consuming `@strapi/strapi` from `dist`) would catch it.
- **A dedicated augmentation entry.** Something like `@strapi/types/<augmentation>` that users add to `tsconfig.json#compilerOptions.types` would make the augmentations apply regardless of whether (and from where) the entry point is imported, instead of depending on import reachability.

### Related issue(s)/PR(s)

- Fixes the type-level regression introduced by #26923 — reported in https://github.com/strapi/strapi/pull/26923#issuecomment-5307280706
- Restores the behaviour added in #25424

cc @nclsndr
