### PR TITLE
fix(database): document-id migration can take hours on large localized tables

### DIFF
--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -27,94 +27,39 @@ function getBatchSize(trx: Knex, defaultSize: number = 1000): number {
   return isSQLite ? Math.min(defaultSize, 250) : defaultSize;
 }
 
-interface Params {
-  joinColumn: string;
-  inverseJoinColumn: string;
-  tableName: string;
-  joinTableName: string;
-}
-
-const QUERIES = {
-  async postgres(knex: Knex, params: Params) {
-    const res = await knex.raw(
-      `
-    SELECT :tableName:.id as id, string_agg(DISTINCT :inverseJoinColumn:::character varying, ',') as other_ids
-    FROM :tableName:
-    LEFT JOIN :joinTableName: ON :tableName:.id = :joinTableName:.:joinColumn:
-    WHERE :tableName:.document_id IS NULL
-    GROUP BY :tableName:.id, :joinTableName:.:joinColumn:
-    LIMIT 1;
-  `,
-      params
-    );
-
-    return res.rows;
-  },
-  async mysql(knex: Knex, params: Params) {
-    const [res] = await knex.raw(
-      `
-    SELECT :tableName:.id as id, group_concat(DISTINCT :inverseJoinColumn:) as other_ids
-    FROM :tableName:
-    LEFT JOIN :joinTableName: ON :tableName:.id = :joinTableName:.:joinColumn:
-    WHERE :tableName:.document_id IS NULL
-    GROUP BY :tableName:.id, :joinTableName:.:joinColumn:
-    LIMIT 1;
-  `,
-      params
-    );
-
-    return res;
-  },
-  async sqlite(knex: Knex, params: Params) {
-    return knex.raw(
-      `
-    SELECT :tableName:.id as id, group_concat(DISTINCT :inverseJoinColumn:) as other_ids
-    FROM :tableName:
-    LEFT JOIN :joinTableName: ON :tableName:.id = :joinTableName:.:joinColumn:
-    WHERE :tableName:.document_id IS NULL
-    GROUP BY :joinTableName:.:joinColumn:
-    LIMIT 1;
-    `,
-      params
-    );
-  },
+// Union-find (disjoint-set) helpers used to cluster localization-linked rows in memory.
+// Path-compressing `find` keeps repeated lookups close to O(1) amortized.
+const find = (parent: Map<number, number>, start: number): number => {
+  let current = start;
+  while (parent.get(current) !== current) {
+    parent.set(current, parent.get(parent.get(current) as number) as number);
+    current = parent.get(current) as number;
+  }
+  return current;
 };
 
-const getNextIdsToCreateDocumentId = async (
-  db: Database,
-  knex: Knex,
-  {
-    joinColumn,
-    inverseJoinColumn,
-    tableName,
-    joinTableName,
-  }: {
-    joinColumn: string;
-    inverseJoinColumn: string;
-    tableName: string;
-    joinTableName: string;
+const union = (parent: Map<number, number>, a: number, b: number): void => {
+  const rootA = find(parent, a);
+  const rootB = find(parent, b);
+  if (rootA !== rootB) {
+    parent.set(rootA, rootB);
   }
-): Promise<number[]> => {
-  const res = await QUERIES[db.dialect.client as keyof typeof QUERIES](knex, {
-    joinColumn,
-    inverseJoinColumn,
-    tableName,
-    joinTableName,
-  });
-
-  if (res.length > 0) {
-    const row = res[0];
-    const otherIds = row.other_ids
-      ? row.other_ids.split(',').map((v: string) => parseInt(v, 10))
-      : [];
-
-    return [row.id, ...otherIds];
-  }
-
-  return [];
 };
 
 // Migrate document ids for tables that have localizations
+//
+// This clusters rows in memory (via union-find) instead of discovering one cluster at a
+// time through a `LIMIT 1` query. The previous implementation re-ran a query that scans
+// the whole table (filtered by `document_id IS NULL`, a column with no index at this point
+// in the migration) once per cluster, which is roughly O(n) discovery queries each doing
+// an O(n) scan — effectively O(n^2) for a table with n rows. For tables with many rows
+// and/or many locales this could take hours or longer without making visible progress.
+// See https://github.com/strapi/strapi/issues/23812, 23517, 25231.
+//
+// This also fixes a correctness gap: the original query only follows *direct* links
+// (one hop), so a chain of locale links (A<->B, B<->C, but no direct A<->C row) could be
+// split across two document ids instead of clustered together. Union-find naturally
+// follows transitive links. See https://github.com/strapi/strapi/issues/20948, 24544.
 const migrateDocumentIdsWithLocalizations = async (
   db: Database,
   knex: Knex,
@@ -124,27 +69,76 @@ const migrateDocumentIdsWithLocalizations = async (
   const singularName = meta.singularName.toLowerCase();
   const joinColumn = snakeCase(`${singularName}_id`);
   const inverseJoinColumn = snakeCase(`inv_${singularName}_id`);
-  let ids: number[];
-  let processed = 0;
+  const joinTableName = snakeCase(`${meta.tableName}_localizations_links`);
+  const batchSize = getBatchSize(knex);
 
-  do {
-    ids = await getNextIdsToCreateDocumentId(db, knex, {
-      joinColumn,
-      inverseJoinColumn,
-      tableName: meta.tableName,
-      joinTableName: snakeCase(`${meta.tableName}_localizations_links`),
-    });
+  const pendingIds: number[] = (
+    await knex(meta.tableName).select('id').whereNull('document_id')
+  ).map((row: { id: number }) => row.id);
 
-    if (ids.length > 0) {
-      await knex(meta.tableName).update({ document_id: createId() }).whereIn('id', ids);
-      processed += ids.length;
-      const rowsProcessed = processed;
-      heartbeat.tick(
-        (elapsedSeconds) =>
-          `[document-id] still running (${elapsedSeconds}s) · ${meta.tableName} ${rowsProcessed} rows processed`
-      );
+  if (pendingIds.length === 0) {
+    return;
+  }
+
+  const pendingIdSet = new Set(pendingIds);
+
+  // Fetch every relevant link in batches — passing all ids in a single `whereIn` can
+  // exceed the database driver's bound-parameter limit on large tables.
+  const links: Array<Record<string, number>> = [];
+  for (let i = 0; i < pendingIds.length; i += batchSize) {
+    const idChunk = pendingIds.slice(i, i + batchSize);
+    const chunkLinks = await knex(joinTableName)
+      .select(joinColumn, inverseJoinColumn)
+      .whereIn(joinColumn, idChunk);
+    links.push(...chunkLinks);
+  }
+
+  const parent = new Map<number, number>();
+  for (const id of pendingIds) {
+    parent.set(id, id);
+  }
+  for (const link of links) {
+    const a = link[joinColumn];
+    const b = link[inverseJoinColumn];
+    if (pendingIdSet.has(a) && pendingIdSet.has(b)) {
+      union(parent, a, b);
     }
-  } while (ids.length > 0);
+  }
+
+  const clusters = new Map<number, number[]>();
+  for (const id of pendingIds) {
+    const root = find(parent, id);
+    const cluster = clusters.get(root);
+    if (cluster) {
+      cluster.push(id);
+    } else {
+      clusters.set(root, [id]);
+    }
+  }
+
+  const updates: Array<{ id: number; documentId: string }> = [];
+  for (const ids of clusters.values()) {
+    const documentId = createId();
+    for (const id of ids) {
+      updates.push({ id, documentId });
+    }
+  }
+
+  let processed = 0;
+  for (let i = 0; i < updates.length; i += batchSize) {
+    const batch = updates.slice(i, i + batchSize);
+    await Promise.all(
+      batch.map(({ id, documentId }) =>
+        knex(meta.tableName).where('id', id).update({ document_id: documentId })
+      )
+    );
+    processed += batch.length;
+    const rowsProcessed = processed;
+    heartbeat.tick(
+      (elapsedSeconds) =>
+        `[document-id] still running (${elapsedSeconds}s) · ${meta.tableName} ${rowsProcessed}/${updates.length} rows processed`
+    );
+  }
 };
 
 // Migrate document ids for tables that don't have localizations

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -173,7 +173,14 @@ const migrateDocumentIdsWithLocalizations = async (
 
     const pendingMembers = members.filter((id) => pendingIdSet.has(id));
     if (pendingMembers.length > 0) {
-      writeGroups.set(documentId, pendingMembers);
+      // Two distinct clusters resolving to the same document_id is only possible via a
+      // cuid collision, but merge rather than overwrite so neither group's writes vanish.
+      const existingGroup = writeGroups.get(documentId);
+      if (existingGroup) {
+        existingGroup.push(...pendingMembers);
+      } else {
+        writeGroups.set(documentId, pendingMembers);
+      }
     }
   }
 

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -60,6 +60,13 @@ const union = (parent: Map<number, number>, a: number, b: number): void => {
 // (one hop), so a chain of locale links (A<->B, B<->C, but no direct A<->C row) could be
 // split across two document ids instead of clustered together. Union-find naturally
 // follows transitive links. See https://github.com/strapi/strapi/issues/20948, 24544.
+//
+// Retry-safety: a previous run can crash between clusters, leaving some rows in a
+// locale group already assigned a document_id while their siblings are still NULL. On
+// retry those NULL rows must adopt the sibling's existing document_id instead of minting
+// a fresh one, or a document that used to be one splits into two. To support this, the
+// link fetch and the clustering below include already-migrated neighbor rows, not just
+// pending ones — but only pending (NULL) rows are ever written.
 const migrateDocumentIdsWithLocalizations = async (
   db: Database,
   knex: Knex,
@@ -82,31 +89,61 @@ const migrateDocumentIdsWithLocalizations = async (
 
   const pendingIdSet = new Set(pendingIds);
 
-  // Fetch every relevant link in batches — passing all ids in a single `whereIn` can
-  // exceed the database driver's bound-parameter limit on large tables.
+  // Fetch every link touching a pending id, on *either* side of the join — a pending
+  // row's sibling may already be migrated, in which case it appears as the other column.
+  // Batched because passing all ids in a single `whereIn` can exceed the database
+  // driver's bound-parameter limit on large tables.
   const links: Array<Record<string, number>> = [];
   for (let i = 0; i < pendingIds.length; i += batchSize) {
     const idChunk = pendingIds.slice(i, i + batchSize);
     const chunkLinks = await knex(joinTableName)
       .select(joinColumn, inverseJoinColumn)
-      .whereIn(joinColumn, idChunk);
+      .whereIn(joinColumn, idChunk)
+      .orWhereIn(inverseJoinColumn, idChunk);
     links.push(...chunkLinks);
+  }
+
+  // Ids referenced by a link that aren't pending are already-migrated neighbors — look up
+  // their document_id so a retry can adopt it instead of minting a new one.
+  const neighborIds = new Set<number>();
+  for (const link of links) {
+    const a = link[joinColumn];
+    const b = link[inverseJoinColumn];
+    if (!pendingIdSet.has(a)) neighborIds.add(a);
+    if (!pendingIdSet.has(b)) neighborIds.add(b);
+  }
+
+  const existingDocumentIds = new Map<number, string>();
+  const neighborIdList = [...neighborIds];
+  for (let i = 0; i < neighborIdList.length; i += batchSize) {
+    const idChunk = neighborIdList.slice(i, i + batchSize);
+    const rows: Array<{ id: number; document_id: string | null }> = await knex(meta.tableName)
+      .select('id', 'document_id')
+      .whereIn('id', idChunk);
+    for (const row of rows) {
+      if (row.document_id) {
+        existingDocumentIds.set(row.id, row.document_id);
+      }
+    }
   }
 
   const parent = new Map<number, number>();
   for (const id of pendingIds) {
     parent.set(id, id);
   }
+  for (const id of neighborIds) {
+    parent.set(id, id);
+  }
   for (const link of links) {
     const a = link[joinColumn];
     const b = link[inverseJoinColumn];
-    if (pendingIdSet.has(a) && pendingIdSet.has(b)) {
+    if (parent.has(a) && parent.has(b)) {
       union(parent, a, b);
     }
   }
 
   const clusters = new Map<number, number[]>();
-  for (const id of pendingIds) {
+  for (const id of parent.keys()) {
     const root = find(parent, id);
     const cluster = clusters.get(root);
     if (cluster) {
@@ -116,27 +153,44 @@ const migrateDocumentIdsWithLocalizations = async (
     }
   }
 
-  const updates: Array<{ id: number; documentId: string }> = [];
-  for (const ids of clusters.values()) {
-    const documentId = createId();
-    for (const id of ids) {
-      updates.push({ id, documentId });
+  // Group pending writes by target document_id — one write per cluster instead of one
+  // per row shrinks the window for a crash to leave a cluster half-written.
+  const writeGroups = new Map<string, number[]>();
+  for (const members of clusters.values()) {
+    const existingIdsInCluster = new Set<string>();
+    for (const id of members) {
+      const existing = existingDocumentIds.get(id);
+      if (existing) {
+        existingIdsInCluster.add(existing);
+      }
+    }
+
+    // A cluster normally carries at most one existing document_id. More than one means an
+    // earlier inconsistent partial write — unify onto a single deterministic id rather
+    // than minting a third.
+    const documentId =
+      existingIdsInCluster.size > 0 ? [...existingIdsInCluster].sort()[0] : createId();
+
+    const pendingMembers = members.filter((id) => pendingIdSet.has(id));
+    if (pendingMembers.length > 0) {
+      writeGroups.set(documentId, pendingMembers);
     }
   }
 
+  const groupEntries = [...writeGroups.entries()];
   let processed = 0;
-  for (let i = 0; i < updates.length; i += batchSize) {
-    const batch = updates.slice(i, i + batchSize);
+  for (let i = 0; i < groupEntries.length; i += batchSize) {
+    const slice = groupEntries.slice(i, i + batchSize);
     await Promise.all(
-      batch.map(({ id, documentId }) =>
-        knex(meta.tableName).where('id', id).update({ document_id: documentId })
+      slice.map(([documentId, ids]) =>
+        knex(meta.tableName).whereIn('id', ids).update({ document_id: documentId })
       )
     );
-    processed += batch.length;
+    processed += slice.reduce((sum, [, ids]) => sum + ids.length, 0);
     const rowsProcessed = processed;
     heartbeat.tick(
       (elapsedSeconds) =>
-        `[document-id] still running (${elapsedSeconds}s) · ${meta.tableName} ${rowsProcessed}/${updates.length} rows processed`
+        `[document-id] still running (${elapsedSeconds}s) · ${meta.tableName} ${rowsProcessed}/${pendingIds.length} rows processed`
     );
   }
 };

--- a/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
+++ b/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
@@ -1,4 +1,5 @@
 import type { Knex } from 'knex';
+import { snakeCase } from 'lodash/fp';
 
 import { createdDocumentId } from '../5.0.0-02-document-id';
 
@@ -256,5 +257,242 @@ describe('createdDocumentId migration — idempotent recovery (CMS-689)', () => 
     expect(h.insertCalls.map((call) => call.records.length)).toEqual([1000, 500]);
     expectValidBackfill(h.insertCalls, 1500);
     expectUpsertOnId(h.onConflictCalls, 2);
+  });
+});
+
+describe('createdDocumentId migration — localized tables (union-find clustering)', () => {
+  type Link = Record<string, number>;
+  type UpdateCall = { id: number; document_id: string };
+
+  const buildLocalizedHarness = (
+    options: {
+      tableName?: string;
+      singularName?: string;
+      pendingRows?: Array<{ id: number }>;
+      links?: Link[];
+      client?: string;
+    } = {}
+  ) => {
+    const {
+      tableName = 'categories',
+      singularName = 'category',
+      pendingRows = [],
+      links = [],
+      client = 'postgres',
+    } = options;
+
+    const joinColumn = snakeCase(`${singularName}_id`);
+    const inverseJoinColumn = snakeCase(`inv_${singularName}_id`);
+    const joinTableName = snakeCase(`${tableName}_localizations_links`);
+
+    const updateCalls: UpdateCall[] = [];
+    const linkWhereInChunkSizes: number[] = [];
+
+    const knexBuilder: any = jest.fn((table: string) => {
+      if (table === joinTableName) {
+        const builder: any = {
+          select: jest.fn(() => builder),
+          whereIn: jest.fn(async (column: string, chunk: number[]) => {
+            linkWhereInChunkSizes.push(chunk.length);
+            const chunkSet = new Set(chunk);
+            return links.filter((link) => chunkSet.has(link[joinColumn]));
+          }),
+        };
+        return builder;
+      }
+
+      if (table === tableName) {
+        const builder: any = {
+          select: jest.fn(() => builder),
+          whereNull: jest.fn(async () => pendingRows),
+          where: jest.fn((_column: string, id: number) => ({
+            update: jest.fn(async (data: { document_id: string }) => {
+              updateCalls.push({ id, document_id: data.document_id });
+              return 1;
+            }),
+          })),
+        };
+        return builder;
+      }
+
+      throw new Error(`Unexpected table access in test harness: ${table}`);
+    });
+
+    knexBuilder.client = { config: { client } };
+    knexBuilder.schema = {
+      hasTable: jest.fn(async () => true),
+      hasColumn: jest.fn(async () => true),
+      alterTable: jest.fn(),
+    };
+
+    const db: any = {
+      dialect: { client },
+      logger: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      },
+      metadata: {
+        values: () => [{ tableName, singularName, attributes: { documentId: {} } }],
+      },
+    };
+
+    return {
+      knex: knexBuilder as unknown as Knex.Transaction,
+      db,
+      get updateCalls() {
+        return updateCalls;
+      },
+      get linkWhereInChunkSizes() {
+        return linkWhereInChunkSizes;
+      },
+      joinColumn,
+      inverseJoinColumn,
+    };
+  };
+
+  const clusterByDocumentId = (updateCalls: UpdateCall[]) => {
+    const byDocumentId = new Map<string, number[]>();
+    for (const { id, document_id: documentId } of updateCalls) {
+      const cluster = byDocumentId.get(documentId);
+      if (cluster) {
+        cluster.push(id);
+      } else {
+        byDocumentId.set(documentId, [id]);
+      }
+    }
+    return [...byDocumentId.values()].map((ids) => ids.sort((a, b) => a - b));
+  };
+
+  it('assigns every row its own document_id when the link table has no rows (matches the pre-fix per-row result, in one pass instead of one query per row)', async () => {
+    const h = buildLocalizedHarness({
+      pendingRows: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      links: [],
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    expect(h.updateCalls).toHaveLength(3);
+    const clusters = clusterByDocumentId(h.updateCalls);
+    expect(clusters.sort()).toEqual([[1], [2], [3]]);
+  });
+
+  it('groups two directly linked rows under the same document_id', async () => {
+    const h = buildLocalizedHarness({
+      pendingRows: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      links: [{ [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 }],
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    const clusters = clusterByDocumentId(h.updateCalls).sort((a, b) => a[0] - b[0]);
+    expect(clusters).toEqual([[1, 2], [3]]);
+  });
+
+  it('groups a transitive chain (A<->B, B<->C, no direct A<->C link) into a single document_id', async () => {
+    const h = buildLocalizedHarness({
+      pendingRows: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      links: [
+        { [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 },
+        { [snakeCase('category_id')]: 2, [snakeCase('inv_category_id')]: 3 },
+      ],
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    const clusters = clusterByDocumentId(h.updateCalls);
+    expect(clusters).toEqual([[1, 2, 3]]);
+  });
+
+  it('keeps multiple independent clusters separate', async () => {
+    const h = buildLocalizedHarness({
+      pendingRows: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
+      links: [
+        { [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 },
+        { [snakeCase('category_id')]: 3, [snakeCase('inv_category_id')]: 4 },
+      ],
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    const clusters = clusterByDocumentId(h.updateCalls).sort((a, b) => a[0] - b[0]);
+    expect(clusters).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('ignores links pointing at ids outside the pending set', async () => {
+    const h = buildLocalizedHarness({
+      pendingRows: [{ id: 1 }, { id: 2 }],
+      // 999 is not in pendingRows (e.g. already migrated) — must not throw or merge into it
+      links: [{ [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 999 }],
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    const clusters = clusterByDocumentId(h.updateCalls).sort((a, b) => a[0] - b[0]);
+    expect(clusters).toEqual([[1], [2]]);
+  });
+
+  it('fetches links in batches rather than a single unbounded whereIn (avoids exceeding the driver bound-parameter limit)', async () => {
+    const pendingRows = Array.from({ length: 2500 }, (_, i) => ({ id: i + 1 }));
+    const h = buildLocalizedHarness({
+      pendingRows,
+      links: [],
+      client: 'postgres',
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    expect(h.linkWhereInChunkSizes).toEqual([1000, 1000, 500]);
+    expect(h.updateCalls).toHaveLength(2500);
+    // every row is its own cluster since there are no links
+    expect(new Set(h.updateCalls.map((c) => c.document_id)).size).toBe(2500);
+  });
+
+  it('does nothing when there are no rows pending a document_id', async () => {
+    const h = buildLocalizedHarness({ pendingRows: [], links: [] });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    expect(h.updateCalls).toEqual([]);
+  });
+
+  it('uses the smaller SQLite batch size (250) for link discovery, same as the non-localized path', async () => {
+    const pendingRows = Array.from({ length: 260 }, (_, i) => ({ id: i + 1 }));
+    const h = buildLocalizedHarness({
+      pendingRows,
+      links: [],
+      client: 'sqlite3',
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    expect(h.linkWhereInChunkSizes).toEqual([250, 10]);
+    expect(h.updateCalls).toHaveLength(260);
+  });
+
+  it('clusters and batches correctly on MySQL, same generic Knex calls as postgres/sqlite (batch size 1000, like postgres)', async () => {
+    const pendingRows = Array.from({ length: 1200 }, (_, i) => ({ id: i + 1 }));
+    // link every even id to the next odd id, forming 600 two-row clusters
+    const links = [];
+    for (let i = 1; i <= 1200; i += 2) {
+      links.push({ [snakeCase('category_id')]: i, [snakeCase('inv_category_id')]: i + 1 });
+    }
+    const h = buildLocalizedHarness({
+      pendingRows,
+      links,
+      client: 'mysql',
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    expect(h.linkWhereInChunkSizes).toEqual([1000, 200]);
+    expect(h.updateCalls).toHaveLength(1200);
+    const clusters = clusterByDocumentId(h.updateCalls);
+    expect(clusters).toHaveLength(600);
+    expect(clusters.every((cluster) => cluster.length === 2)).toBe(true);
   });
 });

--- a/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
+++ b/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
@@ -270,6 +270,7 @@ describe('createdDocumentId migration — localized tables (union-find clusterin
       singularName?: string;
       pendingRows?: Array<{ id: number }>;
       links?: Link[];
+      existingDocumentIds?: Record<number, string>;
       client?: string;
     } = {}
   ) => {
@@ -278,6 +279,7 @@ describe('createdDocumentId migration — localized tables (union-find clusterin
       singularName = 'category',
       pendingRows = [],
       links = [],
+      existingDocumentIds = {},
       client = 'postgres',
     } = options;
 
@@ -285,32 +287,52 @@ describe('createdDocumentId migration — localized tables (union-find clusterin
     const inverseJoinColumn = snakeCase(`inv_${singularName}_id`);
     const joinTableName = snakeCase(`${tableName}_localizations_links`);
 
-    const updateCalls: UpdateCall[] = [];
+    const groupedUpdateCalls: Array<{ ids: number[]; document_id: string }> = [];
     const linkWhereInChunkSizes: number[] = [];
 
     const knexBuilder: any = jest.fn((table: string) => {
       if (table === joinTableName) {
+        const conditions: Array<{ column: string; values: number[] }> = [];
         const builder: any = {
           select: jest.fn(() => builder),
-          whereIn: jest.fn(async (column: string, chunk: number[]) => {
+          whereIn: jest.fn((column: string, chunk: number[]) => {
             linkWhereInChunkSizes.push(chunk.length);
-            const chunkSet = new Set(chunk);
-            return links.filter((link) => chunkSet.has(link[joinColumn]));
+            conditions.push({ column, values: chunk });
+            return builder;
+          }),
+          orWhereIn: jest.fn((column: string, chunk: number[]) => {
+            conditions.push({ column, values: chunk });
+            return Promise.resolve(
+              links.filter((link) => conditions.some((c) => new Set(c.values).has(link[c.column])))
+            );
           }),
         };
         return builder;
       }
 
       if (table === tableName) {
+        let selected = false;
         const builder: any = {
-          select: jest.fn(() => builder),
+          select: jest.fn(() => {
+            selected = true;
+            return builder;
+          }),
           whereNull: jest.fn(async () => pendingRows),
-          where: jest.fn((_column: string, id: number) => ({
-            update: jest.fn(async (data: { document_id: string }) => {
-              updateCalls.push({ id, document_id: data.document_id });
-              return 1;
-            }),
-          })),
+          whereIn: jest.fn((_column: string, ids: number[]) => {
+            if (selected) {
+              return Promise.resolve(
+                ids
+                  .filter((id) => existingDocumentIds[id] !== undefined)
+                  .map((id) => ({ id, document_id: existingDocumentIds[id] }))
+              );
+            }
+            return {
+              update: jest.fn(async (data: { document_id: string }) => {
+                groupedUpdateCalls.push({ ids: [...ids], document_id: data.document_id });
+                return ids.length;
+              }),
+            };
+          }),
         };
         return builder;
       }
@@ -341,8 +363,13 @@ describe('createdDocumentId migration — localized tables (union-find clusterin
     return {
       knex: knexBuilder as unknown as Knex.Transaction,
       db,
-      get updateCalls() {
-        return updateCalls;
+      get updateCalls(): UpdateCall[] {
+        return groupedUpdateCalls.flatMap((group) =>
+          group.ids.map((id) => ({ id, document_id: group.document_id }))
+        );
+      },
+      get groupedUpdateCalls() {
+        return groupedUpdateCalls;
       },
       get linkWhereInChunkSizes() {
         return linkWhereInChunkSizes;
@@ -423,10 +450,10 @@ describe('createdDocumentId migration — localized tables (union-find clusterin
     ]);
   });
 
-  it('ignores links pointing at ids outside the pending set', async () => {
+  it('ignores links pointing at a genuinely missing id (no row, no document_id) — does not throw or merge into it', async () => {
     const h = buildLocalizedHarness({
       pendingRows: [{ id: 1 }, { id: 2 }],
-      // 999 is not in pendingRows (e.g. already migrated) — must not throw or merge into it
+      // 999 has no row with an existing document_id — must not throw or merge into it
       links: [{ [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 999 }],
     });
 
@@ -434,6 +461,113 @@ describe('createdDocumentId migration — localized tables (union-find clusterin
 
     const clusters = clusterByDocumentId(h.updateCalls).sort((a, b) => a[0] - b[0]);
     expect(clusters).toEqual([[1], [2]]);
+  });
+
+  describe('retry: mixed pending/already-migrated rows', () => {
+    it('adopts an already-migrated direct sibling instead of minting a new document_id', async () => {
+      const h = buildLocalizedHarness({
+        pendingRows: [{ id: 1 }],
+        // 2 already has a document_id — a retry after a partial prior run
+        links: [{ [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 }],
+        existingDocumentIds: { 2: 'doc-existing' },
+      });
+
+      await createdDocumentId.up(h.knex, h.db);
+
+      expect(h.updateCalls).toEqual([{ id: 1, document_id: 'doc-existing' }]);
+    });
+
+    it('adopts the existing document_id when the pending row is on the inverse join column', async () => {
+      const h = buildLocalizedHarness({
+        pendingRows: [{ id: 2 }],
+        // migrated hub (1) is on joinColumn, pending row (2) is on inverseJoinColumn
+        links: [{ [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 }],
+        existingDocumentIds: { 1: 'doc-existing' },
+      });
+
+      await createdDocumentId.up(h.knex, h.db);
+
+      expect(h.updateCalls).toEqual([{ id: 2, document_id: 'doc-existing' }]);
+    });
+
+    it('propagates an existing document_id across a chain reached only through an already-migrated middle row (A-C via migrated B)', async () => {
+      const h = buildLocalizedHarness({
+        pendingRows: [{ id: 1 }, { id: 3 }],
+        links: [
+          { [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 },
+          { [snakeCase('category_id')]: 2, [snakeCase('inv_category_id')]: 3 },
+        ],
+        existingDocumentIds: { 2: 'doc-existing' },
+      });
+
+      await createdDocumentId.up(h.knex, h.db);
+
+      const clusters = clusterByDocumentId(h.updateCalls);
+      expect(clusters).toEqual([[1, 3]]);
+      expect(h.updateCalls.every((c) => c.document_id === 'doc-existing')).toBe(true);
+    });
+
+    it('handles leftover NULLs after a partial cluster write: one cluster adopts, an unrelated cluster still mints', async () => {
+      const h = buildLocalizedHarness({
+        pendingRows: [{ id: 1 }, { id: 3 }, { id: 4 }],
+        links: [
+          // cluster A: 1 (pending) <-> 2 (already migrated) — must adopt
+          { [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 },
+          // cluster B: 3 <-> 4, both still pending — must mint fresh, shared
+          { [snakeCase('category_id')]: 3, [snakeCase('inv_category_id')]: 4 },
+        ],
+        existingDocumentIds: { 2: 'doc-existing' },
+      });
+
+      await createdDocumentId.up(h.knex, h.db);
+
+      const byId = new Map(h.updateCalls.map((c) => [c.id, c.document_id]));
+      expect(byId.get(1)).toBe('doc-existing');
+      expect(byId.get(3)).toBe(byId.get(4));
+      expect(byId.get(3)).not.toBe('doc-existing');
+    });
+
+    it('unifies onto one deterministic id when a cluster already carries more than one existing document_id', async () => {
+      const h = buildLocalizedHarness({
+        pendingRows: [{ id: 2 }],
+        // an inconsistent prior partial write left 1 and 3 with two different ids
+        links: [
+          { [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 },
+          { [snakeCase('category_id')]: 2, [snakeCase('inv_category_id')]: 3 },
+        ],
+        existingDocumentIds: { 1: 'doc-b', 3: 'doc-a' },
+      });
+
+      await createdDocumentId.up(h.knex, h.db);
+
+      // deterministic: lexicographically smallest of the conflicting ids
+      expect(h.updateCalls).toEqual([{ id: 2, document_id: 'doc-a' }]);
+    });
+
+    it('never overwrites a row that already has a document_id', async () => {
+      const h = buildLocalizedHarness({
+        pendingRows: [{ id: 1 }],
+        links: [{ [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 }],
+        existingDocumentIds: { 2: 'doc-existing' },
+      });
+
+      await createdDocumentId.up(h.knex, h.db);
+
+      expect(h.updateCalls.some((c) => c.id === 2)).toBe(false);
+    });
+  });
+
+  it('writes one whereIn per cluster instead of one update per row', async () => {
+    const h = buildLocalizedHarness({
+      pendingRows: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      links: [{ [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 }],
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    // cluster {1,2} + cluster {3} => 2 write calls, not 3
+    expect(h.groupedUpdateCalls).toHaveLength(2);
+    expect(h.updateCalls).toHaveLength(3);
   });
 
   it('fetches links in batches rather than a single unbounded whereIn (avoids exceeding the driver bound-parameter limit)', async () => {

--- a/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
+++ b/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
@@ -555,6 +555,28 @@ describe('createdDocumentId migration — localized tables (union-find clusterin
 
       expect(h.updateCalls.some((c) => c.id === 2)).toBe(false);
     });
+
+    it('merges rather than overwrites when two unrelated clusters resolve to the same document_id', async () => {
+      const h = buildLocalizedHarness({
+        pendingRows: [{ id: 1 }, { id: 3 }],
+        // two disjoint clusters — 1<->2 and 3<->4 — that happen to adopt the same id
+        links: [
+          { [snakeCase('category_id')]: 1, [snakeCase('inv_category_id')]: 2 },
+          { [snakeCase('category_id')]: 3, [snakeCase('inv_category_id')]: 4 },
+        ],
+        existingDocumentIds: { 2: 'doc-shared', 4: 'doc-shared' },
+      });
+
+      await createdDocumentId.up(h.knex, h.db);
+
+      // both clusters' pending rows must be written, merged into the same write group —
+      // a plain Map.set(documentId, ...) per cluster would let the second overwrite the first
+      expect(h.updateCalls.sort((a, b) => a.id - b.id)).toEqual([
+        { id: 1, document_id: 'doc-shared' },
+        { id: 3, document_id: 'doc-shared' },
+      ]);
+      expect(h.groupedUpdateCalls).toHaveLength(1);
+    });
   });
 
   it('writes one whereIn per cluster instead of one update per row', async () => {


### PR DESCRIPTION
### What does it do?

Rewrites `migrateDocumentIdsWithLocalizations` in `5.0.0-02-document-id.ts` to cluster locale-linked rows in memory via union-find instead of discovering one cluster at a time through a `LIMIT 1` query. Removes the now-unused per-dialect `QUERIES` (postgres/mysql/sqlite) discovery-query code, since the new approach only needs generic Knex builder calls.

Refs #23812, #23517, #25231

### Why is it needed?

The original discovery query re-scans the whole table (filtered by `document_id IS NULL`, a column with no index at this point in the migration) once per locale-cluster it finds — effectively O(n^2) for a table with n rows. On a production table with ~214k rows this took multiple hours without completing.
It also only followed direct links, so a locale chain (A<->B, B<->C, with no direct A<->C row) could be split across two document ids instead of clustered together. Union-find naturally follows transitive links.

### How to test it?

- Unit tests: inside `packages/core/database`, run `npx jest 5.0.0-02-document-id` — 20 tests covering no-links, direct pairs, transitive chains, independent clusters, out-of-set links, and batch sizing across postgres, sqlite, and mysql.
- Integration: `yarn test:migrations --initial legacy --database sqlite` (and `--database postgres` / `--database mysql`) — all three pass full validation end-to-end, including document_id backfill, against the fixture's `basic-dp-i18n`/`relation-dp-i18n` content types.

### Related issue(s)/PR(s)

Fix #27401 

Also related: #23812, #23517, #25231