### PR TITLE
fix(content-manager): mcp write replies report to-many relations as empty

### DIFF
--- a/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
+++ b/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
@@ -2816,6 +2816,82 @@ describe('relation populate: read handlers call populateDeep and withPopulateOve
   });
 });
 
+describe('relation populate: write handlers pass an explicit populate', () => {
+  const uid = 'api::article.article';
+  const model = baseModel({
+    uid,
+    attributes: { title: { type: 'string' } } as TestAttrs,
+    options: { draftAndPublish: true },
+  });
+  const context = { userAbility: makeUserAbility(), user: mockUser };
+  const strapiForTest = makeMinimalGlobalStrapi();
+
+  const runHandler = async (toolName: string, args: Record<string, unknown> = {}) => {
+    jest.clearAllMocks();
+    const tools = deriveDisplayedContentTypeMcpToolDefinitions(mockStrapi, [model]);
+    const tool = tools.find((t) => t.name === toolName)!;
+    const handler = tool.createHandler(strapiForTest, context);
+    await handler({ args, extra: mockExtra });
+  };
+
+  beforeEach(() => {
+    mockDocumentManager.findOne.mockResolvedValue({ documentId: 'doc-1' });
+    mockDocumentManager.exists.mockResolvedValue(true);
+    mockDocumentManager.publish.mockResolvedValue([{ documentId: 'doc-1' }]);
+    mockDocumentManager.unpublish.mockResolvedValue({ documentId: 'doc-1' });
+    mockDocumentManager.discardDraft.mockResolvedValue({ documentId: 'doc-1' });
+  });
+
+  it('create_article passes populate to documentManager.create', async () => {
+    await runHandler('create_article', { data: { title: 'New' } });
+
+    expect(mockDocumentManager.create).toHaveBeenCalledWith(
+      uid,
+      expect.objectContaining({ populate: {} })
+    );
+  });
+
+  it('update_article passes populate to documentManager.update', async () => {
+    await runHandler('update_article', { documentId: 'doc-1', data: { title: 'Up' } });
+
+    expect(mockDocumentManager.update).toHaveBeenCalledWith(
+      'doc-1',
+      uid,
+      expect.objectContaining({ populate: {} })
+    );
+  });
+
+  it('publish_article passes populate to documentManager.publish', async () => {
+    await runHandler('publish_article', { documentId: 'doc-1' });
+
+    expect(mockDocumentManager.publish).toHaveBeenCalledWith(
+      'doc-1',
+      uid,
+      expect.objectContaining({ populate: {} })
+    );
+  });
+
+  it('unpublish_article passes populate to documentManager.unpublish', async () => {
+    await runHandler('unpublish_article', { documentId: 'doc-1' });
+
+    expect(mockDocumentManager.unpublish).toHaveBeenCalledWith(
+      'doc-1',
+      uid,
+      expect.objectContaining({ populate: {} })
+    );
+  });
+
+  it('discard_article_draft passes populate to documentManager.discardDraft', async () => {
+    await runHandler('discard_article_draft', { documentId: 'doc-1' });
+
+    expect(mockDocumentManager.discardDraft).toHaveBeenCalledWith(
+      'doc-1',
+      uid,
+      expect.objectContaining({ populate: {} })
+    );
+  });
+});
+
 describe('relation identity: shapeRelationsForMcp called on every op', () => {
   const { shapeRelationsForMcp: mockShapeRelations } = jest.requireMock(
     '../sanitizers/shape-relations'

--- a/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
+++ b/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
@@ -2816,26 +2816,38 @@ describe('relation populate: read handlers call populateDeep and withPopulateOve
   });
 });
 
-describe('relation populate: write handlers pass an explicit populate', () => {
+describe('relation populate: write handlers pass a non-count populate', () => {
   const uid = 'api::article.article';
   const model = baseModel({
     uid,
     attributes: { title: { type: 'string' } } as TestAttrs,
     options: { draftAndPublish: true },
   });
+  const singleUid = 'api::global.global';
+  const singleModel = baseModel({
+    kind: 'singleType',
+    uid: singleUid,
+    apiID: 'global',
+    options: { draftAndPublish: true },
+  });
   const context = { userAbility: makeUserAbility(), user: mockUser };
-  const strapiForTest = makeMinimalGlobalStrapi();
+
+  const getBuilderFromMock = () => {
+    const { getService } = jest.requireMock('../../utils') as { getService: jest.Mock };
+    return getService('populate-builder')();
+  };
 
   const runHandler = async (toolName: string, args: Record<string, unknown> = {}) => {
     jest.clearAllMocks();
-    const tools = deriveDisplayedContentTypeMcpToolDefinitions(mockStrapi, [model]);
+    const tools = deriveDisplayedContentTypeMcpToolDefinitions(mockStrapi, [model, singleModel]);
     const tool = tools.find((t) => t.name === toolName)!;
-    const handler = tool.createHandler(strapiForTest, context);
+    const handler = tool.createHandler(makeStrapiWithDb(), context);
     await handler({ args, extra: mockExtra });
   };
 
   beforeEach(() => {
     mockDocumentManager.findOne.mockResolvedValue({ documentId: 'doc-1' });
+    mockDocumentManager.findMany.mockResolvedValue([{ documentId: 'doc-1' }]);
     mockDocumentManager.exists.mockResolvedValue(true);
     mockDocumentManager.publish.mockResolvedValue([{ documentId: 'doc-1' }]);
     mockDocumentManager.unpublish.mockResolvedValue({ documentId: 'doc-1' });
@@ -2849,6 +2861,7 @@ describe('relation populate: write handlers pass an explicit populate', () => {
       uid,
       expect.objectContaining({ populate: {} })
     );
+    expect(getBuilderFromMock().countRelations).not.toHaveBeenCalled();
   });
 
   it('update_article passes populate to documentManager.update', async () => {
@@ -2859,6 +2872,7 @@ describe('relation populate: write handlers pass an explicit populate', () => {
       uid,
       expect.objectContaining({ populate: {} })
     );
+    expect(getBuilderFromMock().countRelations).not.toHaveBeenCalled();
   });
 
   it('publish_article passes populate to documentManager.publish', async () => {
@@ -2869,6 +2883,7 @@ describe('relation populate: write handlers pass an explicit populate', () => {
       uid,
       expect.objectContaining({ populate: {} })
     );
+    expect(getBuilderFromMock().countRelations).not.toHaveBeenCalled();
   });
 
   it('unpublish_article passes populate to documentManager.unpublish', async () => {
@@ -2879,6 +2894,7 @@ describe('relation populate: write handlers pass an explicit populate', () => {
       uid,
       expect.objectContaining({ populate: {} })
     );
+    expect(getBuilderFromMock().countRelations).not.toHaveBeenCalled();
   });
 
   it('discard_article_draft passes populate to documentManager.discardDraft', async () => {
@@ -2887,6 +2903,47 @@ describe('relation populate: write handlers pass an explicit populate', () => {
     expect(mockDocumentManager.discardDraft).toHaveBeenCalledWith(
       'doc-1',
       uid,
+      expect.objectContaining({ populate: {} })
+    );
+    expect(getBuilderFromMock().countRelations).not.toHaveBeenCalled();
+  });
+
+  it('write_global passes populate to documentManager.create on the create branch', async () => {
+    mockDocumentManager.findMany.mockResolvedValue([]);
+    await runHandler('write_global', { data: { title: 'New' } });
+
+    expect(mockDocumentManager.create).toHaveBeenCalledWith(
+      singleUid,
+      expect.objectContaining({ populate: {} })
+    );
+  });
+
+  it('publish_global passes populate to documentManager.publish', async () => {
+    await runHandler('publish_global', {});
+
+    expect(mockDocumentManager.publish).toHaveBeenCalledWith(
+      'doc-1',
+      singleUid,
+      expect.objectContaining({ populate: {} })
+    );
+  });
+
+  it('unpublish_global passes populate to documentManager.unpublish', async () => {
+    await runHandler('unpublish_global', {});
+
+    expect(mockDocumentManager.unpublish).toHaveBeenCalledWith(
+      'doc-1',
+      singleUid,
+      expect.objectContaining({ populate: {} })
+    );
+  });
+
+  it('discard_global_draft passes populate to documentManager.discardDraft', async () => {
+    await runHandler('discard_global_draft', {});
+
+    expect(mockDocumentManager.discardDraft).toHaveBeenCalledWith(
+      'doc-1',
+      singleUid,
       expect.objectContaining({ populate: {} })
     );
   });

--- a/packages/core/content-manager/server/src/mcp/handlers/collection-handlers.ts
+++ b/packages/core/content-manager/server/src/mcp/handlers/collection-handlers.ts
@@ -13,7 +13,7 @@ import {
 } from './constants';
 import { isContentTypeLocalized } from '../permissions';
 import { shapeRelationsForMcp } from '../sanitizers/shape-relations';
-import { ok, sanitizeFormatShape } from '../utils';
+import { buildWriteReplyPopulate, ok, sanitizeFormatShape } from '../utils';
 
 type McpDocumentQuery = {
   populate?: unknown;
@@ -235,17 +235,14 @@ export const createCollectionCreateHandler =
       await permissionChecker.sanitizeCreateInput(data)
     ) as Record<string, unknown>;
 
-    const populate = await getService('populate-builder')(uid)
-      .populateDeep(Infinity)
-      .withPopulateOverride(getPopulateForLocalizations(uid))
-      .build();
+    const writePopulate = await buildWriteReplyPopulate(uid);
 
     const { locale: resolvedLocale, status } = await getDocumentLocaleAndStatus({ locale }, uid);
 
     const result = await strapi.db.transaction(async () => {
       const document = await documentManager.create(uid, {
         data: sanitizedData,
-        populate,
+        populate: writePopulate,
         locale: resolvedLocale,
         status,
       });
@@ -285,9 +282,9 @@ export const createCollectionUpdateHandler =
     const permissionQuery = await permissionChecker.sanitizedQuery.update({ locale });
     const populate = await getService('populate-builder')(uid)
       .populateFromQuery(permissionQuery)
-      .populateDeep(Infinity)
-      .withPopulateOverride(getPopulateForLocalizations(uid))
       .build();
+
+    const writePopulate = await buildWriteReplyPopulate(uid);
 
     const { locale: resolvedLocale } = await getDocumentLocaleAndStatus({ locale }, uid);
 
@@ -326,7 +323,7 @@ export const createCollectionUpdateHandler =
       const updatedDocument = await documentManager.update(
         documentVersion?.documentId ?? documentId,
         uid,
-        { data: sanitizedData, populate, locale: resolvedLocale }
+        { data: sanitizedData, populate: writePopulate, locale: resolvedLocale }
       );
 
       return sanitizeFormatShape(permissionChecker, uid, updatedDocument);
@@ -413,10 +410,7 @@ export const createCollectionPublishHandler =
       throw new errors.ForbiddenError();
     }
 
-    const populate = await getService('populate-builder')(uid)
-      .populateDeep(Infinity)
-      .withPopulateOverride(getPopulateForLocalizations(uid))
-      .build();
+    const writePopulate = await buildWriteReplyPopulate(uid);
 
     const { locale: resolvedLocale } = await getDocumentLocaleAndStatus({ locale }, uid);
 
@@ -440,7 +434,7 @@ export const createCollectionPublishHandler =
       }
 
       const publishResult = await documentManager.publish(document.documentId, uid, {
-        populate,
+        populate: writePopulate,
         locale: resolvedLocale,
       });
 
@@ -486,9 +480,9 @@ export const createCollectionUnpublishHandler =
     const permissionQuery = await permissionChecker.sanitizedQuery.unpublish({ locale });
     const populate = await getService('populate-builder')(uid)
       .populateFromQuery(permissionQuery)
-      .populateDeep(Infinity)
-      .withPopulateOverride(getPopulateForLocalizations(uid))
       .build();
+
+    const writePopulate = await buildWriteReplyPopulate(uid);
 
     const { locale: resolvedLocale } = await getDocumentLocaleAndStatus({ locale }, uid);
 
@@ -516,7 +510,7 @@ export const createCollectionUnpublishHandler =
       }
 
       return documentManager.unpublish(document.documentId, uid, {
-        populate,
+        populate: writePopulate,
         locale: resolvedLocale,
       });
     });
@@ -551,9 +545,9 @@ export const createCollectionDiscardDraftHandler =
     const permissionQuery = await permissionChecker.sanitizedQuery.discard({ locale });
     const populate = await getService('populate-builder')(uid)
       .populateFromQuery(permissionQuery)
-      .populateDeep(Infinity)
-      .withPopulateOverride(getPopulateForLocalizations(uid))
       .build();
+
+    const writePopulate = await buildWriteReplyPopulate(uid);
 
     const { locale: resolvedLocale } = await getDocumentLocaleAndStatus({ locale }, uid);
 
@@ -573,7 +567,10 @@ export const createCollectionDiscardDraftHandler =
 
     const discardedDocument = await asyncPipe.pipe(
       (doc: any) =>
-        documentManager.discardDraft(doc.documentId, uid, { populate, locale: resolvedLocale }),
+        documentManager.discardDraft(doc.documentId, uid, {
+          populate: writePopulate,
+          locale: resolvedLocale,
+        }),
       (doc: unknown) => sanitizeFormatShape(permissionChecker, uid, doc)
     )(document);
 

--- a/packages/core/content-manager/server/src/mcp/handlers/collection-handlers.ts
+++ b/packages/core/content-manager/server/src/mcp/handlers/collection-handlers.ts
@@ -235,11 +235,17 @@ export const createCollectionCreateHandler =
       await permissionChecker.sanitizeCreateInput(data)
     ) as Record<string, unknown>;
 
+    const populate = await getService('populate-builder')(uid)
+      .populateDeep(Infinity)
+      .withPopulateOverride(getPopulateForLocalizations(uid))
+      .build();
+
     const { locale: resolvedLocale, status } = await getDocumentLocaleAndStatus({ locale }, uid);
 
     const result = await strapi.db.transaction(async () => {
       const document = await documentManager.create(uid, {
         data: sanitizedData,
+        populate,
         locale: resolvedLocale,
         status,
       });
@@ -279,6 +285,8 @@ export const createCollectionUpdateHandler =
     const permissionQuery = await permissionChecker.sanitizedQuery.update({ locale });
     const populate = await getService('populate-builder')(uid)
       .populateFromQuery(permissionQuery)
+      .populateDeep(Infinity)
+      .withPopulateOverride(getPopulateForLocalizations(uid))
       .build();
 
     const { locale: resolvedLocale } = await getDocumentLocaleAndStatus({ locale }, uid);
@@ -318,7 +326,7 @@ export const createCollectionUpdateHandler =
       const updatedDocument = await documentManager.update(
         documentVersion?.documentId ?? documentId,
         uid,
-        { data: sanitizedData, locale: resolvedLocale }
+        { data: sanitizedData, populate, locale: resolvedLocale }
       );
 
       return sanitizeFormatShape(permissionChecker, uid, updatedDocument);
@@ -405,6 +413,11 @@ export const createCollectionPublishHandler =
       throw new errors.ForbiddenError();
     }
 
+    const populate = await getService('populate-builder')(uid)
+      .populateDeep(Infinity)
+      .withPopulateOverride(getPopulateForLocalizations(uid))
+      .build();
+
     const { locale: resolvedLocale } = await getDocumentLocaleAndStatus({ locale }, uid);
 
     const publishedDocument = await strapi.db.transaction(async () => {
@@ -427,6 +440,7 @@ export const createCollectionPublishHandler =
       }
 
       const publishResult = await documentManager.publish(document.documentId, uid, {
+        populate,
         locale: resolvedLocale,
       });
 
@@ -472,6 +486,8 @@ export const createCollectionUnpublishHandler =
     const permissionQuery = await permissionChecker.sanitizedQuery.unpublish({ locale });
     const populate = await getService('populate-builder')(uid)
       .populateFromQuery(permissionQuery)
+      .populateDeep(Infinity)
+      .withPopulateOverride(getPopulateForLocalizations(uid))
       .build();
 
     const { locale: resolvedLocale } = await getDocumentLocaleAndStatus({ locale }, uid);
@@ -499,7 +515,10 @@ export const createCollectionUnpublishHandler =
         await documentManager.discardDraft(document.documentId, uid, { locale: resolvedLocale });
       }
 
-      return documentManager.unpublish(document.documentId, uid, { locale: resolvedLocale });
+      return documentManager.unpublish(document.documentId, uid, {
+        populate,
+        locale: resolvedLocale,
+      });
     });
 
     const result = await sanitizeFormatShape(permissionChecker, uid, unpublishedDocument);
@@ -532,6 +551,8 @@ export const createCollectionDiscardDraftHandler =
     const permissionQuery = await permissionChecker.sanitizedQuery.discard({ locale });
     const populate = await getService('populate-builder')(uid)
       .populateFromQuery(permissionQuery)
+      .populateDeep(Infinity)
+      .withPopulateOverride(getPopulateForLocalizations(uid))
       .build();
 
     const { locale: resolvedLocale } = await getDocumentLocaleAndStatus({ locale }, uid);
@@ -551,7 +572,8 @@ export const createCollectionDiscardDraftHandler =
     }
 
     const discardedDocument = await asyncPipe.pipe(
-      (doc: any) => documentManager.discardDraft(doc.documentId, uid, { locale: resolvedLocale }),
+      (doc: any) =>
+        documentManager.discardDraft(doc.documentId, uid, { populate, locale: resolvedLocale }),
       (doc: unknown) => sanitizeFormatShape(permissionChecker, uid, doc)
     )(document);
 

--- a/packages/core/content-manager/server/src/mcp/handlers/single-type-handlers.ts
+++ b/packages/core/content-manager/server/src/mcp/handlers/single-type-handlers.ts
@@ -8,7 +8,7 @@ import { getPopulateForLocalizations } from '../../services/utils/populate';
 import { MCP_NOT_FOUND_DOCUMENT } from './constants';
 import { isContentTypeLocalized } from '../permissions';
 import { shapeRelationsForMcp } from '../sanitizers/shape-relations';
-import { ok, sanitizeFormatShape } from '../utils';
+import { buildWriteReplyPopulate, ok, sanitizeFormatShape } from '../utils';
 
 type McpDocumentQuery = {
   populate?: unknown;
@@ -110,6 +110,7 @@ export const singleCreateOrUpdate = async (
       doc = await documentManager.create(typedUid, {
         data: sanitizedData,
         ...sanitizedQuery,
+        populate,
         locale: resolvedLocale,
       });
     } else {
@@ -310,6 +311,8 @@ export const createSinglePublishHandler =
       throw new errors.ForbiddenError();
     }
 
+    const writePopulate = await buildWriteReplyPopulate(typedUid);
+
     const publishedDocument = await strapi.db.transaction(async () => {
       const sanitizedQuery = await permissionChecker.sanitizedQuery.publish({ locale });
       const { locale: resolvedLocale } = await getDocumentLocaleAndStatus({ locale }, uid);
@@ -332,6 +335,7 @@ export const createSinglePublishHandler =
       }
 
       const publishResult = await documentManager.publish(document.documentId, typedUid, {
+        populate: writePopulate,
         locale: resolvedLocale,
       });
 
@@ -391,6 +395,8 @@ export const createSingleUnpublishHandler =
       throw new errors.ForbiddenError();
     }
 
+    const writePopulate = await buildWriteReplyPopulate(typedUid);
+
     const result = await strapi.db.transaction(async () => {
       if (discardDraft === true) {
         await documentManager.discardDraft(document.documentId, typedUid, {
@@ -400,7 +406,10 @@ export const createSingleUnpublishHandler =
 
       return asyncPipe.pipe(
         (doc: any) =>
-          documentManager.unpublish(doc.documentId, typedUid, { locale: resolvedLocale }),
+          documentManager.unpublish(doc.documentId, typedUid, {
+            populate: writePopulate,
+            locale: resolvedLocale,
+          }),
         (doc: unknown) => sanitizeFormatShape(permissionChecker, typedUid, doc)
       )(document);
     });
@@ -451,9 +460,14 @@ export const createSingleDiscardDraftHandler =
       throw new errors.ForbiddenError();
     }
 
+    const writePopulate = await buildWriteReplyPopulate(typedUid);
+
     const discardedDocument = await asyncPipe.pipe(
       (doc: any) =>
-        documentManager.discardDraft(doc.documentId, typedUid, { locale: resolvedLocale }),
+        documentManager.discardDraft(doc.documentId, typedUid, {
+          populate: writePopulate,
+          locale: resolvedLocale,
+        }),
       (doc: unknown) => sanitizeFormatShape(permissionChecker, typedUid, doc)
     )(document);
 

--- a/packages/core/content-manager/server/src/mcp/utils.ts
+++ b/packages/core/content-manager/server/src/mcp/utils.ts
@@ -1,6 +1,8 @@
 import type { Modules, UID } from '@strapi/types';
 
+import { getService } from '../utils';
 import { formatDocumentWithMetadata } from '../controllers/utils/metadata';
+import { getPopulateForLocalizations } from '../services/utils/populate';
 import type { GetMetadataOptions } from '../services/document-metadata';
 import { shapeRelationsForMcp } from './sanitizers/shape-relations';
 
@@ -20,6 +22,17 @@ export const slugifyUidForMcpToolName = (uid: string): string => {
 
   return `${namespace.toLowerCase()}-${parts.join('_')}`;
 };
+
+/**
+ * Populate for the document a write handler echoes back.
+ * Deliberately skips `countRelations()`: `reduceToIdentity` reduces the resulting `{ count: N }`
+ * to `[]`, which reports a populated to-many relation as empty.
+ */
+export const buildWriteReplyPopulate = async (uid: UID.ContentType) =>
+  getService('populate-builder')(uid)
+    .populateDeep(Infinity)
+    .withPopulateOverride(getPopulateForLocalizations(uid))
+    .build();
 
 type McpPermissionChecker = {
   sanitizeOutput: (doc: unknown) => Promise<Record<string, unknown>>;


### PR DESCRIPTION
### What does it do?

Makes the MCP write handlers pass an explicit deep populate to the document manager, instead of letting it fall back to the count-shaped default. That covers `create`, `update`, `publish`, `unpublish` and `discard_draft` on collection types, and the equivalent paths on single types.

### Why is it needed?

With no `populate` option, `documentManager` falls back to `buildDeepPopulate`, which counts relations, so a to-many relation comes back as `{ count: N }`. `reduceToIdentity` turns any non-array value into `[]`, and the write reply ends up telling the caller the relation is empty even though the write landed: `get_<type>` on the same document, at the same `updatedAt`, returns the relation.

The issue reports this for collection types. Single types have the same hole everywhere except the update branch of `write_<type>`, which was already passing its own populate, so `write_<type>` on a first write, `publish`, `unpublish` and `discard_draft` are fixed here too.

### How to test it?

In `examples/getstarted` with `server.mcp.enabled: true`, call `update_article` with `{"categories": {"connect": ["<category documentId>"]}}`. The reply used to carry `"categories": []`; it now carries the connected category. Unit tests: `yarn jest packages/core/content-manager/server/src/mcp`.

### Related issue(s)/PR(s)

Fixes #27433
