### PR TITLE
enhancement(upload): reject oversized images before sharp decode

### DIFF
--- a/packages/core/upload/server/src/config.ts
+++ b/packages/core/upload/server/src/config.ts
@@ -11,7 +11,11 @@ export const config = {
     concurrentUploadSize: 1,
     concurrentUploadRequests: 1,
   },
-  validator(config: { concurrentUploadSize?: unknown; concurrentUploadRequests?: unknown }) {
+  validator(config: {
+    concurrentUploadSize?: unknown;
+    concurrentUploadRequests?: unknown;
+    security?: { maxImageResolution?: unknown };
+  }) {
     const assertPositiveInteger = (key: string, value: unknown) => {
       if (value === undefined) {
         return;
@@ -27,5 +31,7 @@ export const config = {
     assertPositiveInteger('concurrentUploadSize', config.concurrentUploadSize);
     // Client-side parallelism: upload requests the admin fires at once.
     assertPositiveInteger('concurrentUploadRequests', config.concurrentUploadRequests);
+    // Max width*height accepted before sharp decodes an image.
+    assertPositiveInteger('security.maxImageResolution', config.security?.maxImageResolution);
   },
 };

--- a/packages/core/upload/server/src/constants.ts
+++ b/packages/core/upload/server/src/constants.ts
@@ -33,6 +33,11 @@ const FOLDER_MODEL_UID = 'plugin::upload.folder';
 const FILE_MODEL_UID = 'plugin::upload.file';
 const API_UPLOAD_FOLDER_BASE_NAME = 'API Uploads';
 
+// Sharp's own built-in decode ceiling (0x3FFF * 0x3FFF). Used as the default for
+// plugin::upload.security.maxImageResolution so the guard is a no-op out of the box;
+// memory-constrained hosts can lower it to reject large images before sharp decodes them.
+const DEFAULT_MAX_IMAGE_RESOLUTION = 268402689;
+
 export {
   ACTIONS,
   FOLDER_MODEL_UID,
@@ -40,6 +45,7 @@ export {
   API_UPLOAD_FOLDER_BASE_NAME,
   ALLOWED_SORT_STRINGS,
   ALLOWED_WEBHOOK_EVENTS,
+  DEFAULT_MAX_IMAGE_RESOLUTION,
   // Re-exported from `shared/` so the admin panel can gate on the same values.
   AI_METADATA_CHUNK_SIZE,
   AI_METADATA_MAX_FILES,

--- a/packages/core/upload/server/src/services/__tests__/upload/pixelLimit.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/pixelLimit.test.ts
@@ -1,0 +1,83 @@
+// enhanceAndValidateFile rejects oversized images before sharp decodes them (issue #25750:
+// large images crashing memory-constrained hosts mid-upload).
+import path from 'path';
+import fse from 'fs-extra';
+import _ from 'lodash';
+import createUploadService from '../../upload';
+import imageManipulation from '../../image-manipulation';
+
+const defaultConfig: Record<string, any> = {
+  'plugin::upload': {
+    breakpoints: {
+      large: 1000,
+      medium: 750,
+    },
+  },
+};
+
+global.strapi = {
+  config: {
+    get: (path: any, defaultValue: any) => _.get(defaultConfig, path, defaultValue),
+  },
+  plugins: {
+    upload: {
+      services: {
+        provider: { upload: jest.fn() },
+        upload: { getSettings: () => ({ responsiveDimensions: false }) },
+        file: { getFolderPath: async () => '/' },
+        'image-manipulation': imageManipulation,
+      },
+    },
+  },
+  plugin: (name: string) => global.strapi.plugins[name],
+} as any;
+
+// enhanceAndValidateFile reads `strapi` from the factory closure (unlike other functions here,
+// which go through the getService() global helper), so the real global must be passed in.
+const uploadService = createUploadService({ strapi: global.strapi } as any);
+
+const imageFilePath = path.join(__dirname, './image.png'); // real dimensions: 1417x1063
+const tmpWorkingDirectory = path.join(__dirname, './tmp-pixel-limit');
+
+const getInputFile = () => ({
+  filepath: imageFilePath,
+  originalFilename: 'image.png',
+  newFilename: 'image.png',
+  mimetype: 'image/png',
+  size: 4000,
+  tmpWorkingDirectory,
+});
+
+describe('enhanceAndValidateFile - pixel limit guard', () => {
+  beforeAll(async () => {
+    await fse.mkdir(tmpWorkingDirectory);
+  });
+
+  afterAll(async () => {
+    await fse.remove(tmpWorkingDirectory);
+  });
+
+  beforeEach(() => {
+    delete defaultConfig['plugin::upload'].security;
+  });
+
+  test('rejects an image above the configured pixel limit without decoding it', async () => {
+    defaultConfig['plugin::upload'].security = { maxImageResolution: 1_000_000 };
+
+    await expect(uploadService._enhanceAndValidateFile(getInputFile() as any, {})).rejects.toThrow(
+      /too large to process/
+    );
+  });
+
+  test('allows the same image when under the configured pixel limit', async () => {
+    defaultConfig['plugin::upload'].security = { maxImageResolution: 10_000_000 };
+
+    const result = await uploadService._enhanceAndValidateFile(getInputFile() as any, {});
+    expect(result.name).toBe('image.png');
+  });
+
+  test('allows the image when no limit is configured (default is a no-op)', async () => {
+    const result = await uploadService._enhanceAndValidateFile(getInputFile() as any, {});
+    expect(result.name).toBe('image.png');
+  });
+});

--- a/packages/core/upload/server/src/services/image-manipulation.ts
+++ b/packages/core/upload/server/src/services/image-manipulation.ts
@@ -5,6 +5,7 @@ import crypto from 'crypto';
 import { strings, file as fileUtils } from '@strapi/utils';
 
 import { getService } from '../utils';
+import { DEFAULT_MAX_IMAGE_RESOLUTION } from '../constants';
 
 import type { UploadableFile } from '../types';
 
@@ -34,6 +35,20 @@ const writeStreamToFile = (stream: NodeJS.ReadWriteStream, path: string) =>
     writeStream.on('error', reject);
   });
 
+// Read once per call site rather than cached, so config changes (e.g. in tests) take effect.
+const getPixelLimit = () =>
+  strapi.config.get<number>(
+    'plugin::upload.security.maxImageResolution',
+    DEFAULT_MAX_IMAGE_RESOLUTION
+  );
+
+// Passed to every sharp() decode so oversized images throw a catchable error instead of
+// exhausting memory. metadata() reads only the header and ignores this option.
+const sharpOptions = () => ({ limitInputPixels: getPixelLimit(), animated: true }) as const;
+
+// No limitInputPixels here: metadata() only reads the header, so this stays cheap regardless
+// of image size, and callers (e.g. the pixel-limit guard in upload.ts) need real dimensions
+// back to make an accurate, informative rejection decision.
 const getMetadata = (file: UploadableFile): Promise<Metadata> => {
   if (!file.filepath) {
     return new Promise((resolve, reject) => {
@@ -73,7 +88,7 @@ const resizeFileTo = async (
 
   let newInfo;
   if (!file.filepath) {
-    const transform = sharp({ animated: true })
+    const transform = sharp(sharpOptions())
       .resize(options)
       .on('info', (info) => {
         newInfo = info;
@@ -81,7 +96,7 @@ const resizeFileTo = async (
 
     await writeStreamToFile(file.getStream().pipe(transform), filePath);
   } else {
-    newInfo = await sharp(file.filepath, { animated: true }).resize(options).toFile(filePath);
+    newInfo = await sharp(file.filepath, sharpOptions()).resize(options).toFile(filePath);
   }
 
   const { width, height, size, pageHeight } = newInfo ?? {};
@@ -135,9 +150,9 @@ const optimize = async (file: UploadableFile) => {
   if ((sizeOptimization || autoOrientation) && isOptimizableFormat(format)) {
     let transformer;
     if (!file.filepath) {
-      transformer = sharp({ animated: true });
+      transformer = sharp(sharpOptions());
     } else {
-      transformer = sharp(file.filepath, { animated: true });
+      transformer = sharp(file.filepath, sharpOptions());
     }
     // reduce image quality
     transformer[format]({ quality: sizeOptimization ? 80 : 100 });
@@ -250,14 +265,14 @@ const breakpointSmallerThan = (breakpoint: number, { width, height }: Dimensions
 const isFaultyImage = async (file: UploadableFile) => {
   if (!file.filepath) {
     return new Promise((resolve, reject) => {
-      const pipeline = sharp();
+      const pipeline = sharp({ limitInputPixels: getPixelLimit() });
       pipeline.stats().then(resolve).catch(reject);
       file.getStream().pipe(pipeline);
     });
   }
 
   try {
-    await sharp(file.filepath).stats();
+    await sharp(file.filepath, { limitInputPixels: getPixelLimit() }).stats();
     return false;
   } catch {
     return true;

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -16,7 +16,7 @@ import { has, toNumber, isNil } from 'lodash/fp';
 
 import type { Core, UID } from '@strapi/types';
 
-import { FILE_MODEL_UID, ALLOWED_WEBHOOK_EVENTS } from '../constants';
+import { FILE_MODEL_UID, ALLOWED_WEBHOOK_EVENTS, DEFAULT_MAX_IMAGE_RESOLUTION } from '../constants';
 import { getService } from '../utils';
 
 import type { Config, File, InputFile, UploadableFile, FileInfo } from '../types';
@@ -213,11 +213,24 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     currentFile.filepath = file.filepath;
     currentFile.getStream = () => fs.createReadStream(file.filepath);
 
-    const { optimize, isImage, isFaultyImage, isOptimizableImage } = strapi
+    const { optimize, isImage, isFaultyImage, isOptimizableImage, getDimensions } = strapi
       .plugin('upload')
       .service('image-manipulation');
 
     if (await isImage(currentFile)) {
+      // Reject oversized images before any sharp decode (resize/optimize/stats), which is
+      // where memory-constrained hosts (e.g. low-RAM cloud tiers) OOM on large uploads.
+      const { width, height } = await getDimensions(currentFile);
+      const maxImageResolution = strapi.config.get<number>(
+        'plugin::upload.security.maxImageResolution',
+        DEFAULT_MAX_IMAGE_RESOLUTION
+      );
+      if (width && height && width * height > maxImageResolution) {
+        throw new ApplicationError(
+          `File "${currentFile.name}" is too large to process (${width}x${height} exceeds the ${maxImageResolution}px limit). Reduce the image size or raise plugin::upload.security.maxImageResolution.`
+        );
+      }
+
       if (await isFaultyImage(currentFile)) {
         throw new ApplicationError('File is not a valid image');
       }
@@ -769,5 +782,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
      * @internal
      */
     _uploadImage: uploadImage,
+    _enhanceAndValidateFile: enhanceAndValidateFile,
   };
 };

--- a/packages/core/upload/server/src/types.ts
+++ b/packages/core/upload/server/src/types.ts
@@ -76,6 +76,8 @@ export interface Config {
   security?: {
     allowedTypes?: string[];
     deniedTypes?: string[];
+    /** Max width*height (pixels) allowed before sharp decodes an image. Defaults to sharp's own limit. */
+    maxImageResolution?: number;
   };
 }
 


### PR DESCRIPTION
>  What does it do?

-   Add a pixel-count guard to @strapi/upload that rejects oversized images before Sharp decodes them. enhanceAndValidateFile now reads image dimensions via getDimensions and compares width * height against a new plugin::upload.security.maxImageResolution config option, throwing an ApplicationError before any resize/optimize/stats call touches the file.
-   The same limit is also passed as limitInputPixels to every sharp() call (resize, optimize, faulty-image check) as defense in depth.
-   Default value is 268402689 (Sharp's own built-in decode ceiling), so out-of-the-box behavior is unchanged, this is an opt-in config option, not a new default restriction, and does not by itself close #25750 (default config still lets oversized images through unrejected; operators on memory-constrained hosts need to lower the value explicitly).

>   Why is it needed?

  Uploading a very large image (extreme resolution, small file size) can exhaust memory when Sharp decodes it, crashing memory-constrained hosts (low-RAM cloud tiers) mid-upload. There was no guard rejecting these before decode. This adds a configurable ceiling so admins on constrained hosts can reject oversized images early, with a clear error message instead of an OOM crash.

>   How to test it?

  Environment: local dev sandbox (examples/getstarted, SQLite).

  1. Set plugin::upload.security.maxImageResolution in config/plugins.js to a low value (e.g. 1000000).
  2. Start yarn develop, go to Media Library.
  3. Upload an image whose width * height exceeds the configured limit, expect rejection with a "too large to process" error, no hang/spike.
  4. Upload a normal image under the limit, expect normal upload, unaffected.
  5. Remove/unset the config option, confirm default behavior (large default ceiling) still lets
  normal-sized images through as before (no regression).

  Unit coverage: packages/core/upload/server/src/services/tests/upload/pixelLimit.test.ts,  rejects above
  limit, allows under limit, allows when unconfigured (no-op default).

  Related issue(s)/PR(s)
  Related to #25750 