### PR TITLE
chore(graphql): migrate unit tests from jest to vitest

### DIFF
--- a/packages/plugins/graphql/jest.config.js
+++ b/packages/plugins/graphql/jest.config.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  displayName: 'Plugin GraphQL',
-  // passWithNoTests: true,
-};

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -55,9 +55,9 @@
     "lint": "run -T eslint . --max-warnings=0",
     "test:ts:back": "run -T tsc -p server/tsconfig.json",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
-    "test:unit": "run -T jest --passWithNoTests",
-    "test:unit:watch": "run -T jest --watch",
-    "watch": "run -T rollup -c -w"
+    "watch": "run -T rollup -c -w",
+    "test:unit:vitest": "vitest run",
+    "test:unit:vitest:watch": "vitest --watch"
   },
   "dependencies": {
     "@apollo/server": "4.13.0",
@@ -82,20 +82,20 @@
     "@strapi/strapi": "5.52.0",
     "@strapi/types": "5.52.0",
     "@types/graphql-depth-limit": "1.1.5",
-    "@types/jest": "29.5.2",
     "@types/koa-bodyparser": "4.3.12",
     "@types/koa__cors": "5.0.0",
     "@types/node": "20.19.41",
     "cross-env": "^7.0.3",
     "eslint-config-custom": "5.52.0",
-    "jest": "29.6.0",
     "koa": "2.16.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
     "tsconfig": "5.52.0",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "catalog:",
+    "vitest-config": "5.52.0"
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/__tests__/merge-publication-args.vitest.test.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/__tests__/merge-publication-args.vitest.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { mergePublicationFilterFromGraphQLArgs } from '../merge-publication-args';
 
 describe('mergePublicationFilterFromGraphQLArgs', () => {

--- a/packages/plugins/graphql/server/tsconfig.json
+++ b/packages/plugins/graphql/server/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   }
 }

--- a/packages/plugins/graphql/vitest.config.ts
+++ b/packages/plugins/graphql/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9453,7 +9453,6 @@ __metadata:
     "@strapi/types": "npm:5.52.0"
     "@strapi/utils": "npm:5.52.0"
     "@types/graphql-depth-limit": "npm:1.1.5"
-    "@types/jest": "npm:29.5.2"
     "@types/koa-bodyparser": "npm:4.3.12"
     "@types/koa__cors": "npm:5.0.0"
     "@types/node": "npm:20.19.41"
@@ -9463,7 +9462,6 @@ __metadata:
     graphql-depth-limit: "npm:^1.1.0"
     graphql-playground-middleware-koa: "npm:^1.6.21"
     graphql-scalars: "npm:1.22.2"
-    jest: "npm:29.6.0"
     koa: "npm:2.16.4"
     koa-bodyparser: "npm:4.4.1"
     koa-compose: "npm:^4.1.0"
@@ -9476,6 +9474,8 @@ __metadata:
     styled-components: "npm:6.4.1"
     tsconfig: "npm:5.52.0"
     typescript: "npm:5.9.3"
+    vitest: "catalog:"
+    vitest-config: "npm:5.52.0"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0


### PR DESCRIPTION
### What does it do?

Fully migrates `@strapi/plugin-graphql` unit tests from Jest to Vitest:

- Convert the merge-publication-args suite to `*.vitest.test.ts`
- Add `vitest.config.ts` + `test:unit:vitest` via shared `vitest-config`
- Remove `jest.config.js`, Jest scripts, and Jest-only dependencies

### Why is it needed?

Incremental Jest → Vitest migration for monorepo backend unit tests.

### How to test it?

```bash
yarn workspace @strapi/plugin-graphql test:unit:vitest
yarn workspace @strapi/plugin-graphql lint
```

### Related issue(s)/PR(s)

Fixes CMS-1484