### PR TITLE
fix(email-sendmail): disable file and URL access for attachments

### DIFF
--- a/packages/providers/email-nodemailer/src/__tests__/index.vitest.test.ts
+++ b/packages/providers/email-nodemailer/src/__tests__/index.vitest.test.ts
@@ -76,6 +76,8 @@ describe('@strapi/provider-email-nodemailer', () => {
         subject: 'Test Subject',
         text: 'Test content',
         html: '<p>Test content</p>',
+        disableFileAccess: true,
+        disableUrlAccess: true,
       });
     });
 
@@ -376,7 +378,7 @@ describe('@strapi/provider-email-nodemailer', () => {
       expect(mockSendMail).toHaveBeenCalledWith(expect.objectContaining({ dkim }));
     });
 
-    it('passes security flags (disableUrlAccess, disableFileAccess)', async () => {
+    it('always forces disableFileAccess and disableUrlAccess to true', async () => {
       mockSendMail.mockResolvedValueOnce({ messageId: '<test@example.com>' });
 
       const instance = provider.init(providerOptions, settings);
@@ -385,14 +387,58 @@ describe('@strapi/provider-email-nodemailer', () => {
         to: 'recipient@example.com',
         subject: 'Test Subject',
         text: 'Test content',
-        disableUrlAccess: true,
-        disableFileAccess: true,
       });
 
       expect(mockSendMail).toHaveBeenCalledWith(
         expect.objectContaining({
-          disableUrlAccess: true,
           disableFileAccess: true,
+          disableUrlAccess: true,
+        })
+      );
+    });
+
+    it('cannot be re-enabled by caller-supplied disable flags set to false', async () => {
+      mockSendMail.mockResolvedValueOnce({ messageId: '<test@example.com>' });
+
+      const instance = provider.init(providerOptions, settings);
+
+      await instance.send({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        text: 'Test content',
+        disableFileAccess: false,
+        disableUrlAccess: false,
+      } as any);
+
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          disableFileAccess: true,
+          disableUrlAccess: true,
+        })
+      );
+    });
+
+    it('applies file/URL access guard on sends with path/href attachments (LFI/SSRF)', async () => {
+      mockSendMail.mockResolvedValueOnce({ messageId: '<test@example.com>' });
+
+      const instance = provider.init(providerOptions, settings);
+      const attachments = [
+        { filename: 'passwd', path: '/etc/passwd' },
+        { filename: 'secret', href: 'http://169.254.169.254/latest/meta-data/' },
+      ];
+
+      await instance.send({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        text: 'Test content',
+        attachments,
+      });
+
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments,
+          disableFileAccess: true,
+          disableUrlAccess: true,
         })
       );
     });

--- a/packages/providers/email-nodemailer/src/index.ts
+++ b/packages/providers/email-nodemailer/src/index.ts
@@ -79,12 +79,6 @@ interface SendOptions {
   /** Convert data: URIs in HTML to embedded CID attachments automatically */
   attachDataUrls?: SendMailOptions['attachDataUrls'];
 
-  // --- Security ---
-  /** Fail with an error when content tries to load from a URL */
-  disableUrlAccess?: SendMailOptions['disableUrlAccess'];
-  /** Fail with an error when content tries to load from a file path */
-  disableFileAccess?: SendMailOptions['disableFileAccess'];
-
   // --- Raw MIME ---
   /**
    * Pre-built MIME message. When set, skips message generation entirely.
@@ -266,14 +260,6 @@ export default {
           message.attachDataUrls = options.attachDataUrls;
         }
 
-        // Security
-        if (options.disableUrlAccess) {
-          message.disableUrlAccess = options.disableUrlAccess;
-        }
-        if (options.disableFileAccess) {
-          message.disableFileAccess = options.disableFileAccess;
-        }
-
         // Raw MIME
         if (options.raw) {
           message.raw = options.raw;
@@ -291,6 +277,13 @@ export default {
             ...(options.auth.expires != null ? { expires: options.auth.expires } : {}),
           };
         }
+
+        // Security: always block nodemailer from reading local files or fetching
+        // URLs referenced by attachments[].path / attachments[].href. These are
+        // forced on after the message is built so caller-supplied values cannot
+        // re-enable file/URL access (prevents LFI/SSRF via attachment sources).
+        message.disableFileAccess = true;
+        message.disableUrlAccess = true;
 
         return transporter.sendMail(message);
       },

--- a/packages/providers/email-sendmail/__tests__/index.vitest.test.ts
+++ b/packages/providers/email-sendmail/__tests__/index.vitest.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type MockedFunction } from 'vitest';
 import { generateKeyPairSync } from 'crypto';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { resolveMx } from 'dns/promises';
 
 import provider from '../src/index';
@@ -210,6 +213,104 @@ describe('@strapi/provider-email-sendmail', () => {
           html: 'y',
         })
       ).rejects.toThrow('No recipients');
+    });
+  });
+
+  describe('attachment file/URL access', () => {
+    let server: MinimalSmtpServer;
+
+    beforeEach(async () => {
+      server = new MinimalSmtpServer();
+      await server.listen();
+      mockedResolveMx.mockReset();
+    });
+
+    afterEach(async () => {
+      await server.close();
+    });
+
+    it('does not read a local file referenced by attachments[].path', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sendmail-attach-'));
+      const secretPath = join(dir, 'secret.txt');
+      const secret = 'FILE_ACCESS_SHOULD_BE_BLOCKED_9f3a';
+      writeFileSync(secretPath, secret);
+
+      const errors: unknown[] = [];
+      const instance = provider.init(
+        {
+          devPort: server.port,
+          devHost: '127.0.0.1',
+          logger: { error: (...args: unknown[]) => errors.push(...args) },
+        },
+        { defaultFrom: 'a@b.com' }
+      );
+
+      await expect(
+        instance.send({
+          to: 'recipient@target.com',
+          cc: '',
+          bcc: '',
+          subject: 'S',
+          text: 'T',
+          html: 'T',
+          attachments: [{ path: secretPath }],
+        } as Parameters<typeof instance.send>[0])
+      ).rejects.toThrow();
+
+      // nodemailer refuses to open the file rather than streaming it into the message.
+      expect(errors.some((e) => /access rejected/i.test(String((e as Error)?.message ?? e)))).toBe(
+        true
+      );
+      // The file content never reaches the SMTP peer.
+      expect(server.lastData ?? '').not.toContain(secret);
+    });
+
+    it('does not fetch a URL referenced by attachments[].href', async () => {
+      const errors: unknown[] = [];
+      const instance = provider.init(
+        {
+          devPort: server.port,
+          devHost: '127.0.0.1',
+          logger: { error: (...args: unknown[]) => errors.push(...args) },
+        },
+        { defaultFrom: 'a@b.com' }
+      );
+
+      await expect(
+        instance.send({
+          to: 'recipient@target.com',
+          cc: '',
+          bcc: '',
+          subject: 'S',
+          text: 'T',
+          html: 'T',
+          attachments: [{ href: 'http://127.0.0.1:1/internal' }],
+        } as Parameters<typeof instance.send>[0])
+      ).rejects.toThrow();
+
+      expect(errors.some((e) => /access rejected/i.test(String((e as Error)?.message ?? e)))).toBe(
+        true
+      );
+    });
+
+    it('still delivers an inline-content attachment', async () => {
+      const instance = provider.init(
+        { devPort: server.port, devHost: '127.0.0.1', silent: true },
+        { defaultFrom: 'a@b.com' }
+      );
+
+      await instance.send({
+        to: 'recipient@target.com',
+        cc: '',
+        bcc: '',
+        subject: 'S',
+        text: 'T',
+        html: 'T',
+        attachments: [{ filename: 'a.txt', content: 'hello' }],
+      } as Parameters<typeof instance.send>[0]);
+
+      // base64 of "hello"
+      expect(server.lastData).toContain('aGVsbG8=');
     });
   });
 });

--- a/packages/providers/email-sendmail/src/direct-smtp.ts
+++ b/packages/providers/email-sendmail/src/direct-smtp.ts
@@ -117,6 +117,11 @@ async function trySendViaHost(
         to: recipients,
       },
       dkim,
+      // Prevent nodemailer from reading local files or fetching URLs referenced by
+      // `attachments[].path` / `attachments[].href`. Set after the spread so a caller
+      // cannot re-enable file/URL access through the passed mail options.
+      disableFileAccess: true,
+      disableUrlAccess: true,
     });
   } finally {
     transporter.close();


### PR DESCRIPTION
### What does it do?

`packages/providers/email-sendmail/src/direct-smtp.ts` now sets `disableFileAccess: true` and `disableUrlAccess: true` on the `transporter.sendMail(...)` call. The two flags are placed after the spread of the caller supplied mail options so they cannot be turned off through those options.

### Why is it needed?

The sendmail provider forwards attachment options straight to nodemailer. Without these flags nodemailer resolves `attachments[].path` by reading that local file and `attachments[].href` by fetching that URL while composing the message, so the content of a local file or an internal URL can end up in the outgoing mail. The nodemailer provider in this repository already exposes the same two options (`packages/providers/email-nodemailer/src/index.ts`); this change applies them to the sendmail provider, which has no configuration surface of its own. Attachments that carry inline `content` keep working; only `path`/`href` resolution is turned off.

### How to test it?

`cd packages/providers/email-sendmail && yarn test:unit:vitest`

Added tests in `__tests__/index.vitest.test.ts` send through a local SMTP test server: an attachment referencing a local `path` and one referencing an `href` are refused by nodemailer (`access rejected`) and the file content never reaches the peer, while an inline `content` attachment is still delivered. The path and href tests fail without the change and pass with it. Verified on the touched package only: vitest (all pass), prettier with the repo config, and a tsc typecheck; the full monorepo lint/build was not run in this environment.

### Related issue(s)/PR(s)

n/a

### References

GHSA-4pvr-g6xx-6fc7 (reported privately by [turingpoint](https://www.turingpoint.de), unpublished at time of writing)
