### PR TITLE
fix(content-manager): reject MCP relation writes combining set with connect or disconnect

### DIFF
--- a/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
+++ b/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
@@ -1151,7 +1151,22 @@ describe('buildDataSchema', () => {
     );
     expect(schema.safeParse({ tags: { set: ['abc'], connect: ['def'] } }).success).toBe(false);
     expect(schema.safeParse({ tags: { set: ['abc'], disconnect: ['def'] } }).success).toBe(false);
+    expect(
+      schema.safeParse({ tags: { set: ['abc'], connect: ['def'], disconnect: ['ghi'] } }).success
+    ).toBe(false);
+  });
+
+  it('xMany relation rejects { set: null } combined with connect or disconnect', () => {
+    const schema = buildDataSchema(
+      mockStrapi,
+      relationModel,
+      relationModel.attributes as TestAttrs
+    );
     expect(schema.safeParse({ tags: { set: null, connect: ['def'] } }).success).toBe(false);
+    expect(schema.safeParse({ tags: { set: null, disconnect: ['def'] } }).success).toBe(false);
+    expect(
+      schema.safeParse({ tags: { set: null, connect: ['def'], disconnect: ['ghi'] } }).success
+    ).toBe(false);
   });
 
   it('xMany relation accepts empty object {}', () => {

--- a/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
+++ b/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
@@ -1143,6 +1143,17 @@ describe('buildDataSchema', () => {
     expect(schema.safeParse({ tags: { set: null } }).success).toBe(true);
   });
 
+  it('xMany relation rejects { set: [...] } combined with connect or disconnect', () => {
+    const schema = buildDataSchema(
+      mockStrapi,
+      relationModel,
+      relationModel.attributes as TestAttrs
+    );
+    expect(schema.safeParse({ tags: { set: ['abc'], connect: ['def'] } }).success).toBe(false);
+    expect(schema.safeParse({ tags: { set: ['abc'], disconnect: ['def'] } }).success).toBe(false);
+    expect(schema.safeParse({ tags: { set: null, connect: ['def'] } }).success).toBe(false);
+  });
+
   it('xMany relation accepts empty object {}', () => {
     const schema = buildDataSchema(
       mockStrapi,

--- a/packages/core/content-manager/server/src/mcp/schemas/data-schema.ts
+++ b/packages/core/content-manager/server/src/mcp/schemas/data-schema.ts
@@ -253,7 +253,16 @@ export const attributeToInputSchema = (
                 'Replace all relations. Array replaces existing; null clears all. Mutually exclusive with connect/disconnect.'
               ),
           })
-          .strict();
+          .strict()
+          .refine(
+            (value) =>
+              value.set === undefined ||
+              (value.connect === undefined && value.disconnect === undefined),
+            {
+              message: 'set is mutually exclusive with connect and disconnect',
+              path: ['set'],
+            }
+          );
       } else {
         s = z.union([
           relDocumentId,


### PR DESCRIPTION
### What does it do?

Adds a `.refine()` to the to-many relation input schema in the MCP tools so a payload carrying `set` together with `connect` or `disconnect` is rejected at the tool boundary.

### Why is it needed?

The docs and the `set` key's own `.describe()` text say `set` is mutually exclusive with `connect`/`disconnect`, but the three keys were independently optional with nothing tying them together. A payload with both was accepted, and `toAssocs` in the database layer then dropped `connect`/`disconnect` as soon as `set` was set, so one of the two requested writes was lost and the caller still got a success.

### How to test it?

Unit tests:

```
yarn test:unit -- packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
```

In `examples/getstarted`, set `mcp: { enabled: true }` in `config/server.js` and call `update_<type>` with a relation object holding both `set` and `connect`. It is now rejected by input validation instead of being accepted with the `connect` half silently dropped. The new test case fails against the previous code.

### Related issue(s)/PR(s)

Fixes #27421
