### PR TITLE
fix(upload): sizeLimit is not enforced when replacing a file

### DIFF
--- a/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
@@ -15,6 +15,7 @@ const providerMethods = {
   upload: jest.fn(),
   replace: jest.fn(),
   delete: jest.fn(),
+  checkFileSize: jest.fn(),
 };
 
 const imageManipulationMock = {
@@ -132,5 +133,32 @@ describe('Upload service - replace()', () => {
 
     expect(providerMethods.replace).toHaveBeenCalledTimes(1);
     expect(providerMethods.delete).not.toHaveBeenCalled();
+  });
+
+  test('checks the file size before writing anything to the provider', async () => {
+    currentDbFile = {
+      id: 3,
+      hash: 'document_ghi789',
+      ext: '.txt',
+      provider: PROVIDER,
+      formats: null,
+    };
+
+    // A rejected size check must abort the replace, leaving the stored file untouched.
+    providerMethods.checkFileSize.mockImplementationOnce(() => {
+      throw new Error('document.txt exceeds size limit of 1 KB.');
+    });
+
+    await expect(
+      uploadService.replace(3, {
+        data: { fileInfo: {} as any },
+        file: inputFile() as any,
+      })
+    ).rejects.toThrow('exceeds size limit');
+
+    expect(providerMethods.checkFileSize).toHaveBeenCalledTimes(1);
+    expect(providerMethods.replace).not.toHaveBeenCalled();
+    expect(providerMethods.upload).not.toHaveBeenCalled();
+    expect(dbUpdate).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -484,6 +484,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       const { fileInfo } = data;
       fileData = await enhanceAndValidateFile(file, fileInfo);
 
+      // Replacing a file writes new bytes just like creating one, so it has to
+      // respect sizeLimit too. Checked before any provider write, and measured on
+      // the same post-optimization file as the create path (uploadFileAndPersist).
+      await getService('provider').checkFileSize(fileData);
+
       // keep a constant hash and extension so the file url doesn't change when the file is replaced
       _.assign(fileData, {
         hash: dbFile.hash,

--- a/packages/providers/upload-local/README.md
+++ b/packages/providers/upload-local/README.md
@@ -44,7 +44,7 @@ module.exports = ({ env }) => ({
 });
 ```
 
-The `sizeLimit` parameter must be a number. Be aware that the unit is in bytes, and the default is 1000000. When setting this value high, you should make sure to also configure the body parser middleware `maxFileSize` so the file can be sent and processed. Read more [here](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#configuration)
+The `sizeLimit` parameter must be a number. Be aware that the unit is in bytes, and the default is 1000000000 (1GB). When setting this value high, you should make sure to also configure the body parser middleware `maxFileSize` so the file can be sent and processed — it defaults to roughly 200MB, and rejects larger files before the upload plugin ever sees them. Read more [here](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#configuration)
 
 ### Security Middleware Configuration
 

--- a/tests/api/core/upload/admin/file-size-limit.test.api.js
+++ b/tests/api/core/upload/admin/file-size-limit.test.api.js
@@ -2,15 +2,18 @@
 
 const fs = require('fs');
 const path = require('path');
-const _ = require('lodash/fp');
 
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
-const { createAuthRequest } = require('api-tests/request');
+const { createAuthRequest, createContentAPIRequest } = require('api-tests/request');
 
 const builder = createTestBuilder();
 let strapi;
 let rq;
+let contentAPIRq;
+
+const smallFile = () => fs.createReadStream(path.join(__dirname, '../utils/rec.jpg'));
+const largeFile = () => fs.createReadStream(path.join(__dirname, '../utils/strapi.png'));
 
 const dogModel = {
   displayName: 'Dog',
@@ -29,6 +32,7 @@ describe('Upload', () => {
     await builder.addContentType(dogModel).build();
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
+    contentAPIRq = await createContentAPIRequest({ strapi });
 
     strapi.config.set('plugin::upload.sizeLimit', 1000);
   });
@@ -44,7 +48,7 @@ describe('Upload', () => {
       const res = await rq({
         method: 'POST',
         url: '/upload',
-        formData: { files: fs.createReadStream(path.join(__dirname, '../utils/strapi.png')) },
+        formData: { files: largeFile() },
       });
       expect(res.statusCode).toBe(413);
     });
@@ -54,10 +58,93 @@ describe('Upload', () => {
       const res = await rq({
         method: 'POST',
         url: '/upload',
-        formData: { files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')) },
+        formData: { files: smallFile() },
       });
 
       expect(res.statusCode).toBe(201);
+    });
+  });
+
+  describe('Replace', () => {
+    // Every replace entry point funnels through uploadService.replace(), which used
+    // to skip the size check entirely — only the create paths were guarded.
+    let fileId;
+
+    beforeEach(async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/upload',
+        formData: { files: smallFile() },
+      });
+
+      expect(res.statusCode).toBe(201);
+      fileId = res.body[0].id;
+    });
+
+    describe('POST /upload/files/:id/replace', () => {
+      test('Rejects when the replacement file is bigger than the size limit', async () => {
+        const res = await rq({
+          method: 'POST',
+          url: `/upload/files/${fileId}/replace`,
+          formData: { files: largeFile() },
+        });
+
+        expect(res.statusCode).toBe(413);
+      });
+
+      test('Can replace with a file smaller than the size limit', async () => {
+        const res = await rq({
+          method: 'POST',
+          url: `/upload/files/${fileId}/replace`,
+          formData: { files: smallFile() },
+        });
+
+        expect(res.statusCode).toBe(200);
+      });
+    });
+
+    describe('POST /upload?id=<id>', () => {
+      test('Rejects when the replacement file is bigger than the size limit', async () => {
+        const res = await rq({
+          method: 'POST',
+          url: `/upload?id=${fileId}`,
+          formData: { files: largeFile() },
+        });
+
+        expect(res.statusCode).toBe(413);
+      });
+
+      test('Can replace with a file smaller than the size limit', async () => {
+        const res = await rq({
+          method: 'POST',
+          url: `/upload?id=${fileId}`,
+          formData: { files: smallFile() },
+        });
+
+        expect(res.statusCode).toBe(200);
+      });
+    });
+
+    describe('POST /api/upload?id=<id> (content API)', () => {
+      test('Rejects when the replacement file is bigger than the size limit', async () => {
+        const res = await contentAPIRq({
+          method: 'POST',
+          url: `/upload?id=${fileId}`,
+          formData: { files: largeFile() },
+        });
+
+        expect(res.statusCode).toBe(413);
+      });
+
+      test('Can replace with a file smaller than the size limit', async () => {
+        const res = await contentAPIRq({
+          method: 'POST',
+          url: `/upload?id=${fileId}`,
+          formData: { files: smallFile() },
+        });
+
+        expect(res.statusCode).toBe(200);
+      });
     });
   });
 });


### PR DESCRIPTION
### What does it do?

Adds the missing `sizeLimit` check to the file replace path.

- Calls `provider.checkFileSize()` in `uploadService.replace()`, after `enhanceAndValidateFile` and before any provider write. All three replace entry points funnel through this one service method, so a single call covers them:
  - `POST /upload/files/:id/replace` — new media library
  - `POST /upload?id=<id>` — legacy media library
  - `POST /api/upload?id=<id>` — content API
- The file is measured after image optimization, the same as the create path in `uploadFileAndPersist`, so both paths agree on what gets measured.
- On rejection the request fails with 413 before anything is written. The existing `finally` block still removes the temporary working directory, and neither the stored file nor the database record is touched.

Beyond the fix:

- Corrects `packages/providers/upload-local/README.md`, which documented the default `sizeLimit` as `1000000` (1MB) when it is actually `1000000000` (1GB), and notes that the body parser's ~200MB `maxFileSize` rejects larger files first.

### Why is it needed?

`sizeLimit` was only checked in `uploadFileAndPersist`, which just the create paths go through. Replacing a file's binary skipped the check completely, so a file over the configured limit could be written to the provider and persisted. This affected both media libraries and the content API, which made `sizeLimit` look like it did nothing.

### How to test it?

Manual test, in `examples/getstarted`:

1. In `examples/getstarted/config/plugins.js`, set a small limit:
   ```js
   upload: { config: { sizeLimit: 100000 } },
   ```
2. `cd examples/getstarted && yarn develop`
3. In the Media Library, upload an image **under** 100KB. It succeeds. Try one **over** 100KB and confirm it is rejected with `<name> exceeds size limit of 100 KB.` — creation was already guarded.
4. Open the asset you uploaded, and replace it with a file **over** 100KB.
   - **Before this change:** 200, the file is replaced.
   - **After this change:** 413, and the original file is left in place.
5. Replace it with a file **under** 100KB and confirm that still works.
6. Repeat steps 4–5 in the legacy media library (`BETA_MEDIA_LIBRARY=false`) — the edit-asset dialog uses `POST /upload?id=<id>`.
7. Optionally check the content API directly:
   ```bash
   curl -i -X POST 'http://localhost:1337/api/upload?id=<id>' \
     -H 'Authorization: Bearer <token>' -F 'files=@big-file.png'
   ```

Automated tests (in addition to the manual steps):

```bash
yarn nx test:unit @strapi/upload -- services/__tests__/upload/replace.test.ts
yarn test:api core/upload/admin/file-size-limit
```

The API test covers all three replace entry points, asserting 413 over the limit and success under it.

### Related issue(s)/PR(s)

fix CMS-1615

Only the enforcement half of that ticket is addressed here. The second half — the default `sizeLimit` of 1GB being unreachable because the body parser rejects at ~209MB first — is left for a follow-up, since making it reachable would change what a default install accepts.
