### PR TITLE
fix(database): honour set: null on relation writes

### DIFF
--- a/packages/core/database/src/entity-manager/__tests__/update-relations.test.ts
+++ b/packages/core/database/src/entity-manager/__tests__/update-relations.test.ts
@@ -52,9 +52,7 @@ describe('entity-manager updateRelations', () => {
     expect(deleteRelations).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1, relIdsToDelete: 'all' })
     );
-    expect(deleteRelations).toHaveBeenCalledWith(
-      expect.not.objectContaining({ relIdsToNotDelete: expect.anything() })
-    );
+    expect((deleteRelations as jest.Mock).mock.calls[0][0]).not.toHaveProperty('relIdsToNotDelete');
   });
 
   it('deletes every relation when set is an empty array', async () => {
@@ -75,5 +73,13 @@ describe('entity-manager updateRelations', () => {
     expect(deleteRelations).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1, relIdsToDelete: [2] })
     );
+  });
+
+  it('leaves the relations alone when set is undefined', async () => {
+    const em = createManager();
+
+    await em.updateRelations('api::shop.shop', 1, { products: { set: undefined } }, {});
+
+    expect(deleteRelations).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/database/src/entity-manager/__tests__/update-relations.test.ts
+++ b/packages/core/database/src/entity-manager/__tests__/update-relations.test.ts
@@ -1,0 +1,79 @@
+import { createEntityManager } from '../index';
+import { deleteRelations } from '../regular-relations';
+
+jest.mock('../../query', () => ({
+  createQueryBuilder: jest.fn(),
+}));
+
+jest.mock('../regular-relations', () => ({
+  deletePreviousOneToAnyRelations: jest.fn(),
+  deletePreviousAnyToOneRelations: jest.fn(),
+  deleteRelations: jest.fn(),
+  cleanOrderColumns: jest.fn(),
+}));
+
+const attribute = {
+  type: 'relation',
+  relation: 'manyToMany',
+  target: 'api::product.product',
+  joinTable: {
+    name: 'shops_products_links',
+    joinColumn: { name: 'shop_id', referencedColumn: 'id' },
+    inverseJoinColumn: { name: 'product_id', referencedColumn: 'id' },
+    orderColumnName: 'product_order',
+    inverseOrderColumnName: 'shop_order',
+    pivotColumns: ['shop_id', 'product_id'],
+  },
+};
+
+const createManager = () => {
+  const db = {
+    metadata: {
+      get: jest.fn(() => ({ attributes: { products: attribute } })),
+    },
+    lifecycles: {
+      run: jest.fn(async () => undefined),
+    },
+  } as any;
+
+  return createEntityManager(db);
+};
+
+describe('entity-manager updateRelations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes every relation when set is null', async () => {
+    const em = createManager();
+
+    await em.updateRelations('api::shop.shop', 1, { products: { set: null } }, {});
+
+    expect(deleteRelations).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, relIdsToDelete: 'all' })
+    );
+    expect(deleteRelations).toHaveBeenCalledWith(
+      expect.not.objectContaining({ relIdsToNotDelete: expect.anything() })
+    );
+  });
+
+  it('deletes every relation when set is an empty array', async () => {
+    const em = createManager();
+
+    await em.updateRelations('api::shop.shop', 1, { products: { set: [] } }, {});
+
+    expect(deleteRelations).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, relIdsToDelete: 'all', relIdsToNotDelete: [] })
+    );
+  });
+
+  it('only deletes the disconnected relations on a partial update', async () => {
+    const em = createManager();
+
+    await em.updateRelations('api::shop.shop', 1, { products: { disconnect: [2] } }, {});
+
+    expect(deleteRelations).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, relIdsToDelete: [2] })
+    );
+  });
+});

--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -159,7 +159,7 @@ const toAssocs = (data: Assocs) => {
     };
   }
 
-  if (data?.set) {
+  if (!isUndefined(data?.set)) {
     return {
       set: isNull(data.set) ? data.set : toIdArray(data.set),
     };


### PR DESCRIPTION
### What does it do?

`toAssocs` in the entity manager tested `data.set` for truthiness, so a `{ set: null }` payload lost the `set` key and fell through to the partial-update branch with an empty connect and disconnect. It now keeps the key whenever `set` is present, which lets `updateRelations` reach its delete-everything path. Polymorphic to-many attributes are left alone: their branch gates on `isEmpty(set)`, so a plain `null` never cleared them either, and changing that would also change what `set: []` does to media fields.

### Why is it needed?

`{ set: null }` is documented as the way to clear a to-many relation, but it returned 200, bumped `updatedAt` and left the relation untouched. `categories: null` cleared the field while `categories: { set: null }` did not.

### How to test it?

`yarn jest --config packages/core/database/jest.config.js --rootDir packages/core/database update-relations` covers it. On examples/getstarted, `strapi.documents('api::article.article').update({ documentId, data: { categories: { set: null } } })` now returns the article with no categories.

### Related issue(s)/PR(s)

Fixes #27432
