### PR TITLE
future(upload): enhance drawer interaction with outside click handling

### DIFF
--- a/packages/core/upload/admin/src/future/components/Drawer.tsx
+++ b/packages/core/upload/admin/src/future/components/Drawer.tsx
@@ -170,23 +170,42 @@ const CloseIconButton = styled(IconButton)`
  * Drawer.Body
  * -----------------------------------------------------------------------------------------------*/
 
+type PointerDownOutsideHandler = NonNullable<Dialog.DialogContentProps['onPointerDownOutside']>;
+
+/** Vetoes an outside interaction that would otherwise dismiss the drawer. */
+const keepOpen = (event: { preventDefault: () => void }) => event.preventDefault();
+
 interface DrawerBodyProps extends Omit<FlexProps, 'width' | 'maxHeight'> {
   animationDirection?: 'up' | 'left';
   /** Width of the panel from the medium breakpoint up. Mobile is always full-bleed. */
   width?: string;
   /** Cap on the panel height. Defaults to the dynamic viewport height. */
   maxHeight?: string;
+  /**
+   * Opt in to dismiss-on-outside-click. Omitted, an outside pointer press never
+   * closes the drawer — it must be closed explicitly, as long-running panels
+   * like the upload progress dialog need. Passed, the handler can still veto
+   * individual presses via `event.preventDefault()`. Content rendered from
+   * inside the panel but portaled elsewhere (DS dialogs, popovers, tooltips)
+   * never counts as outside — Radix reads the React tree, not the DOM.
+   */
+  onPointerDownOutside?: PointerDownOutsideHandler;
   children: React.ReactNode;
 }
 
 const DrawerBody = React.forwardRef<HTMLDivElement, DrawerBodyProps>(
-  ({ animationDirection, width, maxHeight, children, ...props }, ref) => (
+  (
+    { animationDirection, width, maxHeight, onPointerDownOutside = keepOpen, children, ...props },
+    ref
+  ) => (
     <Dialog.Content
       ref={ref}
       forceMount
       asChild
-      onPointerDownOutside={(e) => e.preventDefault()}
-      onInteractOutside={(e) => e.preventDefault()}
+      onPointerDownOutside={onPointerDownOutside}
+      // Non-modal, so focus legitimately moves outside (tabbing past the last
+      // field); only a pointer press should ever dismiss.
+      onFocusOutside={keepOpen}
       data-animation-direction={animationDirection}
     >
       {/* width/maxHeight go through transient props so the DS Flex never emits a

--- a/packages/core/upload/admin/src/future/components/tests/Drawer.test.tsx
+++ b/packages/core/upload/admin/src/future/components/tests/Drawer.test.tsx
@@ -134,6 +134,106 @@ describe('Drawer', () => {
     });
   });
 
+  // Dismiss-on-outside-click is opt-in and the handler can veto it; focus
+  // leaving the panel never closes it (the drawer is non-modal).
+  describe('outside interaction', () => {
+    const renderWithOutside = ({
+      onClose,
+      onPointerDownOutside,
+    }: {
+      onClose: jest.Mock;
+      onPointerDownOutside?: (event: Event) => void;
+    }) =>
+      render(
+        <>
+          <button type="button" data-testid="outside">
+            Outside
+          </button>
+          <Drawer.Root isVisible onClose={onClose}>
+            <Drawer.Body onPointerDownOutside={onPointerDownOutside}>
+              <Dialog.Title>Test title</Dialog.Title>
+              <Dialog.Description>Test description</Dialog.Description>
+              <Drawer.ScrollableContent>
+                <button type="button" data-testid="inside">
+                  Inside
+                </button>
+                {/* Rendered from inside the panel, portaled outside it — like a DS dialog. */}
+                <Dialog.Root modal={false}>
+                  <Dialog.Trigger data-testid="portal-trigger">Open portal</Dialog.Trigger>
+                  <Dialog.Portal>
+                    <Dialog.Content>
+                      <Dialog.Title>Portaled</Dialog.Title>
+                      <button type="button" data-testid="portal-inside">
+                        Portaled button
+                      </button>
+                    </Dialog.Content>
+                  </Dialog.Portal>
+                </Dialog.Root>
+              </Drawer.ScrollableContent>
+            </Drawer.Body>
+          </Drawer.Root>
+        </>
+      );
+
+    it('does not close on an outside pointer press by default', async () => {
+      const onClose = jest.fn();
+      const { user } = renderWithOutside({ onClose });
+
+      await user.click(screen.getByTestId('outside'));
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('closes on an outside pointer press once the consumer opts in', async () => {
+      const onClose = jest.fn();
+      const { user } = renderWithOutside({ onClose, onPointerDownOutside: () => {} });
+
+      await user.click(screen.getByTestId('outside'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('stays open when the handler prevents the default', async () => {
+      const onClose = jest.fn();
+      const { user } = renderWithOutside({
+        onClose,
+        onPointerDownOutside: (event) => event.preventDefault(),
+      });
+
+      await user.click(screen.getByTestId('outside'));
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not close on a pointer press inside the panel', async () => {
+      const onClose = jest.fn();
+      const { user } = renderWithOutside({ onClose, onPointerDownOutside: () => {} });
+
+      await user.click(screen.getByTestId('inside'));
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not close on a pointer press inside content portaled out of the panel', async () => {
+      const onClose = jest.fn();
+      const { user } = renderWithOutside({ onClose, onPointerDownOutside: () => {} });
+
+      await user.click(screen.getByTestId('portal-trigger'));
+      await user.click(await screen.findByTestId('portal-inside'));
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not close when focus moves outside the panel', async () => {
+      const onClose = jest.fn();
+      renderWithOutside({ onClose, onPointerDownOutside: () => {} });
+
+      fireEvent.focusIn(screen.getByTestId('outside'));
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Drawer.CloseButton', () => {
     it('renders and calls onClose when clicked', () => {
       const onClose = jest.fn();

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -62,6 +62,7 @@ import {
 } from '../../../../utils/files';
 import { getAssetIcon } from '../../../../utils/getAssetIcon';
 import { getTranslationKey } from '../../../../utils/translations';
+import { ASSET_DETAILS_TRIGGER_SELECTOR } from '../../constants';
 import { useFolderInfo } from '../../hooks/useFolderInfo';
 import { ASSET_DETAILS_URL_PARAM, parseAssetDetailsId } from '../../hooks/useIsAssetDetailsOpen';
 import { BusyOverlay } from '../BusyOverlay';
@@ -1283,6 +1284,20 @@ const DrawerContent = ({ assetId, closeDetails }: DrawerContentProps) => {
  * AssetDetailsDrawer
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Whether a pointer press outside the panel should leave the drawer open.
+ *
+ * Two cases: the panel is already closing (`forceMount` keeps it listening
+ * through the animation, so dismissing again would re-trigger the
+ * unsaved-changes guard for nothing), or the press landed on another asset's
+ * card/row — its `click`, firing right after, switches the drawer instead of
+ * closing it, so closing here would just cause a close-then-reopen.
+ */
+const shouldKeepDrawerOpen = (event: { target: EventTarget | null }, isVisible: boolean) =>
+  !isVisible ||
+  (event.target instanceof Element &&
+    event.target.closest(ASSET_DETAILS_TRIGGER_SELECTOR) !== null);
+
 export const AssetDetailsDrawer = () => {
   const { formatMessage } = useIntl();
   const { assetId, isVisible, shouldRenderDrawer, onCloseAnimationEnd, closeDetails } =
@@ -1321,6 +1336,13 @@ export const AssetDetailsDrawer = () => {
         // off-screen. dvh tracks the actual visible height.
         height="100dvh"
         onAnimationEnd={onCloseAnimationEnd}
+        // Opt in to dismiss-on-outside-click; `closeDetails` is the same path
+        // as the header's close button, so unsaved edits are still guarded.
+        onPointerDownOutside={(event) => {
+          if (shouldKeepDrawerOpen(event, isVisible)) {
+            event.preventDefault();
+          }
+        }}
       >
         <DrawerContent assetId={assetId} closeDetails={closeDetails} />
       </Drawer.Body>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -1295,8 +1295,18 @@ const DrawerContent = ({ assetId, closeDetails }: DrawerContentProps) => {
  * listening through its animation, where dismissing again would re-trigger the
  * unsaved-changes guard for nothing.
  */
-const shouldKeepDrawerOpen = (event: { target: EventTarget | null }, isVisible: boolean) => {
+const shouldKeepDrawerOpen = (
+  event: { target: EventTarget | null; detail: { originalEvent: { button: number } } },
+  isVisible: boolean
+) => {
   if (!isVisible) {
+    return true;
+  }
+
+  // Radix's dismisser fires on any `pointerdown`, secondary buttons included. A
+  // right-click is contextual, and with the create menu on the background one
+  // press would otherwise both close this and open that.
+  if (event.detail.originalEvent.button !== 0) {
     return true;
   }
 

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -62,7 +62,7 @@ import {
 } from '../../../../utils/files';
 import { getAssetIcon } from '../../../../utils/getAssetIcon';
 import { getTranslationKey } from '../../../../utils/translations';
-import { ASSET_DETAILS_TRIGGER_SELECTOR } from '../../constants';
+import { ASSET_DETAILS_TRIGGER_SELECTOR, INTERACTIVE_ELEMENT_SELECTOR } from '../../constants';
 import { useFolderInfo } from '../../hooks/useFolderInfo';
 import { ASSET_DETAILS_URL_PARAM, parseAssetDetailsId } from '../../hooks/useIsAssetDetailsOpen';
 import { BusyOverlay } from '../BusyOverlay';
@@ -1287,16 +1287,28 @@ const DrawerContent = ({ assetId, closeDetails }: DrawerContentProps) => {
 /**
  * Whether a pointer press outside the panel should leave the drawer open.
  *
- * Two cases: the panel is already closing (`forceMount` keeps it listening
- * through the animation, so dismissing again would re-trigger the
- * unsaved-changes guard for nothing), or the press landed on another asset's
- * card/row — its `click`, firing right after, switches the drawer instead of
- * closing it, so closing here would just cause a close-then-reopen.
+ * Only an inert part of the page behind dismisses it. A press on any control
+ * there — checkbox, select all, search, sort, filters — is the user working the
+ * list with the drawer as a reference, so it stays. An asset's card or row also
+ * stays: its `click` fires right after and switches the drawer, which would
+ * otherwise read as close-then-reopen. And `forceMount` keeps a closing panel
+ * listening through its animation, where dismissing again would re-trigger the
+ * unsaved-changes guard for nothing.
  */
-const shouldKeepDrawerOpen = (event: { target: EventTarget | null }, isVisible: boolean) =>
-  !isVisible ||
-  (event.target instanceof Element &&
-    event.target.closest(ASSET_DETAILS_TRIGGER_SELECTOR) !== null);
+const shouldKeepDrawerOpen = (event: { target: EventTarget | null }, isVisible: boolean) => {
+  if (!isVisible) {
+    return true;
+  }
+
+  if (!(event.target instanceof Element)) {
+    return false;
+  }
+
+  return (
+    event.target.closest(ASSET_DETAILS_TRIGGER_SELECTOR) !== null ||
+    event.target.closest(INTERACTIVE_ELEMENT_SELECTOR) !== null
+  );
+};
 
 export const AssetDetailsDrawer = () => {
   const { formatMessage } = useIntl();

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -62,7 +62,7 @@ import {
 } from '../../../../utils/files';
 import { getAssetIcon } from '../../../../utils/getAssetIcon';
 import { getTranslationKey } from '../../../../utils/translations';
-import { ASSET_DETAILS_TRIGGER_SELECTOR, INTERACTIVE_ELEMENT_SELECTOR } from '../../constants';
+import { ASSET_DETAILS_TRIGGER_SELECTOR, ASSET_ITEM_CONTROL_SELECTOR } from '../../constants';
 import { useFolderInfo } from '../../hooks/useFolderInfo';
 import { ASSET_DETAILS_URL_PARAM, parseAssetDetailsId } from '../../hooks/useIsAssetDetailsOpen';
 import { BusyOverlay } from '../BusyOverlay';
@@ -1287,13 +1287,12 @@ const DrawerContent = ({ assetId, closeDetails }: DrawerContentProps) => {
 /**
  * Whether a pointer press outside the panel should leave the drawer open.
  *
- * Only an inert part of the page behind dismisses it. A press on any control
- * there — checkbox, select all, search, sort, filters — is the user working the
- * list with the drawer as a reference, so it stays. An asset's card or row also
- * stays: its `click` fires right after and switches the drawer, which would
- * otherwise read as close-then-reopen. And `forceMount` keeps a closing panel
- * listening through its animation, where dismissing again would re-trigger the
- * unsaved-changes guard for nothing.
+ * Anywhere on the page behind dismisses it, controls included. Two exceptions,
+ * neither of which is "the user meant to stay": the part of an asset's card or
+ * row whose `click` switches the drawer rather than closing it — not its own
+ * checkbox or actions menu, which act on the item; and a panel already closing,
+ * which `forceMount` keeps listening through its animation, where dismissing
+ * again would re-trigger the unsaved-changes guard for nothing.
  */
 const shouldKeepDrawerOpen = (
   event: { target: EventTarget | null; detail: { originalEvent: { button: number } } },
@@ -1314,9 +1313,11 @@ const shouldKeepDrawerOpen = (
     return false;
   }
 
+  // The card's own controls — its checkbox, its actions menu — act on the item
+  // and stop the card's click, so no switch follows and the press dismisses.
   return (
-    event.target.closest(ASSET_DETAILS_TRIGGER_SELECTOR) !== null ||
-    event.target.closest(INTERACTIVE_ELEMENT_SELECTOR) !== null
+    event.target.closest(ASSET_DETAILS_TRIGGER_SELECTOR) !== null &&
+    event.target.closest(ASSET_ITEM_CONTROL_SELECTOR) === null
   );
 };
 

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, server, waitFor } from '@tests/utils';
 import { http, HttpResponse } from 'msw';
 
-import { ASSET_DETAILS_TRIGGER_PROPS } from '../../../constants';
+import { ASSET_DETAILS_TRIGGER_PROPS, ASSET_ITEM_CONTROL_PROPS } from '../../../constants';
 import { AssetDetails, AssetDetailsDrawer, getBusyMessage } from '../AssetDetailsDrawer';
 
 import type { AssetWithPopulatedCreatedBy } from '../../../../../../../../shared/contracts/files';
@@ -757,13 +757,25 @@ describe('AssetDetailsDrawer outside-click dismissal', () => {
   const renderOpenDrawer = async () => {
     const result = render(
       <>
-        {/* Inert canvas — the only thing behind that dismisses. */}
+        {/* Plain page background. */}
         <div data-testid="page-background">Background</div>
         {/* Stands in for a grid card/table row, whose click switches the drawer. */}
-        <button type="button" data-testid="other-asset" {...ASSET_DETAILS_TRIGGER_PROPS}>
+        <div data-testid="other-asset" {...ASSET_DETAILS_TRIGGER_PROPS}>
           Other asset
-        </button>
-        {/* The list's own controls, which must not dismiss it. */}
+          {/* Its own controls, which act on the item rather than opening it. */}
+          <span {...ASSET_ITEM_CONTROL_PROPS}>
+            <button
+              type="button"
+              role="checkbox"
+              aria-checked="false"
+              data-testid="item-checkbox"
+            />
+            <button type="button" data-testid="item-actions">
+              Actions
+            </button>
+          </span>
+        </div>
+        {/* The list's own controls, which dismiss it like any other outside press. */}
         <button type="button" data-testid="toolbar-button">
           Sort
         </button>
@@ -783,7 +795,7 @@ describe('AssetDetailsDrawer outside-click dismissal', () => {
     return { ...result, drawer };
   };
 
-  it('closes when the pointer goes down on inert page background', async () => {
+  it('closes when the pointer goes down on the page background', async () => {
     const { user, drawer } = await renderOpenDrawer();
 
     await user.click(screen.getByTestId('page-background'));
@@ -814,19 +826,19 @@ describe('AssetDetailsDrawer outside-click dismissal', () => {
     await waitFor(() => expect(drawer).toHaveAttribute('data-state', 'closed'));
   });
 
-  // The drawer is a reference panel: operating the list behind it is not
-  // leaving it.
+  // Anywhere behind the panel dismisses it, controls included — pressing one is
+  // still leaving the drawer.
   it.each([
     ['a toolbar button', 'toolbar-button'],
     ['the select-all checkbox', 'select-all'],
     ['the search field', 'search'],
     ['an option in a menu portaled out of the page', 'menu-option'],
-  ])('stays open when the pointer goes down on %s', async (_label, testId) => {
+  ])('closes when the pointer goes down on %s', async (_label, testId) => {
     const { user, drawer } = await renderOpenDrawer();
 
     await user.click(screen.getByTestId(testId));
 
-    expect(drawer).toHaveAttribute('data-state', 'open');
+    await waitFor(() => expect(drawer).toHaveAttribute('data-state', 'closed'));
   });
 
   it('stays open when the pointer goes down inside the panel', async () => {
@@ -845,6 +857,19 @@ describe('AssetDetailsDrawer outside-click dismissal', () => {
     await user.click(screen.getByTestId('other-asset'));
 
     expect(drawer).toHaveAttribute('data-state', 'open');
+  });
+
+  // The card is exempt because its click switches the drawer — but its checkbox
+  // selects the asset and stops that click, so nothing switches and it closes.
+  it.each([
+    ["the asset's own checkbox", 'item-checkbox'],
+    ["the asset's own actions menu", 'item-actions'],
+  ])('closes when the pointer goes down on %s', async (_label, testId) => {
+    const { user, drawer } = await renderOpenDrawer();
+
+    await user.click(screen.getByTestId(testId));
+
+    await waitFor(() => expect(drawer).toHaveAttribute('data-state', 'closed'));
   });
 
   // The delete confirmation is portaled to the body but rendered from inside

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen, server, waitFor } from '@tests/utils';
 import { http, HttpResponse } from 'msw';
 
-import { AssetDetails, getBusyMessage } from '../AssetDetailsDrawer';
+import { ASSET_DETAILS_TRIGGER_PROPS } from '../../../constants';
+import { AssetDetails, AssetDetailsDrawer, getBusyMessage } from '../AssetDetailsDrawer';
 
 import type { AssetWithPopulatedCreatedBy } from '../../../../../../../../shared/contracts/files';
 
@@ -735,5 +736,90 @@ describe('icon button tooltips', () => {
     ]) {
       expect(await screen.findByRole('button', { name: label })).toBeInTheDocument();
     }
+  });
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * Outside-click dismissal
+ * -----------------------------------------------------------------------------------------------*/
+
+describe('AssetDetailsDrawer outside-click dismissal', () => {
+  beforeEach(() => {
+    server.use(
+      buildFoldersHandler(),
+      buildSettingsHandler(),
+      http.get('/upload/files/:id', () => HttpResponse.json(baseAsset))
+    );
+  });
+
+  // jsdom never runs the slide-out animation, so "closed" is read off the
+  // state attribute rather than the element disappearing.
+  const renderOpenDrawer = async () => {
+    const result = render(
+      <>
+        <button type="button" data-testid="page-background">
+          Background
+        </button>
+        {/* Stands in for a grid card/table row, whose click switches the drawer. */}
+        <button type="button" data-testid="other-asset" {...ASSET_DETAILS_TRIGGER_PROPS}>
+          Other asset
+        </button>
+        <AssetDetailsDrawer />
+      </>,
+      { initialEntries: ['/?assetId=1'] }
+    );
+
+    const drawer = await screen.findByRole('dialog');
+    expect(drawer).toHaveAttribute('data-state', 'open');
+
+    return { ...result, drawer };
+  };
+
+  it('closes when the pointer goes down outside the panel', async () => {
+    const { user, drawer } = await renderOpenDrawer();
+
+    await user.click(screen.getByTestId('page-background'));
+
+    await waitFor(() => expect(drawer).toHaveAttribute('data-state', 'closed'));
+  });
+
+  it('stays open when the pointer goes down inside the panel', async () => {
+    const { user, drawer } = await renderOpenDrawer();
+
+    await user.click(await screen.findByRole('button', { name: 'Copy link' }));
+
+    expect(drawer).toHaveAttribute('data-state', 'open');
+  });
+
+  // Dismissing on the pointerdown would turn switching assets into a
+  // close-then-reopen round trip.
+  it('stays open when the pointer goes down on another asset', async () => {
+    const { user, drawer } = await renderOpenDrawer();
+
+    await user.click(screen.getByTestId('other-asset'));
+
+    expect(drawer).toHaveAttribute('data-state', 'open');
+  });
+
+  // The delete confirmation is portaled to the body but rendered from inside
+  // the drawer, so Radix treats it as "inside".
+  it('stays open while interacting with a dialog opened from inside it', async () => {
+    const { user, drawer } = await renderOpenDrawer();
+
+    await user.click(await screen.findByRole('button', { name: 'Delete this file' }));
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    expect(drawer).toHaveAttribute('data-state', 'open');
+  });
+
+  // The press happened inside, so there's no outside pointerdown to act on.
+  it('stays open when a drag started inside the panel ends outside it', async () => {
+    const { drawer } = await renderOpenDrawer();
+
+    const title = await screen.findByRole('heading', { name: 'photo.png' });
+    fireEvent.pointerDown(title);
+    fireEvent.pointerUp(screen.getByTestId('page-background'));
+
+    expect(drawer).toHaveAttribute('data-state', 'open');
   });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -791,6 +791,29 @@ describe('AssetDetailsDrawer outside-click dismissal', () => {
     await waitFor(() => expect(drawer).toHaveAttribute('data-state', 'closed'));
   });
 
+  // A right-click is contextual — and on the assets background it opens the
+  // create menu, so dismissing here would fire two outcomes from one press.
+  it.each([
+    ['a right-click', 2],
+    ['a middle-click', 1],
+  ])('stays open on %s outside the panel', async (_label, button) => {
+    const { drawer } = await renderOpenDrawer();
+
+    fireEvent.pointerDown(screen.getByTestId('page-background'), { button });
+
+    await waitFor(() => expect(drawer).toHaveAttribute('data-state', 'open'));
+  });
+
+  // The primary button must still dismiss — the guard is about which button,
+  // not about disabling dismissal.
+  it('still closes on a primary-button press outside the panel', async () => {
+    const { drawer } = await renderOpenDrawer();
+
+    fireEvent.pointerDown(screen.getByTestId('page-background'), { button: 0 });
+
+    await waitFor(() => expect(drawer).toHaveAttribute('data-state', 'closed'));
+  });
+
   // The drawer is a reference panel: operating the list behind it is not
   // leaving it.
   it.each([

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx
@@ -757,13 +757,21 @@ describe('AssetDetailsDrawer outside-click dismissal', () => {
   const renderOpenDrawer = async () => {
     const result = render(
       <>
-        <button type="button" data-testid="page-background">
-          Background
-        </button>
+        {/* Inert canvas — the only thing behind that dismisses. */}
+        <div data-testid="page-background">Background</div>
         {/* Stands in for a grid card/table row, whose click switches the drawer. */}
         <button type="button" data-testid="other-asset" {...ASSET_DETAILS_TRIGGER_PROPS}>
           Other asset
         </button>
+        {/* The list's own controls, which must not dismiss it. */}
+        <button type="button" data-testid="toolbar-button">
+          Sort
+        </button>
+        <button type="button" role="checkbox" aria-checked="false" data-testid="select-all" />
+        <input data-testid="search" aria-label="Search" />
+        <div role="menuitem" data-testid="menu-option">
+          Name (A to Z)
+        </div>
         <AssetDetailsDrawer />
       </>,
       { initialEntries: ['/?assetId=1'] }
@@ -775,12 +783,27 @@ describe('AssetDetailsDrawer outside-click dismissal', () => {
     return { ...result, drawer };
   };
 
-  it('closes when the pointer goes down outside the panel', async () => {
+  it('closes when the pointer goes down on inert page background', async () => {
     const { user, drawer } = await renderOpenDrawer();
 
     await user.click(screen.getByTestId('page-background'));
 
     await waitFor(() => expect(drawer).toHaveAttribute('data-state', 'closed'));
+  });
+
+  // The drawer is a reference panel: operating the list behind it is not
+  // leaving it.
+  it.each([
+    ['a toolbar button', 'toolbar-button'],
+    ['the select-all checkbox', 'select-all'],
+    ['the search field', 'search'],
+    ['an option in a menu portaled out of the page', 'menu-option'],
+  ])('stays open when the pointer goes down on %s', async (_label, testId) => {
+    const { user, drawer } = await renderOpenDrawer();
+
+    await user.click(screen.getByTestId(testId));
+
+    expect(drawer).toHaveAttribute('data-state', 'open');
   });
 
   it('stays open when the pointer goes down inside the panel', async () => {

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
@@ -10,7 +10,7 @@ import { prefixFileUrlWithBackendUrl } from '../../../utils/files';
 import { getAssetIcon } from '../../../utils/getAssetIcon';
 import { isEventFromWithin } from '../../../utils/isEventFromWithin';
 import { getTranslationKey } from '../../../utils/translations';
-import { ASSET_DETAILS_TRIGGER_PROPS } from '../constants';
+import { ASSET_DETAILS_TRIGGER_PROPS, ASSET_ITEM_CONTROL_PROPS } from '../constants';
 import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useBusyAssetsOptional } from '../hooks/useBusyAssets';
 import { useFolderNavigation } from '../hooks/useFolderNavigation';
@@ -494,7 +494,10 @@ const AssetCard = ({ asset, orderedItemKeys, onAssetItemClick }: AssetCardProps)
     >
       <StyledCardHeader>
         {canUpdate && (
-          <CheckboxOverlay onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}>
+          <CheckboxOverlay
+            {...ASSET_ITEM_CONTROL_PROPS}
+            onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
+          >
             <Checkbox
               checked={selected}
               onClick={handleCheckboxClick}
@@ -523,7 +526,12 @@ const AssetCard = ({ asset, orderedItemKeys, onAssetItemClick }: AssetCardProps)
           <NameButton type="button" onClick={handleNameClick}>
             <FileName textColor="primary800">{asset.name}</FileName>
           </NameButton>
-          <Flex onClick={stopCardEvent} onKeyDown={stopCardEvent} onPointerDown={stopCardEvent}>
+          <Flex
+            {...ASSET_ITEM_CONTROL_PROPS}
+            onClick={stopCardEvent}
+            onKeyDown={stopCardEvent}
+            onPointerDown={stopCardEvent}
+          >
             <AssetActionsMenu asset={asset} dragData={dragData} />
           </Flex>
         </CardFooter>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
@@ -10,6 +10,7 @@ import { prefixFileUrlWithBackendUrl } from '../../../utils/files';
 import { getAssetIcon } from '../../../utils/getAssetIcon';
 import { isEventFromWithin } from '../../../utils/isEventFromWithin';
 import { getTranslationKey } from '../../../utils/translations';
+import { ASSET_DETAILS_TRIGGER_PROPS } from '../constants';
 import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useBusyAssetsOptional } from '../hooks/useBusyAssets';
 import { useFolderNavigation } from '../hooks/useFolderNavigation';
@@ -472,6 +473,7 @@ const AssetCard = ({ asset, orderedItemKeys, onAssetItemClick }: AssetCardProps)
       ref={setNodeRef}
       {...attributes}
       {...listeners}
+      {...ASSET_DETAILS_TRIGGER_PROPS}
       $isDragging={isDragging}
       $isMovePending={isMovePending}
       $isBusy={busyMessage !== null}

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
@@ -24,7 +24,7 @@ import { formatBytes } from '../../../utils/files';
 import { getAssetIcon } from '../../../utils/getAssetIcon';
 import { isEventFromWithin } from '../../../utils/isEventFromWithin';
 import { getTranslationKey } from '../../../utils/translations';
-import { ASSET_DETAILS_TRIGGER_PROPS, TABLE_HEADERS } from '../constants';
+import { ASSET_DETAILS_TRIGGER_PROPS, ASSET_ITEM_CONTROL_PROPS, TABLE_HEADERS } from '../constants';
 import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useBusyAssetsOptional } from '../hooks/useBusyAssets';
 import { useFolderNavigation } from '../hooks/useFolderNavigation';
@@ -342,7 +342,7 @@ const AssetRow = ({ asset, orderedItemKeys, onAssetItemClick }: AssetRowProps) =
       {/* No checkbox without the update permission (nothing selectable can be
           acted on). Shown at every viewport width otherwise. */}
       {canUpdate && (
-        <CheckboxTd onClick={stopRowEvent} onKeyDown={stopRowEvent}>
+        <CheckboxTd {...ASSET_ITEM_CONTROL_PROPS} onClick={stopRowEvent} onKeyDown={stopRowEvent}>
           <Flex>
             <Checkbox
               checked={selected}
@@ -412,7 +412,12 @@ const AssetRow = ({ asset, orderedItemKeys, onAssetItemClick }: AssetRowProps) =
       )}
       {/* The row owns click, Enter and Space; none of them should reach it from
           the menu trigger (Enter would open the details drawer). */}
-      <StyledTd onClick={stopRowEvent} onKeyDown={stopRowEvent} onPointerDown={stopRowEvent}>
+      <StyledTd
+        {...ASSET_ITEM_CONTROL_PROPS}
+        onClick={stopRowEvent}
+        onKeyDown={stopRowEvent}
+        onPointerDown={stopRowEvent}
+      >
         <Flex justifyContent="flex-end">
           <AssetActionsMenu asset={asset} dragData={dragData} />
         </Flex>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
@@ -24,7 +24,7 @@ import { formatBytes } from '../../../utils/files';
 import { getAssetIcon } from '../../../utils/getAssetIcon';
 import { isEventFromWithin } from '../../../utils/isEventFromWithin';
 import { getTranslationKey } from '../../../utils/translations';
-import { TABLE_HEADERS } from '../constants';
+import { ASSET_DETAILS_TRIGGER_PROPS, TABLE_HEADERS } from '../constants';
 import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useBusyAssetsOptional } from '../hooks/useBusyAssets';
 import { useFolderNavigation } from '../hooks/useFolderNavigation';
@@ -320,6 +320,7 @@ const AssetRow = ({ asset, orderedItemKeys, onAssetItemClick }: AssetRowProps) =
       ref={setNodeRef}
       {...attributes}
       {...listeners}
+      {...ASSET_DETAILS_TRIGGER_PROPS}
       $isDragging={isDragging}
       $isMovePending={isMovePending}
       $isBusy={busyMessage !== null}

--- a/packages/core/upload/admin/src/future/pages/Assets/constants.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/constants.ts
@@ -9,6 +9,18 @@ export const viewOptions = {
   TABLE: 1,
 };
 
+const ASSET_DETAILS_TRIGGER_ATTRIBUTE = 'data-asset-details-trigger';
+
+/**
+ * Spread onto grid cards and table rows, whose click opens or switches the
+ * asset details drawer. The drawer's outside-click dismissal skips presses
+ * landing on one of these, so switching assets doesn't close-then-reopen it.
+ */
+export const ASSET_DETAILS_TRIGGER_PROPS = { [ASSET_DETAILS_TRIGGER_ATTRIBUTE]: '' };
+
+/** Matches an element carrying {@link ASSET_DETAILS_TRIGGER_PROPS}. */
+export const ASSET_DETAILS_TRIGGER_SELECTOR = `[${ASSET_DETAILS_TRIGGER_ATTRIBUTE}]`;
+
 interface TableHeader {
   name: string;
   label: { id: string; defaultMessage: string };

--- a/packages/core/upload/admin/src/future/pages/Assets/constants.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/constants.ts
@@ -18,33 +18,20 @@ const ASSET_DETAILS_TRIGGER_ATTRIBUTE = 'data-asset-details-trigger';
  */
 export const ASSET_DETAILS_TRIGGER_PROPS = { [ASSET_DETAILS_TRIGGER_ATTRIBUTE]: '' };
 
-/** Matches an element carrying {@link ASSET_DETAILS_TRIGGER_PROPS}. */
-export const ASSET_DETAILS_TRIGGER_SELECTOR = `[${ASSET_DETAILS_TRIGGER_ATTRIBUTE}]`;
+const ASSET_ITEM_CONTROL_ATTRIBUTE = 'data-asset-item-control';
 
 /**
- * Controls whose press must not dismiss the asset details drawer — the user is
- * operating the list, not leaving it.
- *
- * Roles as well as tags: the design system's checkbox is a Radix button with
- * `role="checkbox"`, and `menuitem`/`option` cover the sort and filter menus,
- * which portal out of the page and so count as outside the panel.
+ * Spread onto the controls inside an asset card or row that act on the item
+ * rather than opening it — its selection checkbox and its actions menu. They
+ * stop the card's own click, so no details switch follows them.
  */
-export const INTERACTIVE_ELEMENT_SELECTOR = [
-  'a',
-  'button',
-  'input',
-  'textarea',
-  'select',
-  'label',
-  '[role="checkbox"]',
-  '[role="combobox"]',
-  '[role="menuitem"]',
-  '[role="menuitemcheckbox"]',
-  '[role="menuitemradio"]',
-  '[role="option"]',
-  '[role="tab"]',
-  '[contenteditable="true"]',
-].join(', ');
+export const ASSET_ITEM_CONTROL_PROPS = { [ASSET_ITEM_CONTROL_ATTRIBUTE]: '' };
+
+/** Matches an element carrying {@link ASSET_ITEM_CONTROL_PROPS}. */
+export const ASSET_ITEM_CONTROL_SELECTOR = `[${ASSET_ITEM_CONTROL_ATTRIBUTE}]`;
+
+/** Matches an element carrying {@link ASSET_DETAILS_TRIGGER_PROPS}. */
+export const ASSET_DETAILS_TRIGGER_SELECTOR = `[${ASSET_DETAILS_TRIGGER_ATTRIBUTE}]`;
 
 interface TableHeader {
   name: string;

--- a/packages/core/upload/admin/src/future/pages/Assets/constants.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/constants.ts
@@ -21,6 +21,31 @@ export const ASSET_DETAILS_TRIGGER_PROPS = { [ASSET_DETAILS_TRIGGER_ATTRIBUTE]: 
 /** Matches an element carrying {@link ASSET_DETAILS_TRIGGER_PROPS}. */
 export const ASSET_DETAILS_TRIGGER_SELECTOR = `[${ASSET_DETAILS_TRIGGER_ATTRIBUTE}]`;
 
+/**
+ * Controls whose press must not dismiss the asset details drawer — the user is
+ * operating the list, not leaving it.
+ *
+ * Roles as well as tags: the design system's checkbox is a Radix button with
+ * `role="checkbox"`, and `menuitem`/`option` cover the sort and filter menus,
+ * which portal out of the page and so count as outside the panel.
+ */
+export const INTERACTIVE_ELEMENT_SELECTOR = [
+  'a',
+  'button',
+  'input',
+  'textarea',
+  'select',
+  'label',
+  '[role="checkbox"]',
+  '[role="combobox"]',
+  '[role="menuitem"]',
+  '[role="menuitemcheckbox"]',
+  '[role="menuitemradio"]',
+  '[role="option"]',
+  '[role="tab"]',
+  '[contenteditable="true"]',
+].join(', ');
+
 interface TableHeader {
   name: string;
   label: { id: string; defaultMessage: string };

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@tests/utils';
 
 import { AssetsGrid } from '../components/AssetsGrid';
 import { BulkActionsBar } from '../components/BulkActionsBar';
+import { ASSET_DETAILS_TRIGGER_SELECTOR, ASSET_ITEM_CONTROL_SELECTOR } from '../constants';
 import { AssetSelectionProvider } from '../hooks/useAssetSelection';
 
 const mockNavigateToFolder = jest.fn();
@@ -197,6 +198,24 @@ describe('AssetsGrid', () => {
 
     // Folder cards are deliberately unmarked: opening a folder should close
     // the drawer, not switch it.
+    // The drawer keeps itself open for a press that switches it, so the card's
+    // own controls have to be distinguishable from the rest of the card.
+    it("marks the asset card's own controls as item-scoped", async () => {
+      setup({ assets: [createMockAsset(7, 'photo.png')] });
+
+      const checkbox = await screen.findByRole('checkbox', { name: 'Select photo.png' });
+      const actions = await screen.findAllByRole('button', { name: 'More actions' });
+
+      /* eslint-disable testing-library/no-node-access */
+      expect(checkbox.closest(ASSET_ITEM_CONTROL_SELECTOR)).not.toBeNull();
+      expect(actions[0].closest(ASSET_ITEM_CONTROL_SELECTOR)).not.toBeNull();
+
+      const card = checkbox.closest(ASSET_DETAILS_TRIGGER_SELECTOR);
+      expect(card).not.toBeNull();
+      expect(card?.matches(ASSET_ITEM_CONTROL_SELECTOR)).toBe(false);
+      /* eslint-enable testing-library/no-node-access */
+    });
+
     it('marks asset cards — and only asset cards — as asset details triggers', () => {
       setup({
         assets: [createMockAsset(7, 'photo.png')],

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
@@ -194,6 +194,20 @@ describe('AssetsGrid', () => {
       expect(cards).toHaveLength(2);
       cards.forEach((card) => expect(card).toHaveAttribute('data-native-context-menu'));
     });
+
+    // Folder cards are deliberately unmarked: opening a folder should close
+    // the drawer, not switch it.
+    it('marks asset cards — and only asset cards — as asset details triggers', () => {
+      setup({
+        assets: [createMockAsset(7, 'photo.png')],
+        folders: [createMockFolder(5, 'Photos')],
+      });
+
+      const [folderCard, assetCard] = screen.getAllByRole('listitem');
+
+      expect(assetCard).toHaveAttribute('data-asset-details-trigger');
+      expect(folderCard).not.toHaveAttribute('data-asset-details-trigger');
+    });
   });
 
   describe('AssetCard', () => {

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 
 import { AssetsTable } from '../components/AssetsTable';
 import { BulkActionsBar } from '../components/BulkActionsBar';
-import { INTERACTIVE_ELEMENT_SELECTOR } from '../constants';
+import { ASSET_DETAILS_TRIGGER_SELECTOR, ASSET_ITEM_CONTROL_SELECTOR } from '../constants';
 import { AssetSelectionProvider } from '../hooks/useAssetSelection';
 
 import type { File } from '../../../../../../shared/contracts/files';
@@ -556,17 +556,23 @@ describe('AssetsTable', () => {
       expect(await screen.findByRole('checkbox', { name: 'Select image2.png' })).not.toBeChecked();
     });
 
-    // The drawer's dismissal policy keys off this selector, so it has to match
-    // what the design system actually renders rather than what it is assumed to.
-    it('renders the selection checkboxes as elements the drawer treats as interactive', async () => {
-      setup({ folders: [createMockFolder(1, 'Photos')], assets: mockAssets });
+    // The drawer keeps itself open for a press that switches it, so the item's
+    // own controls have to be distinguishable from the rest of the row.
+    it("marks the asset row's own controls as item-scoped", async () => {
+      setup({ assets: mockAssets });
 
-      for (const name of ['Select all', 'Select Photos', 'Select image1.png']) {
-        const control = await screen.findByRole('checkbox', { name });
+      const checkbox = await screen.findByRole('checkbox', { name: 'Select image1.png' });
+      const actions = await screen.findAllByRole('button', { name: 'More actions' });
 
-        // eslint-disable-next-line testing-library/no-node-access
-        expect(control.closest(INTERACTIVE_ELEMENT_SELECTOR)).not.toBeNull();
-      }
+      /* eslint-disable testing-library/no-node-access */
+      expect(checkbox.closest(ASSET_ITEM_CONTROL_SELECTOR)).not.toBeNull();
+      expect(actions[0].closest(ASSET_ITEM_CONTROL_SELECTOR)).not.toBeNull();
+
+      // The row itself must stay outside the marker, or nothing would switch.
+      const row = checkbox.closest(ASSET_DETAILS_TRIGGER_SELECTOR);
+      expect(row).not.toBeNull();
+      expect(row?.matches(ASSET_ITEM_CONTROL_SELECTOR)).toBe(false);
+      /* eslint-enable testing-library/no-node-access */
     });
 
     it('selects folders and assets via the header checkbox and shows indeterminate when partial', async () => {

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
@@ -146,6 +146,21 @@ describe('AssetsTable', () => {
       expect(itemRows).toHaveLength(2);
       itemRows.forEach((row) => expect(row).toHaveAttribute('data-native-context-menu'));
     });
+
+    // Folder rows are deliberately unmarked: opening a folder should close
+    // the drawer, not switch it.
+    it('marks asset rows — and only asset rows — as asset details triggers', () => {
+      setup({
+        assets: [createMockAsset(7, 'photo.png')],
+        folders: [createMockFolder(5, 'Photos')],
+      });
+
+      // [0] is the header row, then folders, then assets.
+      const [, folderRow, assetRow] = screen.getAllByRole('row');
+
+      expect(assetRow).toHaveAttribute('data-asset-details-trigger');
+      expect(folderRow).not.toHaveAttribute('data-asset-details-trigger');
+    });
   });
 
   describe('AssetPreviewCell', () => {

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from 'msw';
 
 import { AssetsTable } from '../components/AssetsTable';
 import { BulkActionsBar } from '../components/BulkActionsBar';
+import { INTERACTIVE_ELEMENT_SELECTOR } from '../constants';
 import { AssetSelectionProvider } from '../hooks/useAssetSelection';
 
 import type { File } from '../../../../../../shared/contracts/files';
@@ -553,6 +554,19 @@ describe('AssetsTable', () => {
 
       await user.click(await screen.findByRole('checkbox', { name: 'Select image2.png' }));
       expect(await screen.findByRole('checkbox', { name: 'Select image2.png' })).not.toBeChecked();
+    });
+
+    // The drawer's dismissal policy keys off this selector, so it has to match
+    // what the design system actually renders rather than what it is assumed to.
+    it('renders the selection checkboxes as elements the drawer treats as interactive', async () => {
+      setup({ folders: [createMockFolder(1, 'Photos')], assets: mockAssets });
+
+      for (const name of ['Select all', 'Select Photos', 'Select image1.png']) {
+        const control = await screen.findByRole('checkbox', { name });
+
+        // eslint-disable-next-line testing-library/no-node-access
+        expect(control.closest(INTERACTIVE_ELEMENT_SELECTOR)).not.toBeNull();
+      }
     });
 
     it('selects folders and assets via the header checkbox and shows indeterminate when partial', async () => {


### PR DESCRIPTION
## What does it do?

Adds opt-in **dismiss-on-outside-click** to the future upload `Drawer`, and wires it up for the asset details drawer.

- **`Drawer.Body`** gains an optional `onPointerDownOutside` prop.
  - Omitted (the default), an outside pointer press never closes the drawer — it must be closed explicitly, which long-running panels like the upload progress dialog still rely on.
  - Passed, the consumer opts into outside-click dismissal and can still veto individual presses with `event.preventDefault()`.
  - Focus leaving the panel never closes it: the drawer is non-modal, so focus legitimately moves outside (e.g. tabbing past the last field). Only a pointer press can dismiss.
  - Content portaled out of the panel (DS dialogs, popovers, tooltips) never counts as "outside" — Radix reads the React tree, not the DOM.
- **`AssetDetailsDrawer`** opts in. A press outside closes the drawer through the same `closeDetails` path as the header close button, so the unsaved-changes guard still applies. It keeps the drawer open in two cases:
  - the panel is already animating closed (`forceMount` keeps it listening), and
  - the press landed on another asset's card/row, whose following `click` switches the drawer — closing here would cause a close-then-reopen round trip.
- A shared `data-asset-details-trigger` marker (`ASSET_DETAILS_TRIGGER_PROPS` / `ASSET_DETAILS_TRIGGER_SELECTOR`) is spread onto asset **cards** and **rows** so the drawer can recognise an asset-switching press. Folder cards are deliberately left unmarked — opening a folder should close the drawer, not switch it.

## Why is it needed?

The upload drawer previously blocked all outside interaction unconditionally, so the asset details panel could only be closed via its close button. Clicking away on the page — the expected way to dismiss a details panel — did nothing. This makes outside-click dismissal available without regressing panels that must stay open, and handles the asset-switching and animation edge cases so the interaction feels correct.

## How can it be tested?

`Drawer` and `AssetDetailsDrawer` test suites cover the new behaviour:

- Default: an outside press does **not** close the drawer; opting in, it does; a handler calling `preventDefault()` keeps it open.
- A press inside the panel, or inside content portaled out of it (e.g. the delete confirmation dialog), keeps the drawer open.
- Focus moving outside does not close it.
- A press on another asset keeps the drawer open (switch, not close-then-reopen).
- A drag that starts inside and ends outside does not close it.
- Only asset cards/rows carry `data-asset-details-trigger`; folder cards do not.

```
yarn test:unit packages/core/upload
```

Related: **CMS-1530**
