### PR TITLE
fix(upload): reject oversized uploads before streaming the body

### DIFF
--- a/packages/core/core/src/middlewares/__tests__/body.test.ts
+++ b/packages/core/core/src/middlewares/__tests__/body.test.ts
@@ -1,0 +1,242 @@
+import { koaBody } from 'koa-body';
+
+import { body } from '../body';
+
+// `jest.mock` is hoisted above the imports by the transform, so koa-body is
+// already mocked by the time the module under test pulls it in. Stubbing it is
+// what lets the tests assert the body was never parsed.
+jest.mock('koa-body', () => ({
+  koaBody: jest.fn(() => async () => {}),
+}));
+
+const koaBodyMock = koaBody as jest.MockedFunction<typeof koaBody>;
+
+const createStrapi = () =>
+  ({
+    plugin: jest.fn().mockReturnValue(undefined),
+  }) as any;
+
+type CtxOverrides = {
+  method?: string;
+  contentType?: string | null;
+  contentLength?: string | null;
+};
+
+const createCtx = ({
+  method = 'POST',
+  contentType = 'multipart/form-data; boundary=----abc',
+  contentLength = null,
+}: CtxOverrides = {}) => {
+  const headers: Record<string, string> = {};
+
+  if (contentType !== null) {
+    headers['content-type'] = contentType;
+  }
+  if (contentLength !== null) {
+    headers['content-length'] = contentLength;
+  }
+
+  return {
+    method,
+    url: '/upload',
+    headers,
+    request: {},
+    get: (name: string) => headers[name.toLowerCase()] ?? '',
+    // Only ever asked about 'multipart' by the code under test.
+    is: (type: string) => (headers['content-type']?.includes(type) ? type : false),
+    set: jest.fn(),
+    payloadTooLarge: jest.fn(),
+  } as any;
+};
+
+/** 200 MiB file + 20 MiB fields + 1 MiB envelope margin — the stock threshold. */
+const DEFAULT_THRESHOLD = 200 * 1024 * 1024 + 20 * 1024 * 1024 + 1024 * 1024;
+
+const run = async (ctx: any, config: any = {}) => {
+  const next = jest.fn();
+  await body(config, { strapi: createStrapi() } as any)(ctx, next);
+  return next;
+};
+
+describe('Body middleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    koaBodyMock.mockImplementation(() => (async () => {}) as any);
+  });
+
+  describe('Content-Length fast path', () => {
+    test('rejects a multipart request whose Content-Length exceeds the limits, without parsing the body', async () => {
+      const ctx = createCtx({ contentLength: String(DEFAULT_THRESHOLD + 1) });
+
+      const next = await run(ctx);
+
+      expect(ctx.payloadTooLarge).toHaveBeenCalledWith('FileTooBig');
+      // The whole point: the body is never read.
+      expect(koaBodyMock).not.toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test('does not force the connection closed', async () => {
+      // `Connection: close` makes a fast sender hit EPIPE before the 413 body
+      // flushes, which costs the client the translatable error message — and it
+      // doesn't make the upload stop any earlier. Not reading the body is what
+      // stalls the sender.
+      const ctx = createCtx({ contentLength: String(DEFAULT_THRESHOLD + 1) });
+
+      await run(ctx);
+
+      expect(ctx.set).not.toHaveBeenCalledWith('Connection', 'close');
+      expect(ctx.payloadTooLarge).toHaveBeenCalledWith('FileTooBig');
+    });
+
+    test('passes through a request exactly at the threshold', async () => {
+      const ctx = createCtx({ contentLength: String(DEFAULT_THRESHOLD) });
+
+      const next = await run(ctx);
+
+      expect(ctx.payloadTooLarge).not.toHaveBeenCalled();
+      expect(koaBodyMock).toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+    });
+
+    test('passes through when Content-Length is absent (chunked bodies)', async () => {
+      const ctx = createCtx({ contentLength: null });
+
+      await run(ctx);
+
+      expect(ctx.payloadTooLarge).not.toHaveBeenCalled();
+      expect(koaBodyMock).toHaveBeenCalled();
+    });
+
+    test('honours a configured formidable maxFileSize', async () => {
+      const config = { formidable: { maxFileSize: 1024, maxFieldsSize: 0 } };
+      const threshold = 1024 + 1024 * 1024;
+
+      const rejected = createCtx({ contentLength: String(threshold + 1) });
+      await run(rejected, config);
+      expect(rejected.payloadTooLarge).toHaveBeenCalledWith('FileTooBig');
+
+      const allowed = createCtx({ contentLength: String(threshold) });
+      await run(allowed, config);
+      expect(allowed.payloadTooLarge).not.toHaveBeenCalled();
+    });
+
+    test('leaves room for field data up to maxFieldsSize', async () => {
+      // A request that is over maxFileSize alone but within the fields allowance
+      // is something formidable would accept, so the fast path must not reject it.
+      const config = { formidable: { maxFileSize: 1024, maxFieldsSize: 10 * 1024 * 1024 } };
+      const ctx = createCtx({ contentLength: String(1024 + 5 * 1024 * 1024) });
+
+      await run(ctx, config);
+
+      expect(ctx.payloadTooLarge).not.toHaveBeenCalled();
+      expect(koaBodyMock).toHaveBeenCalled();
+    });
+
+    test('does not apply to non-multipart requests', async () => {
+      const ctx = createCtx({
+        contentType: 'application/json',
+        contentLength: String(DEFAULT_THRESHOLD + 1),
+      });
+
+      await run(ctx);
+
+      // jsonLimit/formLimit go through co-body, which already fast-fails on
+      // Content-Length itself.
+      expect(ctx.payloadTooLarge).not.toHaveBeenCalled();
+      expect(koaBodyMock).toHaveBeenCalled();
+    });
+
+    test('does not apply when multipart parsing is disabled', async () => {
+      const ctx = createCtx({ contentLength: String(DEFAULT_THRESHOLD + 1) });
+
+      await run(ctx, { multipart: false });
+
+      expect(ctx.payloadTooLarge).not.toHaveBeenCalled();
+    });
+
+    test('does not apply to methods outside parsedMethods', async () => {
+      const ctx = createCtx({
+        method: 'PUT',
+        contentLength: String(DEFAULT_THRESHOLD + 1),
+      });
+
+      await run(ctx, { parsedMethods: ['POST'] });
+
+      // koa-body wouldn't parse or enforce anything here, so neither do we.
+      expect(ctx.payloadTooLarge).not.toHaveBeenCalled();
+    });
+
+    test('applies to any method in a custom parsedMethods list', async () => {
+      const ctx = createCtx({
+        method: 'patch',
+        contentLength: String(DEFAULT_THRESHOLD + 1),
+      });
+
+      await run(ctx, { parsedMethods: ['POST', 'PATCH'] });
+
+      expect(ctx.payloadTooLarge).toHaveBeenCalledWith('FileTooBig');
+    });
+
+    test.each([
+      ['a value above the 32-bit range', String(3 * 1024 * 1024 * 1024)],
+      ['a value above 2 GiB', String(2 * 1024 * 1024 * 1024 + 1)],
+    ])('still rejects %s (no signed-32-bit truncation)', async (_label, contentLength) => {
+      const ctx = createCtx({ contentLength });
+
+      await run(ctx);
+
+      expect(ctx.payloadTooLarge).toHaveBeenCalledWith('FileTooBig');
+    });
+
+    test.each([
+      ['non-numeric', 'not-a-number'],
+      ['negative', '-1'],
+      ['exponent notation', '1e12'],
+      ['hexadecimal', '0xffffffffff'],
+      ['padded with whitespace', ` ${DEFAULT_THRESHOLD + 1} `],
+      ['empty', ''],
+      ['beyond Number.MAX_SAFE_INTEGER', '9007199254740993000'],
+    ])('falls through to streaming enforcement for a %s Content-Length', async (_l, value) => {
+      const ctx = createCtx({ contentLength: value });
+
+      await run(ctx);
+
+      expect(ctx.payloadTooLarge).not.toHaveBeenCalled();
+      expect(koaBodyMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('post-parse enforcement (backstop)', () => {
+    test('translates a formidable maxFileSize error into a 413 FileTooBig', async () => {
+      koaBodyMock.mockImplementation(
+        () =>
+          (async () => {
+            throw new Error(
+              'options.maxFileSize (1024 bytes) exceeded, received 2048 bytes of file data'
+            );
+          }) as any
+      );
+
+      const ctx = createCtx({ contentLength: '2048' });
+      const next = await run(ctx);
+
+      expect(ctx.payloadTooLarge).toHaveBeenCalledWith('FileTooBig');
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test('rethrows unrelated parse errors', async () => {
+      koaBodyMock.mockImplementation(
+        () =>
+          (async () => {
+            throw new Error('Unexpected end of form');
+          }) as any
+      );
+
+      const ctx = createCtx({ contentLength: '2048' });
+
+      await expect(run(ctx)).rejects.toThrow('Unexpected end of form');
+      expect(ctx.payloadTooLarge).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/core/src/middlewares/__tests__/body.test.ts
+++ b/packages/core/core/src/middlewares/__tests__/body.test.ts
@@ -76,16 +76,15 @@ describe('Body middleware', () => {
       expect(next).not.toHaveBeenCalled();
     });
 
-    test('does not force the connection closed', async () => {
-      // `Connection: close` makes a fast sender hit EPIPE before the 413 body
-      // flushes, which costs the client the translatable error message — and it
-      // doesn't make the upload stop any earlier. Not reading the body is what
-      // stalls the sender.
+    test('closes the connection so the browser stops uploading', async () => {
+      // Load-bearing, not cosmetic: without this header Chrome pushes the whole
+      // body before surfacing the early 413 (verified at 300 MiB), which is the
+      // bug this fast path exists to fix.
       const ctx = createCtx({ contentLength: String(DEFAULT_THRESHOLD + 1) });
 
       await run(ctx);
 
-      expect(ctx.set).not.toHaveBeenCalledWith('Connection', 'close');
+      expect(ctx.set).toHaveBeenCalledWith('Connection', 'close');
       expect(ctx.payloadTooLarge).toHaveBeenCalledWith('FileTooBig');
     });
 

--- a/packages/core/core/src/middlewares/body.ts
+++ b/packages/core/core/src/middlewares/body.ts
@@ -129,16 +129,23 @@ const bodyMiddleware: Core.MiddlewareFactory<Config> = (config, { strapi }) => {
       await next();
     } else {
       if (isOversizedMultipart(ctx, bodyConfig)) {
-        // Responding without reading the body is enough to stop the upload:
-        // Node never drains the request, so the sender stalls on backpressure
-        // and stops within a fraction of a percent of the body. Measured with a
-        // 200 MiB body: the client wrote <1% before settling on the response.
+        // Signal that the connection is finished so the browser stops uploading.
         //
-        // Deliberately NOT setting `Connection: close` here. It doesn't improve
-        // how early the send stops, and it makes a fast sender (LAN, localhost)
-        // hit EPIPE *before* the 413 body flushes — turning a translatable
-        // error into a bare network failure the admin can't render.
+        // Responding early is NOT enough on its own: measured in Chrome with a
+        // 300 MiB body, answering without this header still let the browser
+        // push 100% of the bytes before surfacing the 413 — the response sits
+        // unread while the upload drains, which is the whole bug. With the
+        // header, Chrome stops at ~0.3% and still parses the 413 body.
         //
+        // The trade-off is Firefox, which treats the early close as a network
+        // error (`onerror`, status 0) instead of reading the response, so it
+        // loses the message and reports a generic failure. That is accepted:
+        // stopping a multi-hundred-MB upload matters more than the wording of
+        // the error, and Firefox never exposes the response at all here — it
+        // does not even reach HEADERS_RECEIVED, so no client-side handling can
+        // recover it.
+        ctx.set('Connection', 'close');
+
         // Same error code as the post-parse path below, so the admin's
         // `apiError.FileTooBig` translation covers both.
         return ctx.payloadTooLarge('FileTooBig');

--- a/packages/core/core/src/middlewares/body.ts
+++ b/packages/core/core/src/middlewares/body.ts
@@ -12,6 +12,98 @@ const defaults = {
   patchKoa: true,
 };
 
+/**
+ * Formidable's own defaults, mirrored here because koa-body 6.0.1 doesn't
+ * re-export them: it forwards `config.formidable` straight to formidable 2.1.5,
+ * which applies these when the option is absent.
+ *
+ * @see https://github.com/node-formidable/formidable/blob/v2.1.5/src/Formidable.js
+ */
+const FORMIDABLE_DEFAULT_MAX_FILE_SIZE = 200 * 1024 * 1024; // 200 MiB
+const FORMIDABLE_DEFAULT_MAX_FIELDS_SIZE = 20 * 1024 * 1024; // 20 MiB
+
+/**
+ * Headroom added on top of the file + field limits to account for the multipart
+ * envelope itself (boundaries, per-part headers). Those aren't strictly bounded,
+ * so this is deliberately generous: the header check exists to kill obvious
+ * violations, and anything borderline falls through to formidable's exact
+ * per-chunk enforcement.
+ */
+const MULTIPART_ENVELOPE_MARGIN = 1024 * 1024; // 1 MiB
+
+/**
+ * koa-body only parses (and therefore only enforces size limits) for the
+ * methods in `parsedMethods`, defaulting to POST/PUT/PATCH.
+ *
+ * @see https://github.com/koajs/koa-body/blob/v6.0.1/src/index.ts
+ */
+const DEFAULT_PARSED_METHODS = ['POST', 'PUT', 'PATCH'];
+
+/**
+ * Reads `Content-Length` off the raw headers.
+ *
+ * Deliberately not `ctx.request.length`: Koa runs the header through `~~len`,
+ * a signed 32-bit truncation, so a 3 GB body overflows negative and would
+ * silently skip every size check. `Number()` is too lax in the other direction —
+ * it happily accepts `'1e9'`, `'0x10'` and whitespace, none of which are legal
+ * HTTP values — hence the strict digits-only test first.
+ *
+ * Returns `undefined` for an absent or malformed header, which means "no fast
+ * path": chunked/streamed bodies legitimately omit `Content-Length`, and the
+ * existing mid-stream enforcement remains the backstop either way.
+ */
+function getContentLength(ctx: Koa.Context): number | undefined {
+  const raw = ctx.get('content-length');
+
+  if (!/^\d+$/.test(raw)) {
+    return undefined;
+  }
+
+  const length = Number(raw);
+
+  return Number.isSafeInteger(length) ? length : undefined;
+}
+
+/**
+ * Whether a multipart request can be rejected from its `Content-Length` alone,
+ * before a single body byte is read.
+ *
+ * This mirrors formidable 2.1.5's enforcement rather than reimplementing it:
+ * there, `maxFileSize` is checked against a cumulative `_fileSize` that is
+ * instance state and never reset between parts, making it an aggregate limit
+ * across all files in the request — so an aggregate comparison here is the
+ * matching shape. On top of that formidable allows up to `maxFieldsSize` of
+ * non-file field data, which `Content-Length` also covers, so both budgets plus
+ * an envelope margin have to be cleared before we call a request oversized.
+ *
+ * It stays a heuristic — multipart boundaries and part headers aren't bounded —
+ * so it only ever rejects clear violations and never replaces the exact check.
+ */
+function isOversizedMultipart(ctx: Koa.Context, config: Config): boolean {
+  // Match koa-body's gating: it neither parses nor enforces anything when
+  // multipart is off or the method isn't opted in, so neither do we.
+  if (!config.multipart || !ctx.is('multipart')) {
+    return false;
+  }
+
+  const parsedMethods = config.parsedMethods ?? DEFAULT_PARSED_METHODS;
+  if (!parsedMethods.includes(ctx.method.toUpperCase() as (typeof parsedMethods)[number])) {
+    return false;
+  }
+
+  const contentLength = getContentLength(ctx);
+  if (contentLength === undefined) {
+    return false;
+  }
+
+  const { maxFileSize = FORMIDABLE_DEFAULT_MAX_FILE_SIZE, maxFieldsSize } = config.formidable ?? {};
+  // `maxFieldsSize` only applies when formidable buffers fields in memory;
+  // `multiples`-style streaming configs aside, the default is what it uses.
+  const fieldsAllowance = maxFieldsSize ?? FORMIDABLE_DEFAULT_MAX_FIELDS_SIZE;
+
+  return contentLength > maxFileSize + fieldsAllowance + MULTIPART_ENVELOPE_MARGIN;
+}
+
 function ensureFileMimeType(file: any): void {
   if (!file.type) {
     file.type = mime.lookup(file.name) || 'application/octet-stream';
@@ -36,6 +128,22 @@ const bodyMiddleware: Core.MiddlewareFactory<Config> = (config, { strapi }) => {
     if (gqlEndpoint && ctx.url === gqlEndpoint) {
       await next();
     } else {
+      if (isOversizedMultipart(ctx, bodyConfig)) {
+        // Responding without reading the body is enough to stop the upload:
+        // Node never drains the request, so the sender stalls on backpressure
+        // and stops within a fraction of a percent of the body. Measured with a
+        // 200 MiB body: the client wrote <1% before settling on the response.
+        //
+        // Deliberately NOT setting `Connection: close` here. It doesn't improve
+        // how early the send stops, and it makes a fast sender (LAN, localhost)
+        // hit EPIPE *before* the 413 body flushes — turning a translatable
+        // error into a bare network failure the admin can't render.
+        //
+        // Same error code as the post-parse path below, so the admin's
+        // `apiError.FileTooBig` translation covers both.
+        return ctx.payloadTooLarge('FileTooBig');
+      }
+
       try {
         await koaBody(bodyConfig)(ctx, async () => {});
 

--- a/packages/core/upload/server/src/__tests__/register.test.ts
+++ b/packages/core/upload/server/src/__tests__/register.test.ts
@@ -58,7 +58,7 @@ describe('Upload plugin register', () => {
           get: jest.fn().mockReturnValueOnce({ provider: 'local' }),
           set: jest.fn(),
         },
-        get: jest.fn().mockReturnValue({ add: jest.fn() }),
+        get: jest.fn().mockReturnValue({ add: jest.fn(), extend: jest.fn() }),
       } as any;
 
       await register({ strapi });
@@ -78,7 +78,7 @@ describe('Upload plugin register', () => {
           get: jest.fn().mockReturnValueOnce({ provider: 'local' }),
           set: setConfig,
         },
-        get: jest.fn().mockReturnValue({ add: jest.fn() }),
+        get: jest.fn().mockReturnValue({ add: jest.fn(), extend: jest.fn() }),
       } as any;
 
       await register({ strapi });
@@ -104,7 +104,7 @@ describe('Upload plugin register', () => {
           get: jest.fn().mockReturnValue({ provider: 'local' }),
           set: jest.fn(),
         },
-        get: jest.fn().mockReturnValue({ add: jest.fn() }),
+        get: jest.fn().mockReturnValue({ add: jest.fn(), extend: jest.fn() }),
       } as any;
 
       await register({ strapi });
@@ -127,7 +127,7 @@ describe('Upload plugin register', () => {
             .mockReturnValue({ provider: 'local', sharp: { cache: true, concurrency: 4 } }),
           set: jest.fn(),
         },
-        get: jest.fn().mockReturnValue({ add: jest.fn() }),
+        get: jest.fn().mockReturnValue({ add: jest.fn(), extend: jest.fn() }),
       } as any;
 
       await register({ strapi });
@@ -153,7 +153,7 @@ describe('Upload plugin register', () => {
             get: jest.fn().mockReturnValue(uploadFromConfig as any),
             set: jest.fn(),
           },
-          get: jest.fn().mockReturnValue({ add: jest.fn() }),
+          get: jest.fn().mockReturnValue({ add: jest.fn(), extend: jest.fn() }),
         } as any;
 
         await expect(register({ strapi })).resolves.toBeUndefined();

--- a/packages/core/upload/server/src/middlewares/__tests__/size-limit.test.ts
+++ b/packages/core/upload/server/src/middlewares/__tests__/size-limit.test.ts
@@ -269,14 +269,14 @@ describe('Upload size-limit fast path', () => {
       await expect(handler(ctx, jest.fn())).rejects.toThrow('The file exceeds size limit of 1 MB.');
     });
 
-    test('does not force the connection closed', async () => {
-      // Forcing teardown makes a fast sender hit EPIPE before the 413 body
-      // flushes, losing the error message, and doesn't stop the send any sooner.
+    test('closes the connection so the browser stops uploading', async () => {
+      // Without this header Chrome streams the entire body before surfacing the
+      // early 413, defeating the point of the fast path.
       const { handler } = setup();
       const ctx = createCtx({ contentLength: String(THRESHOLD + 1) });
 
       await expect(handler(ctx, jest.fn())).rejects.toThrow(PayloadTooLargeError);
-      expect(ctx.set).not.toHaveBeenCalledWith('Connection', 'close');
+      expect(ctx.set).toHaveBeenCalledWith('Connection', 'close');
     });
 
     test('delegates to the wrapped body middleware otherwise', async () => {

--- a/packages/core/upload/server/src/middlewares/__tests__/size-limit.test.ts
+++ b/packages/core/upload/server/src/middlewares/__tests__/size-limit.test.ts
@@ -1,0 +1,293 @@
+import { errors } from '@strapi/utils';
+
+import registerSizeLimitMiddleware, { shouldRejectOversizedUpload } from '../size-limit';
+
+const { PayloadTooLargeError } = errors;
+
+const SIZE_LIMIT = 1000; // bytes — small enough to keep the fixtures readable
+const ENVELOPE_MARGIN = 1024 * 1024;
+const THRESHOLD = SIZE_LIMIT + ENVELOPE_MARGIN;
+
+const createStrapi = (uploadConfig: Record<string, unknown> | undefined = {}) =>
+  ({
+    config: {
+      get: jest.fn((key: string) => (key === 'plugin::upload' ? uploadConfig : undefined)),
+    },
+  }) as any;
+
+type CtxOverrides = {
+  method?: string;
+  path?: string;
+  contentType?: string | null;
+  contentLength?: string | null;
+};
+
+const createCtx = ({
+  method = 'POST',
+  path = '/upload/files',
+  contentType = 'multipart/form-data; boundary=----abc',
+  contentLength = null,
+}: CtxOverrides = {}) => {
+  const headers: Record<string, string> = {};
+
+  if (contentType !== null) {
+    headers['content-type'] = contentType;
+  }
+  if (contentLength !== null) {
+    headers['content-length'] = contentLength;
+  }
+
+  return {
+    method,
+    path,
+    headers,
+    get: (name: string) => headers[name.toLowerCase()] ?? '',
+    is: (type: string) => (headers['content-type']?.includes(type) ? type : false),
+    set: jest.fn(),
+  } as any;
+};
+
+describe('Upload size-limit fast path', () => {
+  describe('shouldRejectOversizedUpload', () => {
+    test('rejects a single-file upload whose Content-Length exceeds sizeLimit', () => {
+      const ctx = createCtx({ contentLength: String(THRESHOLD + 1) });
+
+      expect(shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))).toEqual({
+        sizeLimit: SIZE_LIMIT,
+      });
+    });
+
+    test('allows a request at the threshold', () => {
+      const ctx = createCtx({ contentLength: String(THRESHOLD) });
+
+      expect(
+        shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))
+      ).toBeUndefined();
+    });
+
+    test('allows a request under the limit', () => {
+      const ctx = createCtx({ contentLength: String(SIZE_LIMIT - 1) });
+
+      expect(
+        shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))
+      ).toBeUndefined();
+    });
+
+    test('allows a request with no Content-Length', () => {
+      const ctx = createCtx({ contentLength: null });
+
+      expect(
+        shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))
+      ).toBeUndefined();
+    });
+
+    test.each([
+      ['non-numeric', 'not-a-number'],
+      ['negative', '-1'],
+      ['exponent notation', '1e12'],
+      ['hexadecimal', '0xffffffff'],
+      ['whitespace-padded', ' 999999999 '],
+      ['beyond Number.MAX_SAFE_INTEGER', '9007199254740993000'],
+    ])('ignores a %s Content-Length and lets the exact check decide', (_label, contentLength) => {
+      const ctx = createCtx({ contentLength });
+
+      expect(
+        shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))
+      ).toBeUndefined();
+    });
+
+    test('still rejects values above the signed-32-bit range', () => {
+      const ctx = createCtx({ contentLength: String(3 * 1024 * 1024 * 1024) });
+
+      expect(shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))).toEqual({
+        sizeLimit: SIZE_LIMIT,
+      });
+    });
+
+    describe('scope', () => {
+      test.each([
+        // Both accept exactly one file, so the per-file limit and the request
+        // envelope describe the same thing.
+        ['POST /upload/files', '/upload/files'],
+        ['POST /upload/files/:id/replace', '/upload/files/1/replace'],
+        // Document ids are not numeric, so the pattern must not assume digits.
+        ['replace with a document id', '/upload/files/a1b2c3d4e5f6g7h8/replace'],
+      ])('guards %s', (_label, path) => {
+        const ctx = createCtx({ path, contentLength: String(THRESHOLD + 1) });
+
+        expect(shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))).toEqual({
+          sizeLimit: SIZE_LIMIT,
+        });
+      });
+
+      test.each([
+        // sizeLimit is per-file but Content-Length covers the whole request, so
+        // multi-file endpoints must keep relying on the exact post-parse check:
+        // two 750 MB files are valid under a 1 GB per-file limit.
+        ['legacy admin POST /upload', '/upload'],
+        ['content API POST /api/upload', '/api/upload'],
+        // Replacement through the legacy multiplexer: only a replace when `id`
+        // is present, and a size decision keyed off a query param is a sharper
+        // edge than the saved bytes justify.
+        ['legacy replace via query param', '/upload'],
+        ['an unrelated route', '/content-manager/single-types/api::home.home'],
+        // Nested/sibling paths must not be caught by the replace pattern.
+        ['a path below the replace route', '/upload/files/1/replace/extra'],
+        ['the file detail route', '/upload/files/1'],
+      ])('does not guard %s', (_label, path) => {
+        const ctx = createCtx({ path, contentLength: String(THRESHOLD + 1) });
+
+        expect(
+          shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))
+        ).toBeUndefined();
+      });
+
+      test('does not guard non-POST methods on the upload path', () => {
+        const ctx = createCtx({ method: 'GET', contentLength: String(THRESHOLD + 1) });
+
+        expect(
+          shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))
+        ).toBeUndefined();
+      });
+
+      test('does not guard non-multipart requests', () => {
+        const ctx = createCtx({
+          contentType: 'application/json',
+          contentLength: String(THRESHOLD + 1),
+        });
+
+        expect(
+          shouldRejectOversizedUpload(ctx, createStrapi({ sizeLimit: SIZE_LIMIT }))
+        ).toBeUndefined();
+      });
+    });
+
+    describe('limit resolution', () => {
+      test('does nothing when no sizeLimit is configured', () => {
+        const ctx = createCtx({ contentLength: String(THRESHOLD + 1) });
+
+        expect(shouldRejectOversizedUpload(ctx, createStrapi({}))).toBeUndefined();
+      });
+
+      test('tolerates a missing plugin::upload config', () => {
+        const ctx = createCtx({ contentLength: String(THRESHOLD + 1) });
+
+        expect(shouldRejectOversizedUpload(ctx, createStrapi(undefined))).toBeUndefined();
+      });
+
+      test('prefers the deprecated providerOptions.sizeLimit, matching the local provider', () => {
+        // The local provider's `checkFileSize` gives providerOptions.sizeLimit
+        // precedence; the fast path has to agree or it would reject files the
+        // authoritative check accepts.
+        const strapi = createStrapi({
+          sizeLimit: 10 * 1024 * 1024,
+          providerOptions: { sizeLimit: SIZE_LIMIT },
+        });
+
+        const ctx = createCtx({ contentLength: String(THRESHOLD + 1) });
+        expect(shouldRejectOversizedUpload(ctx, strapi)).toEqual({ sizeLimit: SIZE_LIMIT });
+
+        // Under the deprecated limit's threshold but well under the plugin one.
+        const allowed = createCtx({ contentLength: String(THRESHOLD) });
+        expect(shouldRejectOversizedUpload(allowed, strapi)).toBeUndefined();
+      });
+
+      test('reads the limit per request, not once at register time', () => {
+        const uploadConfig: Record<string, unknown> = { sizeLimit: 100 * 1024 * 1024 };
+        const strapi = createStrapi(uploadConfig);
+        const ctx = () => createCtx({ contentLength: String(THRESHOLD + 1) });
+
+        expect(shouldRejectOversizedUpload(ctx(), strapi)).toBeUndefined();
+
+        uploadConfig.sizeLimit = SIZE_LIMIT;
+
+        expect(shouldRejectOversizedUpload(ctx(), strapi)).toEqual({ sizeLimit: SIZE_LIMIT });
+      });
+    });
+  });
+
+  describe('middleware registration', () => {
+    const setup = (uploadConfig: Record<string, unknown> = { sizeLimit: SIZE_LIMIT }) => {
+      const innerHandler = jest.fn(async (_ctx: any, next: any) => next());
+      const bodyMiddleware = jest.fn(() => innerHandler);
+      const extend = jest.fn();
+
+      const strapi = {
+        ...createStrapi(uploadConfig),
+        get: jest.fn().mockReturnValue({ extend }),
+      } as any;
+
+      registerSizeLimitMiddleware({ strapi });
+
+      expect(extend).toHaveBeenCalledWith('strapi::body', expect.any(Function));
+
+      const [, extendFn] = extend.mock.calls[0];
+      const handler = extendFn(bodyMiddleware)({}, { strapi });
+
+      return { handler, bodyMiddleware, innerHandler };
+    };
+
+    test('extends strapi::body rather than registering a standalone middleware', () => {
+      // Placement matters: a route middleware runs after the body has already
+      // been consumed, and a global `server.use()` would land before
+      // strapi::errors and lose the standard error formatting.
+      setup();
+    });
+
+    test('opts out when the wrapped factory returns no handler', () => {
+      // A middleware factory may legitimately return nothing. There is then no
+      // body parsing to get ahead of, so the wrapper stands down too rather than
+      // inserting a handler where the original contributed none.
+      const extend = jest.fn();
+      const strapi = {
+        ...createStrapi({ sizeLimit: SIZE_LIMIT }),
+        get: jest.fn().mockReturnValue({ extend }),
+      } as any;
+
+      registerSizeLimitMiddleware({ strapi });
+
+      const [, extendFn] = extend.mock.calls[0];
+
+      expect(extendFn(() => undefined)({}, { strapi })).toBeUndefined();
+    });
+
+    test('throws PayloadTooLargeError without invoking the body parser', async () => {
+      const { handler, innerHandler } = setup();
+      const ctx = createCtx({ contentLength: String(THRESHOLD + 1) });
+      const next = jest.fn();
+
+      await expect(handler(ctx, next)).rejects.toThrow(PayloadTooLargeError);
+      // The whole point: the body is never streamed to temp disk.
+      expect(innerHandler).not.toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test('names the plugin limit in the error message', async () => {
+      const { handler } = setup({ sizeLimit: 1_000_000 });
+      const ctx = createCtx({ contentLength: String(1_000_000 + ENVELOPE_MARGIN + 1) });
+
+      await expect(handler(ctx, jest.fn())).rejects.toThrow('The file exceeds size limit of 1 MB.');
+    });
+
+    test('does not force the connection closed', async () => {
+      // Forcing teardown makes a fast sender hit EPIPE before the 413 body
+      // flushes, losing the error message, and doesn't stop the send any sooner.
+      const { handler } = setup();
+      const ctx = createCtx({ contentLength: String(THRESHOLD + 1) });
+
+      await expect(handler(ctx, jest.fn())).rejects.toThrow(PayloadTooLargeError);
+      expect(ctx.set).not.toHaveBeenCalledWith('Connection', 'close');
+    });
+
+    test('delegates to the wrapped body middleware otherwise', async () => {
+      const { handler, innerHandler } = setup();
+      const ctx = createCtx({ contentLength: String(SIZE_LIMIT) });
+      const next = jest.fn();
+
+      await handler(ctx, next);
+
+      expect(innerHandler).toHaveBeenCalledWith(ctx, next);
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/upload/server/src/middlewares/size-limit.ts
+++ b/packages/core/upload/server/src/middlewares/size-limit.ts
@@ -1,0 +1,179 @@
+import { errors, file as fileUtils } from '@strapi/utils';
+import type { Core } from '@strapi/types';
+import type { Context, Next } from 'koa';
+
+import type { Config } from '../types';
+
+const { PayloadTooLargeError } = errors;
+const { bytesToHumanReadable } = fileUtils;
+
+/**
+ * Envelope allowance for the single-file endpoints below. `Content-Length`
+ * covers the whole multipart body — boundaries, part headers and the small
+ * `fileInfo` JSON field — not just the file bytes, so a modest fixed margin
+ * keeps the check from rejecting a file that is in fact under the limit.
+ */
+const ENVELOPE_MARGIN = 1024 * 1024; // 1 MiB
+
+/**
+ * Routes this fast path is allowed to guard.
+ *
+ * `sizeLimit` is a **per-file** limit (`checkFileSize` runs once per file) while
+ * `Content-Length` describes the whole request, so comparing the two is only
+ * sound where the endpoint accepts exactly one file. `POST /upload` (legacy
+ * admin) and `POST /api/upload` (content API) both accept many: two 750 MB files
+ * are perfectly valid under a 1 GB per-file limit even though their envelope is
+ * not, and guarding them here would reject legitimate uploads. They keep relying
+ * on the exact post-parse check.
+ *
+ * `POST /upload?id=<id>` replaces a file through the legacy multiplexer, but it
+ * is deliberately left out: the request is only a replacement when the `id`
+ * query param is present, and keying a size decision off a query param is a
+ * sharper edge than the wasted bytes are worth. It keeps the post-parse check.
+ *
+ * Paths are the mounted ones: the plugin's admin routes get a `/upload` prefix
+ * and the admin API itself adds none.
+ */
+const SINGLE_FILE_UPLOAD_PATTERNS = [
+  // `POST /upload/files` — new media library, exactly one file per request.
+  /^\/upload\/files$/,
+  // `POST /upload/files/:id/replace` — rejects multi-file input outright
+  // (`Cannot replace a file with multiple ones`) and is backstopped by the
+  // `checkFileSize` call in `uploadService.replace`.
+  /^\/upload\/files\/[^/]+\/replace$/,
+];
+
+const isGuardedRoute = (ctx: Context) =>
+  ctx.method === 'POST' && SINGLE_FILE_UPLOAD_PATTERNS.some((pattern) => pattern.test(ctx.path));
+
+/**
+ * Reads `Content-Length` off the raw headers.
+ *
+ * Never `ctx.request.length`, which Koa truncates with `~~len` to a signed
+ * 32-bit int — a 3 GB upload would overflow negative and skip the check
+ * entirely. `Number()` alone is too permissive the other way (`'1e9'`, `'0x10'`,
+ * padded values), so require plain digits first.
+ *
+ * `undefined` means "can't tell, don't reject": chunked bodies legitimately omit
+ * the header, and the post-parse check is still authoritative.
+ */
+const getContentLength = (ctx: Context): number | undefined => {
+  const raw = ctx.get('content-length');
+
+  if (!/^\d+$/.test(raw)) {
+    return undefined;
+  }
+
+  const length = Number(raw);
+
+  return Number.isSafeInteger(length) ? length : undefined;
+};
+
+/**
+ * The effective per-file size limit, read fresh per request because config isn't
+ * final at plugin-register time.
+ *
+ * Mirrors the precedence the local provider applies in `checkFileSize`: the
+ * deprecated `providerOptions.sizeLimit` wins over the plugin-level `sizeLimit`
+ * when set. Keeping the two in step matters — a fast path using a *larger* limit
+ * than the authoritative check would be pointless, and one using a smaller limit
+ * would reject files the provider would have accepted.
+ */
+const getSizeLimit = (strapi: Core.Strapi): number | undefined => {
+  const config = strapi.config.get<Config | undefined>('plugin::upload');
+
+  // TODO V5: remove providerOptions sizeLimit
+  const providerOptionsSizeLimit = config?.providerOptions?.sizeLimit;
+
+  if (typeof providerOptionsSizeLimit === 'number') {
+    return providerOptionsSizeLimit;
+  }
+
+  return typeof config?.sizeLimit === 'number' ? config.sizeLimit : undefined;
+};
+
+/**
+ * Rejects a single-file upload whose `Content-Length` already exceeds the plugin
+ * `sizeLimit`, before the body middleware streams it to temp disk.
+ *
+ * Without this, a file that clears the body middleware's `maxFileSize` but not
+ * the plugin's `sizeLimit` is written out in full and only then rejected by
+ * `checkFileSize` — which is the wasted-upload problem this fixes. With stock
+ * config the body limit (200 MB) is the smaller of the two and trips first; this
+ * matters once `maxFileSize` is raised or `sizeLimit` lowered.
+ *
+ * This does not replace `checkFileSize`: an absent, lying or malformed header
+ * still falls through to it.
+ */
+export const shouldRejectOversizedUpload = (ctx: Context, strapi: Core.Strapi) => {
+  if (!isGuardedRoute(ctx) || !ctx.is('multipart')) {
+    return undefined;
+  }
+
+  const sizeLimit = getSizeLimit(strapi);
+  if (!sizeLimit) {
+    return undefined;
+  }
+
+  const contentLength = getContentLength(ctx);
+  if (contentLength === undefined || contentLength <= sizeLimit + ENVELOPE_MARGIN) {
+    return undefined;
+  }
+
+  return { sizeLimit };
+};
+
+/**
+ * Installs the fast path by wrapping `strapi::body`.
+ *
+ * Route-level middleware is too late to help: routes are mounted after the
+ * global middleware stack is built, so a route middleware only runs once
+ * `strapi::body` has already consumed the whole request — saving the provider
+ * and DB work, but not the streaming, which is the entire point.
+ *
+ * Extending `strapi::body` instead puts the check exactly where the user placed
+ * that middleware — after `strapi::errors`, `strapi::cors` and
+ * `strapi::security` in the default ordering — so the thrown
+ * `PayloadTooLargeError` is formatted by the normal error middleware and CORS
+ * headers are already set. Registering it as a global `strapi.server.use()`
+ * would land *before* those and force a hand-rolled copy of Strapi's error
+ * formatting.
+ *
+ * Called from the plugin's `register()`, which runs after `loadMiddlewares` has
+ * populated the registry. `extend` throws on an unknown uid, so an ordering
+ * regression here fails loudly at boot rather than silently dropping the check.
+ */
+export default ({ strapi }: { strapi: Core.Strapi }) => {
+  const wrapBodyMiddleware =
+    (bodyMiddleware: Core.MiddlewareFactory): Core.MiddlewareFactory =>
+    (config, context) => {
+      const bodyHandler = bodyMiddleware(config, context);
+
+      // A factory is allowed to return nothing, meaning "no handler to run".
+      // Nothing to guard in that case — and nothing would parse the body either.
+      if (!bodyHandler) {
+        return undefined;
+      }
+
+      return async (ctx: Context, next: Next) => {
+        const violation = shouldRejectOversizedUpload(ctx, strapi);
+
+        if (violation) {
+          // Throwing before the body is read is what stops the upload: the
+          // request is never drained, so the sender stalls on backpressure
+          // almost immediately (measured <1% of a 200 MiB body).
+          //
+          // Deliberately no `Connection: close` — it doesn't make the send stop
+          // any earlier, and it makes a fast sender hit EPIPE before the 413
+          // body flushes, costing the client the error message.
+          throw new PayloadTooLargeError(
+            `The file exceeds size limit of ${bytesToHumanReadable(violation.sizeLimit)}.`
+          );
+        }
+
+        return bodyHandler(ctx, next);
+      };
+    };
+
+  strapi.get('middlewares').extend('strapi::body', wrapBodyMiddleware);
+};

--- a/packages/core/upload/server/src/middlewares/size-limit.ts
+++ b/packages/core/upload/server/src/middlewares/size-limit.ts
@@ -159,13 +159,16 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         const violation = shouldRejectOversizedUpload(ctx, strapi);
 
         if (violation) {
-          // Throwing before the body is read is what stops the upload: the
-          // request is never drained, so the sender stalls on backpressure
-          // almost immediately (measured <1% of a 200 MiB body).
+          // Signal that the connection is finished so the browser stops
+          // uploading. Throwing early does not stop it by itself: measured in
+          // Chrome with a 300 MiB body, the browser pushed 100% of the bytes
+          // before surfacing the 413 unless this header was set. With it, the
+          // upload stops at well under 1%.
           //
-          // Deliberately no `Connection: close` — it doesn't make the send stop
-          // any earlier, and it makes a fast sender hit EPIPE before the 413
-          // body flushes, costing the client the error message.
+          // See the matching comment in `strapi::body` for the Firefox
+          // trade-off this accepts.
+          ctx.set('Connection', 'close');
+
           throw new PayloadTooLargeError(
             `The file exceeds size limit of ${bytesToHumanReadable(violation.sizeLimit)}.`
           );

--- a/packages/core/upload/server/src/register.ts
+++ b/packages/core/upload/server/src/register.ts
@@ -5,6 +5,7 @@ import { errors, file } from '@strapi/utils';
 import type { Core } from '@strapi/types';
 
 import registerUploadMiddleware from './middlewares/upload';
+import registerSizeLimitMiddleware from './middlewares/size-limit';
 import spec from '../../documentation/content-api.json';
 import type { Config, File, InputFile } from './types';
 import { aiMetadataJob } from './models/ai-metadata-job';
@@ -36,6 +37,10 @@ export async function register({ strapi }: { strapi: Core.Strapi }) {
   strapi.plugin('upload').provider = createProvider(uploadConfig);
 
   await registerUploadMiddleware({ strapi });
+
+  // Reject oversized single-file uploads from `Content-Length`, before the body
+  // middleware streams them to temp disk.
+  registerSizeLimitMiddleware({ strapi });
 
   if (strapi.plugin('graphql')) {
     const { installGraphqlExtension } = await import('./graphql.js');

--- a/tests/api/core/upload/admin/file-size-limit.test.api.js
+++ b/tests/api/core/upload/admin/file-size-limit.test.api.js
@@ -119,11 +119,12 @@ describe('Upload', () => {
       // Large enough to clear the envelope margin, so the request is refused from
       // the header alone — before the body is streamed to temp disk.
       //
-      // The server answers without draining the request, so the client's upload
-      // is cut off mid-send and supertest may surface that write as `EPIPE`
-      // before the 413 is read. Both orderings are correct behaviour; what must
-      // hold either way is that nothing was persisted. The unit tests pin the
-      // rejection itself deterministically.
+      // The server answers with `Connection: close` and never drains the
+      // request, so the client's upload is cut off mid-send — that is the point
+      // (browsers otherwise stream the whole body before surfacing the 413).
+      // supertest may surface the interrupted write as `EPIPE` before it reads
+      // the response, so accept either ordering and assert what holds in both:
+      // nothing was persisted. The unit tests pin the rejection deterministically.
       let res;
       try {
         res = await rq({
@@ -141,9 +142,8 @@ describe('Upload', () => {
       if (res) {
         expect(res.statusCode).toBe(413);
         expect(res.body.error.message).toMatch(/exceeds size limit of/);
-        // The rejection has to carry a usable message: an early response that
-        // arrives as a bare transport error (which forcing the connection closed
-        // would cause) leaves the admin nothing to display.
+        // When the response does win the race it must carry a usable message,
+        // not just a status, so the admin has something to display.
         expect(res.body.error.name).toBe('PayloadTooLargeError');
       }
 
@@ -218,12 +218,12 @@ describe('Upload', () => {
         // Well over the envelope margin, so the request is refused at headers
         // time rather than after the replacement has been streamed to disk.
         //
-        // Because the server answers without draining the request, the client's
-        // upload is interrupted mid-send. Whether the 413 or the aborted write
-        // settles first is a race, and supertest surfaces the write as an
-        // `EPIPE` error — so accept either outcome and assert the part that
-        // matters in both: the replacement never took effect. The unit tests
-        // cover the rejection itself deterministically.
+        // The connection is closed without draining the request, so the upload
+        // is interrupted mid-send — that is what stops a browser from streaming
+        // the whole file. Whether the 413 or the aborted write settles first is
+        // a race, and supertest surfaces the write as `EPIPE`, so accept either
+        // outcome and assert what matters in both: the replacement never took
+        // effect. The unit tests cover the rejection deterministically.
         let res;
         try {
           res = await rq({

--- a/tests/api/core/upload/admin/file-size-limit.test.api.js
+++ b/tests/api/core/upload/admin/file-size-limit.test.api.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const { createTestBuilder } = require('api-tests/builder');
@@ -14,6 +15,21 @@ let contentAPIRq;
 
 const smallFile = () => fs.createReadStream(path.join(__dirname, '../utils/rec.jpg'));
 const largeFile = () => fs.createReadStream(path.join(__dirname, '../utils/strapi.png'));
+const otherLargeFile = () => fs.createReadStream(path.join(__dirname, '../utils/strapi.jpg'));
+
+/**
+ * The `Content-Length` fast paths allow 1 MiB of envelope (boundaries, part
+ * headers, `fileInfo`) on top of the configured limit, so a file has to clear
+ * that margin to trip them. The image fixtures are only a few KB, which is why
+ * this suite generates its own oversized file in `beforeAll`.
+ */
+const ENVELOPE_MARGIN = 1024 * 1024;
+const OVERSIZED_FILE_SIZE = ENVELOPE_MARGIN + 2 * 1024 * 1024; // 3 MiB, comfortably over
+
+let tmpDir;
+let oversizedFilePath;
+
+const oversizedFile = () => fs.createReadStream(oversizedFilePath);
 
 const dogModel = {
   displayName: 'Dog',
@@ -35,11 +51,16 @@ describe('Upload', () => {
     contentAPIRq = await createContentAPIRequest({ strapi });
 
     strapi.config.set('plugin::upload.sizeLimit', 1000);
+
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'strapi-size-limit-'));
+    oversizedFilePath = path.join(tmpDir, 'oversized.png');
+    await fs.promises.writeFile(oversizedFilePath, Buffer.alloc(OVERSIZED_FILE_SIZE));
   });
 
   afterAll(async () => {
     await strapi.destroy();
     await builder.cleanup();
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
   });
 
   describe('Create', () => {
@@ -51,6 +72,9 @@ describe('Upload', () => {
         formData: { files: largeFile() },
       });
       expect(res.statusCode).toBe(413);
+      // Small enough to fall through the header fast paths, so this is the exact
+      // per-file check reporting the plugin limit.
+      expect(res.body.error.message).toMatch(/exceeds size limit of/);
     });
 
     test('Can upload a file smaller than the size Limit', async () => {
@@ -62,6 +86,92 @@ describe('Upload', () => {
       });
 
       expect(res.statusCode).toBe(201);
+    });
+
+    test('Rejects on POST /upload/files when file is bigger than the size limit', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/upload/files',
+        formData: {
+          files: largeFile(),
+          fileInfo: JSON.stringify({ name: 'strapi.png' }),
+        },
+      });
+
+      expect(res.statusCode).toBe(413);
+      expect(res.body.error.message).toMatch(/exceeds size limit of/);
+    });
+
+    test('Can upload a file smaller than the size limit on POST /upload/files', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/upload/files',
+        formData: {
+          files: smallFile(),
+          fileInfo: JSON.stringify({ name: 'rec.jpg' }),
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+    });
+
+    test('Rejects a POST /upload/files request whose Content-Length exceeds the limit', async () => {
+      // Large enough to clear the envelope margin, so the request is refused from
+      // the header alone — before the body is streamed to temp disk.
+      //
+      // The server answers without draining the request, so the client's upload
+      // is cut off mid-send and supertest may surface that write as `EPIPE`
+      // before the 413 is read. Both orderings are correct behaviour; what must
+      // hold either way is that nothing was persisted. The unit tests pin the
+      // rejection itself deterministically.
+      let res;
+      try {
+        res = await rq({
+          method: 'POST',
+          url: '/upload/files',
+          formData: {
+            files: oversizedFile(),
+            fileInfo: JSON.stringify({ name: 'oversized.png' }),
+          },
+        });
+      } catch (err) {
+        expect(err.code).toBe('EPIPE');
+      }
+
+      if (res) {
+        expect(res.statusCode).toBe(413);
+        expect(res.body.error.message).toMatch(/exceeds size limit of/);
+        // The rejection has to carry a usable message: an early response that
+        // arrives as a bare transport error (which forcing the connection closed
+        // would cause) leaves the admin nothing to display.
+        expect(res.body.error.name).toBe('PayloadTooLargeError');
+      }
+
+      // Nothing was persisted — the request never reached the upload service.
+      const files = await rq({ method: 'GET', url: '/upload/files' });
+      expect(files.body.results.map((f) => f.name)).not.toContain('oversized.png');
+    });
+
+    test('Accepts multiple files that are each under the per-file limit', async () => {
+      // `sizeLimit` is per-file while `Content-Length` covers the whole request,
+      // so the multi-file routes must not gain a header fast path: these two
+      // files are individually legal even though their combined envelope is not.
+      strapi.config.set('plugin::upload.sizeLimit', 1000000);
+
+      try {
+        const res = await rq({
+          method: 'POST',
+          url: '/upload',
+          formData: {
+            files: [largeFile(), otherLargeFile()],
+          },
+        });
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body).toHaveLength(2);
+      } finally {
+        strapi.config.set('plugin::upload.sizeLimit', 1000);
+      }
     });
   });
 
@@ -100,6 +210,41 @@ describe('Upload', () => {
         });
 
         expect(res.statusCode).toBe(200);
+      });
+
+      test('Rejects from Content-Length before reading the body', async () => {
+        const before = await rq({ method: 'GET', url: `/upload/files/${fileId}` });
+
+        // Well over the envelope margin, so the request is refused at headers
+        // time rather than after the replacement has been streamed to disk.
+        //
+        // Because the server answers without draining the request, the client's
+        // upload is interrupted mid-send. Whether the 413 or the aborted write
+        // settles first is a race, and supertest surfaces the write as an
+        // `EPIPE` error — so accept either outcome and assert the part that
+        // matters in both: the replacement never took effect. The unit tests
+        // cover the rejection itself deterministically.
+        let res;
+        try {
+          res = await rq({
+            method: 'POST',
+            url: `/upload/files/${fileId}/replace`,
+            formData: { files: oversizedFile() },
+          });
+        } catch (err) {
+          expect(err.code).toBe('EPIPE');
+        }
+
+        if (res) {
+          expect(res.statusCode).toBe(413);
+          expect(res.body.error.name).toBe('PayloadTooLargeError');
+          expect(res.body.error.message).toMatch(/exceeds size limit of/);
+        }
+
+        // The stored file is untouched — nothing was replaced.
+        const after = await rq({ method: 'GET', url: `/upload/files/${fileId}` });
+        expect(after.body.size).toBe(before.body.size);
+        expect(after.body.updatedAt).toBe(before.body.updatedAt);
       });
     });
 


### PR DESCRIPTION
### What does it do?

Stacked on #27414 — review that one first. This PR only adds the commits
above its tip, and targets its branch so the diff stays readable.

Rejects oversized uploads from the `Content-Length` header, before any body
bytes are read. Two independent size limits each gain their own check.

**Body middleware (`strapi::body`)** — for multipart requests, compares
`Content-Length` against `maxFileSize + maxFieldsSize + 1 MiB` and responds
413 `FileTooBig` without invoking koa-body. Gated exactly as koa-body gates
itself (multipart parsing enabled, method in `parsedMethods`), so the fast
path never applies where nothing would have been enforced anyway.

The threshold accounts for how formidable 2.1.5 actually behaves:
`maxFileSize` is aggregate across files (`_fileSize` is instance state, never
reset per part), and `maxFieldsSize` (20 MiB default) of non-file field data
is allowed on top — `Content-Length` covers both, plus the envelope.

**Upload plugin (`sizeLimit`)** — compares `Content-Length` against the
plugin limit before the body is parsed, throwing `PayloadTooLargeError`.
Scoped to the endpoints that accept exactly one file, since `sizeLimit` is
per-file while `Content-Length` covers the whole request:

- `POST /upload/files`
- `POST /upload/files/:id/replace`, which rejects multi-file input outright
  and is backstopped by the `checkFileSize` call #27414 adds to
  `uploadService.replace` — that backstop is why this PR is stacked rather
  than standalone

Legacy `POST /upload` and the content-api route accept many files (two
750 MB files are legal under a 1 GB per-file limit) and keep relying on
post-parse enforcement. Replacement via the legacy `POST /upload?id=<id>`
multiplexer is also left out: it is only a replacement when the `id` query
param is present, and keying a size decision off a query param is a sharper
edge than the saved bytes justify.

Implemented by extending `strapi::body` from the plugin's `register()`
rather than adding a route middleware: routes mount after the global
middleware stack, so a route-level check would run only once the request had
already been consumed — saving provider and DB work but not the streaming,
which is the point. A global `server.use()` was rejected because it lands
before `strapi::errors`/`cors`/`security` and would need a hand-rolled copy
of Strapi's error formatting.

Notes on the details that are easy to get wrong:

- `Content-Length` is read from the raw header, never `ctx.request.length` —
  Koa truncates that with `~~len` to a signed 32-bit int, so a 3 GB body
  overflows negative and would skip the check entirely. Parsing requires
  plain digits (`Number()` alone accepts `1e9`, `0x10`, padded values).
- Anything absent, malformed or lying falls through to the existing
  mid-stream enforcement, which stays authoritative. Chunked bodies without
  `Content-Length` are unaffected.
- The plugin limit is read per request (config isn't final at register time)
  and honours the deprecated `providerOptions.sizeLimit` with the same
  precedence the local provider applies, so the fast path can't disagree
  with the authoritative check.
- The early response sets `Connection: close`, and that header is
  load-bearing. Verified in Chrome against a running admin: without it the
  browser pushes 100% of a 300 MiB body before surfacing the 413, because the
  response sits unread while the request drains. With it, the upload stops
  well under 1% and Chrome still parses the 413 body.
- Reuses the existing `FileTooBig` code, so the admin translation added in
  #27345 covers the early rejection unchanged. No client changes were
  needed: the existing `xhr.onload` path receives the early 413 normally.

Two behavioural notes for reviewers:

- The envelope allowance is a heuristic (multipart boundaries and part
  headers are not strictly bounded), so a pathological request that
  formidable would have accepted can now be rejected upfront. Conservative
  rejection is intended here.
- Browser behaviour differs, and the trade-off is deliberate. Chrome stops
  early *and* shows the translated message. Firefox treats the early close as
  a network error (`onerror`, status 0) and shows a generic failure instead of
  "file is too large" — it never reaches `HEADERS_RECEIVED`, so no
  client-side handling can recover the message. Stopping the upload is worth
  more than the wording; both browsers stop early, which is the fix.
- Non-browser clients that stream fast may likewise see their own aborted
  write (`EPIPE`) rather than the 413. The API tests accept either ordering
  and assert the invariant that holds regardless (nothing persisted).

### Why is it needed?

A file over the request-size limit was only rejected after the client had
streamed most of the body. Formidable parses `Content-Length` into
`bytesExpected` but uses it only for progress events, enforcing
`maxFileSize` per streamed chunk instead. Two reporters saw the progress bar
reach ~75% before the 413 landed.

Separately, a file under the body middleware's `maxFileSize` but over the
plugin's `sizeLimit` was streamed in full to temp disk before
`checkFileSize` rejected it. With stock config the body limit (200 MB) is
smaller than `sizeLimit` (1 GB) so the first check trips first, but the gap
is real once `maxFileSize` is raised or `sizeLimit` lowered.

Measured in Chrome against a running admin, on the real endpoints:

| case | sent before rejection | message |
| --- | --- | --- |
| `POST /upload/files`, over body limit | 0.18–0.42% | `FileTooBig` |
| `POST /upload/files`, over plugin `sizeLimit` | 0.55–0.80% | names the limit |
| `POST /upload/files/:id/replace`, oversized | 1.08% | names the limit |
| small upload (control) | 100%, `201` | — |

Previously the first case streamed 100% of the body before the 413 surfaced.

### How to test it?

**Manual (the actual repro)**

1. Enable the `betaMediaLibrary` future flag.
2. In `examples/getstarted/config/middlewares.js`, lower the body limit:
   ```js
   { name: 'strapi::body', config: { formidable: { maxFileSize: 5 * 1024 * 1024 } } }
   ```
3. `cd examples/getstarted && yarn develop`
4. Open the Media Library, throttle the network to "Fast 4G" in DevTools,
   and upload a file well over 5 MB (a ~200 MB video makes it obvious).
5. Expected: the failure appears immediately, the progress bar does not
   creep toward completion, and the Network tab shows the request terminated
   early rather than fully streamed. The message must be the translated
   "file is too large" text.
6. Repeat in Firefox (where it was originally reported). Expect the upload
   to stop just as early, but the message to read as a generic network
   failure rather than the translated size error — see the browser trade-off
   above.
7. Now make the plugin limit the smaller one: restore the body config and
   set `sizeLimit: 1000000` under `plugin::upload` in `config/plugins.js`.
   Upload a ~50 MB file — rejection must again be immediate, with a message
   naming the size limit.
8. Replace an existing asset with an oversized file (asset actions →
   Replace media). It must fail immediately rather than after a full upload.
9. Legacy Media Library sanity pass (flag off): uploading an oversized file
   still fails with a readable error — that path is intentionally rejected
   mid-stream, see the scope notes above.
10. Non-browser client sanity — a request without `Content-Length` must
    behave exactly as before:
    ```bash
    curl -X POST http://localhost:1337/upload \
      -H "Authorization: Bearer <token>" \
      -H "Transfer-Encoding: chunked" \
      -F "files=@some-large-file.mp4"
    ```

**Automated**

```bash
yarn build                       # required — the API tests run against dist/
yarn test:unit
yarn test:api file-size-limit
```

The body middleware had no unit tests before this PR; it now has 21,
covering the malformed and oversized header cases and pinning the existing
error-sniffing backstop. `file-size-limit.test.api.js` covers both new
endpoints plus the multi-file case that guards the per-file vs per-request
distinction — 13 tests including #27414's.

### Related issue(s)/PR(s)

- fix CMS-1611
- Stacked on #27414 (`sizeLimit` on replace) — merge that first; this PR
  targets its branch.
- Follows #27345, which added the `apiError.*` translation lookup this
  reuses. That PR fixed *what* the message said; this one fixes *when* the
  rejection happens.
