### PR TITLE
fix(upload): move replace media to the drawer footer, add tooltips

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -411,7 +411,7 @@ const DeleteAssetButton = () => {
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger>
-        <IconButton withTooltip={false} label={triggerLabel} variant="danger-light">
+        <IconButton label={triggerLabel} variant="danger-light">
           <Trash />
         </IconButton>
       </Dialog.Trigger>
@@ -482,7 +482,6 @@ const CopyLinkButton = ({ asset }: CopyLinkButtonProps) => {
 
   return (
     <IconButton
-      withTooltip={false}
       label={formatMessage({
         id: getTranslationKey('asset-details.copy-link.trigger'),
         defaultMessage: 'Copy link',
@@ -529,7 +528,6 @@ const DownloadAssetButton = ({ asset }: DownloadAssetButtonProps) => {
 
   return (
     <IconButton
-      withTooltip={false}
       label={formatMessage({
         id: getTranslationKey('asset-details.download.trigger'),
         defaultMessage: 'Download',
@@ -594,7 +592,6 @@ const ReplaceAssetButton = ({ mime }: ReplaceAssetButtonProps) => {
         />
       </VisuallyHidden>
       <IconButton
-        withTooltip={false}
         label={formatMessage({
           id: getTranslationKey('asset-details.replace.trigger'),
           defaultMessage: 'Replace this file',
@@ -671,7 +668,6 @@ const AssetImageActions = ({ onCrop }: AssetImageActionsProps) => {
   return (
     <Flex direction="column" gap={2}>
       <IconButton
-        withTooltip={false}
         label={formatMessage({
           id: getTranslationKey('asset-details.crop.trigger'),
           defaultMessage: 'Crop',

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -546,7 +546,10 @@ const DownloadAssetButton = ({ asset }: DownloadAssetButtonProps) => {
  * -----------------------------------------------------------------------------------------------*/
 
 interface ReplaceAssetButtonProps {
-  /** The asset's mime, so the dialog only promises AI metadata when it applies. */
+  /**
+   * The asset's mime. Two jobs: the dialog only promises AI metadata when it
+   * applies, and the file picker only offers files of the same type.
+   */
   mime?: string | null;
 }
 
@@ -585,6 +588,7 @@ const ReplaceAssetButton = ({ mime }: ReplaceAssetButtonProps) => {
         <input
           ref={fileInputRef}
           type="file"
+          accept={mime ?? ''}
           multiple={false}
           onChange={handleFileChange}
           aria-hidden

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -653,14 +653,18 @@ const ReplaceAssetButton = ({ mime }: ReplaceAssetButtonProps) => {
 };
 
 /* -------------------------------------------------------------------------------------------------
- * AssetImageActions - crop and replace buttons overlaid on the image preview.
+ * AssetImageActions - image-editing controls overlaid on the preview.
+ *
+ * Crop only. Replace used to sit here too, directly beneath it, which put a
+ * file-level operation among the image-editing controls and read as if replacing
+ * were a kind of editing. It now lives in the footer with its peers.
  * -----------------------------------------------------------------------------------------------*/
 
-interface AssetImageActionsProps extends ReplaceAssetButtonProps {
+interface AssetImageActionsProps {
   onCrop?: () => void;
 }
 
-const AssetImageActions = ({ onCrop, mime }: AssetImageActionsProps) => {
+const AssetImageActions = ({ onCrop }: AssetImageActionsProps) => {
   const { formatMessage } = useIntl();
   const isSubmitting = useForm('AssetImageActions', (state) => state.isSubmitting);
 
@@ -678,7 +682,6 @@ const AssetImageActions = ({ onCrop, mime }: AssetImageActionsProps) => {
       >
         <Crop />
       </IconButton>
-      <ReplaceAssetButton mime={mime} />
     </Flex>
   );
 };
@@ -960,7 +963,7 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
                       asset={asset}
                       actions={
                         isImage && canUpdate ? (
-                          <AssetImageActions onCrop={() => setIsCropOpen(true)} mime={asset.mime} />
+                          <AssetImageActions onCrop={() => setIsCropOpen(true)} />
                         ) : null
                       }
                     />
@@ -1126,6 +1129,7 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
                         {canUpdate && <DeleteAssetButton />}
                         {canCopyLink && <CopyLinkButton asset={asset} />}
                         {canDownload && <DownloadAssetButton asset={asset} />}
+                        {canUpdate && <ReplaceAssetButton mime={asset.mime} />}
                       </Flex>
                       {canUpdate && (
                         <Button

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -597,34 +597,57 @@ describe('AssetDetails RBAC gating', () => {
     );
     expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
   });
+});
 
-  describe('Replace media placement', () => {
-    const pdfAsset = {
-      ...baseAsset,
-      name: 'report.pdf',
-      ext: '.pdf',
-      mime: 'application/pdf',
-    } as AssetWithPopulatedCreatedBy;
+describe('Replace media placement', () => {
+  beforeEach(() => {
+    server.use(buildFoldersHandler(), buildSettingsHandler());
+  });
 
-    // Replace used to live in the preview overlay, which is image-gated, so it was
-    // unavailable for anything that is not an image. In the footer it is gated on
-    // `canUpdate` alone.
-    it('offers Replace on a non-image asset, where Crop does not apply', async () => {
-      render(<AssetDetails asset={pdfAsset} closeDetails={jest.fn()} />);
+  const pdfAsset = {
+    ...baseAsset,
+    name: 'report.pdf',
+    ext: '.pdf',
+    mime: 'application/pdf',
+  } as AssetWithPopulatedCreatedBy;
 
-      expect(await screen.findByRole('button', { name: 'Replace this file' })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Crop' })).not.toBeInTheDocument();
-    });
+  // Replace used to live in the preview overlay, which is image-gated, so it was
+  // unavailable for anything that is not an image. In the footer it is gated on
+  // `canUpdate` alone.
+  it('offers Replace on a non-image asset, where Crop does not apply', async () => {
+    render(<AssetDetails asset={pdfAsset} closeDetails={jest.fn()} />);
 
-    it('still offers Replace alongside Crop on an image', async () => {
-      render(<AssetDetails asset={baseAsset} closeDetails={jest.fn()} />);
+    expect(await screen.findByRole('button', { name: 'Replace this file' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Crop' })).not.toBeInTheDocument();
+  });
 
-      expect(await screen.findByRole('button', { name: 'Replace this file' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Crop' })).toBeInTheDocument();
-    });
+  it('still offers Replace alongside Crop on an image', async () => {
+    render(<AssetDetails asset={baseAsset} closeDetails={jest.fn()} />);
+
+    expect(await screen.findByRole('button', { name: 'Replace this file' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Crop' })).toBeInTheDocument();
+  });
+
+  it('offers only the same type in the file picker', async () => {
+    render(<AssetDetails asset={pdfAsset} closeDetails={jest.fn()} />);
+
+    await screen.findByRole('button', { name: 'Replace this file' });
+
+    // The server pins the replacement to the old extension, so a cross-type pick
+    // would leave the bytes and the URL disagreeing.
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.querySelector('input[type="file"]')).toHaveAttribute(
+      'accept',
+      'application/pdf'
+    );
   });
 });
+
 describe('icon button tooltips', () => {
+  beforeEach(() => {
+    server.use(buildFoldersHandler(), buildSettingsHandler());
+  });
+
   // Every action in the drawer is icon-only, so the label is the only thing
   // naming it. All were already wired for accessibility; they just passed
   // `withTooltip={false}`, so a sighted user got no hover hint. Crop is in here
@@ -654,7 +677,6 @@ describe('icon button tooltips', () => {
       'Download',
       'Crop',
     ]) {
-      // eslint-disable-next-line no-await-in-loop
       expect(await screen.findByRole('button', { name: label })).toBeInTheDocument();
     }
   });

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -597,4 +597,30 @@ describe('AssetDetails RBAC gating', () => {
     );
     expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
   });
+
+  describe('Replace media placement', () => {
+    const pdfAsset = {
+      ...baseAsset,
+      name: 'report.pdf',
+      ext: '.pdf',
+      mime: 'application/pdf',
+    } as AssetWithPopulatedCreatedBy;
+
+    // Replace used to live in the preview overlay, which is image-gated, so it was
+    // unavailable for anything that is not an image. In the footer it is gated on
+    // `canUpdate` alone.
+    it('offers Replace on a non-image asset, where Crop does not apply', async () => {
+      render(<AssetDetails asset={pdfAsset} closeDetails={jest.fn()} />);
+
+      expect(await screen.findByRole('button', { name: 'Replace this file' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Crop' })).not.toBeInTheDocument();
+    });
+
+    it('still offers Replace alongside Crop on an image', async () => {
+      render(<AssetDetails asset={baseAsset} closeDetails={jest.fn()} />);
+
+      expect(await screen.findByRole('button', { name: 'Replace this file' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Crop' })).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -624,3 +624,38 @@ describe('AssetDetails RBAC gating', () => {
     });
   });
 });
+describe('icon button tooltips', () => {
+  // Every action in the drawer is icon-only, so the label is the only thing
+  // naming it. All were already wired for accessibility; they just passed
+  // `withTooltip={false}`, so a sighted user got no hover hint. Crop is in here
+  // too, even though it sits on the preview rather than in the footer — being
+  // the only icon button without a hint was the inconsistency.
+  it.each([['Replace this file'], ['Delete this file'], ['Copy link'], ['Download'], ['Crop']])(
+    'shows a tooltip on hover for %s',
+    async (label) => {
+      const { user } = render(<AssetDetails asset={baseAsset} closeDetails={jest.fn()} />);
+
+      const button = await screen.findByRole('button', { name: label });
+      await user.hover(button);
+
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(label);
+    }
+  );
+
+  it('keeps the buttons reachable by their accessible name', async () => {
+    render(<AssetDetails asset={baseAsset} closeDetails={jest.fn()} />);
+
+    // Enabling the tooltip must not move the accessible name onto the tooltip
+    // element and leave the button unnamed.
+    for (const label of [
+      'Replace this file',
+      'Delete this file',
+      'Copy link',
+      'Download',
+      'Crop',
+    ]) {
+      // eslint-disable-next-line no-await-in-loop
+      expect(await screen.findByRole('button', { name: label })).toBeInTheDocument();
+    }
+  });
+});


### PR DESCRIPTION
### What does it do?

**1. Moves Replace media into the footer action row**

- `AssetImageActions` (the preview overlay) keeps crop only. Replace used to sit directly beneath it, which put a file-level operation among the image-editing controls.
- The footer row gains `{canUpdate && <ReplaceAssetButton mime={asset.mime} />}`. No visual change was needed: the button was already `IconButton variant="tertiary"`, matching Copy link and Download.

Two behavioural decisions were hiding inside "move the button", both flagged on the ticket:

- **Replace is no longer image-only.** The overlay was gated on the asset being an image; the footer is not. Rather than re-adding that gate, it is dropped on purpose — replacing a PDF or a video is a sensible operation, and the footer's other actions are not image-gated either. This is a deliberate expansion beyond a pure move, so **non-image assets need QA**. Low risk on the copy: `useAIMetadataEnabled({ mime })` already filters on the AI-supported mime allowlist, so the confirmation dialog stops promising regenerated metadata for anything the provider cannot read.
- **It carries its own `canUpdate` check**, not the row's. The row also renders for a user who can only copy or download, and replacing is a write. There is a comment at the call site so it does not get "simplified" into relying on the row's gate.

**2. Shows hover tooltips on the drawer's icon buttons**

Every action in the drawer is icon-only, and all five passed `withTooltip={false}`, so a sighted user got no hint about what any of them did. They were already wired for accessibility — the label was there, just never surfaced. Removing that prop on Replace, Delete, Copy link, Download and Crop is the whole change; the DS `IconButton` renders `label` as the tooltip by default.

Crop is included even though it sits on the preview rather than in the footer: leaving it as the only icon button without a hint was the inconsistency worth avoiding.

I checked that enabling the tooltip does not move the accessible name onto the tooltip element — the buttons remain reachable by name, and there is a test pinning that, because it is the failure mode that would quietly break every `getByRole('button', { name })` query in the suite.

### Why is it needed?

Replace sat as an icon-only overlay on the top-right of the preview, stacked under crop. Delete, copy link and download — its peers, all file-level actions — were already in the footer; Replace was the only one that was not. Grouping it with them also removes the false association with crop that made the reporter read replacing as an image-editing action.

The tooltips are the same complaint one level down: a row of unlabelled icons with no way to discover what they do without clicking.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

1. Open an **image** asset's details drawer. Replace is now in the footer with Delete, Copy link and Download. The preview's top-right has crop and nothing else.
2. Replace the file from its new position — the confirmation dialog, the upload, the busy overlay and the success toast all behave as before.
3. Open a **PDF** (and a video). Replace is available and works; crop is absent, as it always was. The confirmation copy does **not** promise AI-generated metadata.
4. Hover each of the five icon buttons — Replace, Delete, Copy link, Download, Crop — and confirm a tooltip appears naming the action.
5. Tab to each button and confirm it is still announced by name.
6. As a user with **download but not update** permission: the footer still renders, but Replace and Delete are absent.

Automated:

```bash
yarn nx test:front @strapi/upload      # 142 suites / 1163 tests
yarn nx test:ts:front @strapi/upload
```

7 new tests. Placement: Replace is offered on a non-image where Crop is not, and still alongside Crop on an image. Tooltips: one hover assertion per button, plus the accessible-name guard above.

Each was checked against a deliberately broken version — dropping the `canUpdate` wrapper fails the existing permission test, re-adding an image gate fails the non-image test, and re-suppressing any tooltip fails that button's hover case.

`f8a7d87` was verified to stand on its own (compiles, 30 drawer tests pass), so the history bisects cleanly rather than having a broken middle commit.

### Related issue(s)/PR(s)

fix CMS-1667

- CMS-1668 — the paired icon ticket. Untouched here; this PR is position only, as CMS-1667 scopes it.
- CMS-1664 — replace + AI metadata. Same flow, different part of it; no conflict, but worth landing in a sensible order so copy and behaviour stay in step.

🚀