### PR TITLE
chore(review-workflows): migrate unit tests from jest to vitest

### DIFF
--- a/packages/core/review-workflows/jest.config.js
+++ b/packages/core/review-workflows/jest.config.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  displayName: 'Core Review Workflows',
-};

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -54,10 +54,10 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint . --max-warnings=0",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
+    "test:unit:vitest": "vitest run",
+    "test:unit:vitest:watch": "vitest --watch",
     "test:ts:back": "run -T tsc -p server/tsconfig.json",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
-    "test:unit": "run -T jest",
-    "test:unit:watch": "run -T jest --watch",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
@@ -92,7 +92,9 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "vitest": "catalog:",
+    "vitest-config": "5.52.0"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/review-workflows/server/src/middlewares/__tests__/review-workflows.vitest.test.ts
+++ b/packages/core/review-workflows/server/src/middlewares/__tests__/review-workflows.vitest.test.ts
@@ -1,9 +1,10 @@
+import { describe, expect, test, vi } from 'vitest';
 import reviewWorkflowsMiddlewares from '../review-workflows';
 
 const strapiMock = {
   server: {
     router: {
-      use: jest.fn(),
+      use: vi.fn(),
     },
   },
 } as any;

--- a/packages/core/review-workflows/server/tsconfig.json
+++ b/packages/core/review-workflows/server/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "tsconfig/base.json",
   "include": ["src", "custom.d.ts", "../shared"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   }
 }

--- a/packages/core/review-workflows/vitest.config.ts
+++ b/packages/core/review-workflows/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9699,6 +9699,8 @@ __metadata:
     react-router-dom: "npm:6.30.4"
     semver: "npm:7.7.4"
     styled-components: "npm:6.4.1"
+    vitest: "catalog:"
+    vitest-config: "npm:5.52.0"
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/admin": ^5.0.0


### PR DESCRIPTION
### What does it do?

Migrates `@strapi/review-workflows` backend unit tests from Jest to Vitest:

- Convert the server middleware suite to `*.vitest.test.ts`
- Add `vitest.config.ts` + `test:unit:vitest` via shared `vitest-config`
- Remove unit `jest.config.js`; keep `test:front` / Jest for admin suites

### Why is it needed?

Incremental Jest → Vitest migration for monorepo backend unit tests.

### How to test it?

```bash
yarn workspace @strapi/review-workflows test:unit:vitest
yarn workspace @strapi/review-workflows lint
```

### Related issue(s)/PR(s)

Fixes CMS-1477

