### PR TITLE
chore: add worktree bootstrap command

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,3 +1,3 @@
 {
-  "setup-worktree": ["yarn install", "yarn build", "yarn ai:sync"]
+  "setup-worktree": ["yarn setup:worktree"]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,19 @@ yarn setup                    # clean + build all packages; hints to run ai:sync
 yarn ai:sync          # link .ai/skills into .agents/ .claude/ .cursor/
 ```
 
+### New worktree bootstrap
+
+- In a newly created worktree, check whether `.claude/skills/git-conventions` resolves to the
+  repository's `.ai/skills/git-conventions`. If the link is absent or stale, run
+  `yarn setup:worktree`.
+- If `.brain` exists, do not initialize or refresh it.
+- If `.brain` is absent, look for the user-level `brain-start` skill.
+  - If unavailable, continue silently; this is the normal external-contributor path.
+  - If available, read it, resolve the CMS Brain CLI from its canonical host checkout, and run
+    `"$BRAIN_CLI" refresh --project strapi/strapi`.
+- If CMS Brain is installed and refresh fails, report the failure and follow the bootstrap skill's
+  remediation. Only the absence of the optional skill is a clean no-op.
+
 ---
 
 ## Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,14 @@ yarn setup
 yarn ai:sync  # link AI skills into your local tool directories (.agents/, .claude/, .cursor/)
 ```
 
+To set up a checkout created with Git worktrees:
+
+```bash
+git worktree add <path> <commit-ish>
+cd <path>
+yarn setup:worktree
+```
+
 ### 4. Start the example application
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "prettier:write": "prettier --write \"**/*.{js,ts,jsx,tsx,json,md,mdx,css,scss,yaml,yml}\"",
     "release": "node scripts/release.js",
     "setup": "yarn && yarn clean && yarn build --skip-nx-cache && tsx scripts/ai-tooling/post-setup.ts",
+    "setup:worktree": "yarn install && yarn build && yarn ai:sync",
     "test:api": "node tests/scripts/run-api-tests.js",
     "test:api:clean": "rimraf ./coverage",
     "test:clean": "run-s -c test:api:clean test:e2e:clean test:cli:clean",


### PR DESCRIPTION
### What does it do?

This PR adds `yarn setup:worktree` as the canonical worktree setup command. Cursor-managed worktrees delegate to this command, while contributors can use the same command after creating a worktree with Git.

It also tells agents how to detect the repository-owned AI tooling links and how to handle optional CMS Brain integration without affecting contributors who do not use it.

### Why is it needed?

The worktree setup sequence was duplicated in Cursor configuration and was not available as one command for other worktree managers. A repository-owned command keeps setup behavior consistent across tools.

### How to test it?

1. Run `yarn setup:worktree`.
2. Confirm the install and full monorepo build complete.
3. Run `yarn ai:status` and confirm the repository skills are linked.
4. Run `yarn ai:test`.

---
_AI assisted_