### PR TITLE
fix(database): avoid multi-table UPDATE for mysql order columns

### DIFF
--- a/packages/core/database/src/entity-manager/__tests__/regular-relations.test.ts
+++ b/packages/core/database/src/entity-manager/__tests__/regular-relations.test.ts
@@ -1,0 +1,129 @@
+import { cleanOrderColumns } from '../regular-relations';
+
+describe('cleanOrderColumns', () => {
+  beforeEach(() => {
+    (global as any).strapi = {
+      db: {
+        dialect: {
+          client: 'mysql',
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const attribute = {
+    relation: 'manyToMany',
+    inversedBy: 'documents',
+    joinTable: {
+      name: 'documents_categories_lnk',
+      joinColumn: { name: 'document_id', referencedTable: 'documents' },
+      inverseJoinColumn: { name: 'category_id', referencedTable: 'categories' },
+      orderColumnName: 'document_order',
+      inverseOrderColumnName: 'category_order',
+    },
+  } as any;
+
+  const createDb = ({ selectResult }: { selectResult: any[] }) => {
+    const raw = jest.fn().mockReturnValue({ transacting: jest.fn().mockResolvedValue(undefined) });
+    const getConnection = jest.fn().mockReturnValue({ raw });
+
+    const query: any = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      transacting: jest.fn().mockResolvedValue(selectResult),
+    };
+
+    const connection = jest.fn().mockReturnValue(query);
+
+    const db = {
+      connection,
+      getConnection,
+    };
+
+    return { db, connection, query, getConnection, raw };
+  };
+
+  it('issues a single-table UPDATE ... CASE for the mysql order column (no multi-table UPDATE)', async () => {
+    const { db, query, getConnection, raw } = createDb({
+      selectResult: [{ id: 30 }, { id: 10 }, { id: 20 }],
+    });
+
+    await cleanOrderColumns({ attribute, db: db as any, id: 1 });
+
+    expect(query.where).toHaveBeenCalledWith('document_id', 1);
+    expect(query.orderBy).toHaveBeenCalledWith([
+      { column: 'document_order' },
+      { column: 'id' },
+    ]);
+
+    expect(getConnection).toHaveBeenCalled();
+    const [sql, bindings] = raw.mock.calls[0];
+
+    // Single target table only: statement never references the join table twice.
+    expect(sql).not.toMatch(/,\s*\(/);
+    expect(sql).not.toMatch(/\bAS b\b/);
+    expect(sql).toMatch(/^UPDATE \?\? SET \?\? = CASE id (WHEN \? THEN \? ){3}END WHERE id IN \(\?, \?, \?\)$/);
+
+    expect(bindings).toEqual([
+      'documents_categories_lnk',
+      'document_order',
+      30,
+      1,
+      10,
+      2,
+      20,
+      3,
+      30,
+      10,
+      20,
+    ]);
+  });
+
+  it('does not issue an UPDATE when there are no rows to reorder', async () => {
+    const { db, getConnection } = createDb({ selectResult: [] });
+
+    await cleanOrderColumns({ attribute, db: db as any, id: 1 });
+
+    expect(getConnection).not.toHaveBeenCalled();
+  });
+
+  it('ranks the mysql inverse order column per partition (per inverseJoinColumn value)', async () => {
+    const { db, raw } = createDb({
+      selectResult: [
+        { id: 1, category_id: 100 },
+        { id: 2, category_id: 100 },
+        { id: 3, category_id: 200 },
+        { id: 4, category_id: 100 },
+      ],
+    });
+
+    await cleanOrderColumns({ attribute, db: db as any, inverseRelIds: [100, 200] });
+
+    const [sql, bindings] = raw.mock.calls[0];
+
+    expect(sql).not.toMatch(/,\s*\(/);
+    expect(sql).not.toMatch(/\bAS b\b/);
+
+    expect(bindings).toEqual([
+      'documents_categories_lnk',
+      'category_order',
+      1,
+      1,
+      2,
+      2,
+      3,
+      1,
+      4,
+      3,
+      1,
+      2,
+      3,
+      4,
+    ]);
+  });
+});

--- a/packages/core/database/src/entity-manager/regular-relations.ts
+++ b/packages/core/database/src/entity-manager/regular-relations.ts
@@ -287,17 +287,30 @@ const cleanOrderColumns = async ({
     switch (strapi.db.dialect.client) {
       case 'mysql': {
         // Here it's MariaDB and MySQL 8
-        const select = selectRowsToOrder(joinTable.name);
-
-        await db
-          .getConnection()
-          .raw(
-            `UPDATE ?? as a, ( ${select.sql} ) AS b
-            SET ?? = b.src_order
-            WHERE b.id = a.id`,
-            [joinTable.name, ...select.bindings, orderColumnName]
-          )
+        // NOTE: A multi-table UPDATE joined to a derived ROW_NUMBER() table is rejected by
+        // MariaDB Galera Cluster (errno 4165, "Galera replication not supported"). Compute the
+        // ranking app-side and apply it as a single-table, PK-keyed UPDATE instead.
+        const rows: { id: ID }[] = await db
+          .connection(joinTable.name)
+          .select('id')
+          .where(joinColumn.name, id)
+          .orderBy([{ column: orderColumnName }, { column: 'id' }])
           .transacting(trx);
+
+        if (rows.length > 0) {
+          const ids = rows.map((row) => row.id);
+          const cases = ids.map(() => 'WHEN ? THEN ?').join(' ');
+          const casesBindings = ids.flatMap((rowId, index) => [rowId, index + 1]);
+          const placeholders = ids.map(() => '?').join(', ');
+
+          await db
+            .getConnection()
+            .raw(
+              `UPDATE ?? SET ?? = CASE id ${cases} END WHERE id IN (${placeholders})`,
+              [joinTable.name, orderColumnName, ...casesBindings, ...ids]
+            )
+            .transacting(trx);
+        }
 
         break;
       }
@@ -345,17 +358,42 @@ const cleanOrderColumns = async ({
     switch (strapi.db.dialect.client) {
       case 'mysql': {
         // Here it's MariaDB and MySQL 8
-        const select = selectRowsToOrder(joinTable.name);
-
-        await db
-          .getConnection()
-          .raw(
-            `UPDATE ?? as a, ( ${select.sql} ) AS b
-            SET ?? = b.inv_order
-            WHERE b.id = a.id`,
-            [joinTable.name, ...select.bindings, inverseOrderColumnName]
-          )
+        // NOTE: A multi-table UPDATE joined to a derived ROW_NUMBER() table is rejected by
+        // MariaDB Galera Cluster (errno 4165, "Galera replication not supported"). Compute the
+        // per-partition ranking app-side and apply it as a single-table, PK-keyed UPDATE instead.
+        const rows: { id: ID; [key: string]: ID }[] = await db
+          .connection(joinTable.name)
+          .select('id', inverseJoinColumn.name)
+          .where(inverseJoinColumn.name, 'in', inverseRelIds)
+          .orderBy([
+            { column: inverseJoinColumn.name },
+            { column: inverseOrderColumnName },
+            { column: 'id' },
+          ])
           .transacting(trx);
+
+        if (rows.length > 0) {
+          const counters = new Map<ID, number>();
+          const ranked = rows.map((row) => {
+            const partition = row[inverseJoinColumn.name];
+            const next = (counters.get(partition) ?? 0) + 1;
+            counters.set(partition, next);
+            return { id: row.id, order: next };
+          });
+
+          const cases = ranked.map(() => 'WHEN ? THEN ?').join(' ');
+          const casesBindings = ranked.flatMap((row) => [row.id, row.order]);
+          const ids = ranked.map((row) => row.id);
+          const placeholders = ids.map(() => '?').join(', ');
+
+          await db
+            .getConnection()
+            .raw(
+              `UPDATE ?? SET ?? = CASE id ${cases} END WHERE id IN (${placeholders})`,
+              [joinTable.name, inverseOrderColumnName, ...casesBindings, ...ids]
+            )
+            .transacting(trx);
+        }
         break;
       }
       default: {


### PR DESCRIPTION
### What does it do?

`cleanOrderColumns` renumbers a join table's order column(s) to stay contiguous (1..N) after a relation changes. On MySQL/MariaDB it did this with a multi-table `UPDATE` joined to a derived table containing a `ROW_NUMBER() OVER (PARTITION BY ...)` window function.

This PR keeps the exact same ordering semantics but computes the ranking app-side (a `SELECT ... ORDER BY`) and applies it as a single-table, PK-keyed `UPDATE ... SET col = CASE id WHEN ? THEN ? ... END WHERE id IN (...)`. Both `updateOrderColumn` and `updateInverseOrderColumn`'s `mysql` branches are updated; `updateInverseOrderColumn` ranks per partition (grouped by the inverse join column) exactly like the original `PARTITION BY` did. The Postgres/sqlite (`default`) branch, which already used a single-target-table form, is unchanged.

### Why is it needed?

**This addresses a critical-severity production issue (#27223).**

A MariaDB **Galera Cluster** cannot build a replication write-set for a multi-table `UPDATE` that references the updated table twice (once directly, once via the derived subquery), and rejects it outright:

```
errno:      4165
sqlState:   HY000
sqlMessage: Galera replication not supported
```

The practical impact: **any write that touches an ordered relation fails** on a Galera-backed database — reassigning a `manyToOne`/`oneToOne` relation, or reordering a `manyToMany`/`oneToMany` list, all 500 as soon as more than one row exists to reorder. This is deterministic and tied to the statement shape, not a concurrency issue, so it affects every Galera deployment (e.g. MariaDB Galera Cluster, Percona XtraDB Cluster) unconditionally.

### How to test it?

Unit tests were added at `packages/core/database/src/entity-manager/__tests__/regular-relations.test.ts` covering:
- the mysql order-column branch produces a single-table `UPDATE ... CASE ... END WHERE id IN (...)` (asserts the SQL never references the join table twice — i.e. never contains `, (` or `AS b`)
- no `UPDATE` is issued when there are no rows to reorder
- the mysql inverse-order-column branch ranks correctly per partition (grouped by the inverse join column), matching the old `PARTITION BY` semantics

```
yarn workspace @strapi/database test:unit regular-relations
```

```
PASS Core database src/entity-manager/__tests__/regular-relations.test.ts
  cleanOrderColumns
    ✓ issues a single-table UPDATE ... CASE for the mysql order column (no multi-table UPDATE)
    ✓ does not issue an UPDATE when there are no rows to reorder
    ✓ ranks the mysql inverse order column per partition (per inverseJoinColumn value)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

Also ran the full `entity-manager` unit suite (21 tests, all passing) and `@strapi/database`'s `test:ts` (typecheck, clean) and `lint` (clean) to confirm no regressions.

Manual reproduction against a real Galera cluster was not performed in this environment (no Galera cluster available here); the fix targets the exact statement shape called out in the issue and preserves the pre-existing single-table form already used on Postgres/sqlite, which Galera is known to accept.

### Related issue(s)/PR(s)

Fixes #27223