### PR TITLE
fix(upload): folder navigation resets media library list scroll and p…

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -60,6 +60,7 @@ import { useFolderNavigation } from './hooks/useFolderNavigation';
 import { useInfiniteAssets } from './hooks/useInfiniteAssets';
 import { useInfiniteScrollSentinel } from './hooks/useInfiniteScrollSentinel';
 import { useListFilters } from './hooks/useListFilters';
+import { useListScrollRestoration } from './hooks/useListScrollRestoration';
 import { useListSort, type FoldersPosition } from './hooks/useListSort';
 import { buildAssetFilters } from './utils/buildAssetFilters';
 import { getListQueryKey } from './utils/listQueryKey';
@@ -693,6 +694,8 @@ export const AssetsPage = () => {
     filter: listFilters.serialized || null,
   });
 
+  const scrollAnchorRef = useListScrollRestoration(listQueryKey);
+
   return (
     <>
       <UploadDropZoneProvider onDrop={handleDrop} disabled={!canCreate}>
@@ -718,6 +721,7 @@ export const AssetsPage = () => {
                     {/* Zero-height marker: leaves the viewport as soon as the list
                       scrolls, flipping the header into its compact state. */}
                     <Box ref={headerSentinelRef} height={0} aria-hidden />
+                    <Box ref={scrollAnchorRef} height={0} aria-hidden />
 
                     <StickyHeader $compact={isHeaderCompact}>
                       <TitleRow>

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
@@ -752,6 +752,94 @@ describe('useInfiniteAssets', () => {
     expect(ids[PAGE_SIZE - 1]).toBe(PAGE_SIZE);
   });
 
+  describe('returning to a folder', () => {
+    const rootPage1 = createMockPage(1, 3, 50);
+    const rootPage2 = createMockPage(2, 3, 50);
+    const subfolderPage1 = createMockPage(1, 1, 2, 2);
+
+    /**
+     * The root has three pages, the subfolder one. `whenBack` lets a test return
+     * something other than settled data after the user comes back — modelling a
+     * re-read that is still in flight rather than instant.
+     */
+    const mockFolders = (whenBack?: () => object | undefined) => {
+      mockUseGetAssetsQuery.mockImplementation(
+        ({ folder, page: p }: { folder: number | null; page: number }) => {
+          if (folder !== null) {
+            return subfolderPage1;
+          }
+
+          return whenBack?.() ?? (p === 2 ? rootPage2 : rootPage1);
+        }
+      );
+    };
+
+    it('restores the pages a folder had loaded when the user comes back to it', () => {
+      mockFolders();
+
+      const { getResult, changeFolder } = renderWithFolder();
+
+      act(() => {
+        getResult().fetchNextPage();
+      });
+
+      expect(getResult().assets).toHaveLength(PAGE_SIZE * 2);
+
+      changeFolder(26);
+
+      expect(getResult().assets).toHaveLength(2);
+
+      changeFolder(null);
+
+      expect(getResult().assets).toHaveLength(PAGE_SIZE * 2);
+      // Page 1 is back too, in front — the whole list returned, not just the
+      // page current when the user left.
+      expect(getResult().assets[0].id).toBe(1);
+      expect(getResult().assets[PAGE_SIZE].id).toBe(PAGE_SIZE + 1);
+      // And it resumes at the page it was read to, so the next scroll asks for
+      // page 3 rather than replaying pages the user already has.
+      expect(mockUseGetAssetsQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({ folder: null, page: 2 }),
+        expect.anything()
+      );
+    });
+
+    it('shows the restored rows rather than a spinner while the pages re-read', () => {
+      // Leaving evicts the folder's cache entries, so returning always re-reads.
+      // But rows stay on screen throughout, so it's a refresh, not a load.
+      let hasReturned = false;
+      mockFolders(() => (hasReturned ? PENDING_QUERY : undefined));
+
+      const { getResult, changeFolder } = renderWithFolder();
+
+      act(() => {
+        getResult().fetchNextPage();
+      });
+
+      changeFolder(26);
+      hasReturned = true;
+      changeFolder(null);
+
+      expect(getResult().isLoading).toBe(false);
+      expect(getResult().assets).toHaveLength(PAGE_SIZE * 2);
+      expect(getResult().pagination?.total).toBe(50);
+    });
+
+    it('still reports loading when the list it returns to has nothing to show', () => {
+      // Nothing was ever loaded for folder 26, so there is nothing to restore.
+      mockUseGetAssetsQuery.mockImplementation(({ folder }: { folder: number | null }) =>
+        folder === null ? rootPage1 : PENDING_QUERY
+      );
+
+      const { getResult, changeFolder } = renderWithFolder();
+
+      changeFolder(26);
+
+      expect(getResult().isLoading).toBe(true);
+      expect(getResult().assets).toHaveLength(0);
+    });
+  });
+
   it('returns error from query', () => {
     const mockError = { status: 500, data: 'Server error' };
     mockUseGetAssetsQuery.mockReturnValue({

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListScrollRestoration.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListScrollRestoration.test.ts
@@ -1,0 +1,128 @@
+import { createElement } from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import { useListScrollRestoration } from '../useListScrollRestoration';
+
+/**
+ * Mirrors the admin layout: the media library renders inside a column marked
+ * `data-strapi-main-content`, and that column is what scrolls. `createElement`
+ * rather than JSX so this stays alongside the other `.ts` hook tests.
+ */
+const Harness = ({ listKey }: { listKey: string }) => {
+  const anchorRef = useListScrollRestoration(listKey);
+
+  return createElement(
+    'div',
+    { 'data-strapi-main-content': true, 'data-testid': 'scroll-root' },
+    createElement('div', { ref: anchorRef })
+  );
+};
+
+const renderHarness = (listKey: string) => render(createElement(Harness, { listKey }));
+
+/**
+ * jsdom has no layout, so `scrollTop` accepts anything. Real browsers clamp it
+ * to the content that exists — which is why a restore must survive more than one
+ * commit — so tests that care install a clamping property with a max they set.
+ */
+const clampScrollTop = (element: HTMLElement, getMax: () => number) => {
+  let top = 0;
+
+  Object.defineProperty(element, 'scrollTop', {
+    configurable: true,
+    get: () => top,
+    set: (value: number) => {
+      top = Math.min(value, getMax());
+    },
+  });
+};
+
+const scrollTo = (element: HTMLElement, top: number) => {
+  element.scrollTop = top;
+  fireEvent.scroll(element);
+};
+
+describe('useListScrollRestoration', () => {
+  it('puts back the offset a list was left at', () => {
+    const { getByTestId, rerender } = renderHarness('folder-1');
+    const root = getByTestId('scroll-root');
+
+    scrollTo(root, 640);
+
+    // Into a subfolder: a list never seen before opens at the top.
+    rerender(createElement(Harness, { listKey: 'folder-2' }));
+    expect(root.scrollTop).toBe(0);
+
+    // And back out again.
+    rerender(createElement(Harness, { listKey: 'folder-1' }));
+    expect(root.scrollTop).toBe(640);
+  });
+
+  it('leaves the offset alone while the list key holds steady', () => {
+    const { getByTestId, rerender } = renderHarness('folder-1');
+    const root = getByTestId('scroll-root');
+
+    scrollTo(root, 640);
+    // Loading another page re-renders without changing the list identity.
+    rerender(createElement(Harness, { listKey: 'folder-1' }));
+
+    expect(root.scrollTop).toBe(640);
+  });
+
+  it('keeps trying until the returning list is tall enough to hold the offset', () => {
+    const { getByTestId, rerender } = renderHarness('folder-1');
+    const root = getByTestId('scroll-root');
+
+    let maxScrollTop = 1000;
+    clampScrollTop(root, () => maxScrollTop);
+
+    scrollTo(root, 640);
+
+    // The subfolder is a single short page — nothing to scroll.
+    maxScrollTop = 0;
+    rerender(createElement(Harness, { listKey: 'folder-2' }));
+    expect(root.scrollTop).toBe(0);
+
+    // Back out. The rows have not rendered yet, so the offset is out of reach.
+    rerender(createElement(Harness, { listKey: 'folder-1' }));
+    expect(root.scrollTop).toBe(0);
+
+    // The restored pages land and the column grows back.
+    maxScrollTop = 1000;
+    rerender(createElement(Harness, { listKey: 'folder-1' }));
+    expect(root.scrollTop).toBe(640);
+  });
+
+  it('gives up on a restore the list never grows into', () => {
+    jest.useFakeTimers();
+
+    try {
+      const { getByTestId, rerender } = renderHarness('folder-1');
+      const root = getByTestId('scroll-root');
+
+      let maxScrollTop = 1000;
+      clampScrollTop(root, () => maxScrollTop);
+
+      scrollTo(root, 640);
+
+      maxScrollTop = 0;
+      rerender(createElement(Harness, { listKey: 'folder-2' }));
+      rerender(createElement(Harness, { listKey: 'folder-1' }));
+
+      // Everything the folder held was deleted while the user was away, so the
+      // offset is never reachable. Once the window closes the list stays put
+      // rather than being yanked on some much later render.
+      jest.advanceTimersByTime(5000);
+      rerender(createElement(Harness, { listKey: 'folder-1' }));
+
+      maxScrollTop = 1000;
+      root.scrollTop = 120;
+      rerender(createElement(Harness, { listKey: 'folder-1' }));
+
+      expect(root.scrollTop).toBe(120);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListScrollRestoration.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListScrollRestoration.test.ts
@@ -125,4 +125,40 @@ describe('useListScrollRestoration', () => {
       jest.useRealTimers();
     }
   });
+
+  // The case above leaves the column short for the whole test, so an expired
+  // restore that still ran would be clamped to 0 and look harmless. Here the
+  // pages arrive *after* the window closes, which is when applying the offset
+  // one last time actually moves the viewport.
+  it('does not apply an expired offset once the list finally grows', () => {
+    jest.useFakeTimers();
+
+    try {
+      const { getByTestId, rerender } = renderHarness('folder-1');
+      const root = getByTestId('scroll-root');
+
+      let maxScrollTop = 1000;
+      clampScrollTop(root, () => maxScrollTop);
+
+      scrollTo(root, 640);
+
+      maxScrollTop = 0;
+      rerender(createElement(Harness, { listKey: 'folder-2' }));
+      rerender(createElement(Harness, { listKey: 'folder-1' }));
+      expect(root.scrollTop).toBe(0);
+
+      // The window closes while the rows are still missing.
+      jest.advanceTimersByTime(5000);
+
+      // They land late, and the user has meanwhile scrolled somewhere of their
+      // own choosing. The next commit must leave that alone.
+      maxScrollTop = 1000;
+      scrollTo(root, 120);
+      rerender(createElement(Harness, { listKey: 'folder-1' }));
+
+      expect(root.scrollTop).toBe(120);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListScrollRestoration.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useListScrollRestoration.test.ts
@@ -161,4 +161,26 @@ describe('useListScrollRestoration', () => {
       jest.useRealTimers();
     }
   });
+
+  it('forgets the least recently scrolled list once the cap is passed', () => {
+    const { getByTestId, rerender } = renderHarness('folder-0');
+    const root = getByTestId('scroll-root');
+
+    clampScrollTop(root, () => 5000);
+
+    // Eleven lists, one past the ten-entry cap, each left at its own offset.
+    for (let i = 0; i < 11; i += 1) {
+      rerender(createElement(Harness, { listKey: `folder-${i}` }));
+      scrollTo(root, 100 + i * 10);
+    }
+
+    // The first is the least recently scrolled, so it has been dropped and
+    // opens at the top.
+    rerender(createElement(Harness, { listKey: 'folder-0' }));
+    expect(root.scrollTop).toBe(0);
+
+    // One still inside the cap comes back where it was left.
+    rerender(createElement(Harness, { listKey: 'folder-10' }));
+    expect(root.scrollTop).toBe(200);
+  });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
@@ -13,6 +13,11 @@ import type { File, Pagination } from '../../../../../../shared/contracts/files'
 
 const PAGE_SIZE = 20;
 
+/**
+ * How many list views keep their loaded pages in memory.
+ */
+const MAX_REMEMBERED_LISTS = 10;
+
 interface UseInfiniteAssetsOptions {
   folder?: number | null;
   sort?: string;
@@ -72,6 +77,13 @@ const flattenPages = (pages: Record<number, File[]>): File[] => {
 };
 
 /**
+ * The highest page an accumulator holds — where the list was last read to, and
+ * so where to resume from on the way back.
+ */
+const deepestPage = (pages: Record<number, File[]>): number =>
+  Object.keys(pages).reduce((deepest, key) => Math.max(deepest, Number(key)), 1);
+
+/**
  * Keeps one earlier page's `getAssets` query subscribed and reports its results
  * back up whenever they change.
  *
@@ -112,6 +124,10 @@ const PageSubscriber = ({
  * The caller MUST render the returned `subscribers` node — that is what keeps
  * every loaded page subscribed, so `{Asset, LIST}` invalidations keep the whole
  * list consistent rather than only the current page.
+ *
+ * Loaded pages survive navigating away and back: each list's accumulator is
+ * remembered (LRU, `MAX_REMEMBERED_LISTS`) and restored when its key returns, so
+ * stepping into a subfolder and back out keeps the rows the user scrolled for.
  */
 const useInfiniteAssets = ({
   folder = null,
@@ -135,13 +151,32 @@ const useInfiniteAssets = ({
   const [pageState, setPageState] = useState<PageState>({ queryKey, page: 1 });
   const [accumulated, setAccumulated] = useState<Accumulated>({ queryKey, listKey, pages: {} });
 
-  // Derived rather than read straight from state: the render that discovers
-  // the key change still reaches the query below, and a list with no page 1
-  // must never be requested at page 2.
-  const page = pageState.queryKey === queryKey ? pageState.page : 1;
+  // Each list's loaded pages, kept across navigation away from it.
+  const memoryRef = useRef(new Map<string, Accumulated>());
 
-  if (pageState.queryKey !== queryKey) {
-    setPageState({ queryKey, page: 1 });
+  const isNewList = pageState.queryKey !== queryKey;
+
+  const remembered = isNewList ? memoryRef.current.get(queryKey) : undefined;
+
+  // Derived rather than read from state: the render that discovers the key
+  // change still reaches the query below, and a list with no page 1 must never
+  // be requested at page 2. A remembered list always holds page 1, so resuming
+  // at its deepest page can't skip one.
+  let page: number;
+  if (!isNewList) {
+    page = pageState.page;
+  } else if (remembered) {
+    page = deepestPage(remembered.pages);
+  } else {
+    page = 1;
+  }
+
+  if (isNewList) {
+    setPageState({ queryKey, page });
+
+    if (remembered) {
+      setAccumulated(remembered);
+    }
   }
 
   const { currentData, isLoading, isFetching, error, startedTimeStamp, fulfilledTimeStamp } =
@@ -159,7 +194,12 @@ const useInfiniteAssets = ({
   // `currentData` is only ever the payload for the args just passed, so it
   // belongs to this key at this page — nothing to infer. Its reference is
   // stable per cache entry, so this settles after one extra render.
-  if (currentData && (!isSameQuery || accumulated.pages[page] !== currentData.results)) {
+  if (
+    // A restore already set the accumulator from memory; don't overwrite it.
+    !remembered &&
+    currentData &&
+    (!isSameQuery || accumulated.pages[page] !== currentData.results)
+  ) {
     setAccumulated(
       isSameQuery
         ? {
@@ -209,6 +249,32 @@ const useInfiniteAssets = ({
     )
   );
 
+  // Remember what this list has read, so leaving it isn't forgetting it. Filed
+  // under `accumulated.queryKey`, not the live `queryKey`: the accumulator names
+  // the list it belongs to, so an entry still describing the list being left
+  // can't be misfiled under the one being entered.
+  useEffect(() => {
+    if (Object.keys(accumulated.pages).length === 0) {
+      return;
+    }
+
+    const memory = memoryRef.current;
+    // Delete before set so the entry moves to the end. Map iterates in
+    // insertion order, so the first key is the least recently used.
+    memory.delete(accumulated.queryKey);
+    memory.set(accumulated.queryKey, accumulated);
+
+    while (memory.size > MAX_REMEMBERED_LISTS) {
+      const oldest = memory.keys().next();
+
+      if (oldest.done) {
+        break;
+      }
+
+      memory.delete(oldest.value);
+    }
+  }, [accumulated]);
+
   // Drop the left folder's cached `getAssets` pages when the folder changes.
   //
   // RTK Query 1.9.7 leaves a query's store subscription in place when its last
@@ -218,8 +284,9 @@ const useInfiniteAssets = ({
   // next `{Asset, LIST}` invalidation (an upload in the new folder) refetch the
   // *previous* folder's pages: one bogus `/upload/files` request per loaded
   // page. There is no public per-entry unsubscribe, so evict the left folder's
-  // entries outright — returning reloads from page 1, which the accumulator
-  // already does on a list change.
+  // entries outright. Returning then re-reads every page it had loaded, but the
+  // rows come straight back from the accumulator memory above — so those
+  // requests refresh a list already on screen rather than being waited on.
   const dispatch = useDispatch();
   const store = useStore();
   const prevFolderRef = useRef(folder);
@@ -321,6 +388,11 @@ const useInfiniteAssets = ({
   ]);
   const isFetchingMore = isFetching && page > 1;
 
+  // A restored list already has rows on screen, so re-reading its current page
+  // is a background refresh — reporting it as loading would swap those rows for
+  // a spinner. Only an empty list has nothing better to show.
+  const isLoadingList = isChangingList || (isLoading && assets.length === 0);
+
   const fetchNextPage = useCallback(() => {
     setPageState((prev) => ({
       queryKey,
@@ -348,7 +420,7 @@ const useInfiniteAssets = ({
     // Falls back to the accumulated total so a consumer showing the count
     // doesn't flash zero mid-transition, matching the possibly stale `assets`.
     pagination: currentData?.pagination ?? accumulated.pagination,
-    isLoading: isLoading || isChangingList,
+    isLoading: isLoadingList,
     isFetchingMore,
     hasNextPage,
     fetchNextPage,

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useListScrollRestoration.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useListScrollRestoration.ts
@@ -92,11 +92,19 @@ export const useListScrollRestoration = (key: string) => {
       return;
     }
 
+    // Before the assignment, not alongside it: past the window the offset has to
+    // be dropped rather than applied one final time to a list the user has since
+    // scrolled themselves.
+    if (Date.now() > pending.deadline) {
+      pendingRef.current = null;
+      return;
+    }
+
     container.scrollTop = pending.top;
 
     // The browser clamps to the content that exists now, so a target the list
     // isn't tall enough for yet stays pending for the next commit.
-    if (container.scrollTop >= pending.top || Date.now() > pending.deadline) {
+    if (container.scrollTop >= pending.top) {
       pendingRef.current = null;
     }
   });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useListScrollRestoration.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useListScrollRestoration.ts
@@ -17,6 +17,13 @@ const SCROLL_ROOT_SELECTOR = '[data-strapi-main-content]';
  */
 const RESTORE_WINDOW_MS = 2000;
 
+/**
+ * How many list offsets to keep. Matches `MAX_REMEMBERED_LISTS` in
+ * `useInfiniteAssets`: the two are keyed identically, so they should forget on
+ * the same terms.
+ */
+const MAX_REMEMBERED_OFFSETS = 10;
+
 interface PendingRestore {
   top: number;
   deadline: number;
@@ -57,7 +64,22 @@ export const useListScrollRestoration = (key: string) => {
     }
 
     const handleScroll = () => {
-      offsetsRef.current.set(keyRef.current, container.scrollTop);
+      const offsets = offsetsRef.current;
+
+      // Delete before set so the entry moves to the end. Map iterates in
+      // insertion order, so the first key is the least recently scrolled.
+      offsets.delete(keyRef.current);
+      offsets.set(keyRef.current, container.scrollTop);
+
+      while (offsets.size > MAX_REMEMBERED_OFFSETS) {
+        const oldest = offsets.keys().next().value;
+
+        if (oldest === undefined) {
+          break;
+        }
+
+        offsets.delete(oldest);
+      }
     };
 
     container.addEventListener('scroll', handleScroll, { passive: true });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useListScrollRestoration.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useListScrollRestoration.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+
+/**
+ * The admin layout marks the element that scrolls the main column (see
+ * `Layouts.Root`). The media library has no scroll container of its own, so the
+ * offset to save and restore belongs to that ancestor.
+ */
+const SCROLL_ROOT_SELECTOR = '[data-strapi-main-content]';
+
+/**
+ * How long a restore keeps retrying after the list key changes.
+ *
+ * A returning list usually comes back from memory in one commit, so the first
+ * attempt lands. When it doesn't — pages still loading, so the content isn't yet
+ * tall enough to scroll that far — later commits retry. Past this window the
+ * offset is dropped rather than yanked out from under someone already reading.
+ */
+const RESTORE_WINDOW_MS = 2000;
+
+interface PendingRestore {
+  top: number;
+  deadline: number;
+}
+
+/**
+ * Remembers where each list was scrolled to and puts it back on return.
+ *
+ * `key` fingerprints the list on screen (folder, search, sort, filters). While
+ * it holds steady the current offset is recorded; when it changes the incoming
+ * key's saved offset is restored, or the list is sent to the top if it has none
+ * — a first visit, or one whose entry has been dropped.
+ *
+ * Returns a callback ref to place on any element inside the scrolling column;
+ * it only locates that column, it is never scrolled itself.
+ *
+ * Restoring a *position* only helps if the rows that filled it come back too —
+ * that is `useInfiniteAssets`' job.
+ */
+export const useListScrollRestoration = (key: string) => {
+  const offsetsRef = useRef(new Map<string, number>());
+  const containerRef = useRef<HTMLElement | null>(null);
+  const detachRef = useRef<(() => void) | null>(null);
+  // The key offsets are currently filed under. In a ref because the scroll
+  // listener is attached once and must read the current value.
+  const keyRef = useRef(key);
+  const pendingRef = useRef<PendingRestore | null>(null);
+
+  const anchorRef = useCallback((node: HTMLElement | null) => {
+    detachRef.current?.();
+    detachRef.current = null;
+    containerRef.current = null;
+
+    const container = node?.closest<HTMLElement>(SCROLL_ROOT_SELECTOR);
+
+    if (!container) {
+      return;
+    }
+
+    const handleScroll = () => {
+      offsetsRef.current.set(keyRef.current, container.scrollTop);
+    };
+
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    containerRef.current = container;
+    detachRef.current = () => container.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  useEffect(() => () => detachRef.current?.(), []);
+
+  // Runs on every commit, not just when `key` changes: a restore the first
+  // commit was too short to satisfy must be retried as the rows arrive, and
+  // there is no state to key that off. Layout phase so the list is never
+  // painted at the wrong offset.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    if (keyRef.current !== key) {
+      keyRef.current = key;
+      pendingRef.current = {
+        top: offsetsRef.current.get(key) ?? 0,
+        deadline: Date.now() + RESTORE_WINDOW_MS,
+      };
+    }
+
+    const pending = pendingRef.current;
+
+    if (!pending) {
+      return;
+    }
+
+    container.scrollTop = pending.top;
+
+    // The browser clamps to the content that exists now, so a target the list
+    // isn't tall enough for yet stays pending for the next commit.
+    if (container.scrollTop >= pending.top || Date.now() > pending.deadline) {
+      pendingRef.current = null;
+    }
+  });
+
+  return anchorRef;
+};

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
@@ -388,6 +388,27 @@ describe('AssetsPage search', () => {
       expect(screen.getAllByText(/^page-one-/)).toHaveLength(20);
     });
 
+    it('brings the loaded pages back when a folder is re-entered, without scrolling again', async () => {
+      respondWithPagedAssets();
+
+      const { user } = renderPage('?folder=1');
+
+      expect(await screen.findByText('page-one-0.png')).toBeInTheDocument();
+
+      await scrollToLoadMore();
+      expect(await screen.findByText('page-two.png')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Go to root' }));
+      expect(await screen.findByText('root.png')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Go to folder 1' }));
+
+      // No second `scrollToLoadMore` on purpose: coming back shows what had been
+      // read, not page 1 with all the scrolling to do over.
+      expect(await screen.findByText('page-two.png')).toBeInTheDocument();
+      expect(screen.getAllByText(/^page-one-/)).toHaveLength(20);
+    });
+
     it('refetches an earlier page after a mutation invalidation (the subscribers node is rendered)', async () => {
       // Page-level guard for the "caller must render `subscribers`" contract: if
       // AssetsPage drops that node, page 1 stops being subscribed, so the rename


### PR DESCRIPTION
## What does it do?

Preserves the media library list's **loaded pages** and **scroll offset** when navigating away from a folder and back.

- **`useInfiniteAssets`** now remembers each list's accumulated pages, keyed by list identity (folder, search, sort, filters) with an LRU cap (`MAX_REMEMBERED_LISTS = 10`). Returning to a list restores its full accumulator — every page it had loaded, not just the one current when the user left — and resumes paging from its deepest page, so the next scroll asks for the following page rather than replaying pages already on screen.
  - Because leaving a folder still evicts its RTK Query cache entries (to avoid stray refetches), returning re-reads its pages. But the rows come straight back from the accumulator, so it reads as a background **refresh**, not a load: `isLoading` stays `false` and the restored rows stay on screen. A list with genuinely nothing to restore still reports loading.
- **`useListScrollRestoration`** (new hook) saves and restores the scroll offset of the admin main-content column (`[data-strapi-main-content]`) per list key. When a returning list isn't yet tall enough to hold the saved offset (pages still loading), it retries across commits for a short window (`RESTORE_WINDOW_MS = 2000`), then gives up rather than yanking the position out from under someone who has started scrolling. `AssetsPage` renders a zero-height anchor and wires in the hook.

## Why is it needed?

Stepping into a subfolder and back out reset the media library to page 1 at the top, discarding whatever the user had scrolled and loaded. In a large folder that meant re-scrolling and re-fetching from the start every time. Now leaving and returning restores both the loaded rows and the scroll position.

## How can it be tested?

New and extended unit tests cover the behaviour:

- `useInfiniteAssets`: returning to a folder restores all previously loaded pages (page 1 included, in order) and resumes at the deepest page; restored rows show immediately instead of a spinner while pages re-read; a list with nothing to restore still reports loading.
- `useListScrollRestoration`: restores the offset a list was left at; leaves it alone while the list key is steady; retries until the returning list is tall enough to hold the offset; gives up on an offset the list never grows into (rather than yanking a later scroll).

```
yarn test:unit packages/core/upload
```

Related: **CMS-1612**
