### PR TITLE
fix(upload): list queued files in the upload progress dialog

### DIFF
--- a/packages/core/upload/admin/src/future/components/UploadProgressDialog.tsx
+++ b/packages/core/upload/admin/src/future/components/UploadProgressDialog.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   CheckCircle,
   ChevronDown,
+  Clock,
   Cross,
   CrossCircle,
   Information,
@@ -559,6 +560,22 @@ const FileRowRenderer = ({ file }: { file: FileProgress }) => {
   const isCurrentFile = file.status === 'uploading';
   const isCompleted = file.status === 'complete';
   const isCancelled = file.status === 'cancelled';
+  const isQueued = file.status === 'pending';
+
+  if (isQueued) {
+    // No bar: there is nothing to report yet, and an indeterminate bar would read
+    // as "in progress" on a file the pool has not picked up.
+    return (
+      <FileRow icon={<Clock fill="neutral600" />} fileName={file.name}>
+        <Typography variant="pi" textColor="neutral600">
+          {formatMessage({
+            id: getTranslationKey('upload.progress.file.queued'),
+            defaultMessage: 'Queued',
+          })}
+        </Typography>
+      </FileRow>
+    );
+  }
 
   if (isCurrentFile) {
     // Determinate only once bytes are actually being reported — a known `size` is not
@@ -658,6 +675,9 @@ export const UploadProgressDialog = () => {
   // in-flight row, not just the first (a `find` here dated to the strictly
   // sequential era and hid all but the lowest-index worker's row).
   const uploadingFiles = files.filter((f) => f.status === 'uploading');
+  // Everything the pool has not reached yet. Listed in queue order, which is the
+  // order `files` is already in, so a row's position tells the user where it sits.
+  const queuedFiles = files.filter((f) => f.status === 'pending');
   const completedFiles = files
     .filter((f) => f.status === 'complete' || f.status === 'error' || f.status === 'cancelled')
     .sort((a, b) => {
@@ -691,6 +711,10 @@ export const UploadProgressDialog = () => {
             paddingRight={4}
           >
             {uploadingFiles.map((file) => (
+              <FileRowRenderer key={file.index} file={file} />
+            ))}
+
+            {queuedFiles.map((file) => (
               <FileRowRenderer key={file.index} file={file} />
             ))}
 

--- a/packages/core/upload/admin/src/future/components/tests/UploadProgressDialog.test.tsx
+++ b/packages/core/upload/admin/src/future/components/tests/UploadProgressDialog.test.tsx
@@ -603,4 +603,72 @@ describe('UploadProgressDialog', () => {
       expect(screen.getByText('uploading-c.png')).toBeInTheDocument();
     });
   });
+
+  describe('queued files', () => {
+    // The whole point of the ticket: with the default concurrency of 1, a 40-file
+    // drop has one row uploading and 39 waiting, and the waiting ones used to be
+    // rendered nowhere at all.
+    it('lists files that have not started yet', () => {
+      setup(
+        createMockState({
+          totalFiles: 4,
+          files: [
+            createMockFile(0, 'started.png', 'uploading'),
+            createMockFile(1, 'waiting-a.png', 'pending'),
+            createMockFile(2, 'waiting-b.png', 'pending'),
+            createMockFile(3, 'done.png', 'complete'),
+          ],
+        })
+      );
+
+      expect(screen.getByText('waiting-a.png')).toBeInTheDocument();
+      expect(screen.getByText('waiting-b.png')).toBeInTheDocument();
+      expect(screen.getAllByText('Queued')).toHaveLength(2);
+    });
+
+    it('renders every file in the batch, whatever its state', () => {
+      const files = [
+        createMockFile(0, 'a.png', 'uploading'),
+        createMockFile(1, 'b.png', 'pending'),
+        createMockFile(2, 'c.png', 'complete'),
+        createMockFile(3, 'd.png', 'error', 'boom'),
+        createMockFile(4, 'e.png', 'cancelled'),
+      ];
+
+      setup(createMockState({ totalFiles: files.length, files }));
+
+      files.forEach((file) => {
+        expect(screen.getByText(file.name)).toBeInTheDocument();
+      });
+    });
+
+    it('shows no progress bar on a queued row', () => {
+      setup(
+        createMockState({
+          totalFiles: 1,
+          files: [createMockFile(0, 'waiting.png', 'pending')],
+        })
+      );
+
+      expect(screen.getByText('Queued')).toBeInTheDocument();
+      // A bar — even an indeterminate one — would read as "in progress" on a file
+      // the pool has not picked up yet.
+      expect(screen.queryAllByRole('progressbar')).toHaveLength(0);
+    });
+
+    it('gives the uploading row a bar and the queued row none', () => {
+      setup(
+        createMockState({
+          totalFiles: 2,
+          files: [
+            createMockFile(0, 'going.png', 'uploading'),
+            createMockFile(1, 'waiting.png', 'pending'),
+          ],
+        })
+      );
+
+      // Exactly one: the in-flight row. The queued row contributes none.
+      expect(screen.getAllByRole('progressbar')).toHaveLength(1);
+    });
+  });
 });

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -87,6 +87,7 @@
   "upload.progress.retry": "Retry",
   "upload.progress.file.uploading": "Uploading...",
   "upload.progress.file.canceled": "Canceled",
+  "upload.progress.file.queued": "Queued",
   "upload.progress.file.uploaded": "Uploaded",
   "upload.progress.file.generatingMetadata": "Uploaded • Generating metadata…",
   "upload.progress.file.metadataGenerated": "Uploaded • Metadata generated",


### PR DESCRIPTION
### What does it do?

Files waiting their turn in the upload pool are now listed in the progress dialog instead of being invisible.

- New `pending` branch in `FileRowRenderer`: a `Clock` icon, a **Queued** label, and **no progress bar** — a bar, even an indeterminate one, reads as "in progress" on a file the pool has not picked up yet.
- Queued rows render between the in-flight rows and the settled ones, in `files` order, so a row's position tells the user roughly where it sits in the queue.
- One new translation key, `upload.progress.file.queued`, alongside the existing `upload.progress.file.*` set. Other locales fall back to the English default until translated.

> ⚠️ **The visual has not been through design.** The ticket is tagged Needs UX and Anka is away until September, so I deliberately picked the least inventive option available: the existing `FileRow` layout, an icon already in `@strapi/icons`, and a single word. The icon choice, the wording, and the ordering are all still open, and nothing here should be read as approved design. Happy to redo the presentation once someone can sign it off — the rendering change underneath is independent of how the row looks.

One thing the ticket suggests that turned out not to be possible: the "dead" `pending: 4` entry in the completed-rows sort cannot be removed. `priority` is typed `Record<FileProgressStatus, number>`, so the record has to stay exhaustive. Left as it is.

### Why is it needed?

Dropping 40 files showed a single row. The other 39 were uploading correctly and were present in the store — they were simply never rendered. `UploadProgressDialog` only ever built two groups, `uploading` and `complete | error | cancelled`, and `pending` appeared in neither. So the number of visible rows was `(files in flight) + (files already settled)`, which with the default `concurrentUploadRequests: 1` is exactly one at the start of a large drop. The list then grew as files finished, which made it look like truncation or a scrolling problem rather than a missing state.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

Leave `concurrentUploadRequests` at its default of 1.

1. Drop 10 files onto the Media Library. Every file is listed immediately: one uploading, the rest marked **Queued**.
2. Watch a few complete. Rows move from Queued to uploading to the completed group; the queue shortens from the top.
3. Confirm a queued row has no progress bar, and the uploading row still does.
4. Raise `concurrentUploadRequests` in the upload plugin settings, drop again, and confirm more rows are uploading at once and the rest still read Queued.
5. Cancel mid-batch — queued rows become Canceled like the rest, and Retry brings them back.

Automated:

```bash
yarn nx test:front @strapi/upload      # 142 suites / 1159 tests
yarn nx test:ts:front @strapi/upload
```

Four new tests: queued files are listed, every status in one batch renders a row, a queued row has no `progressbar`, and an uploading row has one while its queued neighbour does not. Each was checked against a broken version — removing the queued group fails three of them, and giving the queued row an indeterminate bar fails two.

### Related issue(s)/PR(s)

fix CMS-1669

- #27415 (CMS-1665) — independent of this, but complementary. That PR merges a second drop into the running batch; because merged files are deliberately queued behind the existing pool, they land in exactly the state this PR makes visible. Without this, #27415 is numerically correct — the total reads 8 — but the merged rows stay hidden. Either can merge first.

🚀