### PR TITLE
fix(content-manager): out of sort memory when listing history versions on mysql

### DIFF
--- a/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
@@ -212,4 +212,24 @@ describe('history-version service', () => {
     });
     expect(results.map((result) => result.id)).toEqual([2, 1]);
   });
+
+  it('leaves out the versions deleted between the two queries', async () => {
+    findPageMock.mockResolvedValueOnce({
+      results: [{ id: 2 }, { id: 1 }],
+      pagination: { page: 1, pageSize: 20, pageCount: 1, total: 2 },
+    });
+    findManyMock.mockResolvedValueOnce([
+      { id: 2, data: { title: 'Second version' }, schema: {}, locale: null },
+    ]);
+
+    const { results } = await historyService.findVersionsPage({
+      query: {
+        contentType: 'api::article.article' as UID.ContentType,
+        documentId: 'randomid',
+      },
+      state: { userAbility: {} },
+    } as any);
+
+    expect(results.map((result) => result.id)).toEqual([2]);
+  });
 });

--- a/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
@@ -3,6 +3,8 @@ import { HISTORY_VERSION_UID } from '../../constants';
 import { createHistoryService } from '../history';
 
 const createMock = jest.fn();
+const findPageMock = jest.fn();
+const findManyMock = jest.fn();
 const userId = 'user-id';
 const fakeDate = new Date('1970-01-01T00:00:00.000Z');
 
@@ -30,6 +32,8 @@ const mockStrapi = {
     i18n: {
       service: jest.fn(() => ({
         getDefaultLocale: jest.fn().mockReturnValue('en'),
+        isLocalizedContentType: jest.fn().mockReturnValue(false),
+        find: jest.fn().mockResolvedValue([]),
       })),
     },
   },
@@ -40,6 +44,8 @@ const mockStrapi = {
       if (uid === HISTORY_VERSION_UID) {
         return {
           create: createMock,
+          findPage: findPageMock,
+          findMany: findManyMock,
         };
       }
     },
@@ -179,5 +185,31 @@ describe('history-version service', () => {
         createdAt: fakeDate,
       },
     });
+  });
+
+  it('sorts the version ids only, then fetches the versions by id', async () => {
+    findPageMock.mockResolvedValueOnce({
+      results: [{ id: 2 }, { id: 1 }],
+      pagination: { page: 1, pageSize: 20, pageCount: 1, total: 2 },
+    });
+    findManyMock.mockResolvedValueOnce([
+      { id: 1, data: { title: 'First version' }, schema: {}, locale: null },
+      { id: 2, data: { title: 'Second version' }, schema: {}, locale: null },
+    ]);
+
+    const { results } = await historyService.findVersionsPage({
+      query: {
+        contentType: 'api::article.article' as UID.ContentType,
+        documentId: 'randomid',
+      },
+      state: { userAbility: {} },
+    } as any);
+
+    expect(findPageMock).toHaveBeenCalledWith(expect.objectContaining({ select: ['id'] }));
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { id: { $in: [2, 1] } },
+      populate: ['createdBy'],
+    });
+    expect(results.map((result) => result.id)).toEqual([2, 1]);
   });
 });

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -43,9 +43,13 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
         locale = params.query.locale || defaultLocale;
       }
 
-      const [{ results, pagination }, localeDictionary] = await Promise.all([
+      // NOTE: We get the IDs first before fetching the full versions, because sorting the whole
+      // snapshots runs MySQL/MariaDB out of sort memory
+      // See: https://github.com/strapi/strapi/issues/27393
+      const [{ results: versionIds, pagination }, localeDictionary] = await Promise.all([
         query.findPage({
           ...params.query,
+          select: ['id'],
           where: {
             $and: [
               { contentType: params.query.contentType },
@@ -53,11 +57,20 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
               ...(locale ? [{ locale }] : []),
             ],
           },
-          populate: ['createdBy'],
           orderBy: [{ createdAt: 'desc' }],
         }),
         serviceUtils.getLocaleDictionary(),
       ]);
+
+      const ids = versionIds.map((version) => version.id);
+      const versions = ids.length
+        ? await query.findMany({
+            where: { id: { $in: ids } },
+            populate: ['createdBy'],
+          })
+        : [];
+      const versionsById = new Map(versions.map((version) => [version.id, version]));
+      const results = ids.map((id) => versionsById.get(id));
 
       const populateEntry = async (entry: HistoryVersionQueryResult) => {
         return traverseEntity(

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -43,10 +43,9 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
         locale = params.query.locale || defaultLocale;
       }
 
-      // NOTE: We get the IDs first before fetching the full versions, because sorting the whole
-      // snapshots runs MySQL/MariaDB out of sort memory
+      // NOTE: We get the IDs first because sorting full rows runs MySQL/MariaDB out of sort memory
       // See: https://github.com/strapi/strapi/issues/27393
-      const [{ results: versionIds, pagination }, localeDictionary] = await Promise.all([
+      const [{ results: versionRows, pagination }, localeDictionary] = await Promise.all([
         query.findPage({
           ...params.query,
           select: ['id'],
@@ -62,7 +61,7 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
         serviceUtils.getLocaleDictionary(),
       ]);
 
-      const ids = versionIds.map((version) => version.id);
+      const ids = versionRows.map((version) => version.id);
       const versions = ids.length
         ? await query.findMany({
             where: { id: { $in: ids } },
@@ -70,7 +69,7 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
           })
         : [];
       const versionsById = new Map(versions.map((version) => [version.id, version]));
-      const results = ids.map((id) => versionsById.get(id));
+      const results = ids.map((id) => versionsById.get(id)).filter(Boolean);
 
       const populateEntry = async (entry: HistoryVersionQueryResult) => {
         return traverseEntity(


### PR DESCRIPTION
### What does it do?

`findVersionsPage` now runs the paginated query with `select: ['id']`, then fetches those versions by id and reorders them in memory. The rows the database has to sort are a couple of integer columns instead of full content snapshots.

### Why is it needed?

`strapi_history_versions` stores a whole snapshot of the entry per row, so `select *` plus `order by created_at desc` makes MySQL/MariaDB sort megabytes of JSON. Past the default 256 KB `sort_buffer_size` the query dies with `ER_OUT_OF_SORTMEMORY` and Content History shows "Whoops! Something went wrong". The reporter hits it with 13 versions of a single document. Same problem, and same fix, as #20312 / #23331 on `strapi_database_schema`.

### How to test it?

On MySQL, save an entry with a large rich text body enough times to build up a few versions, then open its Content History. It should list the versions instead of erroring. `sort_buffer_size` can be lowered to reproduce it faster on smaller content.

### Related issue(s)/PR(s)

fixes: #27393
