### PR TITLE
fix(admin): out of sort memory when listing audit logs on mysql

### DIFF
--- a/packages/core/admin/ee/server/src/audit-logs/services/__tests__/find-many.test.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/__tests__/find-many.test.ts
@@ -1,0 +1,52 @@
+import { createAuditLogsService } from '../audit-logs';
+
+describe('Audit logs service | findMany', () => {
+  const logs = [
+    { id: 1, action: 'entry.create', date: '2026-01-01', payload: {}, user: null },
+    { id: 2, action: 'entry.update', date: '2026-01-02', payload: {}, user: null },
+  ];
+
+  const mockFindPage = jest.fn().mockResolvedValue({
+    results: [{ id: 2 }, { id: 1 }],
+    pagination: { page: 1, pageSize: 10, pageCount: 1, total: 2 },
+  });
+  const mockFindMany = jest.fn().mockResolvedValue(logs);
+
+  const strapi = {
+    db: {
+      query: jest.fn(() => ({ findPage: mockFindPage, findMany: mockFindMany })),
+    },
+    get: jest.fn(() => ({
+      transform: jest.fn(() => ({ orderBy: [{ date: 'desc' }, { id: 'asc' }] })),
+    })),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should sort the log ids only, then fetch the logs by id', async () => {
+    const service = createAuditLogsService(strapi);
+
+    const result = await service.findMany({ page: 1, pageSize: 10 });
+
+    expect(mockFindPage).toHaveBeenCalledWith(expect.objectContaining({ select: ['id'] }));
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { id: { $in: [2, 1] } },
+      populate: ['user'],
+      select: ['action', 'date', 'payload'],
+    });
+    expect(result.results.map((log: any) => log.id)).toEqual([2, 1]);
+    expect(result.pagination).toMatchObject({ page: 1, pageCount: 1, total: 2 });
+  });
+
+  it('should leave out the logs deleted between the two queries', async () => {
+    mockFindMany.mockResolvedValueOnce([logs[1]]);
+
+    const service = createAuditLogsService(strapi);
+
+    const result = await service.findMany({ page: 1, pageSize: 10 });
+
+    expect(result.results.map((log: any) => log.id)).toEqual([2]);
+  });
+});

--- a/packages/core/admin/ee/server/src/audit-logs/services/__tests__/find-many.test.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/__tests__/find-many.test.ts
@@ -36,7 +36,7 @@ describe('Audit logs service | findMany', () => {
       populate: ['user'],
       select: ['action', 'date', 'payload'],
     });
-    expect(result.results.map((log: any) => log.id)).toEqual([2, 1]);
+    expect(result.results.map((log) => log.id)).toEqual([2, 1]);
     expect(result.pagination).toMatchObject({ page: 1, pageCount: 1, total: 2 });
   });
 
@@ -47,6 +47,6 @@ describe('Audit logs service | findMany', () => {
 
     const result = await service.findMany({ page: 1, pageSize: 10 });
 
-    expect(result.results.map((log: any) => log.id)).toEqual([2]);
+    expect(result.results.map((log) => log.id)).toEqual([2]);
   });
 });

--- a/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts
@@ -52,7 +52,7 @@ const createAuditLogsService = (strapi: Core.Strapi) => {
         select: ['id'],
       });
 
-      const ids = logRows.map((log: any) => log.id);
+      const ids = logRows.map((log) => log.id);
       const logs = ids.length
         ? await strapi.db.query('admin::audit-log').findMany({
             where: { id: { $in: ids } },
@@ -60,8 +60,8 @@ const createAuditLogsService = (strapi: Core.Strapi) => {
             select: ['action', 'date', 'payload'],
           })
         : [];
-      const logsById = new Map(logs.map((log: any) => [log.id, log]));
-      const results = ids.map((id: any) => logsById.get(id)).filter(Boolean);
+      const logsById = new Map(logs.map((log) => [log.id, log]));
+      const results = ids.map((id) => logsById.get(id)).filter(Boolean);
 
       const sanitizedResults = results.map((result: any) => {
         const { user, ...rest } = result;

--- a/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts
@@ -45,11 +45,23 @@ const createAuditLogsService = (strapi: Core.Strapi) => {
     },
 
     async findMany(query: unknown) {
-      const { results, pagination } = await strapi.db.query('admin::audit-log').findPage({
-        populate: ['user'],
-        select: ['action', 'date', 'payload'],
+      // NOTE: We get the IDs first because sorting full rows runs MySQL/MariaDB out of sort memory
+      // See: https://github.com/strapi/strapi/issues/27399
+      const { results: logRows, pagination } = await strapi.db.query('admin::audit-log').findPage({
         ...strapi.get('query-params').transform('admin::audit-log', query),
+        select: ['id'],
       });
+
+      const ids = logRows.map((log: any) => log.id);
+      const logs = ids.length
+        ? await strapi.db.query('admin::audit-log').findMany({
+            where: { id: { $in: ids } },
+            populate: ['user'],
+            select: ['action', 'date', 'payload'],
+          })
+        : [];
+      const logsById = new Map(logs.map((log: any) => [log.id, log]));
+      const results = ids.map((id: any) => logsById.get(id)).filter(Boolean);
 
       const sanitizedResults = results.map((result: any) => {
         const { user, ...rest } = result;


### PR DESCRIPTION
### What does it do?

`findMany` now runs the paginated audit log query with `select: ['id']`, then fetches those logs by id and puts them back in order in memory. The database only sorts a couple of small columns instead of full payload snapshots.

### Why is it needed?

Every `strapi_audit_logs` row carries a JSON payload, so selecting `payload` next to `order by date desc` makes MySQL/MariaDB pull those payloads into the sort buffer. Past the default 256 KB `sort_buffer_size` the query dies with `ER_OUT_OF_SORTMEMORY` and Settings > Audit Logs shows an error. Same problem, and same fix, as #27393 and as #20312 / #23331 before it on `strapi_database_schema`.

### How to test it?

On MySQL, run `examples/getstarted` with an EE license and make enough admin edits on large entries to build up audit logs with big payloads, then open Settings > Audit Logs. The list should render instead of erroring. `sort_buffer_size` can be lowered to reproduce it faster on smaller payloads.

### Related issue(s)/PR(s)

fixes: #27399
