### PR TITLE
fix(admin): harden RelativeTime against invalid dates after login

### DIFF
--- a/packages/core/admin/admin/src/components/RelativeTime.tsx
+++ b/packages/core/admin/admin/src/components/RelativeTime.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Duration, intervalToDuration, isPast } from 'date-fns';
+import { Duration, intervalToDuration, isPast, isValid } from 'date-fns';
 import { useIntl } from 'react-intl';
 
 const intervals: Array<keyof Duration> = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'];
@@ -33,6 +33,15 @@ interface RelativeTimeProps extends React.ComponentPropsWithoutRef<'time'> {
 const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
   ({ timestamp, customIntervals = [], ...restProps }, forwardedRef) => {
     const { formatRelativeTime, formatDate, formatTime } = useIntl();
+
+    // Invalid dates crash intervalToDuration / toISOString ("Start Date is invalid" — #27013, #27382).
+    if (!isValid(timestamp)) {
+      return (
+        <time ref={forwardedRef} role="time" {...restProps}>
+          -
+        </time>
+      );
+    }
 
     /**
      * TODO: make this auto-update, like a clock.

--- a/packages/core/admin/admin/src/components/tests/RelativeTime.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/RelativeTime.test.tsx
@@ -46,4 +46,13 @@ describe('RelativeTime', () => {
 
     expect(screen.getByRole('time')).toHaveTextContent('now');
   });
+
+  it('renders a safe fallback for invalid dates instead of crashing (#27382)', () => {
+    render(<RelativeTime timestamp={new Date('')} />);
+
+    const timeElement = screen.getByRole('time');
+    expect(timeElement).toBeInTheDocument();
+    expect(timeElement).toHaveTextContent('-');
+    expect(timeElement).not.toHaveAttribute('datetime');
+  });
 });

--- a/packages/core/content-manager/admin/src/components/RelativeTime.tsx
+++ b/packages/core/content-manager/admin/src/components/RelativeTime.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Duration, intervalToDuration, isPast } from 'date-fns';
+import { Duration, intervalToDuration, isPast, isValid } from 'date-fns';
 import { useIntl } from 'react-intl';
 
 const intervals: Array<keyof Duration> = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'];
@@ -33,6 +33,15 @@ interface RelativeTimeProps extends React.ComponentPropsWithoutRef<'time'> {
 const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
   ({ timestamp, customIntervals = [], ...restProps }, forwardedRef) => {
     const { formatRelativeTime, formatDate, formatTime } = useIntl();
+
+    // Invalid dates crash intervalToDuration / toISOString ("Start Date is invalid" — #27013, #27382).
+    if (!isValid(timestamp)) {
+      return (
+        <time ref={forwardedRef} role="time" {...restProps}>
+          -
+        </time>
+      );
+    }
 
     /**
      * TODO: make this auto-update, like a clock.

--- a/packages/core/content-manager/admin/src/components/tests/RelativeTime.test.tsx
+++ b/packages/core/content-manager/admin/src/components/tests/RelativeTime.test.tsx
@@ -48,4 +48,13 @@ describe('RelativeTime', () => {
 
     expect(screen.getByRole('time')).toHaveTextContent('now');
   });
+
+  it('renders a safe fallback for invalid dates instead of crashing (#27382)', () => {
+    render(<RelativeTime timestamp={new Date('')} />);
+
+    const timeElement = screen.getByRole('time');
+    expect(timeElement).toBeInTheDocument();
+    expect(timeElement).toHaveTextContent('-');
+    expect(timeElement).not.toHaveAttribute('datetime');
+  });
 });

--- a/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
+++ b/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
@@ -341,6 +341,93 @@ describe('homepage service', () => {
       expect(wire[0].publishedAt).not.toEqual({});
     });
 
+    it('omits documents without a parseable updatedAt instead of emitting "" (#27382)', async () => {
+      /**
+       * `updatedAt: toIsoDateString(...) ?? ''` produced empty strings on the wire.
+       * `new Date('')` is Invalid Date → RelativeTime throws RangeError: Start Date is invalid.
+       */
+      (strapiContentTypes.hasDraftAndPublish as jest.Mock).mockImplementation(() => false);
+
+      const contentTypes = {
+        'api::article.article': {
+          uid: 'api::article.article',
+          info: { displayName: 'Article' },
+          kind: 'collectionType',
+          options: { draftAndPublish: false },
+          attributes: {},
+        },
+      };
+
+      const findArticleDocuments = jest.fn(async () => [
+        {
+          documentId: 'article-bad',
+          title: 'Missing date',
+          updatedAt: null,
+        },
+        {
+          documentId: 'article-good',
+          title: 'Has date',
+          updatedAt: '2026-07-10T16:24:13.962Z',
+        },
+      ]);
+      const findConfigurations = jest.fn(async () => [
+        {
+          value: JSON.stringify({
+            uid: 'api::article.article',
+            settings: { mainField: 'title' },
+          }),
+        },
+      ]);
+
+      const strapi = {
+        admin: {
+          services: {
+            permission: {
+              findMany: jest.fn(async () => [{ subject: 'api::article.article' }]),
+            },
+          },
+        },
+        contentTypes,
+        requestContext: {
+          get: jest.fn(() => ({
+            state: {
+              user: { id: 1 },
+              userAbility: {},
+            },
+          })),
+        },
+        db: {
+          query: jest.fn(() => ({
+            findMany: findConfigurations,
+          })),
+        },
+        plugin: jest.fn(() => ({
+          service: jest.fn(() => ({
+            create: jest.fn(() => ({
+              cannot: {
+                read: jest.fn(() => false),
+              },
+              sanitizedQuery: {
+                read: jest.fn(async (query: unknown) => query),
+              },
+            })),
+          })),
+        })),
+        contentType: jest.fn((uid: keyof typeof contentTypes) => contentTypes[uid]),
+        documents: jest.fn(() => ({
+          findMany: findArticleDocuments,
+        })),
+      };
+
+      const service = createHomepageService({ strapi } as any);
+      const result = await service.queryLastDocuments({ sort: 'updatedAt:desc' }, false);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].documentId).toBe('article-good');
+      expect(result[0].updatedAt).toBe('2026-07-10T16:24:13.962Z');
+      expect(result[0].updatedAt).not.toBe('');
+    });
+
     it('converts Date timestamps to ISO strings and keeps them after populate spread', async () => {
       (strapiContentTypes.hasDraftAndPublish as jest.Mock).mockImplementation(() => true);
 

--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -157,7 +157,14 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     meta: ContentTypeMeta,
     populate?: string[]
   ) => {
-    return documents.map((document) => {
+    return documents.flatMap((document) => {
+      // Never emit "" / invalid timestamps: `new Date('')` is Invalid Date and crashes
+      // RelativeTime with "Start Date is invalid" (#27382). Drop entries we cannot date.
+      const updatedAt = toIsoDateString(document.updatedAt);
+      if (!updatedAt) {
+        return [];
+      }
+
       const additionalFields =
         populate?.reduce(
           (acc, key) => {
@@ -166,21 +173,24 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
           },
           {} as Record<string, any>
         ) || {};
-      return {
-        documentId: document.documentId,
-        locale: document.locale ?? null,
-        title: document[meta.mainField ?? 'documentId'],
-        contentTypeUid: meta.uid,
-        contentTypeDisplayName: meta.contentType.info.displayName,
-        kind: meta.contentType.kind,
-        ...additionalFields,
-        // Keep dates last so populate cannot overwrite with non-JSON-safe values
-        updatedAt: toIsoDateString(document.updatedAt) ?? '',
-        publishedAt:
-          meta.hasDraftAndPublish && document.publishedAt
-            ? toIsoDateString(document.publishedAt)
-            : null,
-      };
+
+      return [
+        {
+          documentId: document.documentId,
+          locale: document.locale ?? null,
+          title: document[meta.mainField ?? 'documentId'],
+          contentTypeUid: meta.uid,
+          contentTypeDisplayName: meta.contentType.info.displayName,
+          kind: meta.contentType.kind,
+          ...additionalFields,
+          // Keep dates last so populate cannot overwrite with non-JSON-safe values
+          updatedAt,
+          publishedAt:
+            meta.hasDraftAndPublish && document.publishedAt
+              ? toIsoDateString(document.publishedAt)
+              : null,
+        },
+      ];
     });
   };
 

--- a/packages/core/content-releases/admin/src/components/RelativeTime.tsx
+++ b/packages/core/content-releases/admin/src/components/RelativeTime.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Duration, intervalToDuration, isPast } from 'date-fns';
+import { Duration, intervalToDuration, isPast, isValid } from 'date-fns';
 import { useIntl } from 'react-intl';
 
 const intervals: Array<keyof Duration> = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'];
@@ -34,6 +34,15 @@ const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
   ({ timestamp, customIntervals = [], ...restProps }, forwardedRef) => {
     const { formatRelativeTime, formatDate, formatTime } = useIntl();
 
+    // Invalid dates crash intervalToDuration / toISOString ("Start Date is invalid" — #27013, #27382).
+    if (!isValid(timestamp)) {
+      return (
+        <time ref={forwardedRef} role="time" {...restProps}>
+          -
+        </time>
+      );
+    }
+
     /**
      * TODO: make this auto-update, like a clock.
      */
@@ -43,9 +52,10 @@ const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
       // see https://github.com/date-fns/date-fns/issues/2891 – No idea why it's all partial it returns it every time.
     }) as Required<Duration>;
 
-    const unit = intervals.find((intervalUnit) => {
-      return interval[intervalUnit] > 0 && Object.keys(interval).includes(intervalUnit);
-    })!;
+    const unit =
+      intervals.find((intervalUnit) => {
+        return interval[intervalUnit] > 0 && Object.keys(interval).includes(intervalUnit);
+      }) ?? 'seconds';
 
     const relativeTime = isPast(timestamp) ? -interval[unit] : interval[unit];
 

--- a/packages/core/content-releases/admin/src/components/tests/RelativeTime.test.tsx
+++ b/packages/core/content-releases/admin/src/components/tests/RelativeTime.test.tsx
@@ -41,4 +41,13 @@ describe('RelativeTime', () => {
     expect(screen.getByRole('time')).toHaveTextContent('5 minutes ago');
     // expect(getByText('5 minutes ago')).toBeInTheDocument();
   });
+
+  it('renders a safe fallback for invalid dates instead of crashing (#27382)', () => {
+    render(<RelativeTime timestamp={new Date('')} />);
+
+    const timeElement = screen.getByRole('time');
+    expect(timeElement).toBeInTheDocument();
+    expect(timeElement).toHaveTextContent('-');
+    expect(timeElement).not.toHaveAttribute('datetime');
+  });
 });


### PR DESCRIPTION
## What does it do?

- Guards `RelativeTime` in `@strapi/admin`, `@strapi/content-manager`, and `@strapi/content-releases` with `date-fns` `isValid()`. Invalid timestamps render `-` instead of calling `intervalToDuration` / `toISOString`.
- Homepage recent-documents no longer emit `updatedAt: ''` when ISO conversion fails; those entries are omitted (empty string → `new Date('')` → Invalid Date).

## Why is it needed?

On Strapi 5.52, production admin can crash immediately after login with `RangeError: Start Date is invalid`. #27066 fixed `Date` objects serializing as `{}`, but left `updatedAt: toIsoDateString(...) ?? ''`. That still produces Invalid Date in the Last edited / Last published widgets and takes down the whole view.

Fixes #27382  
Related: #27013, #27066

## How to test it?

```bash
yarn workspace @strapi/content-manager test:unit --testPathPattern='homepage'
yarn workspace @strapi/admin test:front --testPathPattern='RelativeTime' --forceExit
yarn workspace @strapi/content-manager test:front --testPathPattern='RelativeTime' --forceExit
yarn workspace @strapi/content-releases test:front --testPathPattern='RelativeTime' --forceExit
```

Manual: build admin, log in, open homepage with content that previously triggered the error — admin should load; widgets show `-` or omit undated rows.

## Related issue(s)/PR(s)

- Fixes #27382
- Follow-up to #27066 / #27013