### PR TITLE
chore(deps): declare tooling and test devDependencies previously resolved by hoisting

### DIFF
--- a/.github/actions/check-pr-status/package.json
+++ b/.github/actions/check-pr-status/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/jest": "29.5.2",
     "@vercel/ncc": "0.38.2",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0"
   }
 }

--- a/.github/actions/check-pr-status/package.json
+++ b/.github/actions/check-pr-status/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/jest": "29.5.2",
     "@vercel/ncc": "0.38.2",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@commitlint/cli": "19.2.0",
     "@commitlint/config-conventional": "19.1.0",
     "@commitlint/prompt-cli": "19.2.0",
+    "@commitlint/types": "19.8.1",
     "@nx/js": "20.8.4",
     "@playwright/test": "1.56.1",
     "@rollup/plugin-commonjs": "28.0.9",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "@commitlint/cli": "19.2.0",
     "@commitlint/config-conventional": "19.1.0",
     "@commitlint/prompt-cli": "19.2.0",
+    "@commitlint/types": "19.8.1",
     "@nx/js": "20.8.4",
     "@playwright/test": "1.56.1",
     "@rollup/plugin-commonjs": "28.0.9",

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -87,6 +87,7 @@
     "@reduxjs/toolkit": "1.9.7",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
+    "@types/jest": "29.5.2",
     "eslint-config-custom": "5.52.1",
     "jest-environment-jsdom": "29.6.1",
     "react": "18.3.1",

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -87,6 +87,7 @@
     "@reduxjs/toolkit": "1.9.7",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
+    "@types/jest": "29.5.2",
     "eslint-config-custom": "5.52.3",
     "jest-environment-jsdom": "29.6.1",
     "react": "18.3.1",

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -74,6 +74,7 @@
   "devDependencies": {
     "@types/cli-progress": "3.11.5",
     "@types/eventsource": "1.1.15",
+    "@types/jest": "29.5.2",
     "@types/lodash": "^4.14.191",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.52.1",

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -74,6 +74,7 @@
   "devDependencies": {
     "@types/cli-progress": "3.11.5",
     "@types/eventsource": "1.1.15",
+    "@types/jest": "29.5.2",
     "@types/lodash": "^4.14.191",
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.52.3",

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -167,6 +167,7 @@
     "@types/passport-local": "1.0.36",
     "@types/pluralize": "0.0.32",
     "@types/react-window": "1.8.8",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "koa-body": "6.0.1",
     "msw": "2.13.4",
@@ -174,6 +175,7 @@
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
     "vite": "5.4.21",
     "vite-plugin-dts": "^4.3.0"
   },

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -167,6 +167,7 @@
     "@types/passport-local": "1.0.36",
     "@types/pluralize": "0.0.32",
     "@types/react-window": "1.8.8",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "koa-body": "6.0.1",
     "msw": "2.13.4",
@@ -174,6 +175,7 @@
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
     "vite": "5.4.21",
     "vite-plugin-dts": "^4.3.0"
   },

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -120,13 +120,16 @@
     "@types/lodash": "^4.14.191",
     "@types/node": "20.19.41",
     "@types/prismjs": "1.26.5",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "koa-body": "6.0.1",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -120,13 +120,16 @@
     "@types/lodash": "^4.14.191",
     "@types/node": "20.19.41",
     "@types/prismjs": "1.26.5",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "koa-body": "6.0.1",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -89,6 +89,7 @@
     "@types/jest": "29.5.2",
     "@types/koa": "2.15.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "msw": "2.13.4",
@@ -97,6 +98,7 @@
     "react-query": "3.39.3",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
     "typescript": "5.9.3"
   },
   "peerDependencies": {

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -89,6 +89,7 @@
     "@types/jest": "29.5.2",
     "@types/koa": "2.15.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "msw": "2.13.4",
@@ -97,6 +98,7 @@
     "react-query": "3.39.3",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
     "typescript": "5.9.3"
   },
   "peerDependencies": {

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -106,6 +106,7 @@
     "@types/node": "20.19.41",
     "@types/pluralize": "0.0.32",
     "@types/react": "18.3.2",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
@@ -114,6 +115,7 @@
     "react-query": "3.39.3",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
     "vitest": "catalog:",
     "vitest-config": "5.52.1"
   },

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -106,6 +106,7 @@
     "@types/node": "20.19.41",
     "@types/pluralize": "0.0.32",
     "@types/react": "18.3.2",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
@@ -114,6 +115,7 @@
     "react-query": "3.39.3",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
     "vitest": "catalog:",
     "vitest-config": "5.52.3"
   },

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -86,10 +86,12 @@
     "@types/stream-json": "1.7.8",
     "@types/tar-stream": "2.2.2",
     "@types/ws": "^8.5.4",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "knex": "3.0.1",
     "koa": "2.16.4",
     "rimraf": "6.1.3",
+    "tsconfig": "5.52.1",
     "typescript": "5.9.3",
     "vitest": "catalog:",
     "vitest-config": "5.52.1"

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -86,10 +86,12 @@
     "@types/stream-json": "1.7.8",
     "@types/tar-stream": "2.2.2",
     "@types/ws": "^8.5.4",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "knex": "3.0.1",
     "koa": "2.16.4",
     "rimraf": "6.1.3",
+    "tsconfig": "5.52.3",
     "typescript": "5.9.3",
     "vitest": "catalog:",
     "vitest-config": "5.52.3"

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -83,13 +83,15 @@
     "@types/koa": "2.15.2",
     "@types/lodash": "^4.14.191",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.1"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -83,13 +83,15 @@
     "@types/koa": "2.15.2",
     "@types/lodash": "^4.14.191",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -67,6 +67,8 @@
     "@types/debug": "^4",
     "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
-    "jest": "29.6.0"
+    "eslint-config-custom": "5.52.1",
+    "jest": "29.6.0",
+    "tsconfig": "5.52.1"
   }
 }

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -67,6 +67,8 @@
     "@types/debug": "^4",
     "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
-    "jest": "29.6.0"
+    "eslint-config-custom": "5.52.3",
+    "jest": "29.6.0",
+    "tsconfig": "5.52.3"
   }
 }

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.52.1",
+    "jest": "29.6.0",
     "tsconfig": "5.52.1",
     "vitest": "catalog:",
     "vitest-config": "5.52.1"

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.52.3",
+    "jest": "29.6.0",
     "tsconfig": "5.52.3",
     "vitest": "catalog:",
     "vitest-config": "5.52.3"

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -86,13 +86,16 @@
     "@testing-library/react": "16.3.2",
     "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "koa-body": "6.0.1",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -86,13 +86,16 @@
     "@testing-library/react": "16.3.2",
     "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "koa-body": "6.0.1",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -115,6 +115,7 @@
     "@types/koa-range": "0.3.5",
     "@types/koa-static": "4.0.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.1",
     "formidable": "3.5.4",
     "jest": "29.6.0",
     "koa": "2.16.4",
@@ -123,7 +124,9 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -115,6 +115,7 @@
     "@types/koa-range": "0.3.5",
     "@types/koa-static": "4.0.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.3",
     "formidable": "3.5.4",
     "jest": "29.6.0",
     "koa": "2.16.4",
@@ -123,7 +124,9 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -76,11 +76,13 @@
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
     "typescript": "5.9.3",
     "vitest": "catalog:",
     "vitest-config": "5.52.1"

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -76,11 +76,13 @@
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
     "typescript": "5.9.3",
     "vitest": "catalog:",
     "vitest-config": "5.52.3"

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -94,6 +94,7 @@
     "@types/koa": "2.15.2",
     "@types/node": "20.19.41",
     "@types/swagger-ui-dist": "3.30.4",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
@@ -103,7 +104,9 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -94,6 +94,7 @@
     "@types/koa": "2.15.2",
     "@types/node": "20.19.41",
     "@types/swagger-ui-dist": "3.30.4",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
@@ -103,7 +104,9 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -83,6 +83,7 @@
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "msw": "2.13.4",
@@ -90,7 +91,9 @@
     "react-dom": "18.3.1",
     "react-query": "3.39.3",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -83,6 +83,7 @@
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "koa": "2.16.4",
     "msw": "2.13.4",
@@ -90,7 +91,9 @@
     "react-dom": "18.3.1",
     "react-query": "3.39.3",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -66,11 +66,15 @@
   "devDependencies": {
     "@strapi/admin": "5.52.1",
     "@strapi/strapi": "5.52.1",
+    "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.1",
+    "jest": "29.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.1",
     "vitest": "catalog:",
     "vitest-config": "5.52.1"
   },

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -66,11 +66,15 @@
   "devDependencies": {
     "@strapi/admin": "5.52.3",
     "@strapi/strapi": "5.52.3",
+    "@types/jest": "29.5.2",
     "@types/node": "20.19.41",
+    "eslint-config-custom": "5.52.3",
+    "jest": "29.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
     "styled-components": "6.4.1",
+    "tsconfig": "5.52.3",
     "vitest": "catalog:",
     "vitest-config": "5.52.3"
   },

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -79,12 +79,14 @@
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "29.5.2",
+    "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -79,12 +79,14 @@
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "29.5.2",
+    "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.4",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -90,7 +90,8 @@
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.52.1",
     "jest": "29.6.0",
-    "rimraf": "6.1.3"
+    "rimraf": "6.1.3",
+    "tsconfig": "5.52.1"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -90,7 +90,8 @@
     "@types/node": "20.19.41",
     "eslint-config-custom": "5.52.3",
     "jest": "29.6.0",
-    "rimraf": "6.1.3"
+    "rimraf": "6.1.3",
+    "tsconfig": "5.52.3"
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,6 +2928,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@commitlint/types@npm:19.8.1":
+  version: 19.8.1
+  resolution: "@commitlint/types@npm:19.8.1"
+  dependencies:
+    "@types/conventional-commits-parser": "npm:^5.0.0"
+    chalk: "npm:^5.3.0"
+  checksum: 10c0/0507db111d1ffd7b60e7ad979b7f9e674d409fc4c64561dfe30737b2c5bfefca7a1b58116106fa4ecb480059cecb13f04fa18f999d2d4a7d665b5ab13a05a803
+  languageName: node
+  linkType: hard
+
 "@commitlint/types@npm:^19.0.3":
   version: 19.0.3
   resolution: "@commitlint/types@npm:19.0.3"
@@ -8829,6 +8839,7 @@ __metadata:
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:16.3.2"
+    "@types/jest": "npm:29.5.2"
     eslint-config-custom: "npm:5.52.1"
     jest-environment-jsdom: "npm:29.6.1"
     jest-styled-components: "npm:7.1.1"
@@ -8890,6 +8901,7 @@ __metadata:
     codemirror5: "npm:codemirror@^5.65.11"
     cross-env: "npm:^7.0.3"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "npm:5.52.1"
     execa: "npm:5.1.1"
     fast-deep-equal: "npm:3.1.3"
     formik: "npm:2.4.9"
@@ -8934,6 +8946,7 @@ __metadata:
     sift: "npm:16.0.1"
     sonner: "npm:2.0.7"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
     typescript: "npm:5.9.3"
     use-context-selector: "npm:1.4.4"
     vite: "npm:5.4.21"
@@ -8966,6 +8979,7 @@ __metadata:
     "@strapi/utils": "npm:5.52.1"
     "@types/cli-progress": "npm:3.11.5"
     "@types/eventsource": "npm:1.1.15"
+    "@types/jest": "npm:29.5.2"
     "@types/lodash": "npm:^4.14.191"
     "@types/node": "npm:20.19.41"
     axios: "npm:1.19.0"
@@ -9023,6 +9037,7 @@ __metadata:
     codemirror5: "npm:codemirror@^5.65.11"
     date-fns: "npm:2.30.0"
     dompurify: "npm:3.4.13"
+    eslint-config-custom: "npm:5.52.1"
     fractional-indexing: "npm:3.2.0"
     highlight.js: "npm:^10.4.1"
     immer: "npm:9.0.21"
@@ -9057,6 +9072,8 @@ __metadata:
     slate-history: "npm:0.93.0"
     slate-react: "npm:0.98.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
+    typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
     zod: "npm:3.25.76"
   peerDependencies:
@@ -9090,6 +9107,7 @@ __metadata:
     "@types/node": "npm:20.19.41"
     date-fns: "npm:2.30.0"
     date-fns-tz: "npm:2.0.1"
+    eslint-config-custom: "npm:5.52.1"
     formik: "npm:2.4.9"
     jest: "npm:29.6.0"
     koa: "npm:2.16.4"
@@ -9103,6 +9121,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
     typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
   peerDependencies:
@@ -9144,6 +9163,7 @@ __metadata:
     "@types/react": "npm:18.3.2"
     ai: "npm:5.0.210"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "npm:5.52.1"
     fs-extra: "npm:11.3.4"
     immer: "npm:9.0.21"
     jest: "npm:29.6.0"
@@ -9163,6 +9183,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
     vitest: "catalog:"
     vitest-config: "npm:5.52.1"
     yup: "npm:0.32.9"
@@ -9286,6 +9307,7 @@ __metadata:
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
     commander: "npm:8.3.0"
+    eslint-config-custom: "npm:5.52.1"
     fs-extra: "npm:11.3.4"
     inquirer: "npm:9.3.8"
     jest: "npm:29.6.0"
@@ -9301,6 +9323,7 @@ __metadata:
     stream-json: "npm:1.9.1"
     tar: "npm:7.5.22"
     tar-stream: "npm:2.2.0"
+    tsconfig: "npm:5.52.1"
     typescript: "npm:5.9.3"
     vitest: "catalog:"
     vitest-config: "npm:5.52.1"
@@ -9390,6 +9413,7 @@ __metadata:
     "@types/koa": "npm:2.15.2"
     "@types/lodash": "npm:^4.14.191"
     "@types/node": "npm:20.19.41"
+    eslint-config-custom: "npm:5.52.1"
     jest: "npm:29.6.0"
     koa: "npm:2.16.4"
     koa-body: "npm:6.0.1"
@@ -9401,6 +9425,7 @@ __metadata:
     react-query: "npm:3.39.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
     yup: "npm:0.32.9"
     zod: "npm:3.25.76"
   peerDependencies:
@@ -9489,6 +9514,7 @@ __metadata:
     "@testing-library/user-event": "npm:14.6.1"
     "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
+    eslint-config-custom: "npm:5.52.1"
     jest: "npm:29.6.0"
     koa: "npm:2.16.4"
     lodash: "npm:4.18.1"
@@ -9501,6 +9527,8 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
+    typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
     zod: "npm:3.25.76"
   peerDependencies:
@@ -9545,8 +9573,10 @@ __metadata:
     "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     debug: "npm:4.3.4"
+    eslint-config-custom: "npm:5.52.1"
     jest: "npm:29.6.0"
     openapi-types: "npm:12.1.3"
+    tsconfig: "npm:5.52.1"
     zod: "npm:3.25.76"
   languageName: unknown
   linkType: soft
@@ -9559,6 +9589,7 @@ __metadata:
     "@strapi/utils": "npm:5.52.1"
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.52.1"
+    jest: "npm:29.6.0"
     lodash: "npm:4.18.1"
     qs: "npm:6.15.3"
     sift: "npm:16.0.1"
@@ -9607,6 +9638,7 @@ __metadata:
     "@testing-library/user-event": "npm:14.6.1"
     "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
+    eslint-config-custom: "npm:5.52.1"
     jest: "npm:29.6.0"
     react: "npm:18.3.1"
     react-colorful: "npm:5.6.1"
@@ -9614,6 +9646,7 @@ __metadata:
     react-intl: "npm:6.6.2"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
     typescript: "npm:5.9.3"
     vitest: "catalog:"
     vitest-config: "npm:5.52.1"
@@ -9650,6 +9683,7 @@ __metadata:
     "@types/swagger-ui-dist": "npm:3.30.4"
     bcryptjs: "npm:2.4.3"
     cheerio: "npm:^1.2.0"
+    eslint-config-custom: "npm:5.52.1"
     formik: "npm:2.4.9"
     fs-extra: "npm:11.3.4"
     immer: "npm:9.0.21"
@@ -9668,6 +9702,8 @@ __metadata:
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
     swagger-ui-dist: "npm:4.19.0"
+    tsconfig: "npm:5.52.1"
+    typescript: "npm:5.9.3"
     yaml: "npm:1.10.3"
     yup: "npm:0.32.9"
   peerDependencies:
@@ -9737,11 +9773,15 @@ __metadata:
     "@strapi/design-system": "npm:2.2.4"
     "@strapi/icons": "npm:2.2.4"
     "@strapi/strapi": "npm:5.52.1"
+    "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
+    eslint-config-custom: "npm:5.52.1"
+    jest: "npm:29.6.0"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
     vitest: "catalog:"
     vitest-config: "npm:5.52.1"
   peerDependencies:
@@ -9769,6 +9809,7 @@ __metadata:
     "@testing-library/user-event": "npm:14.6.1"
     "@types/jest": "npm:29.5.2"
     bcryptjs: "npm:2.4.3"
+    eslint-config-custom: "npm:5.52.1"
     formik: "npm:2.4.9"
     immer: "npm:9.0.21"
     jest: "npm:29.6.0"
@@ -9785,6 +9826,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    typescript: "npm:5.9.3"
     url-join: "npm:4.0.1"
     yup: "npm:0.32.9"
     zod: "npm:3.25.76"
@@ -9930,6 +9972,7 @@ __metadata:
     "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "npm:5.52.1"
     fractional-indexing: "npm:3.2.0"
     jest: "npm:29.6.0"
     koa: "npm:2.16.4"
@@ -9946,6 +9989,8 @@ __metadata:
     react-router-dom: "npm:6.30.4"
     semver: "npm:7.7.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
+    typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/admin": ^5.0.0
@@ -10160,6 +10205,7 @@ __metadata:
     rimraf: "npm:6.1.3"
     semver: "npm:7.7.4"
     simple-git: "npm:3.36.0"
+    tsconfig: "npm:5.52.1"
     undici: "npm:6.28.0"
   bin:
     upgrade: ./bin/upgrade.js
@@ -10196,6 +10242,7 @@ __metadata:
     byte-size: "npm:8.1.1"
     cropperjs: "npm:1.6.2"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "npm:5.52.1"
     file-type: "npm:21.3.4"
     formidable: "npm:3.5.4"
     formik: "npm:2.4.9"
@@ -10221,6 +10268,8 @@ __metadata:
     react-select: "npm:5.8.0"
     sharp: "npm:0.35.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.1"
+    typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
     zod: "npm:3.25.76"
   peerDependencies:
@@ -11391,6 +11440,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/linkify-it@npm:^5":
+  version: 5.0.0
+  resolution: "@types/linkify-it@npm:5.0.0"
+  checksum: 10c0/7bbbf45b9dde17bf3f184fee585aef0e7342f6954f0377a24e4ff42ab5a85d5b806aaa5c8d16e2faf2a6b87b2d94467a196b7d2b85c9c7de2f0eaac5487aaab8
+  languageName: node
+  linkType: hard
+
 "@types/lodash@npm:^4.14.149, @types/lodash@npm:^4.14.165, @types/lodash@npm:^4.14.191":
   version: 4.14.197
   resolution: "@types/lodash@npm:4.14.197"
@@ -11432,7 +11488,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/markdown-it@npm:*, @types/markdown-it@npm:13.0.7":
+"@types/markdown-it@npm:*":
+  version: 14.2.0
+  resolution: "@types/markdown-it@npm:14.2.0"
+  dependencies:
+    "@types/linkify-it": "npm:^5"
+    "@types/mdurl": "npm:^2"
+  checksum: 10c0/60ff1a0495ef303310744566342c49b4b3e76fbdca82c5ec28d88731fc934b0c63335d25bca6133903c877f2c41c59cdfddefb3626c6ee0780b9573ddf6aefe4
+  languageName: node
+  linkType: hard
+
+"@types/markdown-it@npm:13.0.7":
   version: 13.0.7
   resolution: "@types/markdown-it@npm:13.0.7"
   dependencies:
@@ -11455,6 +11521,13 @@ __metadata:
   version: 1.0.5
   resolution: "@types/mdurl@npm:1.0.5"
   checksum: 10c0/8991c781eb94fb3621e48e191251a94057908fc14be60f52bdd7c48684af923ffa77559ea979450a0475f85c08f8a472f99ff9c2ca4308961b9b9d35fd7584f7
+  languageName: node
+  linkType: hard
+
+"@types/mdurl@npm:^2":
+  version: 2.0.0
+  resolution: "@types/mdurl@npm:2.0.0"
+  checksum: 10c0/cde7bb571630ed1ceb3b92a28f7b59890bb38b8f34cd35326e2df43eebfc74985e6aa6fd4184e307393bad8a9e0783a519a3f9d13c8e03788c0f98e5ec869c5e
   languageName: node
   linkType: hard
 
@@ -14416,6 +14489,7 @@ __metadata:
     "@actions/github": "npm:6.0.0"
     "@types/jest": "npm:29.5.2"
     "@vercel/ncc": "npm:0.38.2"
+    eslint-config-custom: "npm:5.52.1"
     jest: "npm:29.6.0"
   languageName: unknown
   linkType: soft
@@ -28147,6 +28221,7 @@ __metadata:
     "@commitlint/cli": "npm:19.2.0"
     "@commitlint/config-conventional": "npm:19.1.0"
     "@commitlint/prompt-cli": "npm:19.2.0"
+    "@commitlint/types": "npm:19.8.1"
     "@nx/js": "npm:20.8.4"
     "@playwright/test": "npm:1.56.1"
     "@rollup/plugin-commonjs": "npm:28.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,6 +2928,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@commitlint/types@npm:19.8.1":
+  version: 19.8.1
+  resolution: "@commitlint/types@npm:19.8.1"
+  dependencies:
+    "@types/conventional-commits-parser": "npm:^5.0.0"
+    chalk: "npm:^5.3.0"
+  checksum: 10c0/0507db111d1ffd7b60e7ad979b7f9e674d409fc4c64561dfe30737b2c5bfefca7a1b58116106fa4ecb480059cecb13f04fa18f999d2d4a7d665b5ab13a05a803
+  languageName: node
+  linkType: hard
+
 "@commitlint/types@npm:^19.0.3":
   version: 19.0.3
   resolution: "@commitlint/types@npm:19.0.3"
@@ -8845,6 +8855,7 @@ __metadata:
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:16.3.2"
+    "@types/jest": "npm:29.5.2"
     eslint-config-custom: "npm:5.52.3"
     jest-environment-jsdom: "npm:29.6.1"
     jest-styled-components: "npm:7.1.1"
@@ -8906,6 +8917,7 @@ __metadata:
     codemirror5: "npm:codemirror@^5.65.11"
     cross-env: "npm:^7.0.3"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "npm:5.52.3"
     execa: "npm:5.1.1"
     fast-deep-equal: "npm:3.1.3"
     formik: "npm:2.4.9"
@@ -8950,6 +8962,7 @@ __metadata:
     sift: "npm:16.0.1"
     sonner: "npm:2.0.7"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
     typescript: "npm:5.9.3"
     use-context-selector: "npm:1.4.4"
     vite: "npm:5.4.21"
@@ -8982,6 +8995,7 @@ __metadata:
     "@strapi/utils": "npm:5.52.3"
     "@types/cli-progress": "npm:3.11.5"
     "@types/eventsource": "npm:1.1.15"
+    "@types/jest": "npm:29.5.2"
     "@types/lodash": "npm:^4.14.191"
     "@types/node": "npm:20.19.41"
     axios: "npm:1.19.0"
@@ -9039,6 +9053,7 @@ __metadata:
     codemirror5: "npm:codemirror@^5.65.11"
     date-fns: "npm:2.30.0"
     dompurify: "npm:3.4.13"
+    eslint-config-custom: "npm:5.52.3"
     fractional-indexing: "npm:3.2.0"
     highlight.js: "npm:^10.4.1"
     immer: "npm:9.0.21"
@@ -9073,6 +9088,8 @@ __metadata:
     slate-history: "npm:0.93.0"
     slate-react: "npm:0.98.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
+    typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
     zod: "npm:4.4.3"
   peerDependencies:
@@ -9106,6 +9123,7 @@ __metadata:
     "@types/node": "npm:20.19.41"
     date-fns: "npm:2.30.0"
     date-fns-tz: "npm:2.0.1"
+    eslint-config-custom: "npm:5.52.3"
     formik: "npm:2.4.9"
     jest: "npm:29.6.0"
     koa: "npm:2.16.4"
@@ -9119,6 +9137,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
     typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
   peerDependencies:
@@ -9160,6 +9179,7 @@ __metadata:
     "@types/react": "npm:18.3.2"
     ai: "npm:5.0.210"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "npm:5.52.3"
     fs-extra: "npm:11.3.4"
     immer: "npm:9.0.21"
     jest: "npm:29.6.0"
@@ -9179,6 +9199,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
     vitest: "catalog:"
     vitest-config: "npm:5.52.3"
     yup: "npm:0.32.9"
@@ -9306,6 +9327,7 @@ __metadata:
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
     commander: "npm:8.3.0"
+    eslint-config-custom: "npm:5.52.3"
     fs-extra: "npm:11.3.4"
     inquirer: "npm:9.3.8"
     jest: "npm:29.6.0"
@@ -9321,6 +9343,7 @@ __metadata:
     stream-json: "npm:1.9.1"
     tar: "npm:7.5.22"
     tar-stream: "npm:2.2.0"
+    tsconfig: "npm:5.52.3"
     typescript: "npm:5.9.3"
     vitest: "catalog:"
     vitest-config: "npm:5.52.3"
@@ -9410,6 +9433,7 @@ __metadata:
     "@types/koa": "npm:2.15.2"
     "@types/lodash": "npm:^4.14.191"
     "@types/node": "npm:20.19.41"
+    eslint-config-custom: "npm:5.52.3"
     jest: "npm:29.6.0"
     koa: "npm:2.16.4"
     koa-body: "npm:6.0.1"
@@ -9421,6 +9445,7 @@ __metadata:
     react-query: "npm:3.39.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
     yup: "npm:0.32.9"
     zod: "npm:4.4.3"
   peerDependencies:
@@ -9509,6 +9534,7 @@ __metadata:
     "@testing-library/user-event": "npm:14.6.1"
     "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
+    eslint-config-custom: "npm:5.52.3"
     jest: "npm:29.6.0"
     koa: "npm:2.16.4"
     lodash: "npm:4.18.1"
@@ -9521,6 +9547,8 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
+    typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
     zod: "npm:4.4.3"
   peerDependencies:
@@ -9565,8 +9593,10 @@ __metadata:
     "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     debug: "npm:4.3.4"
+    eslint-config-custom: "npm:5.52.3"
     jest: "npm:29.6.0"
     openapi-types: "npm:12.1.3"
+    tsconfig: "npm:5.52.3"
     zod: "npm:4.4.3"
   languageName: unknown
   linkType: soft
@@ -9579,6 +9609,7 @@ __metadata:
     "@strapi/utils": "npm:5.52.3"
     "@types/node": "npm:20.19.41"
     eslint-config-custom: "npm:5.52.3"
+    jest: "npm:29.6.0"
     lodash: "npm:4.18.1"
     qs: "npm:6.15.3"
     sift: "npm:16.0.1"
@@ -9627,6 +9658,7 @@ __metadata:
     "@testing-library/user-event": "npm:14.6.1"
     "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
+    eslint-config-custom: "npm:5.52.3"
     jest: "npm:29.6.0"
     react: "npm:18.3.1"
     react-colorful: "npm:5.6.1"
@@ -9634,6 +9666,7 @@ __metadata:
     react-intl: "npm:6.6.2"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
     typescript: "npm:5.9.3"
     vitest: "catalog:"
     vitest-config: "npm:5.52.3"
@@ -9670,6 +9703,7 @@ __metadata:
     "@types/swagger-ui-dist": "npm:3.30.4"
     bcryptjs: "npm:2.4.3"
     cheerio: "npm:^1.2.0"
+    eslint-config-custom: "npm:5.52.3"
     formik: "npm:2.4.9"
     fs-extra: "npm:11.3.4"
     immer: "npm:9.0.21"
@@ -9688,6 +9722,8 @@ __metadata:
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
     swagger-ui-dist: "npm:4.19.0"
+    tsconfig: "npm:5.52.3"
+    typescript: "npm:5.9.3"
     yaml: "npm:1.10.3"
     yup: "npm:0.32.9"
   peerDependencies:
@@ -9757,11 +9793,15 @@ __metadata:
     "@strapi/design-system": "npm:2.2.4"
     "@strapi/icons": "npm:2.2.4"
     "@strapi/strapi": "npm:5.52.3"
+    "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
+    eslint-config-custom: "npm:5.52.3"
+    jest: "npm:29.6.0"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
     vitest: "catalog:"
     vitest-config: "npm:5.52.3"
   peerDependencies:
@@ -9789,6 +9829,7 @@ __metadata:
     "@testing-library/user-event": "npm:14.6.1"
     "@types/jest": "npm:29.5.2"
     bcryptjs: "npm:2.4.3"
+    eslint-config-custom: "npm:5.52.3"
     formik: "npm:2.4.9"
     immer: "npm:9.0.21"
     jest: "npm:29.6.0"
@@ -9805,6 +9846,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.4"
     styled-components: "npm:6.4.1"
+    typescript: "npm:5.9.3"
     url-join: "npm:4.0.1"
     yup: "npm:0.32.9"
     zod: "npm:4.4.3"
@@ -9950,6 +9992,7 @@ __metadata:
     "@types/jest": "npm:29.5.2"
     "@types/node": "npm:20.19.41"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "npm:5.52.3"
     fractional-indexing: "npm:3.2.0"
     jest: "npm:29.6.0"
     koa: "npm:2.16.4"
@@ -9966,6 +10009,8 @@ __metadata:
     react-router-dom: "npm:6.30.4"
     semver: "npm:7.7.4"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
+    typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/admin": ^5.0.0
@@ -10177,6 +10222,7 @@ __metadata:
     rimraf: "npm:6.1.3"
     semver: "npm:7.7.4"
     simple-git: "npm:3.36.0"
+    tsconfig: "npm:5.52.3"
     undici: "npm:6.28.1"
   bin:
     upgrade: ./bin/upgrade.js
@@ -10213,6 +10259,7 @@ __metadata:
     byte-size: "npm:8.1.1"
     cropperjs: "npm:1.6.2"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "npm:5.52.3"
     file-type: "npm:21.3.4"
     formidable: "npm:3.5.4"
     formik: "npm:2.4.9"
@@ -10238,6 +10285,8 @@ __metadata:
     react-select: "npm:5.8.0"
     sharp: "npm:0.35.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "npm:5.52.3"
+    typescript: "npm:5.9.3"
     yup: "npm:0.32.9"
     zod: "npm:4.4.3"
   peerDependencies:
@@ -11408,6 +11457,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/linkify-it@npm:^5":
+  version: 5.0.0
+  resolution: "@types/linkify-it@npm:5.0.0"
+  checksum: 10c0/7bbbf45b9dde17bf3f184fee585aef0e7342f6954f0377a24e4ff42ab5a85d5b806aaa5c8d16e2faf2a6b87b2d94467a196b7d2b85c9c7de2f0eaac5487aaab8
+  languageName: node
+  linkType: hard
+
 "@types/lodash@npm:^4.14.149, @types/lodash@npm:^4.14.165, @types/lodash@npm:^4.14.191":
   version: 4.14.197
   resolution: "@types/lodash@npm:4.14.197"
@@ -11449,7 +11505,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/markdown-it@npm:*, @types/markdown-it@npm:13.0.7":
+"@types/markdown-it@npm:*":
+  version: 14.2.0
+  resolution: "@types/markdown-it@npm:14.2.0"
+  dependencies:
+    "@types/linkify-it": "npm:^5"
+    "@types/mdurl": "npm:^2"
+  checksum: 10c0/60ff1a0495ef303310744566342c49b4b3e76fbdca82c5ec28d88731fc934b0c63335d25bca6133903c877f2c41c59cdfddefb3626c6ee0780b9573ddf6aefe4
+  languageName: node
+  linkType: hard
+
+"@types/markdown-it@npm:13.0.7":
   version: 13.0.7
   resolution: "@types/markdown-it@npm:13.0.7"
   dependencies:
@@ -11472,6 +11538,13 @@ __metadata:
   version: 1.0.5
   resolution: "@types/mdurl@npm:1.0.5"
   checksum: 10c0/8991c781eb94fb3621e48e191251a94057908fc14be60f52bdd7c48684af923ffa77559ea979450a0475f85c08f8a472f99ff9c2ca4308961b9b9d35fd7584f7
+  languageName: node
+  linkType: hard
+
+"@types/mdurl@npm:^2":
+  version: 2.0.0
+  resolution: "@types/mdurl@npm:2.0.0"
+  checksum: 10c0/cde7bb571630ed1ceb3b92a28f7b59890bb38b8f34cd35326e2df43eebfc74985e6aa6fd4184e307393bad8a9e0783a519a3f9d13c8e03788c0f98e5ec869c5e
   languageName: node
   linkType: hard
 
@@ -14390,6 +14463,7 @@ __metadata:
     "@actions/github": "npm:6.0.0"
     "@types/jest": "npm:29.5.2"
     "@vercel/ncc": "npm:0.38.2"
+    eslint-config-custom: "npm:5.52.3"
     jest: "npm:29.6.0"
   languageName: unknown
   linkType: soft
@@ -27908,6 +27982,7 @@ __metadata:
     "@commitlint/cli": "npm:19.2.0"
     "@commitlint/config-conventional": "npm:19.1.0"
     "@commitlint/prompt-cli": "npm:19.2.0"
+    "@commitlint/types": "npm:19.8.1"
     "@nx/js": "npm:20.8.4"
     "@playwright/test": "npm:1.56.1"
     "@rollup/plugin-commonjs": "npm:28.0.9"


### PR DESCRIPTION
### What does it do?

Declares, in each workspace's `package.json`, the tooling and test dependencies that were previously only resolvable because Yarn's default `node-modules` linker **hoists** everything into the root `node_modules`. Every added dependency is pinned to the **version already used elsewhere in the monorepo** — no version bumps, and no new packages enter the lockfile.

Concretely, this adds the previously-implicit:

- **`tsconfig`** — 14 workspaces whose `tsconfig.json` does `extends: "tsconfig/base.json"` (`admin`, `content-manager`, `content-releases`, `content-type-builder`, `data-transfer`, `email`, `openapi`, `review-workflows`, `upload`, `color-picker`, `documentation`, `i18n`, `sentry`, `upgrade`).
- **`eslint-config-custom`** — 15 workspaces whose `.eslintrc.cjs` extends it, including `.github/actions/check-pr-status`.
- **`typescript`** — 6 workspaces that compile with `tsc` (`content-manager`, `review-workflows`, `upload`, `documentation`, `i18n`, `users-permissions`).
- **`jest`** (`permissions`, `sentry`) and **`@types/jest`** (`admin-test-utils`, `cloud-cli`, `sentry`) — exercised by those packages' test suites.
- **`@commitlint/types`** (root) — imported by `.commitlintrc.ts`.

The `nodeLinker` value is **not** changed by this PR — it stays `node-modules`.

### Why is it needed?

These gaps were found by temporarily switching `nodeLinker` to `pnpm` and building the monorepo. A strict/isolated linker only lets a package resolve what it declares, so it immediately surfaces every dependency that today "works by accident" via root hoisting:

- Missing `tsconfig` → `tsc` fails with `TS6053: File 'tsconfig/base.json' not found`.
- Missing `eslint-config-custom` → ESLint fails with `couldn't find the config "eslint-config-custom/back"`.
- Missing `typescript` → an optional `typescript` peer splits `msw` into two virtual copies whose `protected` members make them nominally incompatible (`HttpHandler` not assignable to `AnyHandler`); declaring `typescript` in those packages collapses it back to one copy.
- Missing `jest` / `@types/jest` → the test suites can't resolve their own runner or its types.

Even though the repo ships with the `node-modules` linker (where hoisting hides all of the above), declaring these dependencies explicitly is correct regardless of linker: it makes each workspace self-contained, prevents breakage under isolated installs, and is a prerequisite for any future move to pnpm.

### How to test it?

- `yarn install --immutable` — passes, and the lockfile is unchanged beyond the added workspace entries (no new package resolutions).
- `yarn version:check` — all package versions still aligned at `5.52.0`.
- `yarn prettier:check` — passes.
- No behavioural or runtime changes: this touches only `package.json` dependency declarations and the resulting `yarn.lock`.

### Related issue(s)/PR(s)

Extracted from #27249, which bundles this together with the remaining dependency declarations (`@types/*`, workspace deps, runtime test deps) and the type fixes those exposed. This PR isolates the self-contained tooling/test subset so it can be reviewed and merged on its own; #27249 can then be rebased onto it.
