### PR TITLE
Preserve special characters in filter and search values

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -14,7 +14,11 @@ import {
   FILTERS_WITH_NO_VALUE,
 } from '../constants/filters';
 import { useControllableState } from '../hooks/useControllableState';
-import { useQueryParams } from '../hooks/useQueryParams';
+import {
+  deepEncodeQueryValues,
+  useQueryParams,
+  withEncodedUserParams,
+} from '../hooks/useQueryParams';
 
 import { createContext } from './Context';
 import { Form, InputProps } from './Form';
@@ -183,9 +187,7 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
   }
 
   const handleSubmit = (data: FilterFormData) => {
-    const value = FILTERS_WITH_NO_VALUE.includes(data.filter)
-      ? 'true'
-      : encodeURIComponent(data.value ?? '');
+    const value = FILTERS_WITH_NO_VALUE.includes(data.filter) ? 'true' : (data.value ?? '');
 
     if (!value) {
       return;
@@ -237,7 +239,11 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
           $and: [...existingFilters, newFilterEntry],
         };
 
-    setQuery({ filters: newFilterQuery, page: 1 }, 'push', true);
+    setQuery(
+      withEncodedUserParams(query, { filters: deepEncodeQueryValues(newFilterQuery), page: 1 }),
+      'push',
+      true
+    );
     setOpen(false);
     setEditingFilter(null);
   };
@@ -396,7 +402,12 @@ const List = () => {
   const handleRemove = (index: number) => {
     const nextFilters = (query?.filters?.$and ?? []).filter((_, i) => i !== index);
 
-    setQuery({ filters: { $and: nextFilters }, page: 1 });
+    setQuery(
+      withEncodedUserParams(query, {
+        filters: deepEncodeQueryValues({ $and: nextFilters }),
+        page: 1,
+      })
+    );
   };
 
   if (!query?.filters?.$and?.length) {
@@ -467,7 +478,7 @@ const AttributeTag = ({
       name,
       filter: operator,
       index,
-      value: FILTERS_WITH_NO_VALUE.includes(operator) ? undefined : decodeURIComponent(value),
+      value: FILTERS_WITH_NO_VALUE.includes(operator) ? undefined : value,
     });
     setOpen(true);
   };
@@ -609,6 +620,7 @@ namespace Filters {
       $and?: Array<Record<string, Record<string, string | Record<string, string>>>>;
     };
     page?: number;
+    _q?: string;
   }
 }
 

--- a/packages/core/admin/admin/src/components/Pagination.tsx
+++ b/packages/core/admin/admin/src/components/Pagination.tsx
@@ -16,7 +16,7 @@ import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
-import { useQueryParams } from '../hooks/useQueryParams';
+import { useQueryParams, withEncodedUserParams } from '../hooks/useQueryParams';
 
 import { createContext } from './Context';
 
@@ -91,15 +91,15 @@ const Root = React.forwardRef<HTMLDivElement, RootProps>(
     { children, defaultPageSize = 10, pageCount = 0, defaultPage = 1, onPageSizeChange, total = 0 },
     forwardedRef
   ) => {
-    const [{ query }, setQuery] = useQueryParams<Pick<PaginationContextValue, 'page' | 'pageSize'>>(
-      {
-        pageSize: defaultPageSize.toString(),
-        page: defaultPage.toString(),
-      }
-    );
+    const [{ query }, setQuery] = useQueryParams<
+      Pick<PaginationContextValue, 'page' | 'pageSize'> & { filters?: unknown; _q?: unknown }
+    >({
+      pageSize: defaultPageSize.toString(),
+      page: defaultPage.toString(),
+    });
 
     const setPageSize = (pageSize: string) => {
-      setQuery({ pageSize, page: '1' });
+      setQuery(withEncodedUserParams(query, { pageSize, page: '1' }));
 
       if (onPageSizeChange) {
         onPageSizeChange(pageSize);

--- a/packages/core/admin/admin/src/components/SearchInput.tsx
+++ b/packages/core/admin/admin/src/components/SearchInput.tsx
@@ -6,7 +6,7 @@ import { useIntl } from 'react-intl';
 
 import { TrackingEvent, useTracking } from '../features/Tracking';
 import { useIsMobile } from '../hooks/useMediaQuery';
-import { useQueryParams } from '../hooks/useQueryParams';
+import { useQueryParams, withEncodedUserParams } from '../hooks/useQueryParams';
 
 interface SearchInputProps {
   disabled?: boolean;
@@ -26,7 +26,11 @@ const SearchInput = ({
   const inputRef = React.useRef<HTMLInputElement>(null);
   const iconButtonRef = React.useRef<HTMLButtonElement>(null);
 
-  const [{ query }, setQuery] = useQueryParams<{ _q: string; page?: number }>();
+  const [{ query }, setQuery] = useQueryParams<{
+    _q?: string;
+    page?: number;
+    filters?: unknown;
+  }>();
 
   const [value, setValue] = React.useState(query?._q || '');
   const [isOpen, setIsOpen] = React.useState(!!value);
@@ -43,9 +47,11 @@ const SearchInput = ({
     }
   }, [isOpen]);
 
+  const clearSearch = () => setQuery(withEncodedUserParams(query, { _q: undefined }));
+
   const handleClear = () => {
     setValue('');
-    setQuery({ _q: '' }, 'remove');
+    clearSearch();
   };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -56,10 +62,10 @@ const SearchInput = ({
       if (trackedEvent) {
         trackUsage(trackedEvent, trackedEventDetails);
       }
-      setQuery({ _q: encodeURIComponent(value), page: 1 });
+      setQuery(withEncodedUserParams(query, { _q: encodeURIComponent(value), page: 1 }));
     } else {
       handleToggle();
-      setQuery({ _q: '' }, 'remove');
+      clearSearch();
     }
   };
 

--- a/packages/core/admin/admin/src/components/Table.tsx
+++ b/packages/core/admin/admin/src/components/Table.tsx
@@ -32,7 +32,7 @@ import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
 
 import { useControllableState } from '../hooks/useControllableState';
-import { useQueryParams } from '../hooks/useQueryParams';
+import { useQueryParams, withEncodedUserParams } from '../hooks/useQueryParams';
 
 import { createContext } from './Context';
 
@@ -182,7 +182,11 @@ const Head = ({ children }: Table.HeadProps) => {
  * be passed to your data-fetching function.
  */
 const HeaderCell = <TData, THead>({ name, label, sortable }: TableHeader<TData, THead>) => {
-  const [{ query }, setQuery] = useQueryParams<{ sort?: `${string}:${'ASC' | 'DESC'}` }>();
+  const [{ query }, setQuery] = useQueryParams<{
+    sort?: `${string}:${'ASC' | 'DESC'}`;
+    filters?: unknown;
+    _q?: unknown;
+  }>();
   const sort = query?.sort ?? '';
   const [sortBy, sortOrder] = sort.split(':');
   const { formatMessage } = useIntl();
@@ -199,9 +203,9 @@ const HeaderCell = <TData, THead>({ name, label, sortable }: TableHeader<TData, 
   const handleClickSort = () => {
     if (sortable) {
       setQuery(
-        {
+        withEncodedUserParams(query, {
           sort: `${name}:${isSorted && sortOrder === 'ASC' ? 'DESC' : 'ASC'}`,
-        },
+        }),
         'push',
         true
       );

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -96,6 +96,33 @@ describe('Filters', () => {
     });
   };
 
+  const renderWithSearch = (search: string) =>
+    renderRTL(
+      <Filters.Root options={DEFAULT_FILTERS}>
+        <Filters.Trigger />
+        <Filters.Popover />
+        <Filters.List />
+        <LocationSpy />
+      </Filters.Root>,
+      { initialEntries: [{ search }] }
+    );
+
+  const addNameFilter = async (user: ReturnType<typeof render>['user'], value: string) => {
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    await user.type(await screen.findByRole('textbox', { name: 'Name' }), value);
+    fireEvent.click(await screen.findByRole('button', { name: 'Add filter' }));
+  };
+
+  const URL_ENCODING_CASES = [
+    ['a literal percent sign', '100%'],
+    ['a percent sign mid-string', '50%off'],
+    ['a trailing percent sign', 'discount%'],
+    ['an ampersand', 'a&b'],
+    ['a plus sign', 'a+b'],
+    ['a hash', 'a#b'],
+    ['text that merely looks pre-encoded', 'a%26b'],
+  ] as const;
+
   it('should open the popover when the trigger is clicked', async () => {
     const { user } = render();
 
@@ -489,5 +516,132 @@ describe('Filters', () => {
     });
     expect(screen.queryByText(/hello world/)).not.toBeInTheDocument();
     expect(screen.queryAllByText(/hello there/)).toHaveLength(1);
+  });
+
+  it.each(URL_ENCODING_CASES)('should show %s on the chip as typed', async (_label, value) => {
+    const { user } = render();
+
+    await addNameFilter(user, value);
+
+    expect(await screen.findByText(`Name $eq ${value}`)).toBeInTheDocument();
+  });
+
+  it.each(URL_ENCODING_CASES)('should store %s url-encoded in the query', async (_label, value) => {
+    const { user } = render();
+
+    await addNameFilter(user, value);
+    await screen.findByText(`Name $eq ${value}`);
+
+    await waitFor(() => {
+      expect(currentSearch).toContain(`filters[$and][0][name][$eq]=${encodeURIComponent(value)}`);
+    });
+  });
+
+  it.each(URL_ENCODING_CASES)(
+    'should open the edit form pre-filled with %s without crashing',
+    async (_label, value) => {
+      const { user } = render();
+
+      await addNameFilter(user, value);
+
+      // Clicking the chip is what used to throw `URI malformed` while rendering the form.
+      await user.click(await screen.findByText(`Name $eq ${value}`));
+
+      expect(await screen.findByRole('button', { name: 'Update filter' })).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: 'Name' })).toHaveValue(value);
+    }
+  );
+
+  it('should edit a percent value and keep the new one', async () => {
+    const { user } = render();
+
+    await addNameFilter(user, '100%');
+    await user.click(await screen.findByText('Name $eq 100%'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Update filter' })).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByRole('textbox', { name: 'Name' });
+    await user.clear(nameInput);
+    await user.type(nameInput, '75%');
+    fireEvent.click(screen.getByRole('button', { name: 'Update filter' }));
+
+    expect(await screen.findByText('Name $eq 75%')).toBeInTheDocument();
+    expect(screen.queryByText('Name $eq 100%')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(currentSearch).toContain('filters[$and][0][name][$eq]=75%25');
+    });
+  });
+
+  const SEARCH_TERMS = [
+    ['a percent sign', '100%'],
+    ['an ampersand', 'a&b'],
+    ['a hash', 'a#b'],
+  ] as const;
+
+  it.each(SEARCH_TERMS)(
+    'should keep a sibling $or filter containing %s when a filter is added',
+    async (_label, term) => {
+      const encodedTerm = encodeURIComponent(term);
+      const { user } = renderWithSearch(`?filters[$or][0][name][$eq]=${encodedTerm}`);
+
+      await addNameFilter(user, 'jimbob');
+      await screen.findByText('Name $eq jimbob');
+
+      await waitFor(() => {
+        expect(currentSearch).toContain(`filters[$or][0][name][$eq]=${encodedTerm}`);
+      });
+    }
+  );
+
+  it.each(SEARCH_TERMS)(
+    'should keep a search term containing %s when a filter is added',
+    async (_label, term) => {
+      const encodedTerm = encodeURIComponent(term);
+      const { user } = renderWithSearch(`?_q=${encodedTerm}`);
+
+      await addNameFilter(user, 'jimbob');
+      await screen.findByText('Name $eq jimbob');
+
+      await waitFor(() => {
+        expect(currentSearch).toContain(`_q=${encodedTerm}`);
+      });
+      expect(new URLSearchParams(currentSearch).get('_q')).toBe(term);
+    }
+  );
+
+  it.each(SEARCH_TERMS)(
+    'should keep a search term containing %s when a filter is removed',
+    async (_label, term) => {
+      const encodedTerm = encodeURIComponent(term);
+      renderWithSearch(`?_q=${encodedTerm}&filters[$and][0][name][$eq]=jimbob`);
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Name $eq jimbob' }));
+
+      await waitFor(() => {
+        expect(getAppliedFilters()).toHaveLength(0);
+      });
+      expect(currentSearch).toContain(`_q=${encodedTerm}`);
+      expect(new URLSearchParams(currentSearch).get('_q')).toBe(term);
+    }
+  );
+
+  it('should remove the right chip when a percent value is applied twice', async () => {
+    const { user } = render();
+
+    await addNameFilter(user, '100%');
+    await screen.findByText('Name $eq 100%');
+    await addNameFilter(user, '100%');
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('Name $eq 100%')).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Name $eq 100%' })[0]);
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('Name $eq 100%')).toHaveLength(1);
+    });
   });
 });

--- a/packages/core/admin/admin/src/components/tests/Pagination.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Pagination.test.tsx
@@ -8,7 +8,7 @@ const LocationDisplay = () => {
 
   return (
     <ul>
-      <li data-testId="location">{location.search}</li>
+      <li data-testid="location">{location.search}</li>
     </ul>
   );
 };
@@ -115,6 +115,20 @@ describe('Pagination', () => {
         await user.click(getByRole('option', { name: '50' }));
 
         expect(getByRole('combobox')).toHaveTextContent('50');
+      });
+
+      it('should keep an applied filter when the user selects a new value', async () => {
+        const encoded = `filters[$and][0][name][$eq]=${encodeURIComponent('a&b')}`;
+        const { user } = render({ initialEntries: [{ search: `?${encoded}` }] });
+
+        await user.click(screen.getByRole('combobox'));
+        await user.click(screen.getByRole('option', { name: '10' }));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('location')).toHaveTextContent('pageSize=10');
+        });
+
+        expect(screen.getByTestId('location')).toHaveTextContent(encoded);
       });
     });
   });

--- a/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
@@ -100,6 +100,64 @@ describe('SearchInput', () => {
     expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
   });
 
+  it('should keep an applied filter containing an ampersand when searching', async () => {
+    const encoded = `filters[$and][0][name][$eq]=${encodeURIComponent('a&b')}`;
+
+    const { user, getByRole } = render(<SearchInput label="Search label" />, {
+      initialEntries: [{ search: `?${encoded}` }],
+      renderOptions: {
+        wrapper({ children }) {
+          return (
+            <>
+              {children}
+              <LocationDisplay />
+            </>
+          );
+        },
+      },
+    });
+
+    await user.click(getByRole('button', { name: 'Search' }));
+    await user.type(getByRole('searchbox', { name: 'Search label' }), 'needle');
+    await user.keyboard('[Enter]');
+
+    await waitFor(() => {
+      expect(getByRole('listitem')).toHaveTextContent('_q=needle');
+    });
+
+    expect(getByRole('listitem')).toHaveTextContent(encoded);
+  });
+
+  it.each([
+    ['a percent sign', '100%'],
+    ['an ampersand', 'a&b'],
+    ['a hash', 'a#b'],
+  ])('should keep a filter containing %s when the search is cleared', async (_label, value) => {
+    const encoded = `filters[$and][0][name][$eq]=${encodeURIComponent(value)}`;
+
+    const { user, getByRole } = render(<SearchInput label="Search label" />, {
+      initialEntries: [{ search: `?${encoded}&_q=needle` }],
+      renderOptions: {
+        wrapper({ children }) {
+          return (
+            <>
+              {children}
+              <LocationDisplay />
+            </>
+          );
+        },
+      },
+    });
+
+    await user.click(getByRole('button', { name: 'Clear' }));
+
+    await waitFor(() => {
+      expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
+    });
+
+    expect(getByRole('listitem')).toHaveTextContent(encoded);
+  });
+
   describe('blur behavior', () => {
     it.each([
       {

--- a/packages/core/admin/admin/src/components/tests/Table.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Table.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@tests/utils';
+import { render, screen, waitFor } from '@tests/utils';
+import { useLocation } from 'react-router-dom';
 
 import { Table } from '../Table';
 
@@ -22,6 +23,12 @@ const mockRows: MockRow[] = [
   { id: 1, short_text: 'hello' },
   { id: 2, short_text: 'there' },
 ];
+
+const LocationDisplay = () => {
+  const location = useLocation();
+
+  return <div data-testid="location">{location.search}</div>;
+};
 
 describe('Table', () => {
   it('should render with content', () => {
@@ -94,5 +101,65 @@ describe('Table', () => {
     expect(screen.getByRole('gridcell', { name: 'hello' })).toBeInTheDocument();
     expect(screen.getByRole('gridcell', { name: '2' })).toBeInTheDocument();
     expect(screen.getByRole('gridcell', { name: 'there' })).toBeInTheDocument();
+  });
+
+  const renderSortableHeaders = (search: string) =>
+    render(
+      <Table.Root rows={mockRows} headers={mockHeaders} isLoading={false}>
+        <Table.Content>
+          <Table.Head>
+            {mockHeaders.map((header) => (
+              <Table.HeaderCell key={header.name} {...header} />
+            ))}
+          </Table.Head>
+          <Table.Body>
+            {mockRows.map((row) => (
+              <Table.Row key={row.id}>
+                <Table.Cell>{row.id}</Table.Cell>
+                <Table.Cell>{row.short_text}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Content>
+      </Table.Root>,
+      {
+        initialEntries: [{ search }],
+        renderOptions: {
+          wrapper({ children }) {
+            return (
+              <>
+                {children}
+                <LocationDisplay />
+              </>
+            );
+          },
+        },
+      }
+    );
+
+  it('should keep an applied filter containing an ampersand when sorting', async () => {
+    const encoded = `filters[$and][0][name][$eq]=${encodeURIComponent('a&b')}`;
+    const { user } = renderSortableHeaders(`?${encoded}`);
+
+    await user.click(screen.getByRole('gridcell', { name: 'id' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('sort=id:ASC');
+    });
+
+    expect(screen.getByTestId('location')).toHaveTextContent(encoded);
+  });
+
+  it('should keep a search term containing an ampersand when sorting', async () => {
+    const encoded = `_q=${encodeURIComponent('R&D')}`;
+    const { user } = renderSortableHeaders(`?${encoded}`);
+
+    await user.click(screen.getByRole('gridcell', { name: 'id' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('sort=id:ASC');
+    });
+
+    expect(screen.getByTestId('location')).toHaveTextContent(encoded);
   });
 });

--- a/packages/core/admin/admin/src/hooks/useQueryParams.ts
+++ b/packages/core/admin/admin/src/hooks/useQueryParams.ts
@@ -39,6 +39,12 @@ const useQueryParams = <TQuery extends object = QueryParams>(initialParams?: TQu
         nextQuery = { ...query, ...nextParams };
       }
 
+      /**
+       * TODO V6: Encoding should be enabled in this step, via `{ encodeValuesOnly: true }`
+       * So the rest of the app doesn't have to worry about it,
+       * It's considered a breaking change because callers currently encode values themselves,
+       * including the user's custom code, and would end up double-encoding them.
+       */
       navigate({ search: stringify(nextQuery, { encode: false }) }, { replace });
     },
     [navigate, query]
@@ -47,4 +53,39 @@ const useQueryParams = <TQuery extends object = QueryParams>(initialParams?: TQu
   return [{ query, rawQuery: search }, setQuery] as const;
 };
 
-export { useQueryParams };
+/**
+ * These functions are used to encode query values when writing them to the URL.
+ * As stated above, it should be handled by `useQueryParams` instead, but that would be a breaking change.
+ */
+
+const deepEncodeQueryValues = <T>(value: T): T => {
+  if (typeof value === 'string') {
+    return encodeURIComponent(value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(deepEncodeQueryValues) as T;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, deepEncodeQueryValues(entry)])
+    ) as T;
+  }
+
+  return value;
+};
+
+const withEncodedUserParams = <
+  T extends object,
+  TQuery extends { filters?: unknown; _q?: unknown },
+>(
+  query: TQuery,
+  nextParams: T
+): T & { filters?: TQuery['filters']; _q?: TQuery['_q'] } => ({
+  ...(query.filters === undefined ? {} : { filters: deepEncodeQueryValues(query.filters) }),
+  ...(query._q === undefined ? {} : { _q: deepEncodeQueryValues(query._q) }),
+  ...nextParams,
+});
+
+export { useQueryParams, deepEncodeQueryValues, withEncodedUserParams };

--- a/packages/core/admin/admin/src/index.ts
+++ b/packages/core/admin/admin/src/index.ts
@@ -60,7 +60,11 @@ export { useHistory } from './features/BackButton';
  */
 export { useInjectReducer } from './hooks/useInjectReducer';
 export { useAPIErrorHandler } from './hooks/useAPIErrorHandler';
-export { useQueryParams } from './hooks/useQueryParams';
+export {
+  useQueryParams,
+  deepEncodeQueryValues,
+  withEncodedUserParams,
+} from './hooks/useQueryParams';
 export { useFetchClient } from './hooks/useFetchClient';
 export { useFocusInputField } from './hooks/useFocusInputField';
 export { useRBAC, type AllowedActions } from './hooks/useRBAC';

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
@@ -10,7 +10,10 @@ import { Page } from '../../../../../../../admin/src/components/PageHelpers';
 import { Pagination } from '../../../../../../../admin/src/components/Pagination';
 import { Table } from '../../../../../../../admin/src/components/Table';
 import { useTypedSelector } from '../../../../../../../admin/src/core/store/hooks';
-import { useQueryParams } from '../../../../../../../admin/src/hooks/useQueryParams';
+import {
+  useQueryParams,
+  withEncodedUserParams,
+} from '../../../../../../../admin/src/hooks/useQueryParams';
 import { useRBAC } from '../../../../../../../admin/src/hooks/useRBAC';
 import { AuditLog } from '../../../../../../../shared/contracts/audit-logs';
 
@@ -31,7 +34,15 @@ const ListPage = () => {
     isLoading: isLoadingRBAC,
   } = useRBAC(permissions?.auditLogs?.read || []);
 
-  const [{ query }, setQuery] = useQueryParams<{ id?: AuditLog['id'] }>();
+  const [{ query }, setQuery] = useQueryParams<{
+    id?: AuditLog['id'];
+    filters?: unknown;
+    _q?: unknown;
+  }>();
+
+  const openLog = (id: AuditLog['id']) =>
+    setQuery(withEncodedUserParams(query, { id }), 'push', true);
+  const closeLog = () => setQuery(withEncodedUserParams(query, { id: undefined }), 'push', true);
   const [usersPageSize, setUsersPageSize] = React.useState(USERS_PAGE_SIZE);
   const {
     auditLogs,
@@ -147,7 +158,7 @@ const ListPage = () => {
             <Table.Loading />
             <Table.Body>
               {results.map((log) => (
-                <Table.Row key={log.id} onClick={() => setQuery({ id: log.id }, 'push', true)}>
+                <Table.Row key={log.id} onClick={() => openLog(log.id)}>
                   {headers.map((header) => {
                     const { name, cellFormatter } = header;
 
@@ -196,7 +207,7 @@ const ListPage = () => {
                   <Table.Cell onClick={(e) => e.stopPropagation()}>
                     <Flex justifyContent="end">
                       <IconButton
-                        onClick={() => setQuery({ id: log.id }, 'push', true)}
+                        onClick={() => openLog(log.id)}
                         withTooltip={false}
                         label={formatMessage(
                           { id: 'app.component.table.view', defaultMessage: '{target} details' },
@@ -219,12 +230,7 @@ const ListPage = () => {
           <Pagination.Links />
         </Pagination.Root>
       </Layouts.Content>
-      {query?.id && (
-        <Modal
-          handleClose={() => setQuery({ id: '' }, 'remove', true)}
-          logId={query.id.toString()}
-        />
-      )}
+      {query?.id && <Modal handleClose={closeLog} logId={query.id.toString()} />}
     </Page.Main>
   );
 };

--- a/packages/core/content-manager/admin/src/hooks/tests/usePersistentQueryParams.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/usePersistentQueryParams.test.ts
@@ -1,5 +1,6 @@
 import { useQueryParams, usePersistentStateScope } from '@strapi/admin/strapi-admin';
 import { renderHook, waitFor } from '@tests/utils';
+import { parse, stringify } from 'qs';
 import { useLocation } from 'react-router-dom';
 
 import { usePersistentPartialQueryParams } from '../usePersistentQueryParams';
@@ -10,6 +11,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('@strapi/admin/strapi-admin', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin'),
   useQueryParams: jest.fn(),
   usePersistentStateScope: jest.fn(),
 }));
@@ -21,6 +23,25 @@ describe('usePersistentPartialQueryParams', () => {
   const keysToPersist = ['page', 'pageSize', 'sort'];
   const pathname = '/content-manager/collection-types/api::article.article';
   const key = `${keyPrefix}${pathname}`;
+
+  const filtersFor = (value: string) => ({ $and: [{ name: { $eq: value } }] });
+
+  const renderWithQuery = (query: Record<string, unknown>) => {
+    (useQueryParams as jest.Mock).mockReturnValue([{ query }, mockSetQuery]);
+    window.localStorage.setItem(key, JSON.stringify({ page: 2 }));
+
+    return renderHook(() =>
+      usePersistentPartialQueryParams({
+        [key]: { paths: keysToPersist },
+      })
+    );
+  };
+
+  const lastFiltersPassedToSetQuery = () => {
+    const [lastCall] = mockSetQuery.mock.calls.slice(-1);
+
+    return (lastCall?.[0] as { filters?: unknown } | undefined)?.filters;
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -289,6 +310,96 @@ describe('usePersistentPartialQueryParams', () => {
     renderHook(() => usePersistentPartialQueryParams(config));
 
     expect(mockSetQuery).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a literal percent sign', '100%', '100%25'],
+    ['a percent sign mid-string', '50%off', '50%25off'],
+    ['an ampersand, which would otherwise truncate the value', 'a&b', 'a%26b'],
+    ['a plus sign, which would otherwise return as a space', 'a+b', 'a%2Bb'],
+    ['a hash, which would otherwise make navigate throw', 'a#b', 'a%23b'],
+    ['text that merely looks pre-encoded', 'a%26b', 'a%2526b'],
+    ['a non-ascii character', 'café', 'caf%C3%A9'],
+  ])('should re-encode %s', async (_label, decoded, encoded) => {
+    renderWithQuery({ filters: filtersFor(decoded) });
+
+    await waitFor(() => {
+      expect(mockSetQuery).toHaveBeenCalledWith(
+        { page: 2, filters: filtersFor(encoded) },
+        'push',
+        true
+      );
+    });
+  });
+
+  it.each(['100%', 'a&b', 'a+b', 'a#b', 'a%26b', 'café', 'a=b', 'plain'])(
+    'should restore %s through the full URL round-trip',
+    async (value) => {
+      renderWithQuery({ filters: filtersFor(value) });
+
+      await waitFor(() => {
+        expect(mockSetQuery).toHaveBeenCalled();
+      });
+
+      // Exactly what setQuery -> the URL -> useQueryParams would produce.
+      const url = stringify({ filters: lastFiltersPassedToSetQuery() }, { encode: false });
+      const reparsed = parse(url) as { filters: { $and: [{ name: { $eq: string } }] } };
+
+      expect(reparsed.filters.$and[0].name.$eq).toBe(value);
+    }
+  );
+
+  it('should not double-encode when the value is hydrated twice', async () => {
+    renderWithQuery({ filters: filtersFor('100%') });
+
+    await waitFor(() => {
+      expect(mockSetQuery).toHaveBeenCalled();
+    });
+
+    const url = stringify({ filters: lastFiltersPassedToSetQuery() }, { encode: false });
+    const reparsed = parse(url) as { filters: unknown };
+
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    renderWithQuery({ filters: reparsed.filters as Record<string, unknown> });
+
+    await waitFor(() => {
+      expect(mockSetQuery).toHaveBeenCalledWith(
+        { page: 2, filters: filtersFor('100%25') },
+        'push',
+        true
+      );
+    });
+  });
+
+  it('should leave non-string filter leaves untouched', async () => {
+    renderWithQuery({ filters: { $and: [{ id: { $eq: 5 } }, { active: { $eq: true } }] } });
+
+    await waitFor(() => {
+      expect(mockSetQuery).toHaveBeenCalledWith(
+        { page: 2, filters: { $and: [{ id: { $eq: 5 } }, { active: { $eq: true } }] } },
+        'push',
+        true
+      );
+    });
+  });
+
+  it('should persist the decoded value to localStorage, not the encoded one', async () => {
+    (useQueryParams as jest.Mock).mockReturnValue([
+      { query: { page: 1, filters: filtersFor('100%') } },
+      mockSetQuery,
+    ]);
+
+    renderHook(() =>
+      usePersistentPartialQueryParams({
+        [key]: { paths: [...keysToPersist, 'filters'] },
+      })
+    );
+
+    await waitFor(() => {
+      const saved = JSON.parse(window.localStorage.getItem(key) ?? '{}');
+      expect(saved.filters).toEqual(filtersFor('100%'));
+    });
   });
 
   describe('isHydrated', () => {

--- a/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
+++ b/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 
-import { usePersistentStateScope, useQueryParams } from '@strapi/admin/strapi-admin';
+import {
+  deepEncodeQueryValues,
+  usePersistentStateScope,
+  useQueryParams,
+} from '@strapi/admin/strapi-admin';
 import get from 'lodash/get';
 import set from 'lodash/set';
 
@@ -70,7 +74,17 @@ export const usePersistentPartialQueryParams = (config: PersistentQueryConfig) =
     }
 
     if (Object.keys(mergedFilteredQuery).length > 0) {
-      setQuery({ ...mergedFilteredQuery, ...query }, 'push', true);
+      const nextQuery: Record<string, unknown> = { ...mergedFilteredQuery, ...query };
+
+      if (nextQuery.filters !== undefined) {
+        //`setQuery` never encodes the values, and it cannot be fixed as it would introduce breaking changes.
+        // This ensures that, when reading the persisted values and writing them in the URI, they are encoded properly.
+        // We are only encoding the filters because we know they can hold values with special characters. We didn't bother
+        // with the other query params because as of today, they are not expected to hold such values.
+        nextQuery.filters = deepEncodeQueryValues(nextQuery.filters);
+      }
+
+      setQuery(nextQuery, 'push', true);
     }
     setIsHydrated(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -18,6 +18,7 @@ import {
   useIsMobile,
   useClipboard,
   tours,
+  withEncodedUserParams,
 } from '@strapi/admin/strapi-admin';
 import {
   Button,
@@ -85,6 +86,7 @@ type ListViewQuery = {
   page?: string;
   pageSize?: string;
   sort?: string;
+  _q?: string;
 };
 
 const ListViewPage = () => {
@@ -231,9 +233,9 @@ const ListViewPage = () => {
         .map((s) => s.trim())
         .filter((s) => !/^status:(ASC|DESC)$/i.test(s))
         .join(',');
-      setQuery({ sort: cleaned || undefined }, 'push', true);
+      setQuery(withEncodedUserParams(query, { sort: cleaned || undefined }), 'push', true);
     }
-  }, [hasStatusFilter, query.sort, setQuery]);
+  }, [hasStatusFilter, query, setQuery]);
 
   const { data, error, isLoading, isFetching } = useGetAllDocumentsQuery(
     {

--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -233,7 +233,6 @@ const ReleasesPage = () => {
 
   const handleTabChange = (tabValue: string) => {
     setQuery({
-      ...query,
       page: 1,
       pageSize: response?.currentData?.meta?.pagination?.pageSize || 16,
       filters: {

--- a/packages/core/upload/admin/src/components/FilterList/FilterList.tsx
+++ b/packages/core/upload/admin/src/components/FilterList/FilterList.tsx
@@ -65,7 +65,7 @@ export const FilterList = ({ appliedFilters, filtersSchema, onRemoveFilter }: Fi
 
     const nextFilters = appliedFilters.filter((prevFilter) => {
       if (typeof filterValue === 'string') {
-        return prevFilter[name]?.[filterType] !== decodeURIComponent(filterValue);
+        return prevFilter[name]?.[filterType] !== filterValue;
       }
       if (typeof filterValue === 'object' && filterValue !== null) {
         return JSON.stringify(prevFilter[name]?.[filterType]) !== JSON.stringify(filterValue);
@@ -94,7 +94,7 @@ export const FilterList = ({ appliedFilters, filtersSchema, onRemoveFilter }: Fi
       const arr = toMimeArray(inner ?? rawValue);
       value = arr ? arr.join(', ') : Object.values(rawValue).join(', ');
     } else {
-      value = decodeURIComponent(rawValue!);
+      value = rawValue!;
     }
 
     let displayedOperator = operator;

--- a/packages/core/upload/admin/src/components/FilterList/tests/FilterList.test.tsx
+++ b/packages/core/upload/admin/src/components/FilterList/tests/FilterList.test.tsx
@@ -56,6 +56,19 @@ describe('<FilterList />', () => {
     },
   ];
 
+  const renderWithFilter = (value: string, onRemoveFilter = jest.fn()) =>
+    render(
+      <DesignSystemProvider>
+        <IntlProvider locale="en" messages={messages} defaultLocale="en">
+          <FilterList
+            appliedFilters={[{ mime: { $contains: value } }]}
+            filtersSchema={filtersSchema}
+            onRemoveFilter={onRemoveFilter}
+          />
+        </IntlProvider>
+      </DesignSystemProvider>
+    );
+
   it('renders and matches the snapshot', () => {
     const filters = [
       { mime: { $contains: 'image' } },
@@ -184,6 +197,31 @@ describe('<FilterList />', () => {
     );
 
     expect(screen.getByText(/type is not file/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onRemoveFilter).toHaveBeenCalledWith([]);
+  });
+
+  it.each([
+    ['a literal percent sign', '100%'],
+    ['a percent sign mid-string', '50%off'],
+    ['a trailing percent sign', 'draft%'],
+    ['an incomplete escape', '100%2'],
+    ['text that merely looks pre-encoded', 'a%26b'],
+    ['an ampersand', 'a&b'],
+  ])('renders %s without crashing, showing it as stored', (_label, value) => {
+    expect(() => renderWithFilter(value)).not.toThrow();
+    expect(
+      screen.getByText(new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'))
+    ).toBeInTheDocument();
+  });
+
+  it('removes a percent-valued filter when its chip is clicked', async () => {
+    const user = userEvent.setup();
+    const onRemoveFilter = jest.fn();
+
+    renderWithFilter('100%', onRemoveFilter);
 
     await user.click(screen.getByRole('button'));
 

--- a/packages/core/upload/admin/src/components/FilterPopover/FilterPopover.tsx
+++ b/packages/core/upload/admin/src/components/FilterPopover/FilterPopover.tsx
@@ -99,9 +99,9 @@ export const FilterPopover = ({
     e.preventDefault();
     e.stopPropagation();
 
-    const encodedValue = encodeURIComponent(modifiedData.value);
+    const { value } = modifiedData;
 
-    if (encodedValue) {
+    if (value) {
       if (modifiedData.name === 'mime') {
         const alreadyAppliedFilters = filters.filter((filter) => {
           return Object.keys(filter)[0] === 'mime';
@@ -240,12 +240,12 @@ export const FilterPopover = ({
             filter[modifiedDataName as 'mime' | 'createdAt' | 'updatedAt'] &&
             filter[modifiedDataName as 'mime' | 'createdAt' | 'updatedAt']?.[
               modifiedDataName as '$contains' | '$notContains' | '$eq' | '$not'
-            ] === encodedValue
+            ] === value
           );
         }) !== undefined;
 
       if (!hasFilter) {
-        const filterToAdd = { [modifiedData.name]: { [modifiedData.filter]: encodedValue } };
+        const filterToAdd = { [modifiedData.name]: { [modifiedData.filter]: value } };
 
         const nextFilters = [...filters, filterToAdd];
 

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -8,6 +8,7 @@ import {
   useForm,
   useNotification,
   useQueryParams,
+  withEncodedUserParams,
   getDisplayName,
 } from '@strapi/admin/strapi-admin';
 import {
@@ -123,7 +124,10 @@ const useAssetOperation = () => {
  * -----------------------------------------------------------------------------------------------*/
 
 export const useAssetDetailsParam = () => {
-  const [{ query }, setQuery] = useQueryParams<{ [ASSET_DETAILS_URL_PARAM]?: string }>();
+  const [{ query }, setQuery] = useQueryParams<{
+    [ASSET_DETAILS_URL_PARAM]?: string;
+    _q?: string;
+  }>();
 
   const assetId = parseAssetDetailsId(query?.[ASSET_DETAILS_URL_PARAM]);
   const hasValidId = assetId !== null;
@@ -155,14 +159,18 @@ export const useAssetDetailsParam = () => {
 
   const openDetails = React.useCallback(
     (id: number) => {
-      setQuery({ [ASSET_DETAILS_URL_PARAM]: String(id) }, 'push', true);
+      setQuery(
+        withEncodedUserParams(query, { [ASSET_DETAILS_URL_PARAM]: String(id) }),
+        'push',
+        true
+      );
     },
-    [setQuery]
+    [query, setQuery]
   );
 
   const closeDetails = React.useCallback(() => {
-    setQuery({ [ASSET_DETAILS_URL_PARAM]: undefined }, 'remove', true);
-  }, [setQuery]);
+    setQuery(withEncodedUserParams(query, { [ASSET_DETAILS_URL_PARAM]: undefined }), 'push', true);
+  }, [query, setQuery]);
 
   return {
     assetId: hasValidId ? assetId : displayAssetId.current,

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useFolderNavigation.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useFolderNavigation.test.ts
@@ -50,7 +50,7 @@ describe('useFolderNavigation', () => {
     renderHook(() => useFolderNavigation());
 
     await waitFor(() => {
-      expect(mockSetQuery).toHaveBeenCalledWith({ folder: '' }, 'remove');
+      expect(mockSetQuery).toHaveBeenCalledWith({ folder: undefined });
     });
   });
 
@@ -181,7 +181,17 @@ describe('useFolderNavigation', () => {
       renderHook(() => useFolderNavigation());
 
       await waitFor(() => {
-        expect(mockSetQuery).toHaveBeenCalledWith({ folder: '' }, 'remove');
+        expect(mockSetQuery).toHaveBeenCalledWith({ _q: 'kitten', folder: undefined });
+      });
+    });
+
+    it('re-encodes a search term holding a percent sign when stripping the folder', async () => {
+      mockUseQueryParams.mockReturnValue([{ query: { folder: 'abc', _q: '100%' } }, mockSetQuery]);
+
+      renderHook(() => useFolderNavigation());
+
+      await waitFor(() => {
+        expect(mockSetQuery).toHaveBeenCalledWith({ _q: '100%25', folder: undefined });
       });
     });
   });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListFilters.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListFilters.test.ts
@@ -159,4 +159,30 @@ describe('useListFilters URL writes', () => {
     expect(result.current.location.search).not.toContain('filters=');
     expect(result.current.navigationType).toBe('REPLACE');
   });
+
+  it.each([
+    ['a percent sign', '100%'],
+    ['an ampersand', 'a&b'],
+    ['a hash', 'a#b'],
+  ])('keeps a search term containing %s intact across filter writes', (_label, term) => {
+    const encoded = encodeURIComponent(term);
+    const { result } = renderHook(
+      () => ({ listFilters: useListFilters(), location: useLocation() }),
+      { initialEntries: [`/?_q=${encoded}`] }
+    );
+
+    act(() => {
+      result.current.listFilters.addFilter({ kind: 'type', condition: 'is', values: ['picture'] });
+    });
+
+    expect(result.current.location.search).toContain(`_q=${encoded}`);
+
+    act(() => {
+      result.current.listFilters.clearFilters();
+    });
+
+    // Clearing must not drop the search along with the filters.
+    expect(result.current.location.search).toContain(`_q=${encoded}`);
+    expect(result.current.location.search).not.toContain('filters=');
+  });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListSort.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListSort.test.ts
@@ -93,7 +93,7 @@ describe('useListSort', () => {
 
     act(() => result.current.setSortBy('mostRecentUpdates'));
 
-    expect(mockSetQuery).toHaveBeenCalledWith({ sort: '' }, 'remove');
+    expect(mockSetQuery).toHaveBeenCalledWith({ sort: undefined });
   });
 
   it('never leaves the list without a sort rule: clearing the last facet restores the default', () => {
@@ -102,7 +102,7 @@ describe('useListSort', () => {
 
     act(() => result.current.setDirection(null));
 
-    expect(mockSetQuery).toHaveBeenCalledWith({ sort: '' }, 'remove');
+    expect(mockSetQuery).toHaveBeenCalledWith({ sort: undefined });
   });
 
   it('toggles folders position through the dedicated param', () => {
@@ -116,6 +116,37 @@ describe('useListSort', () => {
     expect(mixed.current.foldersPosition).toBe('mixed');
 
     act(() => mixed.current.setFoldersPosition('top'));
-    expect(mockSetQuery).toHaveBeenCalledWith({ folders: '' }, 'remove');
+    expect(mockSetQuery).toHaveBeenCalledWith({ folders: undefined });
+  });
+
+  it.each([
+    ['a percent sign', '100%', '100%25'],
+    ['an ampersand', 'a&b', 'a%26b'],
+    ['a hash', 'a#b', 'a%23b'],
+  ])('re-encodes %s in the search term when the sort changes', (_label, raw, encoded) => {
+    mockQuery = { _q: raw };
+    const { result } = renderHook(() => useListSort());
+
+    act(() => result.current.setSortBy('oldestUploads'));
+
+    expect(mockSetQuery).toHaveBeenCalledWith({ _q: encoded, sort: 'createdAt:ASC' });
+  });
+
+  it('re-encodes the search term when the sort is reset to the default', () => {
+    mockQuery = { sort: 'createdAt:ASC', _q: '100%' };
+    const { result } = renderHook(() => useListSort());
+
+    act(() => result.current.setSortBy('mostRecentUpdates'));
+
+    expect(mockSetQuery).toHaveBeenCalledWith({ _q: '100%25', sort: undefined });
+  });
+
+  it('re-encodes the search term when the folders position toggles', () => {
+    mockQuery = { _q: '100%' };
+    const { result } = renderHook(() => useListSort());
+
+    act(() => result.current.setFoldersPosition('mixed'));
+
+    expect(mockSetQuery).toHaveBeenCalledWith({ _q: '100%25', folders: 'mixed' });
   });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useFolderNavigation.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useFolderNavigation.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
-import { useQueryParams } from '@strapi/admin/strapi-admin';
+import { useQueryParams, withEncodedUserParams } from '@strapi/admin/strapi-admin';
 
 import type { Folder } from '../../../../../../shared/contracts/folders';
 
@@ -50,8 +50,8 @@ export const useFolderNavigation = () => {
    * Strips a `?folder=` value we can't parse.
    */
   const stripFolderParam = useCallback(() => {
-    setQuery({ folder: '' }, 'remove');
-  }, [setQuery]);
+    setQuery(withEncodedUserParams(query, { folder: undefined }));
+  }, [query, setQuery]);
 
   // Malformed ?folder= values (e.g. abc) parse as null; strip the param from the URL.
   // Deleted/missing folders (404) are handled in AssetsPage — that needs a fetch.

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useListFilters.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useListFilters.ts
@@ -1,4 +1,4 @@
-import { useQueryParams } from '@strapi/admin/strapi-admin';
+import { useQueryParams, withEncodedUserParams } from '@strapi/admin/strapi-admin';
 
 /**
  * Filter state for the assets list, backed by a single `?filters=` query param
@@ -203,7 +203,7 @@ export interface ListFilters {
 }
 
 export const useListFilters = (): ListFilters => {
-  const [{ query }, setQuery] = useQueryParams<{ filters?: string }>();
+  const [{ query }, setQuery] = useQueryParams<{ filters?: string; _q?: string }>();
 
   const filters = parseFiltersParam(query?.filters);
 
@@ -213,9 +213,9 @@ export const useListFilters = (): ListFilters => {
   // URL stays shareable and refresh-safe either way.
   const writeFilters = (next: ListFilter[]) => {
     if (next.length === 0) {
-      setQuery({ filters: '' }, 'remove', true);
+      setQuery(withEncodedUserParams(query, { filters: undefined }), 'push', true);
     } else {
-      setQuery({ filters: serializeFilters(next) }, 'push', true);
+      setQuery(withEncodedUserParams(query, { filters: serializeFilters(next) }), 'push', true);
     }
   };
 

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useListSort.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useListSort.ts
@@ -1,4 +1,4 @@
-import { useQueryParams } from '@strapi/admin/strapi-admin';
+import { useQueryParams, withEncodedUserParams } from '@strapi/admin/strapi-admin';
 
 /**
  * Sort state for the assets list, backed by URL query params so the current
@@ -92,7 +92,11 @@ export interface ListSort {
 }
 
 export const useListSort = (): ListSort => {
-  const [{ query }, setQuery] = useQueryParams<{ sort?: string; folders?: string }>();
+  const [{ query }, setQuery] = useQueryParams<{
+    sort?: string;
+    folders?: string;
+    _q?: string;
+  }>();
 
   const { sortBy, direction, isExplicit } = parseSortParam(query?.sort);
   const foldersPosition: FoldersPosition = query?.folders === 'mixed' ? 'mixed' : 'top';
@@ -106,9 +110,9 @@ export const useListSort = (): ListSort => {
     const serialized = serializeSort(nextSortBy, nextDirection);
 
     if (nextSortBy === DEFAULT_SORT_BY && nextDirection === null) {
-      setQuery({ sort: '' }, 'remove');
+      setQuery(withEncodedUserParams(query, { sort: undefined }));
     } else {
-      setQuery({ sort: serialized });
+      setQuery(withEncodedUserParams(query, { sort: serialized }));
     }
   };
 
@@ -118,9 +122,9 @@ export const useListSort = (): ListSort => {
 
   const setFoldersPosition = (position: FoldersPosition) => {
     if (position === 'mixed') {
-      setQuery({ folders: 'mixed' });
+      setQuery(withEncodedUserParams(query, { folders: 'mixed' }));
     } else {
-      setQuery({ folders: '' }, 'remove');
+      setQuery(withEncodedUserParams(query, { folders: undefined }));
     }
   };
 

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.tsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.tsx
@@ -7,6 +7,8 @@ import {
   Pagination,
   useTracking,
   useQueryParams,
+  withEncodedUserParams,
+  deepEncodeQueryValues,
   Layouts,
 } from '@strapi/admin/strapi-admin';
 import {
@@ -173,10 +175,7 @@ export const MediaLibrary = () => {
     // we have to navigate the user to that page, in case a folder
     // was created successfully in order for them to see it
     if (created && query?.page !== '1') {
-      setQuery({
-        ...query,
-        page: 1,
-      });
+      setQuery(withEncodedUserParams(query, { page: 1 }));
     }
 
     setShowEditFolderDialog((prev) => !prev);
@@ -198,7 +197,7 @@ export const MediaLibrary = () => {
       location: 'upload',
       sort: value,
     });
-    setQuery({ sort: value as Query['sort'] });
+    setQuery(withEncodedUserParams(query, { sort: value as Query['sort'] }));
   };
 
   const handleEditFolder = (folder: FolderRow) => {
@@ -222,10 +221,7 @@ export const MediaLibrary = () => {
       assetsData?.pagination?.page &&
       assetsData.pagination.page > 1
     ) {
-      setQuery({
-        ...query,
-        page: assetsData.pagination.page - 1,
-      });
+      setQuery(withEncodedUserParams(query, { page: assetsData.pagination.page - 1 }));
     }
   };
 
@@ -302,7 +298,7 @@ export const MediaLibrary = () => {
                     tag={ReactRouterLink}
                     to={{
                       pathname: `${pathname}/configuration`,
-                      search: stringify(query, { encode: false }),
+                      search: stringify(deepEncodeQueryValues(query), { encode: false }),
                     }}
                     label={formatMessage({
                       id: 'app.links.configure-view',

--- a/packages/core/upload/admin/src/pages/App/components/Filters.tsx
+++ b/packages/core/upload/admin/src/pages/App/components/Filters.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 
-import { useQueryParams } from '@strapi/admin/strapi-admin';
+import {
+  deepEncodeQueryValues,
+  useQueryParams,
+  withEncodedUserParams,
+} from '@strapi/admin/strapi-admin';
 import { Button, Popover } from '@strapi/design-system';
 import { Filter } from '@strapi/icons';
 import { useIntl } from 'react-intl';
@@ -22,7 +26,12 @@ export const Filters = () => {
   const filters = query?.filters?.$and || [];
 
   const handleRemoveFilter: FilterListProps['onRemoveFilter'] = (nextFilters) => {
-    setQuery({ filters: { $and: nextFilters }, page: 1 } as Query);
+    setQuery(
+      withEncodedUserParams(query, {
+        filters: deepEncodeQueryValues({ $and: nextFilters }),
+        page: 1,
+      }) as Query
+    );
   };
 
   const handleSubmit: FilterPopoverProps['onSubmit'] = (filters) => {
@@ -30,7 +39,12 @@ export const Filters = () => {
       location: 'content-manager',
       filter: Object.keys(filters[filters.length - 1])[0],
     });
-    setQuery({ filters: { $and: filters }, page: 1 } as Query);
+    setQuery(
+      withEncodedUserParams(query, {
+        filters: deepEncodeQueryValues({ $and: filters }),
+        page: 1,
+      }) as Query
+    );
   };
 
   return (

--- a/packages/core/upload/admin/src/pages/App/components/Header.tsx
+++ b/packages/core/upload/admin/src/pages/App/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useQueryParams, Layouts } from '@strapi/admin/strapi-admin';
+import { deepEncodeQueryValues, useQueryParams, Layouts } from '@strapi/admin/strapi-admin';
 import { Button, Flex, Link } from '@strapi/design-system';
 import { ArrowLeft, Plus } from '@strapi/icons';
 import { stringify } from 'qs';
@@ -40,7 +40,7 @@ export const Header = ({
   const { pathname } = useLocation();
   const [{ query }] = useQueryParams();
   const backQuery = {
-    ...query,
+    ...deepEncodeQueryValues(query),
     folder:
       folder?.parent && typeof folder.parent !== 'number' && folder.parent.id
         ? folder.parent.id

--- a/packages/core/upload/admin/src/pages/App/components/tests/Filters.test.tsx
+++ b/packages/core/upload/admin/src/pages/App/components/tests/Filters.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from '@tests/utils';
+import { useLocation } from 'react-router-dom';
+
+import { Filters } from '../Filters';
+
+const LocationSpy = () => <div data-testid="location">{useLocation().search}</div>;
+
+const CREATED_AT = 'filters[$and][0][createdAt][$eq]=2024-01-01';
+const UPDATED_AT = 'filters[$and][1][updatedAt][$eq]=2024-02-02';
+
+const setup = (search: string) =>
+  render(
+    <>
+      <Filters />
+      <LocationSpy />
+    </>,
+    { initialEntries: [{ search }] }
+  );
+
+const getLocation = () => screen.getByTestId('location').textContent ?? '';
+
+const getChipRemoveButton = (label: string | RegExp) => {
+  const labels = screen.getAllByText(/\$eq/);
+  const index = labels.findIndex((node) => Boolean(node.textContent?.match(label)));
+
+  return screen.getAllByRole('button', { name: '' })[index];
+};
+
+describe('Media Library <Filters />', () => {
+  it.each([
+    ['a percent sign', '100%'],
+    ['an ampersand', 'a&b'],
+    ['a hash', 'a#b'],
+  ])('keeps a search term containing %s when a filter chip is removed', async (_label, term) => {
+    const { user } = setup(`?_q=${encodeURIComponent(term)}&${CREATED_AT}&${UPDATED_AT}`);
+
+    await user.click(getChipRemoveButton(/createdAt \$eq/));
+
+    await waitFor(() => {
+      expect(getLocation()).not.toContain('createdAt');
+    });
+
+    expect(getLocation()).toContain(`_q=${encodeURIComponent(term)}`);
+    expect(new URLSearchParams(getLocation()).get('_q')).toBe(term);
+    expect(getLocation()).toContain('[updatedAt][$eq]=2024-02-02');
+  });
+});

--- a/packages/core/upload/admin/src/pages/App/components/tests/Header.test.tsx
+++ b/packages/core/upload/admin/src/pages/App/components/tests/Header.test.tsx
@@ -101,4 +101,22 @@ describe('Header', () => {
 
     expect(getByText('Back')).toBeInTheDocument();
   });
+
+  test.each([
+    ['a percent sign', '100%', '100%25'],
+    ['an ampersand', 'a&b', 'a%26b'],
+    ['a hash', 'a#b', 'a%23b'],
+  ])('re-encodes %s in a carried-over filter on the back link', (_label, raw, encoded) => {
+    (useQueryParams as jest.Mock).mockReturnValueOnce([
+      { rawQuery: '', query: { folder: 2, filters: { $and: [{ name: { $eq: raw } }] } } },
+      jest.fn(),
+    ]);
+
+    const { getByRole } = setup({ folder: FIXTURE_FOLDER });
+
+    expect(getByRole('link', { name: 'Back' })).toHaveAttribute(
+      'href',
+      expect.stringContaining(`filters[$and][0][name][$eq]=${encoded}`)
+    );
+  });
 });

--- a/packages/core/upload/admin/src/utils/getFolderURL.ts
+++ b/packages/core/upload/admin/src/utils/getFolderURL.ts
@@ -1,3 +1,4 @@
+import { deepEncodeQueryValues } from '@strapi/admin/strapi-admin';
 import { stringify } from 'qs';
 
 import type { Query } from '../../../shared/contracts/files';
@@ -10,7 +11,7 @@ export const getFolderURL = (
   const { _q, ...queryParamsWithoutQ } = currentQuery;
   const queryParamsString = stringify(
     {
-      ...queryParamsWithoutQ,
+      ...deepEncodeQueryValues(queryParamsWithoutQ),
       folder,
       folderPath,
     },

--- a/packages/core/upload/admin/src/utils/tests/getFolderURL.test.ts
+++ b/packages/core/upload/admin/src/utils/tests/getFolderURL.test.ts
@@ -37,6 +37,20 @@ describe('getFolderURL', () => {
     ).toBe('/media-library?folder=1&folderPath=/1/2/3');
   });
 
+  test.each([
+    ['a percent sign', '100%', '100%25'],
+    ['an ampersand', 'a&b', 'a%26b'],
+    ['a hash', 'a#b', 'a%23b'],
+  ])('re-encodes %s in a carried-over filter', (_label, raw, encoded) => {
+    expect(
+      getFolderURL(
+        FIXTURE_PATHNAME,
+        { filters: { $and: [{ name: { $eq: raw } }] } },
+        { folder: FIXTURE_FOLDER }
+      )
+    ).toBe(`/media-library?filters[$and][0][name][$eq]=${encoded}&folder=1`);
+  });
+
   test('includes folderPath if provided and folder is undefined', () => {
     expect(getFolderURL(FIXTURE_PATHNAME, FIXTURE_QUERY, { folderPath: FIXTURE_FOLDER_PATH })).toBe(
       '/media-library?folderPath=/1/2/3'

--- a/packages/plugins/i18n/admin/src/components/LocalePicker.tsx
+++ b/packages/plugins/i18n/admin/src/components/LocalePicker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { useQueryParams } from '@strapi/admin/strapi-admin';
+import { useQueryParams, withEncodedUserParams } from '@strapi/admin/strapi-admin';
 import { SingleSelect, SingleSelectOption } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
@@ -12,6 +12,8 @@ import type { I18nBaseQuery } from '../types';
 
 interface Query extends I18nBaseQuery {
   page?: number;
+  filters?: unknown;
+  _q?: unknown;
 }
 
 const LocalePicker = () => {
@@ -26,15 +28,15 @@ const LocalePicker = () => {
   const handleChange = React.useCallback(
     (code: string, replace = false) => {
       setQuery(
-        {
+        withEncodedUserParams(query, {
           page: 1,
           plugins: { ...query.plugins, i18n: { locale: code } },
-        },
+        }),
         'push',
         replace
       );
     },
-    [query.plugins, setQuery]
+    [query, setQuery]
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
### What does it do?

This PR fixes three closely related bugs, each originating from encoded/decoded characters in the URI.

#### 1. `useEffect` hop when loading a page with encoded filters

- I navigate to any Collection Type list view
- I add a filter on any free text field, like `field is "100%"`
- I acknowledge that the URI shows `…&filters[$and][…][field][$eq]=100%25`
- I refresh the page

**Expected behavior:** the filter still holds the value `"100%25"`

**Actual behavior:** the filter changed its value to `"100%"`, meaning that an additional refresh breaks the page

> [!NOTE]
> This also applies to the search bar.

#### 2. The _Edit Popover_ throws an error when trying to edit a filter

- I navigate to any Collection Type list view
- I open the dev console
- I add a filter on any free text field, like `field is "100%"`
- I click on the filter to edit it

**Expected behavior:** the popover opens correctly, no error is printed in the dev console

**Actual behavior:** I see an error in the dev console and it prevents me from opening the popover

#### 3. Filters get decoded in the URI when adding a new one

- I navigate to any Collection Type list view
- I add a filter on any free text field, like `field is "100%"`
- I acknowledge that the URI shows `…&filters[$and][…][field][$eq]=100%25`
- I add another filter (any type)

**Expected behavior:** the new filter is added without mutating any other

**Actual behavior:** the older filter's value is changed to `"100%"`

### Implementation details

The proposed fix is a little bit more complex than what it could be because I refrained from updating the `useQueryParams` hook; I felt like changing the default behavior there (of centralizing encoding and decoding) could lead to breaking changes. Please let me know what you think about that.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/27220
- Ticket: [EE-112](https://linear.app/strapi/issue/EE-112/filters-unguarded-decodeuricomponent-crashes-the-page-when-editing-a)