### PR TITLE
fix(database): relation reorder saves the wrong position

### DIFF
--- a/packages/core/database/src/entity-manager/__tests__/relations-orderer.test.ts
+++ b/packages/core/database/src/entity-manager/__tests__/relations-orderer.test.ts
@@ -62,8 +62,8 @@ describe('Given I have some relations in the database', () => {
 
       expect(orderer.get()).toMatchObject([
         { id: 2, order: 4 },
-        { id: 5, order: 7 },
-        { id: 4, order: 7 },
+        { id: 5, order: 9.5 },
+        { id: 4, order: 9.5 },
         { id: 3, order: 10 },
       ]);
     });
@@ -89,7 +89,7 @@ describe('Given I have some relations in the database', () => {
 
       expect(orderer.get()).toMatchObject([
         { id: 5, order: 0.5 },
-        { id: 1, order: 1.25 },
+        { id: 1, order: 1.5 },
         { id: 3, order: 3 },
         { id: 2, order: 3.5 },
       ]);
@@ -182,6 +182,70 @@ describe('Given I have some relations in the database', () => {
         { id: 2, order: 2 },
       ]);
       expect(orderer.getOrderMap()[3]).toBeLessThan(0.5);
+    });
+  });
+
+  describe('When I connect before a relation whose neighbours are not loaded', () => {
+    test('Then it is placed immediately before it', () => {
+      const orderer = relationsOrderer(
+        [
+          { id: 1, order: 1 },
+          { id: 9, order: 9 },
+          { id: 10, order: 10 },
+        ],
+        'id',
+        'order'
+      );
+
+      orderer.connect([{ id: 4, position: { before: 9 } }]);
+
+      const orderMap = orderer.getOrderMap();
+      expect(orderMap[4]).toBeGreaterThan(8);
+      expect(orderMap[4]).toBeLessThan(9);
+    });
+  });
+
+  describe('When I connect after a relation whose neighbours are not loaded', () => {
+    test('Then it is placed immediately after it', () => {
+      const orderer = relationsOrderer(
+        [
+          { id: 1, order: 1 },
+          { id: 5, order: 5 },
+          { id: 10, order: 10 },
+        ],
+        'id',
+        'order'
+      );
+
+      orderer.connect([{ id: 4, position: { after: 5 } }]);
+
+      const orderMap = orderer.getOrderMap();
+      expect(orderMap[4]).toBeGreaterThan(5);
+      expect(orderMap[4]).toBeLessThan(6);
+    });
+  });
+
+  describe('When I connect several relations before the same anchor', () => {
+    test('Then they are all placed immediately before it, in payload order', () => {
+      const orderer = relationsOrderer(
+        [
+          { id: 1, order: 1 },
+          { id: 5, order: 5 },
+          { id: 10, order: 10 },
+        ],
+        'id',
+        'order'
+      );
+
+      orderer.connect([
+        { id: 6, position: { before: 5 } },
+        { id: 7, position: { before: 5 } },
+      ]);
+
+      const orderMap = orderer.getOrderMap();
+      expect(orderMap[6]).toBeGreaterThan(4);
+      expect(orderMap[7]).toBeLessThan(5);
+      expect(orderMap[6]).toBeLessThan(orderMap[7]);
     });
   });
 

--- a/packages/core/database/src/entity-manager/relations-orderer.ts
+++ b/packages/core/database/src/entity-manager/relations-orderer.ts
@@ -163,6 +163,11 @@ const sortConnectArray = (connectArr: Link[], initialArr: Link[] = [], strictSor
  * - The final step would be to recalculate fractional order values.
  *      [ { id: 2, order: 4 }, { id: 5, order: 3.33 },  { id: 4, order: 3.66 }, { id: 3, order: 10 } ]
  *
+ * `initArr` is not the full relation list. For an ordered connect, `updateRelations` loads only
+ * the rows named as anchors by the payload plus the lowest- and highest-ordered rows, so entries
+ * that are adjacent in `computedRelations` are not adjacent in the stored list. Placement must be
+ * computed from the anchor's own order, never from its neighbours in this array.
+ *
  * @param {Array<*>} initArr - array of relations to initialize the class with
  * @param {string} idColumn - the column name of the id
  * @param {string} orderColumn - the column name of the order
@@ -205,11 +210,7 @@ const relationsOrderer = <TRelation extends Record<string, ID | number | null>>(
     if (r.position?.before) {
       const { idx: beforeIdx, relation } = findRelation(r.position.before);
       if (relation.init) {
-        const prevRelation = beforeIdx > 0 ? computedRelations[beforeIdx - 1] : null;
-        r.order =
-          prevRelation && prevRelation.order < relation.order
-            ? (prevRelation.order + relation.order) / 2
-            : relation.order - 0.5;
+        r.order = relation.order - 0.5;
       } else {
         r.order = relation.order;
       }
@@ -217,12 +218,7 @@ const relationsOrderer = <TRelation extends Record<string, ID | number | null>>(
     } else if (r.position?.after) {
       const { idx: afterIdx, relation } = findRelation(r.position.after);
       if (relation.init) {
-        const nextRelation =
-          afterIdx < computedRelations.length - 1 ? computedRelations[afterIdx + 1] : null;
-        r.order =
-          nextRelation && nextRelation.order > relation.order
-            ? (relation.order + nextRelation.order) / 2
-            : relation.order + 0.5;
+        r.order = relation.order + 0.5;
       } else {
         r.order = relation.order;
       }


### PR DESCRIPTION
### What does it do?

Computes `before` / `after` placement from the anchor relation's own order, instead of interpolating between the entries either side of the anchor in `computedRelations`.

`relationsOrderer` is initialised with a partial list. For an ordered connect, `updateRelations` loads only the rows named as anchors by the payload plus the lowest- and highest-ordered rows (the `adjacentRelations` query in `entity-manager/index.ts`). Entries that are adjacent in that array are not adjacent in the stored list, so `computedRelations[beforeIdx - 1]` usually resolves to the lowest-ordered row and the midpoint lands far from the anchor.

strapi/strapi#26112 introduced the interpolation to stop two connects sharing an order value. Shared order values are not a problem: `getOrderMap()` splits each equal-order group into fractional slots, and `cleanOrderColumns` then renumbers the join table to 1..N with `ROW_NUMBER()`.

The `start` branch and the `order: 0` handling from strapi/strapi#26112 are unchanged.

Two existing expectations move back to their [pre-strapi/strapi#26112](<https://github.com/pre-strapi/strapi/issues/26112>) values (`9.5` from `7`, `1.5` from `1.25`). Both assert intermediate fractional values rather than resulting positions; the sequences they produce are identical before and after (`[2, 5, 4, 3]` and `[5, 1, 3, 2]`).

Also adds regression tests for the partial-list shape and documents the constraint on `relationsOrderer`.

### Why is it needed?

Since 5.51.0, dragging a relation to a new position saves it at a different position.

On a list of 100 relations, moving an item to position 10 saves it at position 6. Across a mixed run of 30 drag operations on a list of 60, `before` and `after` land wrong 7 times out of 8. `start` and `end` are unaffected, so the failure shows whenever a relation is dropped next to another one, which is most drags. Reproduced on PostgreSQL 17.9, MySQL 8.4.8 and MariaDB 11.8.6.

### How to test it?

Postgres or MySQL, a collection type with an ordered relation, for example `page` with a `manyToMany` to `widget`.

1. Create 100 widgets and attach them all to one page.
2. In the Content Manager, drag the widget at position 50 so it sits above the widget at position 10.
3. Save and reload the entry.

On `develop` the widget is at position 6. With this change it is at position 10.

Unit tests: `yarn workspace @strapi/database test:unit relations-orderer`. The three added tests fail without the source change.

### Related issue(s)/PR(s)

Regression introduced by strapi/strapi#26112, which fixed strapi/strapi#25958. The `start` handling and `order: 0` preservation from that PR are kept, so strapi/strapi#25958 stays fixed.

Reported through support, internal reference TID9902.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)