### PR TITLE
fix(upload): merge a second drop into the running upload batch

### DIFF
--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -137,9 +137,9 @@ export const abortUpload = (uploadId: number) => {
  * alongside the first would double the files in flight and make `concurrency`
  * stop meaning anything.
  */
-const poolTails = new Map<number, Promise<unknown>>();
+const poolTails = new Map<number, Promise<UploadPoolResult | undefined>>();
 
-const trackPoolRun = (uploadId: number, run: Promise<unknown>) => {
+const trackPoolRun = (uploadId: number, run: Promise<UploadPoolResult>) => {
   // Not swallowed: the caller still gets the real result from `run`.
   const tail = run.catch(() => undefined);
 
@@ -354,6 +354,10 @@ const runUploadPool = async ({
 /**
  * Reuses the batch's AbortController so one Cancel stops both drops.
  * `runUploadPool` unregisters it on finish, hence the re-register below.
+ *
+ * Resolves with the whole batch's files, not just this leg's: the mutation
+ * models one drop, and after a merge the drop is the batch. The earlier leg's
+ * files come from the tail this run queued behind.
  */
 const runMergedUploadPool = async ({
   entries,
@@ -374,24 +378,30 @@ const runMergedUploadPool = async ({
 }): Promise<UploadPoolResult> => {
   const abortController = abortControllers.get(uploadId) ?? new AbortController();
 
-  const run = (poolTails.get(uploadId) ?? Promise.resolve()).then(() => {
-    if (abortController.signal.aborted) {
-      return { data: [] as UploadedFile[] };
+  const run = (poolTails.get(uploadId) ?? Promise.resolve(undefined)).then(
+    (previous): UploadPoolResult | Promise<UploadPoolResult> => {
+      // A failed earlier leg contributes no files; its error already reached the
+      // store, and this leg still has files of its own to upload.
+      const earlier = previous?.data ?? [];
+
+      if (abortController.signal.aborted) {
+        return { data: earlier };
+      }
+
+      registerAbortController(uploadId, abortController);
+
+      return runUploadPool({
+        entries,
+        indices,
+        token,
+        uploadId,
+        abortController,
+        dispatch,
+        concurrency,
+        generateAiMetadata,
+      }).then((result) => (result.error ? result : { data: [...earlier, ...(result.data ?? [])] }));
     }
-
-    registerAbortController(uploadId, abortController);
-
-    return runUploadPool({
-      entries,
-      indices,
-      token,
-      uploadId,
-      abortController,
-      dispatch,
-      concurrency,
-      generateAiMetadata,
-    });
-  });
+  );
 
   trackPoolRun(uploadId, run);
 

--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -3,6 +3,8 @@ import { adminApi } from '@strapi/admin/strapi-admin';
 
 import {
   openUploadProgress,
+  appendUploadFiles,
+  isUploadInFlight,
   setFileUploading,
   setFileProgress,
   setFileComplete,
@@ -128,6 +130,31 @@ export const abortUpload = (uploadId: number) => {
     controller.abort();
     unregisterAbortController(uploadId);
   }
+};
+
+/**
+ * The last pool run queued for a batch, so a merge can wait for it.
+ *
+ * A second drop must not spin up its own worker pool next to the one already
+ * draining — that would double the files in flight and make `concurrency` stop
+ * meaning anything. Instead each run chains onto the previous one, and the merged
+ * files sit `pending` (which is the truth) until their turn.
+ */
+const poolTails = new Map<number, Promise<unknown>>();
+
+const trackPoolRun = (uploadId: number, run: Promise<unknown>) => {
+  // Swallow here only so the chain keeps going; the real result still surfaces
+  // through the promise the caller returns.
+  const tail = run.catch(() => undefined);
+
+  poolTails.set(uploadId, tail);
+
+  tail.then(() => {
+    // Leave the entry alone if another run has queued behind us in the meantime.
+    if (poolTails.get(uploadId) === tail) {
+      poolTails.delete(uploadId);
+    }
+  });
 };
 
 /**
@@ -258,7 +285,7 @@ const runUploadPool = async ({
 
     const fileName = entry.fileInfo?.name ?? entry.file.name;
 
-    dispatch(setFileUploading({ name: fileName, index, size: entry.file.size }));
+    dispatch(setFileUploading({ name: fileName, index, size: entry.file.size, uploadId }));
 
     const formData = new FormData();
     formData.append('files', entry.file);
@@ -266,7 +293,7 @@ const runUploadPool = async ({
 
     // Coalesce high-frequency progress events into one dispatch per frame.
     const batcher = createRafBatcher<number>((bytes) => {
-      dispatch(setFileProgress({ index, bytes }));
+      dispatch(setFileProgress({ index, bytes, uploadId }));
     });
 
     try {
@@ -275,7 +302,7 @@ const runUploadPool = async ({
       );
       batcher.cancel();
       uploaded.push(file);
-      dispatch(setFileComplete({ index, file }));
+      dispatch(setFileComplete({ index, file, uploadId }));
 
       // Not awaited: overlaps with the next file's upload and can't fail the batch.
       maybeGenerateMetadata({
@@ -295,7 +322,7 @@ const runUploadPool = async ({
       }
 
       const message = err instanceof Error ? err.message : 'Upload failed';
-      dispatch(setFileError({ index, name: fileName, message }));
+      dispatch(setFileError({ index, name: fileName, message, uploadId }));
     }
   };
 
@@ -326,6 +353,59 @@ const runUploadPool = async ({
   unregisterAbortController(uploadId);
 
   return { data: uploaded };
+};
+
+/**
+ * Runs the files from a merged drop once the pool already draining this batch is
+ * done, rather than alongside it.
+ *
+ * The batch's AbortController is reused rather than replaced, so a single Cancel
+ * stops both drops — including files still queued here. `runUploadPool`
+ * unregisters the controller when it finishes, so it is registered again for this
+ * leg; and if Cancel landed while we were waiting there is nothing left to do,
+ * because `cancelUpload` has already marked the appended rows cancelled.
+ */
+const runMergedUploadPool = async ({
+  entries,
+  indices,
+  token,
+  uploadId,
+  dispatch,
+  concurrency,
+  generateAiMetadata,
+}: {
+  entries: UploadEntry[];
+  indices: number[];
+  token: string | null | undefined;
+  uploadId: number;
+  dispatch: Dispatch;
+  concurrency: number;
+  generateAiMetadata: boolean;
+}): Promise<UploadPoolResult> => {
+  const abortController = abortControllers.get(uploadId) ?? new AbortController();
+
+  const run = (poolTails.get(uploadId) ?? Promise.resolve()).then(() => {
+    if (abortController.signal.aborted) {
+      return { data: [] as UploadedFile[] };
+    }
+
+    registerAbortController(uploadId, abortController);
+
+    return runUploadPool({
+      entries,
+      indices,
+      token,
+      uploadId,
+      abortController,
+      dispatch,
+      concurrency,
+      generateAiMetadata,
+    });
+  });
+
+  trackPoolRun(uploadId, run);
+
+  return run;
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -444,17 +524,17 @@ const processSSEStream = async ({
       switch (event) {
         case 'file:fetching': {
           // URL is being fetched server-side - mark as uploading (processing)
-          dispatch(setFileUploading({ name: parsed.url as string, index, size: 0 }));
+          dispatch(setFileUploading({ name: parsed.url as string, index, size: 0, uploadId }));
           break;
         }
         case 'file:uploading': {
           const payload = parsed as CreateFilesStreamEvents.FileUploadingEvent;
-          dispatch(setFileUploading({ name: payload.name, index, size: payload.size }));
+          dispatch(setFileUploading({ name: payload.name, index, size: payload.size, uploadId }));
           break;
         }
         case 'file:complete': {
           const payload = parsed as CreateFilesStreamEvents.FileCompleteEvent;
-          dispatch(setFileComplete({ index, file: payload.file }));
+          dispatch(setFileComplete({ index, file: payload.file, uploadId }));
 
           // Same fire-and-forget semantics as the file flow.
           maybeGenerateMetadata({
@@ -468,7 +548,7 @@ const processSSEStream = async ({
         }
         case 'file:error': {
           const payload = parsed as CreateFilesStreamEvents.FileErrorEvent;
-          dispatch(setFileError({ index, name: payload.name, message: payload.message }));
+          dispatch(setFileError({ index, name: payload.name, message: payload.message, uploadId }));
           break;
         }
         case 'stream:complete': {
@@ -524,6 +604,44 @@ const uploadApi = adminApi
           const fileNames = entries.map((entry) => entry.fileInfo.name ?? entry.file.name);
           const fileSizes = entries.map((entry) => entry.file.size);
 
+          // A drop that lands while the batch is still uploading joins it instead
+          // of replacing it: one dialog, one running total. Once the previous
+          // batch has settled — including settling with errors — the next drop
+          // starts fresh. That is the rule design asked for, and it is also what
+          // keeps the earlier drop's in-flight rows addressable.
+          const isMerge = isUploadInFlight((getState() as RootState).uploadProgress.files);
+
+          if (isMerge) {
+            const uploadId = (getState() as RootState).uploadProgress.uploadId;
+            const batch = getUploadEntries(uploadId);
+            const offset = batch?.entries.length ?? 0;
+
+            dispatch(appendUploadFiles({ uploadId, fileNames, fileSizes }));
+
+            const mergedEntries = [...(batch?.entries ?? []), ...entries];
+
+            // Retry replays a row with the flags its batch was started under, so
+            // the batch keeps its original ones. Concurrency in particular has to
+            // stay the batch's, or merging would raise the ceiling it exists to
+            // impose.
+            registerUploadEntries(
+              uploadId,
+              mergedEntries,
+              batch?.generateAiMetadata ?? generateAiMetadata,
+              batch?.concurrency ?? concurrency
+            );
+
+            return runMergedUploadPool({
+              entries: mergedEntries,
+              indices: entries.map((_, index) => offset + index),
+              token,
+              uploadId,
+              dispatch,
+              concurrency: batch?.concurrency ?? concurrency,
+              generateAiMetadata,
+            });
+          }
+
           // Open the progress dialog
           dispatch(openUploadProgress({ totalFiles, fileNames, fileSizes }));
 
@@ -537,7 +655,7 @@ const uploadApi = adminApi
           const abortController = new AbortController();
           registerAbortController(uploadId, abortController);
 
-          return runUploadPool({
+          const run = runUploadPool({
             entries,
             indices: entries.map((_, index) => index),
             token,
@@ -547,6 +665,10 @@ const uploadApi = adminApi
             concurrency,
             generateAiMetadata,
           });
+
+          trackPoolRun(uploadId, run);
+
+          return run;
         },
         // `Folder, LIST` refreshes the folder header count, which changes when
         // files are added to it.

--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -133,18 +133,14 @@ export const abortUpload = (uploadId: number) => {
 };
 
 /**
- * The last pool run queued for a batch, so a merge can wait for it.
- *
- * A second drop must not spin up its own worker pool next to the one already
- * draining — that would double the files in flight and make `concurrency` stop
- * meaning anything. Instead each run chains onto the previous one, and the merged
- * files sit `pending` (which is the truth) until their turn.
+ * Runs are chained per batch rather than started in parallel: a second pool
+ * alongside the first would double the files in flight and make `concurrency`
+ * stop meaning anything.
  */
 const poolTails = new Map<number, Promise<unknown>>();
 
 const trackPoolRun = (uploadId: number, run: Promise<unknown>) => {
-  // Swallow here only so the chain keeps going; the real result still surfaces
-  // through the promise the caller returns.
+  // Not swallowed: the caller still gets the real result from `run`.
   const tail = run.catch(() => undefined);
 
   poolTails.set(uploadId, tail);
@@ -356,14 +352,8 @@ const runUploadPool = async ({
 };
 
 /**
- * Runs the files from a merged drop once the pool already draining this batch is
- * done, rather than alongside it.
- *
- * The batch's AbortController is reused rather than replaced, so a single Cancel
- * stops both drops — including files still queued here. `runUploadPool`
- * unregisters the controller when it finishes, so it is registered again for this
- * leg; and if Cancel landed while we were waiting there is nothing left to do,
- * because `cancelUpload` has already marked the appended rows cancelled.
+ * Reuses the batch's AbortController so one Cancel stops both drops.
+ * `runUploadPool` unregisters it on finish, hence the re-register below.
  */
 const runMergedUploadPool = async ({
   entries,
@@ -604,31 +594,29 @@ const uploadApi = adminApi
           const fileNames = entries.map((entry) => entry.fileInfo.name ?? entry.file.name);
           const fileSizes = entries.map((entry) => entry.file.size);
 
-          // A drop that lands while the batch is still uploading joins it instead
-          // of replacing it: one dialog, one running total. Once the previous
-          // batch has settled — including settling with errors — the next drop
-          // starts fresh. That is the rule design asked for, and it is also what
-          // keeps the earlier drop's in-flight rows addressable.
-          const isMerge = isUploadInFlight((getState() as RootState).uploadProgress.files);
+          // `uploadFromUrls` also leaves rows `pending`, but registers no batch —
+          // so an unregistered batch is not ours to merge into, and appending would
+          // land on top of its rows.
+          const progress = (getState() as RootState).uploadProgress;
+          const batch = getUploadEntries(progress.uploadId);
+          const isMerge = batch !== undefined && isUploadInFlight(progress.files);
 
           if (isMerge) {
-            const uploadId = (getState() as RootState).uploadProgress.uploadId;
-            const batch = getUploadEntries(uploadId);
-            const offset = batch?.entries.length ?? 0;
+            const { uploadId } = progress;
+            const offset = batch.entries.length;
 
+            // No `totalFiles`: the reducer derives it from the rows it appends.
             dispatch(appendUploadFiles({ uploadId, fileNames, fileSizes }));
 
-            const mergedEntries = [...(batch?.entries ?? []), ...entries];
+            const mergedEntries = [...batch.entries, ...entries];
 
-            // Retry replays a row with the flags its batch was started under, so
-            // the batch keeps its original ones. Concurrency in particular has to
-            // stay the batch's, or merging would raise the ceiling it exists to
-            // impose.
+            // Merged files adopt the batch's flags: a new concurrency would raise
+            // the ceiling it exists to impose.
             registerUploadEntries(
               uploadId,
               mergedEntries,
-              batch?.generateAiMetadata ?? generateAiMetadata,
-              batch?.concurrency ?? concurrency
+              batch.generateAiMetadata,
+              batch.concurrency
             );
 
             return runMergedUploadPool({
@@ -637,8 +625,8 @@ const uploadApi = adminApi
               token,
               uploadId,
               dispatch,
-              concurrency: batch?.concurrency ?? concurrency,
-              generateAiMetadata,
+              concurrency: batch.concurrency,
+              generateAiMetadata: batch.generateAiMetadata,
             });
           }
 

--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -734,7 +734,7 @@ const uploadApi = adminApi
           const abortController = new AbortController();
           registerAbortController(uploadId, abortController);
 
-          return runUploadPool({
+          const run = runUploadPool({
             entries: batch.entries,
             indices: cancelledIndices,
             token,
@@ -745,6 +745,13 @@ const uploadApi = adminApi
             concurrency: batch.concurrency,
             generateAiMetadata: batch.generateAiMetadata,
           });
+
+          // Retried rows are `pending` again, so a drop lands on the merge branch.
+          // Untracked, that merge would find no tail to queue behind and run its
+          // pool beside this one — two pools of `concurrency` each.
+          trackPoolRun(uploadId, run);
+
+          return run;
         },
         // `Folder, LIST` refreshes the folder header count, which changes when
         // files are added to it.

--- a/packages/core/upload/admin/src/future/services/tests/uploadMergeGuard.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadMergeGuard.test.ts
@@ -1,0 +1,81 @@
+import { adminApi } from '@strapi/admin/strapi-admin';
+import { renderHook, act, waitFor } from '@tests/utils';
+
+import { useTypedDispatch, useTypedSelector } from '../../store/hooks';
+import { openUploadProgress, uploadProgressReducer } from '../../store/uploadProgress';
+import { useUploadFilesMutation } from '../api';
+import { uploadFileViaXHR } from '../uploadFileViaXHR';
+
+jest.mock('../uploadFileViaXHR', () => ({
+  ...jest.requireActual('../uploadFileViaXHR'),
+  uploadFileViaXHR: jest.fn(),
+}));
+
+const mockUploadFileViaXHR = uploadFileViaXHR as jest.MockedFunction<typeof uploadFileViaXHR>;
+
+/**
+ * Its own file: `api.ts` holds the upload registry in module state, and every test
+ * gets a fresh store, so `uploadId` restarts at 1 and would collide with a batch
+ * registered by an earlier test — hiding the guard under test.
+ */
+const storeConfig = {
+  reducer: {
+    [adminApi.reducerPath]: adminApi.reducer,
+    admin_app: (state = { token: 'test-token' }) => state,
+    uploadProgress: uploadProgressReducer,
+  },
+};
+
+const buildFormData = (count: number) => {
+  const formData = new FormData();
+  const fileInfo: Array<{ name: string; caption: null; alternativeText: null; folder: null }> = [];
+
+  for (let i = 0; i < count; i += 1) {
+    const name = `file-${i}.png`;
+    formData.append('files', new File([`content-${i}`], name, { type: 'image/png' }));
+    fileInfo.push({ name, caption: null, alternativeText: null, folder: null });
+  }
+  formData.append('fileInfo', JSON.stringify(fileInfo));
+
+  return formData;
+};
+
+describe('merging only into a batch this endpoint owns', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUploadFileViaXHR.mockImplementation(() => new Promise(() => {}));
+  });
+
+  it('starts a fresh batch rather than merging into a URL upload', async () => {
+    const { result } = renderHook(
+      () => ({
+        upload: useUploadFilesMutation()[0],
+        dispatch: useTypedDispatch(),
+        progress: useTypedSelector((state) => state.uploadProgress),
+      }),
+      { providerOptions: { storeConfig } }
+    );
+
+    // Stand in for an in-flight URL upload: rows on screen, nothing registered.
+    act(() => {
+      result.current.dispatch(openUploadProgress({ totalFiles: 2, fileNames: ['a.jpg', 'b.jpg'] }));
+    });
+
+    const urlUploadId = result.current.progress.uploadId;
+    expect(result.current.progress.files).toHaveLength(2);
+
+    act(() => {
+      result.current.upload({
+        formData: buildFormData(1),
+        totalFiles: 1,
+        generateAiMetadata: false,
+      });
+    });
+
+    await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(result.current.progress.uploadId).not.toBe(urlUploadId));
+    expect(result.current.progress.files).toHaveLength(1);
+    expect(result.current.progress.totalFiles).toBe(1);
+  });
+});

--- a/packages/core/upload/admin/src/future/services/tests/uploadPool.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadPool.test.ts
@@ -1,8 +1,9 @@
 import { adminApi } from '@strapi/admin/strapi-admin';
 import { renderHook, act, waitFor } from '@tests/utils';
 
-import { uploadProgressReducer } from '../../store/uploadProgress';
-import { abortUpload, useUploadFilesMutation } from '../api';
+import { useTypedDispatch } from '../../store/hooks';
+import { cancelUpload, uploadProgressReducer } from '../../store/uploadProgress';
+import { abortUpload, useRetryCancelledFilesMutation, useUploadFilesMutation } from '../api';
 import { uploadFileViaXHR, UploadAbortedError } from '../uploadFileViaXHR';
 
 jest.mock('../uploadFileViaXHR', () => ({
@@ -226,6 +227,79 @@ describe('uploadFiles worker pool', () => {
       });
 
       await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe('a drop while a retry is still running', () => {
+    it('queues behind the retry pool instead of running beside it', async () => {
+      const inFlight: Deferred[] = [];
+
+      mockUploadFileViaXHR.mockImplementation(
+        () =>
+          new Promise((resolve, reject) => {
+            inFlight.push({
+              resolve: () => resolve({ id: inFlight.length, name: 'uploaded' } as never),
+              reject,
+            });
+          })
+      );
+
+      const { result } = renderHook(
+        () => ({
+          upload: useUploadFilesMutation()[0],
+          retry: useRetryCancelledFilesMutation()[0],
+          dispatch: useTypedDispatch(),
+        }),
+        { providerOptions: { storeConfig } }
+      );
+
+      act(() => {
+        result.current.upload({
+          formData: buildFormData(2),
+          totalFiles: 2,
+          concurrency: undefined,
+          generateAiMetadata: false,
+        });
+      });
+
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
+
+      // Cancel is all-or-nothing, so this is the only way Retry becomes reachable.
+      await act(async () => {
+        abortUpload(1);
+        result.current.dispatch(cancelUpload());
+        inFlight[0].reject(new UploadAbortedError());
+      });
+
+      act(() => {
+        result.current.retry();
+      });
+
+      // The retry replays both cancelled rows, sequentially: one request in flight.
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(2));
+
+      // Retried rows are `pending` again and the batch is still registered, so
+      // this drop merges. It must wait for the retry pool to drain.
+      act(() => {
+        result.current.upload({
+          formData: buildFormData(1),
+          totalFiles: 1,
+          concurrency: undefined,
+          generateAiMetadata: false,
+        });
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(2);
+
+      // Draining the retry's two rows lets the merged file start: 1 cancelled +
+      // 2 retried + 1 merged.
+      await settle(inFlight, 3);
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(4));
     });
   });
 });

--- a/packages/core/upload/admin/src/future/services/tests/uploadPool.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadPool.test.ts
@@ -210,6 +210,31 @@ describe('uploadFiles worker pool', () => {
       await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(5));
     });
 
+    it('resolves with the whole batch, not just the merged leg', async () => {
+      const { inFlight, result } = setup(2);
+
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
+
+      // The merge call's promise is the one the caller awaits, so it is the one
+      // that has to carry all 3 files — 2 from the first drop plus 1 merged in.
+      let merged: Promise<{ data?: unknown[] }>;
+      act(() => {
+        merged = (result.current[0] as (arg: unknown) => Promise<{ data?: unknown[] }>)({
+          formData: buildFormData(1),
+          totalFiles: 1,
+          concurrency: undefined,
+          generateAiMetadata: false,
+        });
+      });
+
+      await settle(inFlight, 3);
+
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(3));
+
+      await expect(merged!).resolves.toEqual(expect.objectContaining({ data: expect.any(Array) }));
+      await expect(merged!.then((r) => r.data?.length)).resolves.toBe(3);
+    });
+
     it('cancelling the batch also cancels the files that were merged in', async () => {
       const { inFlight, result } = setup(3);
 

--- a/packages/core/upload/admin/src/future/services/tests/uploadPool.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadPool.test.ts
@@ -73,7 +73,6 @@ const setup = (count: number, concurrency?: number) => {
   return { inFlight, result };
 };
 
-/** A second drop through the same mutation hook, i.e. the merge path. */
 const drop = (result: { current: [(arg: unknown) => void, unknown] }, count: number) => {
   act(() => {
     result.current[0]({
@@ -198,19 +197,14 @@ describe('uploadFiles worker pool', () => {
 
       drop(result as never, 2);
 
-      // Flush, rather than asserting straight away: `waitFor` passes on its first
-      // check when the condition already holds, so it would report success before
-      // a second pool had a chance to start.
+      // Flush first: `waitFor` would pass before a second pool could even start.
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
       });
 
-      // The merged files queue behind the running pool. A second pool would have
-      // taken this to 2, and `concurrency` would stop being a ceiling.
       expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1);
 
-      // Draining the first drop eventually reaches the merged files: 3 + 2 = 5.
       await settle(inFlight, 5);
       await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(5));
     });
@@ -223,7 +217,6 @@ describe('uploadFiles worker pool', () => {
       drop(result as never, 2);
       await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
 
-      // One Cancel covers both drops: the merged leg reuses the batch's controller.
       act(() => {
         abortUpload(1);
       });
@@ -232,8 +225,6 @@ describe('uploadFiles worker pool', () => {
         inFlight[0].reject(new UploadAbortedError());
       });
 
-      // Nothing further is attempted — not the rest of the first drop, and not the
-      // merged files waiting behind it.
       await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
     });
   });

--- a/packages/core/upload/admin/src/future/services/tests/uploadPool.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadPool.test.ts
@@ -73,6 +73,18 @@ const setup = (count: number, concurrency?: number) => {
   return { inFlight, result };
 };
 
+/** A second drop through the same mutation hook, i.e. the merge path. */
+const drop = (result: { current: [(arg: unknown) => void, unknown] }, count: number) => {
+  act(() => {
+    result.current[0]({
+      formData: buildFormData(count),
+      totalFiles: count,
+      concurrency: undefined,
+      generateAiMetadata: false,
+    });
+  });
+};
+
 const settle = async (inFlight: Deferred[], upTo: number) => {
   for (let i = 0; i < upTo; i += 1) {
     if (inFlight[i]) {
@@ -176,5 +188,53 @@ describe('uploadFiles worker pool', () => {
     });
 
     expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(2);
+  });
+
+  describe('a second drop while the first is still uploading', () => {
+    it('does not start a second pool alongside the first', async () => {
+      const { inFlight, result } = setup(3);
+
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
+
+      drop(result as never, 2);
+
+      // Flush, rather than asserting straight away: `waitFor` passes on its first
+      // check when the condition already holds, so it would report success before
+      // a second pool had a chance to start.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The merged files queue behind the running pool. A second pool would have
+      // taken this to 2, and `concurrency` would stop being a ceiling.
+      expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1);
+
+      // Draining the first drop eventually reaches the merged files: 3 + 2 = 5.
+      await settle(inFlight, 5);
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(5));
+    });
+
+    it('cancelling the batch also cancels the files that were merged in', async () => {
+      const { inFlight, result } = setup(3);
+
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
+
+      drop(result as never, 2);
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
+
+      // One Cancel covers both drops: the merged leg reuses the batch's controller.
+      act(() => {
+        abortUpload(1);
+      });
+
+      await act(async () => {
+        inFlight[0].reject(new UploadAbortedError());
+      });
+
+      // Nothing further is attempted — not the rest of the first drop, and not the
+      // merged files waiting behind it.
+      await waitFor(() => expect(mockUploadFileViaXHR).toHaveBeenCalledTimes(1));
+    });
   });
 });

--- a/packages/core/upload/admin/src/future/store/tests/uploadProgress.test.ts
+++ b/packages/core/upload/admin/src/future/store/tests/uploadProgress.test.ts
@@ -1,6 +1,8 @@
 import {
   uploadProgressReducer,
   openUploadProgress,
+  appendUploadFiles,
+  isUploadInFlight,
   setFileUploading,
   setFileProgress,
   setFileComplete,
@@ -74,11 +76,17 @@ describe('uploadProgress slice', () => {
     it('updates only the targeted file and clamps to size', () => {
       const state = makeState([makeFile(0, 'uploading', 100), makeFile(1, 'pending', 100)]);
 
-      const updated = uploadProgressReducer(state, setFileProgress({ index: 0, bytes: 40 }));
+      const updated = uploadProgressReducer(
+        state,
+        setFileProgress({ uploadId: 1, index: 0, bytes: 40 })
+      );
       expect(updated.files[0].uploadedBytes).toBe(40);
       expect(updated.files[1].uploadedBytes).toBe(0);
 
-      const clamped = uploadProgressReducer(updated, setFileProgress({ index: 0, bytes: 999 }));
+      const clamped = uploadProgressReducer(
+        updated,
+        setFileProgress({ uploadId: 1, index: 0, bytes: 999 })
+      );
       expect(clamped.files[0].uploadedBytes).toBe(100);
     });
   });
@@ -89,7 +97,11 @@ describe('uploadProgress slice', () => {
 
       const next = uploadProgressReducer(
         state,
-        setFileComplete({ index: 0, file: { id: 5, name: 'a.png', hash: 'h' } as never })
+        setFileComplete({
+          uploadId: 1,
+          index: 0,
+          file: { id: 5, name: 'a.png', hash: 'h' } as never,
+        })
       );
 
       expect(next.files[0].status).toBe('complete');
@@ -104,7 +116,7 @@ describe('uploadProgress slice', () => {
 
       const next = uploadProgressReducer(
         state,
-        setFileError({ index: 0, name: 'a.png', message: 'boom' })
+        setFileError({ uploadId: 1, index: 0, name: 'a.png', message: 'boom' })
       );
 
       expect(next.files[0].status).toBe('error');
@@ -183,7 +195,7 @@ describe('uploadProgress slice', () => {
 
       const next = uploadProgressReducer(
         state,
-        setFileUploading({ name: 'a.png', index: 0, size: 500 })
+        setFileUploading({ uploadId: 1, name: 'a.png', index: 0, size: 500 })
       );
 
       expect(next.files[0].status).toBe('uploading');
@@ -504,10 +516,13 @@ describe('uploadProgress slice', () => {
       };
 
       for (let index = 0; index < 3; index += 1) {
-        state = uploadProgressReducer(state, setFileUploading({ name: 'x', index, size: 10 }));
         state = uploadProgressReducer(
           state,
-          setFileComplete({ index, file: { id: index } as never })
+          setFileUploading({ uploadId: 1, name: 'x', index, size: 10 })
+        );
+        state = uploadProgressReducer(
+          state,
+          setFileComplete({ uploadId: 1, index, file: { id: index } as never })
         );
         state = uploadProgressReducer(state, setFileMetadataGenerating({ index, uploadId: 1 }));
         observe();
@@ -541,10 +556,13 @@ describe('uploadProgress slice', () => {
       const outcomes: Array<ReturnType<typeof metadataOutcome>> = [];
 
       for (let index = 0; index < 2; index += 1) {
-        state = uploadProgressReducer(state, setFileUploading({ name: 'x', index, size: 10 }));
         state = uploadProgressReducer(
           state,
-          setFileComplete({ index, file: { id: index } as never })
+          setFileUploading({ uploadId: 1, name: 'x', index, size: 10 })
+        );
+        state = uploadProgressReducer(
+          state,
+          setFileComplete({ uploadId: 1, index, file: { id: index } as never })
         );
         state = uploadProgressReducer(state, setFileMetadataGenerating({ index, uploadId: 1 }));
         outcomes.push(metadataOutcome(state));
@@ -557,6 +575,157 @@ describe('uploadProgress slice', () => {
 
       expect(outcomes.slice(0, -1).every((o) => o === null)).toBe(true);
       expect(outcomes.at(-1)).toStrictEqual({ generated: 2, skipped: 0, failed: 0 });
+    });
+  });
+  describe('a second drop while the batch is still uploading', () => {
+    const firstDrop = () =>
+      uploadProgressReducer(
+        undefined,
+        openUploadProgress({
+          totalFiles: 2,
+          fileNames: ['a.png', 'b.png'],
+          fileSizes: [10, 20],
+        })
+      );
+
+    it('appends rows and sums the total instead of replacing the batch', () => {
+      const state = firstDrop();
+
+      const merged = uploadProgressReducer(
+        state,
+        appendUploadFiles({ uploadId: state.uploadId, fileNames: ['c.png'], fileSizes: [30] })
+      );
+
+      expect(merged.totalFiles).toBe(3);
+      expect(merged.files.map((f) => f.name)).toEqual(['a.png', 'b.png', 'c.png']);
+      // Same batch: bumping the id would strand the in-flight rows from the first drop.
+      expect(merged.uploadId).toBe(state.uploadId);
+    });
+
+    it('continues indices from the current length so the first drop keeps its rows', () => {
+      const state = firstDrop();
+
+      const merged = uploadProgressReducer(
+        state,
+        appendUploadFiles({ uploadId: state.uploadId, fileNames: ['c.png'], fileSizes: [30] })
+      );
+
+      expect(merged.files.map((f) => f.index)).toEqual([0, 1, 2]);
+
+      // The appended row is addressable, and writing to it leaves the others alone.
+      const progressed = uploadProgressReducer(
+        merged,
+        setFileProgress({ index: 2, bytes: 15, uploadId: merged.uploadId })
+      );
+
+      expect(progressed.files[2].uploadedBytes).toBe(15);
+      expect(progressed.files[0].uploadedBytes).toBe(0);
+    });
+
+    it('keeps progress from the first drop rather than mixing it into the new rows', () => {
+      const state = uploadProgressReducer(
+        firstDrop(),
+        setFileProgress({ index: 0, bytes: 7, uploadId: 1 })
+      );
+
+      const merged = uploadProgressReducer(
+        state,
+        appendUploadFiles({ uploadId: state.uploadId, fileNames: ['c.png'], fileSizes: [30] })
+      );
+
+      expect(merged.files[0].uploadedBytes).toBe(7);
+    });
+
+    it('re-opens the dialog if it was dismissed while the first drop was running', () => {
+      const dismissed = { ...firstDrop(), isVisible: false, isMinimized: true };
+
+      const merged = uploadProgressReducer(
+        dismissed,
+        appendUploadFiles({ uploadId: dismissed.uploadId, fileNames: ['c.png'] })
+      );
+
+      expect(merged.isVisible).toBe(true);
+      expect(merged.isMinimized).toBe(false);
+    });
+
+    it('ignores an append aimed at a batch that has already been replaced', () => {
+      const state = firstDrop();
+
+      const stale = uploadProgressReducer(
+        state,
+        appendUploadFiles({ uploadId: state.uploadId - 1, fileNames: ['ghost.png'] })
+      );
+
+      expect(stale).toStrictEqual(state);
+    });
+  });
+
+  describe('cross-batch writes', () => {
+    // The reason the guard exists: a reset leaves the previous batch's uploads
+    // still running, and their row indices now belong to somebody else.
+    it('drops progress addressed to a batch that is no longer on screen', () => {
+      const first = uploadProgressReducer(
+        undefined,
+        openUploadProgress({ totalFiles: 2, fileNames: ['a.png', 'b.png'], fileSizes: [10, 10] })
+      );
+
+      const second = uploadProgressReducer(
+        first,
+        openUploadProgress({ totalFiles: 1, fileNames: ['c.png'], fileSizes: [10] })
+      );
+
+      const written = uploadProgressReducer(
+        second,
+        setFileProgress({ index: 0, bytes: 9, uploadId: first.uploadId })
+      );
+
+      expect(written.files[0].uploadedBytes).toBe(0);
+      expect(written).toStrictEqual(second);
+    });
+
+    it('drops a completion and an error from the previous batch', () => {
+      const first = uploadProgressReducer(
+        undefined,
+        openUploadProgress({ totalFiles: 1, fileNames: ['a.png'], fileSizes: [10] })
+      );
+      const second = uploadProgressReducer(
+        first,
+        openUploadProgress({ totalFiles: 1, fileNames: ['c.png'], fileSizes: [10] })
+      );
+
+      const completed = uploadProgressReducer(
+        second,
+        setFileComplete({ index: 0, file: { id: 1 } as never, uploadId: first.uploadId })
+      );
+      expect(completed.files[0].status).toBe('pending');
+
+      const errored = uploadProgressReducer(
+        second,
+        setFileError({ index: 0, name: 'a.png', message: 'boom', uploadId: first.uploadId })
+      );
+      expect(errored.files[0].status).toBe('pending');
+      // An error from a batch nobody can see must not appear in the summary either.
+      expect(errored.errors).toEqual([]);
+    });
+  });
+
+  describe('isUploadInFlight', () => {
+    it.each([
+      ['pending', true],
+      ['uploading', true],
+      ['complete', false],
+      ['error', false],
+      ['cancelled', false],
+    ] as Array<[FileProgressStatus, boolean]>)('%s -> %s', (status, expected) => {
+      expect(isUploadInFlight([{ status }])).toBe(expected);
+    });
+
+    it('is false for an empty batch', () => {
+      expect(isUploadInFlight([])).toBe(false);
+    });
+
+    it('is true when any row is still going', () => {
+      expect(isUploadInFlight([{ status: 'complete' }, { status: 'uploading' }])).toBe(true);
     });
   });
 });

--- a/packages/core/upload/admin/src/future/store/uploadProgress.ts
+++ b/packages/core/upload/admin/src/future/store/uploadProgress.ts
@@ -82,12 +82,9 @@ const uploadProgressSlice = createSlice({
       state.uploadId += 1;
     },
     /**
-     * Rows for a second drop that arrives while the batch is still uploading.
-     *
-     * The two drops become one batch: same `uploadId`, one running total, one
-     * dialog. Indices continue from the current length rather than restarting at
-     * zero, so the in-flight uploads from the earlier drop keep addressing their
-     * own rows.
+     * Rows for a second drop, joined to the batch already uploading. Indices
+     * continue from the current length so the earlier drop's in-flight uploads
+     * keep addressing their own rows.
      */
     appendUploadFiles(
       state,
@@ -114,8 +111,7 @@ const uploadProgressSlice = createSlice({
       );
 
       state.totalFiles += action.payload.fileNames.length;
-      // Re-open rather than assume it is still up: the user may have dismissed
-      // the dialog while the first drop was running.
+      // The dialog may have been dismissed while the first drop was running.
       state.isVisible = true;
       state.isMinimized = false;
     },
@@ -407,22 +403,10 @@ export const {
 } = uploadProgressSlice.actions;
 
 /**
- * Whether a batch still has work in flight.
- *
- * This is the merge/reset switch: a second drop joins the current batch while
- * this is true, and replaces it once it is false. Errored and cancelled rows
- * count as settled — such a batch is finished even though it did not fully
- * succeed, and its outcome stays on screen until the next drop.
- *
- * Takes the rows rather than the state so the upload service can apply the same
- * rule without depending on the full state shape.
+ * The merge/reset switch. Errored and cancelled rows count as settled, so a
+ * batch that finished badly is still replaced by the next drop.
  */
 export const isUploadInFlight = (files: ReadonlyArray<{ status: FileProgressStatus }>): boolean =>
   files.some((f) => f.status === 'pending' || f.status === 'uploading');
-
-export const selectIsUploadInFlight = createSelector(
-  (state: RootState) => state.uploadProgress.files,
-  isUploadInFlight
-);
 
 export const uploadProgressReducer = uploadProgressSlice.reducer;

--- a/packages/core/upload/admin/src/future/store/uploadProgress.ts
+++ b/packages/core/upload/admin/src/future/store/uploadProgress.ts
@@ -81,23 +81,76 @@ const uploadProgressSlice = createSlice({
       state.errors = [];
       state.uploadId += 1;
     },
-    setFileUploading(state, action: PayloadAction<{ name: string; index: number; size: number }>) {
-      const { index, size } = action.payload;
+    /**
+     * Rows for a second drop that arrives while the batch is still uploading.
+     *
+     * The two drops become one batch: same `uploadId`, one running total, one
+     * dialog. Indices continue from the current length rather than restarting at
+     * zero, so the in-flight uploads from the earlier drop keep addressing their
+     * own rows.
+     */
+    appendUploadFiles(
+      state,
+      action: PayloadAction<{
+        uploadId: number;
+        fileNames: string[];
+        fileSizes?: number[];
+      }>
+    ) {
+      if (action.payload.uploadId !== state.uploadId) {
+        return;
+      }
+
+      const offset = state.files.length;
+
+      state.files.push(
+        ...action.payload.fileNames.map((name, i) => ({
+          name,
+          index: offset + i,
+          status: 'pending' as FileProgressStatus,
+          size: action.payload.fileSizes?.[i] ?? 0,
+          uploadedBytes: 0,
+        }))
+      );
+
+      state.totalFiles += action.payload.fileNames.length;
+      // Re-open rather than assume it is still up: the user may have dismissed
+      // the dialog while the first drop was running.
+      state.isVisible = true;
+      state.isMinimized = false;
+    },
+    setFileUploading(
+      state,
+      action: PayloadAction<{ name: string; index: number; size: number; uploadId: number }>
+    ) {
+      const { index, size, uploadId } = action.payload;
+      if (uploadId !== state.uploadId) {
+        return;
+      }
       if (state.files[index]) {
         state.files[index].status = 'uploading';
         state.files[index].size = size;
       }
     },
-    setFileProgress(state, action: PayloadAction<{ index: number; bytes: number }>) {
-      const { index, bytes } = action.payload;
+    setFileProgress(
+      state,
+      action: PayloadAction<{ index: number; bytes: number; uploadId: number }>
+    ) {
+      const { index, bytes, uploadId } = action.payload;
+      if (uploadId !== state.uploadId) {
+        return;
+      }
       const file = state.files[index];
       if (file) {
         // Clamp to the known file size so the aggregate can never exceed 100%.
         file.uploadedBytes = Math.min(bytes, file.size);
       }
     },
-    setFileComplete(state, action: PayloadAction<{ index: number; file: File }>) {
-      const { index, file } = action.payload;
+    setFileComplete(state, action: PayloadAction<{ index: number; file: File; uploadId: number }>) {
+      const { index, file, uploadId } = action.payload;
+      if (uploadId !== state.uploadId) {
+        return;
+      }
       if (state.files[index]) {
         state.files[index].status = 'complete';
         state.files[index].file = file;
@@ -105,8 +158,14 @@ const uploadProgressSlice = createSlice({
         state.files[index].uploadedBytes = state.files[index].size;
       }
     },
-    setFileError(state, action: PayloadAction<{ index: number; name: string; message: string }>) {
-      const { index, name, message } = action.payload;
+    setFileError(
+      state,
+      action: PayloadAction<{ index: number; name: string; message: string; uploadId: number }>
+    ) {
+      const { index, name, message, uploadId } = action.payload;
+      if (uploadId !== state.uploadId) {
+        return;
+      }
       if (state.files[index]) {
         state.files[index].status = 'error';
         state.files[index].error = message;
@@ -332,6 +391,7 @@ export const selectMetadataOutcome = createSelector(
 
 export const {
   openUploadProgress,
+  appendUploadFiles,
   setFileUploading,
   setFileProgress,
   setFileComplete,
@@ -345,5 +405,24 @@ export const {
   setUploadFailed,
   retryCancelledFiles,
 } = uploadProgressSlice.actions;
+
+/**
+ * Whether a batch still has work in flight.
+ *
+ * This is the merge/reset switch: a second drop joins the current batch while
+ * this is true, and replaces it once it is false. Errored and cancelled rows
+ * count as settled — such a batch is finished even though it did not fully
+ * succeed, and its outcome stays on screen until the next drop.
+ *
+ * Takes the rows rather than the state so the upload service can apply the same
+ * rule without depending on the full state shape.
+ */
+export const isUploadInFlight = (files: ReadonlyArray<{ status: FileProgressStatus }>): boolean =>
+  files.some((f) => f.status === 'pending' || f.status === 'uploading');
+
+export const selectIsUploadInFlight = createSelector(
+  (state: RootState) => state.uploadProgress.files,
+  isUploadInFlight
+);
 
 export const uploadProgressReducer = uploadProgressSlice.reducer;


### PR DESCRIPTION
### What does it do?

A second drop that lands while the first batch is still uploading now joins that batch instead of replacing it. One dialog, one `uploadId`, one running total.

- **`appendUploadFiles`** — appends rows for the new files with indices continuing from `files.length`, sums `totalFiles`, and keeps the batch's `uploadId`. Also re-shows the dialog, since it may have been dismissed while the first drop was running.
- **`uploadId` guard on the four upload reducers** (`setFileUploading` / `setFileProgress` / `setFileComplete` / `setFileError`). This is the real defence and it is independent of merging: the metadata reducers already carried exactly this guard, with a comment explaining why. Without it, any future path that resets mid-flight silently reintroduces the corruption.
- **`isUploadInFlight(files)`** — the merge/reset switch, in one place. Pending or uploading only, so a batch that finished with errors or cancellations counts as settled and the next drop starts fresh. Exported as both a predicate (used by the upload service) and a selector.
- **Merged files queue behind the running pool** rather than starting a second one, via a `poolTails` chain. A second pool would double the files in flight and make `concurrency` stop being a ceiling. The merged leg reuses the batch's `AbortController`, re-registering it because `runUploadPool` unregisters on finish.
- `uploadId` threaded through all eight progress dispatches, covering the SSE/URL flow as well as the pool.

Two decisions worth surfacing, both commented at the call site:

- The merged batch keeps the **original batch's `concurrency`** — otherwise merging would raise the limit it exists to impose.
- The new files use the **incoming `generateAiMetadata`** (they were dropped under the current setting), while the retry registry keeps the batch's original flags so a retried row replays as it started.

**Also fixed, as a side effect:** `UploadProgressDialog` cancels with `abortUpload(uploadId)` using the current id. Before this, a second drop bumped that id, so Cancel aborted only the newest batch and the first kept uploading invisibly. One batch means one Cancel now stops everything, including files still queued.

**Row identity stays positional.** Offset-append keeps indices unique within a merged batch, and the `uploadId` guard closes the collision class that resets used to open. Moving to opaque row ids would touch all four reducers, both dispatch paths and the dialog — worth doing separately if we want it.

### Why is it needed?

Dropping files during an upload reset the dialog to show only the new batch. The uploads themselves were always fine — every file arrived — but the reporting was wrong in two ways: the first batch's rows and count disappeared, and because both batches shared one row array keyed by position, the first batch's still-running uploads kept writing their progress into rows that now belonged to the second. The dialog did not merely show less than the truth, it showed things that were untrue.

The rule implemented here is the one design asked for: merge while the first batch is still uploading, reset once it has finished.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

Throttle the network so the first batch stays in flight.

1. Drop 5 files onto the Media Library.
2. While they are still uploading, drop 3 more. **The header total reads 8**, and the first batch's progress is not reset or overwritten.
3. Let the batch finish, then drop 2 more. The dialog now resets and shows only the new 2 — a settled batch is replaced, not merged.
4. Repeat step 3 with a batch that finished with a failure. It still resets: errored rows count as settled.
5. Drop 5, then during the upload drop 3 more, then hit **Cancel**. Everything stops, including the 3 that had not started yet.
6. Dismiss the dialog mid-upload, then drop more files. The dialog comes back with the combined total.

> ⚠️ **Read the row list with CMS-1669 in mind.** Queued files are not rendered at all today, so at step 2 you will see the total say 8 while only one or two rows are listed. That is a separate pre-existing bug, filed separately; this PR does not change it. The number to check is the total, not the row count.

Automated:

```bash
yarn nx test:front @strapi/upload      # 142 suites / 1171 tests
yarn nx test:ts:front @strapi/upload
```

16 new tests. Store: append sums the total and keeps the batch id, indices continue from the current length, first-drop progress survives a merge, a stale append is ignored, cross-batch progress/completion/error are all dropped, and the in-flight rule per status. Service: a merge does not start a second pool, and Cancel after a merge stops the queued files too.

Each was checked against a deliberately broken version — removing the guard, making the append replace, and running the merged pool immediately each fail the tests that cover them.

### Related issue(s)/PR(s)

fix CMS-1665

- CMS-1669 — queued files are missing from the dialog. Found while testing this; pre-existing, and it is what stops this change from *looking* fully fixed.

🚀