### PR TITLE
fix(admin): keep api token permissions on localized content types at boot

### DIFF
--- a/packages/core/admin/server/src/services/__tests__/permission.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/permission.test.ts
@@ -254,5 +254,65 @@ describe('Permission Service', () => {
       expect(deletedIds).not.toContain(1);
       expect(deletedIds).not.toContain(2);
     });
+
+    test('keeps apiToken permissions when every applicable property is nil', async () => {
+      const permsInDb = [
+        {
+          id: 1,
+          action: 'action-1',
+          actionParameters: {},
+          subject: 'api',
+          properties: {},
+          role: { id: 1 },
+          apiToken: null,
+        },
+        {
+          id: 2,
+          action: 'action-1',
+          actionParameters: {},
+          subject: 'api',
+          properties: {},
+          role: null,
+          apiToken: { id: 1 },
+        },
+      ];
+
+      const findMany = jest.fn(() => Promise.resolve(permsInDb));
+      const cleanPermissionFields = jest.fn((perms: { properties: object }[]) =>
+        perms.map((perm) => ({ ...perm, properties: { ...perm.properties, fields: [] } }))
+      );
+      const dbDelete = jest.fn(({ where }: { where: { id: number } }) =>
+        Promise.resolve({ where: { id: where.id } })
+      );
+      const update = jest.fn(() => Promise.resolve());
+      const count = jest.fn(() => Promise.resolve(2));
+
+      global.strapi = merge(global.strapi, {
+        db: { query: () => ({ findMany, delete: dbDelete, update, count }) },
+        admin: {
+          services: {
+            'content-type': { cleanPermissionFields },
+            permission: {
+              actionProvider: {
+                has: jest.fn(() => true),
+                get: jest.fn(() => ({
+                  subjects: ['api'],
+                  options: { applyToProperties: ['fields', 'locales'] },
+                })),
+                appliesToProperty: jest.fn(() => Promise.resolve(true)),
+              },
+            },
+          },
+        },
+        eventHub: { emit: jest.fn() },
+      });
+
+      await cleanPermissionsInDatabase();
+
+      const deletedIds = dbDelete.mock.calls.map((c) => (c ? c[0].where.id : undefined));
+      expect(deletedIds).toContain(1);
+      expect(deletedIds).not.toContain(2);
+      expect(update).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/admin/server/src/services/permission/queries.ts
+++ b/packages/core/admin/server/src/services/permission/queries.ts
@@ -112,9 +112,11 @@ const filterPermissionsToRemove = async (permissions: Permission[]) => {
     const isRegisteredAction = actionProvider.has(permission.action);
     const hasInvalidProperties = isArray(applyToProperties) && invalidProperties.every(eq(true));
     const isInvalidSubject = isArray(subjects) && !subjects.includes(permission.subject as string);
+    // On an api token permission, nil properties mean "everything", not "invalid"
+    const hasApiToken = !isNil(prop('apiToken', permission));
 
     // If the permission has an invalid action, an invalid subject or invalid properties, then add it to the toBeRemoved collection
-    if (!isRegisteredAction || isInvalidSubject || hasInvalidProperties) {
+    if (!isRegisteredAction || isInvalidSubject || (hasInvalidProperties && !hasApiToken)) {
       permissionsToRemove.push(permission);
     }
   }


### PR DESCRIPTION
### What does it do?

`filterPermissionsToRemove` no longer applies the nil-property rule to permissions owned by an api token.

### Why is it needed?

`cleanPermissionsInDatabase` runs on every boot and drops any permission whose applicable properties are all nil. Permissions created through `POST /admin/admin-tokens` are stored with `properties: {}` on purpose, since a nil `fields` set means "all fields" there. On a localized content type both `fields` and `locales` apply, both are nil, so the row was deleted at the next restart. The token kept authenticating and could do nothing, with nothing logged. A non-localized type survived only because the `locales` check happened to return false.

The orphan filter a few lines below already treats api-token rows as a separate case; this brings the property rule in line with it. The issue also flags that nil `locales` reads as "no locales" at request time. That inconsistency predates this and is left alone.

### How to test it?

Run `examples/getstarted`, create an admin token with a `plugin::content-manager.explorer.read` permission on `api::article.article` and no `properties`, then restart the server. `GET /admin/admin-tokens/:id` should still list the permission.

`yarn jest --config packages/core/admin/jest.config.js --rootDir packages/core/admin permission.test` covers it. The new case fails against the previous code.

### Related issue(s)/PR(s)

Fixes #27418