### PR TITLE
chore(lint): make oxlint a blocking ci gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,12 +125,11 @@ jobs:
         run: yarn nx affected --target=lint --parallel --nx-ignore-cycles
 
   lint_oxlint:
-    name: 'lint_oxlint (observation)'
+    name: 'lint_oxlint'
     runs-on: ubuntu-latest
     needs: [conditions]
     if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true'
     timeout-minutes: 10
-    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -140,7 +139,7 @@ jobs:
           node-version: 22
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
-      - name: Run OxLint (non-blocking)
+      - name: Run OxLint
         run: yarn lint:oxlint
 
   typescript:
@@ -690,6 +689,7 @@ jobs:
       [
         pretty,
         lint,
+        lint_oxlint,
         build,
         docs_build,
         typescript,

--- a/packages/plugins/users-permissions/server/src/controllers/__tests__/auth-sessions.test.js
+++ b/packages/plugins/users-permissions/server/src/controllers/__tests__/auth-sessions.test.js
@@ -323,6 +323,7 @@ describe('Auth controller - sessions', () => {
               domain: 'example.com',
               sameSite: 'strict',
               secure: true,
+              maxAge: 3600000,
             },
           };
         }
@@ -349,6 +350,7 @@ describe('Auth controller - sessions', () => {
           expires: expect.any(Date),
         })
       );
+      expect(ctx.cookies.set.mock.calls[0][2]).not.toHaveProperty('maxAge');
     });
   });
 });

--- a/packages/utils/oxlint-config/base.ts
+++ b/packages/utils/oxlint-config/base.ts
@@ -53,5 +53,7 @@ export const base = {
     // .github/actions/check-pr-status has an Nx lint target; these paths do not.
     '.github/scripts/**',
     '.github/actions/community-pr-triage/**',
+    // Parser TS(1016) on can/cannot cannot be suppressed locally; restore via CMS-1692.
+    'packages/core/content-manager/server/src/services/permission-checker.ts',
   ],
 } satisfies Partial<OxlintConfig>;


### PR DESCRIPTION
### What does it do?

This PR turns OxLint into a required CI check. The `lint_oxlint` job no longer continues on error, and a failure now fails `aggregate_test_result`.

To keep that job green, it also clears the last correctness leftovers: a redundant empty-object fallback when spreading audit-log payloads, and an unused `maxAge` binding when clearing the users-permissions refresh cookie on logout. Logout still expires the cookie with `expires: new Date(0)` and does not send `maxAge`.

OxLint still cannot suppress parser `TS(1016)` on `can` / `cannot` in the content-manager permission checker, where a required `field` follows an optional `entity`. Inline disables, rule offs, and bulk suppressions do not apply to parser diagnostics. This PR skips that one file in OxLint so the gate can ship. ESLint still lints it. Restore OxLint coverage once parser diagnostics can be suppressed locally, or once those signatures can change without reopening the call contract. A previous attempt to change the signatures is closed [#27190](https://github.com/strapi/strapi/pull/27190).

ESLint stays in dual-run. Extra OxLint categories are out of scope here and should land as later PRs after this gate is in place.

### Why is it needed?

[#26923](https://github.com/strapi/strapi/pull/26923) landed OxLint as an observational sidecar. Correctness is now clean except that closed skip, so new OxLint diagnostics should fail CI from this PR onward.

### How to test it?

From the repo root, with Node 22 and a yarn install:

1. Run `yarn lint:oxlint`. It should exit 0.
2. On GitHub Actions, confirm `lint_oxlint` is no longer named `(observation)`, has no `continue-on-error`, and is listed under `aggregate_test_result`.
3. Run the users-permissions auth-sessions unit tests and confirm logout cookie clear still sets `expires` and does not send `maxAge`.

### Related issues / PRs

- #26923 — non-blocking OxLint sidecar this PR promotes to a required check
- #27190 — closed signature change for the permission checker (not revived; file skipped instead)

---

_AI assisted_
