### PR TITLE
security(graphql): warn about unbounded operation limits

### DIFF
--- a/docs/docs/docs/01-core/configuration/00-intro.md
+++ b/docs/docs/docs/01-core/configuration/00-intro.md
@@ -76,6 +76,7 @@ module.exports = () => ({
 
       defaultLimit: 25,
       maxLimit: 100,
+      depthLimit: 10,
 
       apolloServer: {
         tracing: true,

--- a/docs/docs/docs/01-core/configuration/01-security-defaults.md
+++ b/docs/docs/docs/01-core/configuration/01-security-defaults.md
@@ -92,6 +92,11 @@ Review these values against your client queries: `maxLimit` can cap list results
 reject deeply nested operations. Use deployment-level rate limiting and timeouts as additional
 defense in depth; these limits are not a complete protection against expensive operations.
 
+The current GraphQL plugin defaults are `maxLimit: -1` (unbounded) and no `depthLimit`. When
+pagination is omitted, the effective list limit is 10. At startup, Strapi warns when its built-in
+`maxLimit` or `depthLimit` is unbounded or invalid. The warning is informational: it does not change
+existing query behavior, and custom Apollo validation rules may independently enforce limits.
+
 ## Upload MIME restrictions
 
 Use an allowlist for common media and document types, plus a denylist for executables and shell scripts. When both are set, denied types take precedence over the allowlist.

--- a/docs/docs/docs/01-core/configuration/01-security-defaults.md
+++ b/docs/docs/docs/01-core/configuration/01-security-defaults.md
@@ -70,6 +70,28 @@ Scaffolded `.env` files include a randomly generated `JWT_SECRET` alongside othe
 
 See [JWT management modes](https://docs.strapi.io/cms/features/users-permissions#jwt-management-modes) for client integration details.
 
+## Optional GraphQL plugin operation limits
+
+GraphQL is optional and is not configured in applications scaffolded by `create-strapi-app`. If your
+application exposes GraphQL, configure list and nesting limits in `config/plugins.js` or
+`config/plugins.ts`:
+
+```js
+module.exports = () => ({
+  graphql: {
+    config: {
+      defaultLimit: 25,
+      maxLimit: 100,
+      depthLimit: 10,
+    },
+  },
+});
+```
+
+Review these values against your client queries: `maxLimit` can cap list results and `depthLimit` can
+reject deeply nested operations. Use deployment-level rate limiting and timeouts as additional
+defense in depth; these limits are not a complete protection against expensive operations.
+
 ## Upload MIME restrictions
 
 Use an allowlist for common media and document types, plus a denylist for executables and shell scripts. When both are set, denied types take precedence over the allowlist.

--- a/packages/plugins/graphql/server/src/__tests__/bootstrap.test.ts
+++ b/packages/plugins/graphql/server/src/__tests__/bootstrap.test.ts
@@ -16,35 +16,47 @@ const mockApolloServer = jest.mocked(ApolloServer);
 describe('getOperationLimitsWarning', () => {
   const recommendation = 'defaultLimit: 25, maxLimit: 100, depthLimit: 10';
   const customRulesNote = 'Custom Apollo validation rules may independently enforce limits.';
+  const documentationUrl = 'https://docs.strapi.io/cms/configurations/plugins';
 
   it.each([
-    [{ maxLimit: -1 }, 'depthLimit, maxLimit'],
+    [{ depthLimit: 10, maxLimit: -1 }, 'maxLimit'],
+    [{ depthLimit: 10, maxLimit: undefined }, 'maxLimit'],
+    [{ depthLimit: 10, maxLimit: null }, 'maxLimit'],
+    [{ depthLimit: 10, maxLimit: Number.NaN }, 'maxLimit'],
+    [{ depthLimit: 10, maxLimit: Number.POSITIVE_INFINITY }, 'maxLimit'],
+    [{ depthLimit: 10, maxLimit: Number.NEGATIVE_INFINITY }, 'maxLimit'],
+    [{ depthLimit: 10, maxLimit: 0 }, 'maxLimit'],
+    [{ depthLimit: 10, maxLimit: -2 }, 'maxLimit'],
     [{ depthLimit: undefined, maxLimit: 100 }, 'depthLimit'],
     [{ depthLimit: null, maxLimit: 100 }, 'depthLimit'],
-    [{ depthLimit: 0, maxLimit: 100 }, 'depthLimit'],
-    [{ depthLimit: -1, maxLimit: 100 }, 'depthLimit'],
     [{ depthLimit: Number.NaN, maxLimit: 100 }, 'depthLimit'],
     [{ depthLimit: Number.POSITIVE_INFINITY, maxLimit: 100 }, 'depthLimit'],
-    [{ depthLimit: 10, maxLimit: -1 }, 'maxLimit'],
-  ])('warns for unbounded built-in %s', (config, keys) => {
+    [{ depthLimit: Number.NEGATIVE_INFINITY, maxLimit: 100 }, 'depthLimit'],
+    [{ depthLimit: 0, maxLimit: 100 }, 'depthLimit'],
+    [{ depthLimit: -1, maxLimit: 100 }, 'depthLimit'],
+  ])('warns for unbounded or invalid built-in limits: %s', (config, keys) => {
     const warning = getOperationLimitsWarning(config);
 
-    expect(warning).toContain(`unbounded for: ${keys}.`);
+    expect(warning).toContain(`unbounded or invalid for: ${keys}.`);
     expect(warning).toContain(recommendation);
     expect(warning).toContain(customRulesNote);
-    expect(warning).toContain('https://docs.strapi.io/cms/configurations/plugins');
+    expect(warning).toContain(documentationUrl);
   });
 
-  it('does not warn when both built-in limits are bounded', () => {
-    expect(getOperationLimitsWarning({ depthLimit: 10, maxLimit: 100 })).toBeUndefined();
-  });
+  it.each([1, 100, Number.MAX_SAFE_INTEGER])(
+    'does not warn when maxLimit is a bounded positive value: %s',
+    (maxLimit) => {
+      expect(getOperationLimitsWarning({ depthLimit: 10, maxLimit })).toBeUndefined();
+    }
+  );
 
   it('still warns when custom Apollo validation rules are present', () => {
-    const warning = getOperationLimitsWarning({
+    const configWithCustomRules = {
       depthLimit: undefined,
       maxLimit: -1,
       apolloServer: { validationRules: [jest.fn()] },
-    });
+    };
+    const warning = getOperationLimitsWarning(configWithCustomRules);
 
     expect(warning).toContain('depthLimit, maxLimit');
     expect(warning).toContain(recommendation);
@@ -73,7 +85,7 @@ describe('bootstrap operation-limit warning', () => {
     });
   });
 
-  it('logs one warning before constructing Apollo when both built-in limits are unbounded', async () => {
+  const createStrapi = ({ depthLimit, maxLimit }: { depthLimit: unknown; maxLimit: unknown }) => {
     const operationWarning = jest.fn((message: string) => {
       if (message.startsWith('Built-in GraphQL operation limits')) {
         mockEvents.push('operation-warning');
@@ -83,8 +95,8 @@ describe('bootstrap operation-limit warning', () => {
       config: jest.fn((key: string) => {
         const config = {
           endpoint: '/graphql',
-          depthLimit: undefined,
-          maxLimit: -1,
+          depthLimit,
+          maxLimit,
           landingPage: false,
           apolloServer: undefined,
         };
@@ -110,7 +122,13 @@ describe('bootstrap operation-limit warning', () => {
       auth: { authenticate: jest.fn() },
     };
 
-    await bootstrap({ strapi: strapi as unknown as Core.Strapi });
+    return { strapi: strapi as unknown as Core.Strapi, operationWarning };
+  };
+
+  it('logs one warning before constructing Apollo when both built-in limits are unbounded', async () => {
+    const { strapi, operationWarning } = createStrapi({ depthLimit: undefined, maxLimit: -1 });
+
+    await bootstrap({ strapi });
 
     expect(operationWarning).toHaveBeenCalledTimes(1);
     expect(operationWarning).toHaveBeenCalledWith(expect.stringContaining('depthLimit, maxLimit'));
@@ -118,4 +136,31 @@ describe('bootstrap operation-limit warning', () => {
     expect(mockApolloServerStart).toHaveBeenCalledTimes(1);
     expect(mockEvents).toEqual(['operation-warning', 'apollo-construction', 'apollo-start']);
   });
+
+  it('does not log an operation-limit warning when both built-in limits are bounded', async () => {
+    const { strapi, operationWarning } = createStrapi({ depthLimit: 10, maxLimit: 100 });
+
+    await bootstrap({ strapi });
+
+    expect(operationWarning).not.toHaveBeenCalledWith(
+      expect.stringContaining('Built-in GraphQL operation limits')
+    );
+  });
+
+  it.each([
+    { depthLimit: undefined, maxLimit: 100 },
+    { depthLimit: 10, maxLimit: 0 },
+  ])(
+    'logs one operation-limit warning when exactly one control is unbounded or invalid',
+    async (limits) => {
+      const { strapi, operationWarning } = createStrapi(limits);
+
+      await bootstrap({ strapi });
+
+      expect(operationWarning).toHaveBeenCalledTimes(1);
+      expect(operationWarning).toHaveBeenCalledWith(
+        expect.stringContaining('Built-in GraphQL operation limits')
+      );
+    }
+  );
 });

--- a/packages/plugins/graphql/server/src/__tests__/bootstrap.test.ts
+++ b/packages/plugins/graphql/server/src/__tests__/bootstrap.test.ts
@@ -1,0 +1,121 @@
+import { ApolloServer } from '@apollo/server';
+import type { Core } from '@strapi/types';
+
+import { bootstrap, getOperationLimitsWarning } from '../bootstrap';
+
+jest.mock('@apollo/server', () => ({
+  ApolloServer: jest.fn(),
+}));
+
+jest.mock('@as-integrations/koa', () => ({
+  koaMiddleware: jest.fn(() => jest.fn()),
+}));
+
+const mockApolloServer = jest.mocked(ApolloServer);
+
+describe('getOperationLimitsWarning', () => {
+  const recommendation = 'defaultLimit: 25, maxLimit: 100, depthLimit: 10';
+  const customRulesNote = 'Custom Apollo validation rules may independently enforce limits.';
+
+  it.each([
+    [{ maxLimit: -1 }, 'depthLimit, maxLimit'],
+    [{ depthLimit: undefined, maxLimit: 100 }, 'depthLimit'],
+    [{ depthLimit: null, maxLimit: 100 }, 'depthLimit'],
+    [{ depthLimit: 0, maxLimit: 100 }, 'depthLimit'],
+    [{ depthLimit: -1, maxLimit: 100 }, 'depthLimit'],
+    [{ depthLimit: Number.NaN, maxLimit: 100 }, 'depthLimit'],
+    [{ depthLimit: Number.POSITIVE_INFINITY, maxLimit: 100 }, 'depthLimit'],
+    [{ depthLimit: 10, maxLimit: -1 }, 'maxLimit'],
+  ])('warns for unbounded built-in %s', (config, keys) => {
+    const warning = getOperationLimitsWarning(config);
+
+    expect(warning).toContain(`unbounded for: ${keys}.`);
+    expect(warning).toContain(recommendation);
+    expect(warning).toContain(customRulesNote);
+    expect(warning).toContain('https://docs.strapi.io/cms/configurations/plugins');
+  });
+
+  it('does not warn when both built-in limits are bounded', () => {
+    expect(getOperationLimitsWarning({ depthLimit: 10, maxLimit: 100 })).toBeUndefined();
+  });
+
+  it('still warns when custom Apollo validation rules are present', () => {
+    const warning = getOperationLimitsWarning({
+      depthLimit: undefined,
+      maxLimit: -1,
+      apolloServer: { validationRules: [jest.fn()] },
+    });
+
+    expect(warning).toContain('depthLimit, maxLimit');
+    expect(warning).toContain(recommendation);
+    expect(warning).toContain(customRulesNote);
+  });
+});
+
+describe('bootstrap operation-limit warning', () => {
+  const mockEvents: string[] = [];
+  const mockApolloServerStart = jest.fn();
+
+  beforeEach(() => {
+    mockEvents.length = 0;
+    mockApolloServer.mockClear();
+    mockApolloServerStart.mockClear();
+    mockApolloServerStart.mockImplementation(async () => {
+      mockEvents.push('apollo-start');
+    });
+    mockApolloServer.mockImplementation(() => {
+      mockEvents.push('apollo-construction');
+
+      return {
+        start: mockApolloServerStart,
+        stop: jest.fn(),
+      } as any;
+    });
+  });
+
+  it('logs one warning before constructing Apollo when both built-in limits are unbounded', async () => {
+    const operationWarning = jest.fn((message: string) => {
+      if (message.startsWith('Built-in GraphQL operation limits')) {
+        mockEvents.push('operation-warning');
+      }
+    });
+    const plugin = {
+      config: jest.fn((key: string) => {
+        const config = {
+          endpoint: '/graphql',
+          depthLimit: undefined,
+          maxLimit: -1,
+          landingPage: false,
+          apolloServer: undefined,
+        };
+
+        return config[key as keyof typeof config];
+      }),
+      service: jest.fn((name: string) => {
+        if (name === 'content-api') {
+          return { buildSchema: jest.fn(() => ({ type: 'schema' })) };
+        }
+
+        return { playground: { setEnabled: jest.fn() } };
+      }),
+    };
+    const strapi = {
+      plugin: jest.fn(() => plugin),
+      log: {
+        warn: operationWarning,
+        debug: jest.fn(),
+        error: jest.fn(),
+      },
+      server: { routes: jest.fn() },
+      auth: { authenticate: jest.fn() },
+    };
+
+    await bootstrap({ strapi: strapi as unknown as Core.Strapi });
+
+    expect(operationWarning).toHaveBeenCalledTimes(1);
+    expect(operationWarning).toHaveBeenCalledWith(expect.stringContaining('depthLimit, maxLimit'));
+    expect(mockApolloServer).toHaveBeenCalledTimes(1);
+    expect(mockApolloServerStart).toHaveBeenCalledTimes(1);
+    expect(mockEvents).toEqual(['operation-warning', 'apollo-construction', 'apollo-start']);
+  });
+});

--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -28,34 +28,31 @@ type StrapiGraphQLContext = BaseContext & {
 type OperationLimitConfig = {
   depthLimit?: unknown;
   maxLimit?: unknown;
-  apolloServer?: {
-    validationRules?: unknown;
-  };
 };
 
 export const getOperationLimitsWarning = ({
   depthLimit: configuredDepthLimit,
   maxLimit,
 }: OperationLimitConfig): string | undefined => {
-  const unboundedKeys: string[] = [];
+  const unboundedOrInvalidKeys: string[] = [];
 
   if (
     typeof configuredDepthLimit !== 'number' ||
     !Number.isFinite(configuredDepthLimit) ||
     configuredDepthLimit <= 0
   ) {
-    unboundedKeys.push('depthLimit');
+    unboundedOrInvalidKeys.push('depthLimit');
   }
 
-  if (maxLimit === -1) {
-    unboundedKeys.push('maxLimit');
+  if (typeof maxLimit !== 'number' || !Number.isFinite(maxLimit) || maxLimit <= 0) {
+    unboundedOrInvalidKeys.push('maxLimit');
   }
 
-  if (unboundedKeys.length === 0) {
+  if (unboundedOrInvalidKeys.length === 0) {
     return undefined;
   }
 
-  return `Built-in GraphQL operation limits are unbounded for: ${unboundedKeys.join(', ')}. Configure these limits (for example: defaultLimit: 25, maxLimit: 100, depthLimit: 10). Custom Apollo validation rules may independently enforce limits. See https://docs.strapi.io/cms/configurations/plugins.`;
+  return `Built-in GraphQL operation limits are unbounded or invalid for: ${unboundedOrInvalidKeys.join(', ')}. Configure these limits (for example: defaultLimit: 25, maxLimit: 100, depthLimit: 10). Custom Apollo validation rules may independently enforce limits. See https://docs.strapi.io/cms/configurations/plugins.`;
 };
 
 export const determineLandingPage = (
@@ -208,6 +205,8 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
     schema,
 
     // Validation
+    // Keep v5 compatibility: depthLimit is passed through unchanged, so an unset or invalid value
+    // does not become an enforced finite limit during an upgrade.
     validationRules: [depthLimit(configuredDepthLimit as number) as any],
 
     // Errors

--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -25,6 +25,39 @@ type StrapiGraphQLContext = BaseContext & {
   rootQueryArgsByPath?: Map<string | number, Record<string, unknown>>;
 };
 
+type OperationLimitConfig = {
+  depthLimit?: unknown;
+  maxLimit?: unknown;
+  apolloServer?: {
+    validationRules?: unknown;
+  };
+};
+
+export const getOperationLimitsWarning = ({
+  depthLimit: configuredDepthLimit,
+  maxLimit,
+}: OperationLimitConfig): string | undefined => {
+  const unboundedKeys: string[] = [];
+
+  if (
+    typeof configuredDepthLimit !== 'number' ||
+    !Number.isFinite(configuredDepthLimit) ||
+    configuredDepthLimit <= 0
+  ) {
+    unboundedKeys.push('depthLimit');
+  }
+
+  if (maxLimit === -1) {
+    unboundedKeys.push('maxLimit');
+  }
+
+  if (unboundedKeys.length === 0) {
+    return undefined;
+  }
+
+  return `Built-in GraphQL operation limits are unbounded for: ${unboundedKeys.join(', ')}. Configure these limits (for example: defaultLimit: 25, maxLimit: 100, depthLimit: 10). Custom Apollo validation rules may independently enforce limits. See https://docs.strapi.io/cms/configurations/plugins.`;
+};
+
 export const determineLandingPage = (
   strapi: Core.Strapi
 ): ApolloServerPlugin<StrapiGraphQLContext> => {
@@ -120,6 +153,16 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
   const { config } = strapi.plugin('graphql');
 
   const path: string = config('endpoint');
+  const configuredDepthLimit = config('depthLimit');
+  const maxLimit = config('maxLimit');
+  const operationLimitsWarning = getOperationLimitsWarning({
+    depthLimit: configuredDepthLimit,
+    maxLimit,
+  });
+
+  if (operationLimitsWarning) {
+    strapi.log.warn(operationLimitsWarning);
+  }
 
   const landingPage = determineLandingPage(strapi);
   /**
@@ -165,7 +208,7 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
     schema,
 
     // Validation
-    validationRules: [depthLimit(config('depthLimit') as number) as any],
+    validationRules: [depthLimit(configuredDepthLimit as number) as any],
 
     // Errors
     formatError: formatGraphqlError,

--- a/tests/api/plugins/graphql/nested-relation-public-permissions.test.api.js
+++ b/tests/api/plugins/graphql/nested-relation-public-permissions.test.api.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { performance } = require('node:perf_hooks');
-
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
 const { createRequest } = require('api-tests/request');
@@ -97,39 +95,14 @@ const setEnabledActions = async (actions) => {
   await roleService.updateRole(publicRole.id, { permissions });
 };
 
-const measureAnonymousQuery = async (query) => {
-  let queryCount = 0;
-  const onQuery = () => {
-    queryCount += 1;
-  };
-  const startHeapUsed = process.memoryUsage().heapUsed;
-  const start = performance.now();
+const executeAnonymousQuery = (query) =>
+  publicRequest({
+    url: '/graphql',
+    method: 'POST',
+    body: { query },
+  });
 
-  strapi.db.connection.on('query', onQuery);
-  try {
-    const response = await publicRequest({
-      url: '/graphql',
-      method: 'POST',
-      body: { query },
-    });
-    const elapsedMs = performance.now() - start;
-    const heapUsedDelta = process.memoryUsage().heapUsed - startHeapUsed;
-
-    return {
-      response,
-      metrics: {
-        queryCount,
-        responseBytes: Buffer.byteLength(JSON.stringify(response.body)),
-        elapsedMs,
-        heapUsedDelta,
-      },
-    };
-  } finally {
-    strapi.db.connection.removeListener('query', onQuery);
-  }
-};
-
-describe('GraphQL operation-limit reachability', () => {
+describe('GraphQL nested-relation public permission reachability', () => {
   beforeAll(async () => {
     await builder.addContentTypes([memberModel, groupModel]).build();
 
@@ -187,7 +160,7 @@ describe('GraphQL operation-limit reachability', () => {
   });
 
   test('requires a public root find scope before the operation is reachable', async () => {
-    const { response } = await measureAnonymousQuery(shallowQuery);
+    const response = await executeAnonymousQuery(shallowQuery);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toMatchObject({
@@ -198,7 +171,7 @@ describe('GraphQL operation-limit reachability', () => {
 
   test('requires a public find scope for each nested relation target', async () => {
     await setEnabledActions([groupFindAction]);
-    const { response } = await measureAnonymousQuery(nestedQuery);
+    const response = await executeAnonymousQuery(nestedQuery);
 
     expect(response.statusCode).toBe(200);
     expect(response.body.data).toEqual({ operationLimitGroups: [null, null] });
@@ -215,35 +188,17 @@ describe('GraphQL operation-limit reachability', () => {
   test('allows bounded direct-v5 nested selections when every public find scope is granted', async () => {
     await setEnabledActions([groupFindAction, memberFindAction]);
 
-    const shallow = await measureAnonymousQuery(shallowQuery);
-    const nested = await measureAnonymousQuery(nestedQuery);
+    const shallow = await executeAnonymousQuery(shallowQuery);
+    const nested = await executeAnonymousQuery(nestedQuery);
 
-    expect(shallow.response.statusCode).toBe(200);
-    expect(shallow.response.body.errors).toBeUndefined();
-    expect(shallow.response.body.data.operationLimitGroups).toHaveLength(2);
-    expect(shallow.metrics).toEqual({
-      queryCount: expect.any(Number),
-      responseBytes: expect.any(Number),
-      elapsedMs: expect.any(Number),
-      heapUsedDelta: expect.any(Number),
-    });
+    expect(shallow.statusCode).toBe(200);
+    expect(shallow.body.errors).toBeUndefined();
+    expect(shallow.body.data.operationLimitGroups).toHaveLength(2);
 
-    expect(nested.response.statusCode).toBe(200);
-    expect(nested.response.body.errors).toBeUndefined();
-    expect(nested.response.body.data.operationLimitGroups).toHaveLength(2);
-    expect(nested.response.body.data.operationLimitGroups[0].members).toHaveLength(2);
-    expect(nested.response.body.data.operationLimitGroups[0].members[0].groups).toHaveLength(2);
-    expect(nested.metrics).toEqual({
-      queryCount: expect.any(Number),
-      responseBytes: expect.any(Number),
-      elapsedMs: expect.any(Number),
-      heapUsedDelta: expect.any(Number),
-    });
-
-    // Diagnostic output is intentional: values are evidence, not performance thresholds.
-    console.info('CMS-1206 bounded anonymous GraphQL metrics', {
-      shallow: shallow.metrics,
-      nested: nested.metrics,
-    });
+    expect(nested.statusCode).toBe(200);
+    expect(nested.body.errors).toBeUndefined();
+    expect(nested.body.data.operationLimitGroups).toHaveLength(2);
+    expect(nested.body.data.operationLimitGroups[0].members).toHaveLength(2);
+    expect(nested.body.data.operationLimitGroups[0].members[0].groups).toHaveLength(2);
   });
 });

--- a/tests/api/plugins/graphql/operation-limits.test.api.js
+++ b/tests/api/plugins/graphql/operation-limits.test.api.js
@@ -1,0 +1,249 @@
+'use strict';
+
+const { performance } = require('node:perf_hooks');
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+let strapi;
+let publicRequest;
+let publicRole;
+let originalPermissions;
+
+const groupModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    members: {
+      type: 'relation',
+      relation: 'manyToMany',
+      target: 'api::operation-limit-member.operation-limit-member',
+      targetAttribute: 'groups',
+    },
+  },
+  displayName: 'Operation Limit Group',
+  singularName: 'operation-limit-group',
+  pluralName: 'operation-limit-groups',
+  description: '',
+  collectionName: '',
+  options: {
+    draftAndPublish: false,
+  },
+};
+
+const memberModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  displayName: 'Operation Limit Member',
+  singularName: 'operation-limit-member',
+  pluralName: 'operation-limit-members',
+  description: '',
+  collectionName: '',
+  options: {
+    draftAndPublish: false,
+  },
+};
+
+const groupFindAction = 'api::operation-limit-group.operation-limit-group.find';
+const memberFindAction = 'api::operation-limit-member.operation-limit-member.find';
+
+const shallowQuery = /* GraphQL */ `
+  query ShallowOperationLimitGroups {
+    operationLimitGroups(pagination: { pageSize: 2 }) {
+      documentId
+      name
+    }
+  }
+`;
+
+const nestedQuery = /* GraphQL */ `
+  query BoundedNestedOperationLimitGroups {
+    operationLimitGroups(pagination: { pageSize: 2 }) {
+      documentId
+      name
+      members(pagination: { pageSize: 2 }) {
+        documentId
+        name
+        groups(pagination: { pageSize: 2 }) {
+          documentId
+          name
+        }
+      }
+    }
+  }
+`;
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const setEnabledActions = async (actions) => {
+  const roleService = strapi.service('plugin::users-permissions.role');
+  const roleDetails = await roleService.findOne(publicRole.id);
+  const permissions = clone(roleDetails.permissions);
+
+  for (const action of actions) {
+    const [type, controller, name] = action.split('.');
+    permissions[type] = permissions[type] || { controllers: {} };
+    permissions[type].controllers = permissions[type].controllers || {};
+    permissions[type].controllers[controller] = permissions[type].controllers[controller] || {};
+    permissions[type].controllers[controller][name] = { enabled: true, policy: '' };
+  }
+
+  await roleService.updateRole(publicRole.id, { permissions });
+};
+
+const measureAnonymousQuery = async (query) => {
+  let queryCount = 0;
+  const onQuery = () => {
+    queryCount += 1;
+  };
+  const startHeapUsed = process.memoryUsage().heapUsed;
+  const start = performance.now();
+
+  strapi.db.connection.on('query', onQuery);
+  try {
+    const response = await publicRequest({
+      url: '/graphql',
+      method: 'POST',
+      body: { query },
+    });
+    const elapsedMs = performance.now() - start;
+    const heapUsedDelta = process.memoryUsage().heapUsed - startHeapUsed;
+
+    return {
+      response,
+      metrics: {
+        queryCount,
+        responseBytes: Buffer.byteLength(JSON.stringify(response.body)),
+        elapsedMs,
+        heapUsedDelta,
+      },
+    };
+  } finally {
+    strapi.db.connection.removeListener('query', onQuery);
+  }
+};
+
+describe('GraphQL operation-limit reachability', () => {
+  beforeAll(async () => {
+    await builder.addContentTypes([memberModel, groupModel]).build();
+
+    strapi = await createStrapiInstance({
+      bypassAuth: false,
+      async bootstrap({ strapi: instance }) {
+        // The API runner defaults this legacy mode to true; the reproduction must use v5 syntax.
+        instance.config.set('plugin::graphql.v4CompatibilityMode', false);
+      },
+    });
+    publicRequest = createRequest({ strapi });
+
+    expect(strapi.plugin('graphql').config('v4CompatibilityMode')).toBe(false);
+
+    const memberDocuments = await Promise.all(
+      ['Member 1', 'Member 2'].map((name) =>
+        strapi.documents('api::operation-limit-member.operation-limit-member').create({
+          data: { name },
+        })
+      )
+    );
+
+    await Promise.all(
+      ['Group 1', 'Group 2'].map((name) =>
+        strapi.documents('api::operation-limit-group.operation-limit-group').create({
+          data: {
+            name,
+            members: {
+              connect: memberDocuments.map(({ documentId }) => ({ documentId })),
+            },
+          },
+        })
+      )
+    );
+
+    publicRole = await strapi.db
+      .query('plugin::users-permissions.role')
+      .findOne({ where: { type: 'public' } });
+    const roleDetails = await strapi
+      .service('plugin::users-permissions.role')
+      .findOne(publicRole.id);
+    originalPermissions = clone(roleDetails.permissions);
+  });
+
+  afterAll(async () => {
+    if (strapi && publicRole && originalPermissions) {
+      await strapi
+        .service('plugin::users-permissions.role')
+        .updateRole(publicRole.id, { permissions: originalPermissions });
+    }
+    if (strapi) {
+      await strapi.destroy();
+    }
+    await builder.cleanup();
+  });
+
+  test('requires a public root find scope before the operation is reachable', async () => {
+    const { response } = await measureAnonymousQuery(shallowQuery);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({
+      data: null,
+      errors: [{ message: 'Forbidden access' }],
+    });
+  });
+
+  test('requires a public find scope for each nested relation target', async () => {
+    await setEnabledActions([groupFindAction]);
+    const { response } = await measureAnonymousQuery(nestedQuery);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.data).toEqual({ operationLimitGroups: [null, null] });
+    expect(response.body.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Forbidden access',
+          path: ['operationLimitGroups', 0, 'members'],
+        }),
+      ])
+    );
+  });
+
+  test('allows bounded direct-v5 nested selections when every public find scope is granted', async () => {
+    await setEnabledActions([groupFindAction, memberFindAction]);
+
+    const shallow = await measureAnonymousQuery(shallowQuery);
+    const nested = await measureAnonymousQuery(nestedQuery);
+
+    expect(shallow.response.statusCode).toBe(200);
+    expect(shallow.response.body.errors).toBeUndefined();
+    expect(shallow.response.body.data.operationLimitGroups).toHaveLength(2);
+    expect(shallow.metrics).toEqual({
+      queryCount: expect.any(Number),
+      responseBytes: expect.any(Number),
+      elapsedMs: expect.any(Number),
+      heapUsedDelta: expect.any(Number),
+    });
+
+    expect(nested.response.statusCode).toBe(200);
+    expect(nested.response.body.errors).toBeUndefined();
+    expect(nested.response.body.data.operationLimitGroups).toHaveLength(2);
+    expect(nested.response.body.data.operationLimitGroups[0].members).toHaveLength(2);
+    expect(nested.response.body.data.operationLimitGroups[0].members[0].groups).toHaveLength(2);
+    expect(nested.metrics).toEqual({
+      queryCount: expect.any(Number),
+      responseBytes: expect.any(Number),
+      elapsedMs: expect.any(Number),
+      heapUsedDelta: expect.any(Number),
+    });
+
+    // Diagnostic output is intentional: values are evidence, not performance thresholds.
+    console.info('CMS-1206 bounded anonymous GraphQL metrics', {
+      shallow: shallow.metrics,
+      nested: nested.metrics,
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?

Adds one nonbreaking GraphQL bootstrap warning when Strapi's built-in `depthLimit` is unset/invalid or `maxLimit` is unlimited, and documents the opt-in `defaultLimit: 25`, `maxLimit: 100`, `depthLimit: 10` profile. The warning is emitted before Apollo starts, names only Strapi-owned controls, and notes that custom Apollo validation rules may independently enforce limits.

### Why is it needed?

GraphQL projects can otherwise run with unbounded built-in operation controls. Existing v5 deployments need an actionable startup signal without silently breaking clients. This is warning/docs hardening; it preserves current behavior while making the configuration risk visible. The observed resource amplification is conditional on public `find` permissions for every selected content type and is not evidence of a demonstrated DoS/OOM.

### How to test it?

- Manual verification:

  1. Start a disposable Strapi v5 project with the GraphQL plugin exposed and default GraphQL operation-limit settings.
  2. Confirm startup emits at most one warning naming the unset/invalid `depthLimit` and/or unlimited `maxLimit`, before Apollo starts, with the plugin-configuration documentation URL.
  3. Configure `defaultLimit: 25`, `maxLimit: 100`, and `depthLimit: 10` in `config/plugins.js` or `config/plugins.ts`, restart, and confirm those controls no longer trigger the warning.
  4. Execute a direct-v5 query against a small disposable relation fixture. Confirm that no public `find` permissions deny the root field, root-only permission denies the nested relation, and both root and nested-target permissions allow the bounded nested query.
  5. If custom Apollo validation rules are configured, confirm they coexist with the informational warning; the warning intentionally does not introspect or suppress itself based on opaque rules.
