### PR TITLE
chore(email): migrate unit tests from jest to vitest

### DIFF
--- a/packages/core/email/jest.config.js
+++ b/packages/core/email/jest.config.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = {
-  preset: '../../../jest-preset.unit.js',
-  displayName: 'Core email',
-};

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -53,13 +53,14 @@
     "build:types:admin": "run -T tsc -p admin/tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint . --max-warnings=0",
-    "test:unit": "run -T jest",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:front:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js",
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",
     "test:front:watch:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js --watchAll",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
-    "watch": "run -T rollup -c -w"
+    "watch": "run -T rollup -c -w",
+    "test:unit:vitest": "vitest run",
+    "test:unit:vitest:watch": "vitest --watch"
   },
   "dependencies": {
     "@strapi/design-system": "2.2.4",
@@ -89,7 +90,9 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "vitest": "catalog:",
+    "vitest-config": "5.52.0"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/email/server/src/__tests__/bootstrap.vitest.test.ts
+++ b/packages/core/email/server/src/__tests__/bootstrap.vitest.test.ts
@@ -1,34 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Core } from '@strapi/types';
 
 import { bootstrap } from '../bootstrap';
 
-jest.mock('@strapi/provider-email-sendmail', () => ({
+vi.mock('@strapi/provider-email-sendmail', () => ({
   init() {
-    return { send: jest.fn() };
+    return { send: vi.fn() };
   },
 }));
 
 const createStrapiMock = (provider = 'sendmail') => {
-  const warn = jest.fn();
-  const registerMany = jest.fn().mockResolvedValue(undefined);
+  const warn = vi.fn();
+  const registerMany = vi.fn().mockResolvedValue(undefined);
   const emailPlugin = { provider: undefined as unknown };
 
   const strapi = {
     config: {
-      get: jest.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue({
         provider,
         providerOptions: {},
         settings: { defaultFrom: 'Strapi <no-reply@strapi.io>' },
       }),
     },
     log: { warn },
-    plugin: jest.fn((name: string) => {
+    plugin: vi.fn((name: string) => {
       if (name === 'email') {
         return emailPlugin;
       }
       return {};
     }),
-    service: jest.fn(() => ({
+    service: vi.fn(() => ({
       actionProvider: { registerMany },
     })),
   } as unknown as Core.Strapi;

--- a/packages/core/email/vitest.config.ts
+++ b/packages/core/email/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { unitPreset } from 'vitest-config/presets/unit';
+
+export default mergeConfig(
+  unitPreset,
+  defineConfig({
+    test: {
+      root: __dirname,
+    },
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9160,6 +9160,8 @@ __metadata:
     react-query: "npm:3.39.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    vitest: "catalog:"
+    vitest-config: "npm:5.52.0"
     yup: "npm:0.32.9"
     zod: "npm:3.25.76"
   peerDependencies:


### PR DESCRIPTION
### What does it do?

Migrates `@strapi/email` backend unit tests from Jest to Vitest:

- Convert the server bootstrap suite to `*.vitest.test.ts`
- Add `vitest.config.ts` + `test:unit:vitest` via shared `vitest-config`
- Remove unit `jest.config.js`; keep `test:front` / Jest for admin suites

### Why is it needed?

Incremental Jest → Vitest migration for monorepo backend unit tests.

### How to test it?

```bash
yarn workspace @strapi/email test:unit:vitest
yarn workspace @strapi/email lint
```

### Related issue(s)/PR(s)

Fixes CMS-1474