### PR TITLE
future(upload): right-click actions in assetspage

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -460,24 +460,6 @@ const SearchSlot = styled(Box)`
   }
 `;
 
-// The main column normally ends with its content, which left the right-click
-// area stopping at the last row — the one place the gesture is most natural.
-// These two give the column a height to hand down to `MainAreaContextMenu`.
-// `min-height`, never `height`, so a long list still grows past the fold; and
-// if the percentage can't resolve, the chain degrades to `auto` and the layout
-// is exactly what it was.
-const FullHeightMain = styled(Page.Main)`
-  display: flex;
-  flex-direction: column;
-  min-height: 100%;
-`;
-
-const PageBody = styled(Box)`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-`;
-
 // Toggle labels are hidden below desktop — icons only (buttons keep aria-label).
 const ToggleLabel = styled.span`
   display: none;
@@ -731,8 +713,8 @@ export const AssetsPage = () => {
                   />
                 }
               >
-                <FullHeightMain>
-                  <PageBody ref={uploadDropZoneRef}>
+                <Page.Main>
+                  <Box ref={uploadDropZoneRef}>
                     <VisuallyHidden>
                       <input type="file" ref={fileInputRef} onChange={handleFileChange} multiple />
                     </VisuallyHidden>
@@ -742,160 +724,157 @@ export const AssetsPage = () => {
                     <Box ref={headerSentinelRef} height={0} aria-hidden />
                     <Box ref={scrollAnchorRef} height={0} aria-hidden />
 
-                    {/* Right-clicking the empty parts of the area offers the same
-                        creation actions as the "New" menu, acting on the folder
-                        currently open. Wraps the header too: its empty band reads
-                        as part of the same surface, and its controls are already
-                        excluded — as is the table's own header row, which will
-                        become interactive once columns are sortable. Items keep
-                        the browser's own menu — see MainAreaContextMenu. */}
+                    {/* Renders no wrapper: it listens on the scrolling column
+                        itself, so the header band and the padding below the list
+                        are both in the hit area. Interactive controls, the table
+                        header row and the list items are excluded — see
+                        MainAreaContextMenu. */}
                     <MainAreaContextMenu
                       disabled={!canCreate}
                       onCreateFolder={() => setIsCreateFolderDialogOpen(true)}
                       onImportFiles={handleFileSelect}
                       onImportFromUrl={() => setIsUrlDialogOpen(true)}
-                    >
-                      <StickyHeader $compact={isHeaderCompact}>
-                        <TitleRow>
-                          <Typography variant="alpha" tag="h1">
-                            {pageHeaderTitle}
-                          </Typography>
-                          {canCreate && (
-                            <SimpleMenu
-                              popoverPlacement="bottom-end"
-                              variant="default"
-                              endIcon={<ChevronDown />}
-                              label={formatMessage({
-                                id: getTranslationKey('new'),
-                                defaultMessage: 'New',
-                              })}
+                    />
+                    <StickyHeader $compact={isHeaderCompact}>
+                      <TitleRow>
+                        <Typography variant="alpha" tag="h1">
+                          {pageHeaderTitle}
+                        </Typography>
+                        {canCreate && (
+                          <SimpleMenu
+                            popoverPlacement="bottom-end"
+                            variant="default"
+                            endIcon={<ChevronDown />}
+                            label={formatMessage({
+                              id: getTranslationKey('new'),
+                              defaultMessage: 'New',
+                            })}
+                          >
+                            <MenuItem
+                              onSelect={() => setIsCreateFolderDialogOpen(true)}
+                              startIcon={<FolderIcon />}
                             >
-                              <MenuItem
-                                onSelect={() => setIsCreateFolderDialogOpen(true)}
-                                startIcon={<FolderIcon />}
-                              >
-                                {formatMessage({
-                                  id: getTranslationKey('folder.create.title'),
-                                  defaultMessage: 'New folder',
-                                })}
-                              </MenuItem>
-                              <MenuItem onSelect={handleFileSelect} startIcon={<Files />}>
-                                {formatMessage({
-                                  id: getTranslationKey('import-files'),
-                                  defaultMessage: 'File upload',
-                                })}
-                              </MenuItem>
-                              <MenuItem
-                                onSelect={() => setIsUrlDialogOpen(true)}
-                                startIcon={<Link />}
-                              >
-                                {formatMessage({
-                                  id: getTranslationKey('import-from-url'),
-                                  defaultMessage: 'File upload from URL',
-                                })}
-                              </MenuItem>
-                            </SimpleMenu>
-                          )}
-                        </TitleRow>
+                              {formatMessage({
+                                id: getTranslationKey('folder.create.title'),
+                                defaultMessage: 'New folder',
+                              })}
+                            </MenuItem>
+                            <MenuItem onSelect={handleFileSelect} startIcon={<Files />}>
+                              {formatMessage({
+                                id: getTranslationKey('import-files'),
+                                defaultMessage: 'File upload',
+                              })}
+                            </MenuItem>
+                            <MenuItem
+                              onSelect={() => setIsUrlDialogOpen(true)}
+                              startIcon={<Link />}
+                            >
+                              {formatMessage({
+                                id: getTranslationKey('import-from-url'),
+                                defaultMessage: 'File upload from URL',
+                              })}
+                            </MenuItem>
+                          </SimpleMenu>
+                        )}
+                      </TitleRow>
 
-                        <Toolbar $compact={isHeaderCompact}>
-                          <FilterSearchGroup>
-                            <Box>
-                              <FilterMenu listFilters={listFilters} />
-                            </Box>
-                            <SearchSlot>
-                              <AssetsSearchInput />
-                            </SearchSlot>
-                          </FilterSearchGroup>
-                          <SortToggleGroup>
-                            <Box>
-                              <SortMenu sort={listSort} showFoldersGroup={!isGridView} />
-                            </Box>
-                            <StyledToggleGroup
-                              type="single"
-                              value={isGridView ? 'grid' : 'table'}
-                              onValueChange={(value) =>
-                                value &&
-                                setView(value === 'grid' ? viewOptions.GRID : viewOptions.TABLE)
-                              }
+                      <Toolbar $compact={isHeaderCompact}>
+                        <FilterSearchGroup>
+                          <Box>
+                            <FilterMenu listFilters={listFilters} />
+                          </Box>
+                          <SearchSlot>
+                            <AssetsSearchInput />
+                          </SearchSlot>
+                        </FilterSearchGroup>
+                        <SortToggleGroup>
+                          <Box>
+                            <SortMenu sort={listSort} showFoldersGroup={!isGridView} />
+                          </Box>
+                          <StyledToggleGroup
+                            type="single"
+                            value={isGridView ? 'grid' : 'table'}
+                            onValueChange={(value) =>
+                              value &&
+                              setView(value === 'grid' ? viewOptions.GRID : viewOptions.TABLE)
+                            }
+                            aria-label={formatMessage({
+                              id: getTranslationKey('view.switch.label'),
+                              defaultMessage: 'View options',
+                            })}
+                          >
+                            <StyledToggleItem
+                              value="table"
                               aria-label={formatMessage({
-                                id: getTranslationKey('view.switch.label'),
-                                defaultMessage: 'View options',
+                                id: getTranslationKey('view.table'),
+                                defaultMessage: 'Table view',
                               })}
                             >
-                              <StyledToggleItem
-                                value="table"
-                                aria-label={formatMessage({
+                              <List />
+                              <ToggleLabel>
+                                {formatMessage({
                                   id: getTranslationKey('view.table'),
                                   defaultMessage: 'Table view',
                                 })}
-                              >
-                                <List />
-                                <ToggleLabel>
-                                  {formatMessage({
-                                    id: getTranslationKey('view.table'),
-                                    defaultMessage: 'Table view',
-                                  })}
-                                </ToggleLabel>
-                              </StyledToggleItem>
-                              <StyledToggleItem
-                                value="grid"
-                                aria-label={formatMessage({
+                              </ToggleLabel>
+                            </StyledToggleItem>
+                            <StyledToggleItem
+                              value="grid"
+                              aria-label={formatMessage({
+                                id: getTranslationKey('view.grid'),
+                                defaultMessage: 'Grid view',
+                              })}
+                            >
+                              <GridIcon />
+                              <ToggleLabel>
+                                {formatMessage({
                                   id: getTranslationKey('view.grid'),
                                   defaultMessage: 'Grid view',
                                 })}
-                              >
-                                <GridIcon />
-                                <ToggleLabel>
-                                  {formatMessage({
-                                    id: getTranslationKey('view.grid'),
-                                    defaultMessage: 'Grid view',
-                                  })}
-                                </ToggleLabel>
-                              </StyledToggleItem>
-                            </StyledToggleGroup>
-                          </SortToggleGroup>
-                        </Toolbar>
+                              </ToggleLabel>
+                            </StyledToggleItem>
+                          </StyledToggleGroup>
+                        </SortToggleGroup>
+                      </Toolbar>
 
-                        <FilterBadges listFilters={listFilters} compact={isHeaderCompact} />
-                      </StickyHeader>
+                      <FilterBadges listFilters={listFilters} compact={isHeaderCompact} />
+                    </StickyHeader>
 
-                      <Layouts.Content>
-                        <BetaNotice />
-                        {/* Renders nothing — keeps every loaded page's query subscribed
-                            so a rename/delete refreshes the whole list. */}
-                        {assetPageSubscribers}
-                        <DropZoneWithOverlay>
-                          <DropFilesMessage
-                            uploadDropZoneRef={uploadDropZoneRef}
-                            folderName={title}
-                          />
-                          <AssetsView
-                            view={view}
-                            folders={folders}
-                            isLoadingFolders={isLoadingFolders}
-                            assets={assets}
-                            isLoadingAssets={isLoadingAssets}
-                            isFetchingMore={isFetchingMore}
-                            hasNextPage={hasNextPage}
-                            fetchNextPage={fetchNextPage}
-                            error={assetsError}
-                            locations={itemLocations}
-                            searchQuery={searchQuery}
-                            assetsSort={listSort.assetsSort}
-                            foldersPosition={listSort.foldersPosition}
-                            hasActiveFilters={listFilters.filters.length > 0}
-                            onClearFilters={listFilters.clearFilters}
-                            onAssetItemClick={openDetails}
-                            onAddAssets={handleFileSelect}
-                            canAddAssets={canCreate}
-                            onClearSearch={clearSearch}
-                          />
-                        </DropZoneWithOverlay>
-                      </Layouts.Content>
-                    </MainAreaContextMenu>
-                  </PageBody>
-                </FullHeightMain>
+                    <Layouts.Content>
+                      <BetaNotice />
+                      {/* Renders nothing — keeps every loaded page's query subscribed
+                          so a rename/delete refreshes the whole list. */}
+                      {assetPageSubscribers}
+                      <DropZoneWithOverlay>
+                        <DropFilesMessage
+                          uploadDropZoneRef={uploadDropZoneRef}
+                          folderName={title}
+                        />
+                        <AssetsView
+                          view={view}
+                          folders={folders}
+                          isLoadingFolders={isLoadingFolders}
+                          assets={assets}
+                          isLoadingAssets={isLoadingAssets}
+                          isFetchingMore={isFetchingMore}
+                          hasNextPage={hasNextPage}
+                          fetchNextPage={fetchNextPage}
+                          error={assetsError}
+                          locations={itemLocations}
+                          searchQuery={searchQuery}
+                          assetsSort={listSort.assetsSort}
+                          foldersPosition={listSort.foldersPosition}
+                          hasActiveFilters={listFilters.filters.length > 0}
+                          onClearFilters={listFilters.clearFilters}
+                          onAssetItemClick={openDetails}
+                          onAddAssets={handleFileSelect}
+                          canAddAssets={canCreate}
+                          onClearSearch={clearSearch}
+                        />
+                      </DropZoneWithOverlay>
+                    </Layouts.Content>
+                  </Box>
+                </Page.Main>
               </Layouts.Root>
             </AssetsDndProvider>
           </BusyAssetsProvider>

--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -742,121 +742,124 @@ export const AssetsPage = () => {
                     <Box ref={headerSentinelRef} height={0} aria-hidden />
                     <Box ref={scrollAnchorRef} height={0} aria-hidden />
 
-                    <StickyHeader $compact={isHeaderCompact}>
-                      <TitleRow>
-                        <Typography variant="alpha" tag="h1">
-                          {pageHeaderTitle}
-                        </Typography>
-                        {canCreate && (
-                          <SimpleMenu
-                            popoverPlacement="bottom-end"
-                            variant="default"
-                            endIcon={<ChevronDown />}
-                            label={formatMessage({
-                              id: getTranslationKey('new'),
-                              defaultMessage: 'New',
-                            })}
-                          >
-                            <MenuItem
-                              onSelect={() => setIsCreateFolderDialogOpen(true)}
-                              startIcon={<FolderIcon />}
-                            >
-                              {formatMessage({
-                                id: getTranslationKey('folder.create.title'),
-                                defaultMessage: 'New folder',
-                              })}
-                            </MenuItem>
-                            <MenuItem onSelect={handleFileSelect} startIcon={<Files />}>
-                              {formatMessage({
-                                id: getTranslationKey('import-files'),
-                                defaultMessage: 'Import files',
-                              })}
-                            </MenuItem>
-                            <MenuItem
-                              onSelect={() => setIsUrlDialogOpen(true)}
-                              startIcon={<Link />}
-                            >
-                              {formatMessage({
-                                id: getTranslationKey('import-from-url'),
-                                defaultMessage: 'Import from URL',
-                              })}
-                            </MenuItem>
-                          </SimpleMenu>
-                        )}
-                      </TitleRow>
-
-                      <Toolbar $compact={isHeaderCompact}>
-                        <FilterSearchGroup>
-                          <Box>
-                            <FilterMenu listFilters={listFilters} />
-                          </Box>
-                          <SearchSlot>
-                            <AssetsSearchInput />
-                          </SearchSlot>
-                        </FilterSearchGroup>
-                        <SortToggleGroup>
-                          <Box>
-                            <SortMenu sort={listSort} showFoldersGroup={!isGridView} />
-                          </Box>
-                          <StyledToggleGroup
-                            type="single"
-                            value={isGridView ? 'grid' : 'table'}
-                            onValueChange={(value) =>
-                              value &&
-                              setView(value === 'grid' ? viewOptions.GRID : viewOptions.TABLE)
-                            }
-                            aria-label={formatMessage({
-                              id: getTranslationKey('view.switch.label'),
-                              defaultMessage: 'View options',
-                            })}
-                          >
-                            <StyledToggleItem
-                              value="table"
-                              aria-label={formatMessage({
-                                id: getTranslationKey('view.table'),
-                                defaultMessage: 'Table view',
-                              })}
-                            >
-                              <List />
-                              <ToggleLabel>
-                                {formatMessage({
-                                  id: getTranslationKey('view.table'),
-                                  defaultMessage: 'Table view',
-                                })}
-                              </ToggleLabel>
-                            </StyledToggleItem>
-                            <StyledToggleItem
-                              value="grid"
-                              aria-label={formatMessage({
-                                id: getTranslationKey('view.grid'),
-                                defaultMessage: 'Grid view',
-                              })}
-                            >
-                              <GridIcon />
-                              <ToggleLabel>
-                                {formatMessage({
-                                  id: getTranslationKey('view.grid'),
-                                  defaultMessage: 'Grid view',
-                                })}
-                              </ToggleLabel>
-                            </StyledToggleItem>
-                          </StyledToggleGroup>
-                        </SortToggleGroup>
-                      </Toolbar>
-
-                      <FilterBadges listFilters={listFilters} compact={isHeaderCompact} />
-                    </StickyHeader>
-
-                    {/* Right-clicking the empty parts of the list offers the same
-                        creation actions as the "New" menu above, acting on the
-                        folder currently open. Items keep the browser's own menu —
-                        see MainAreaContextMenu. */}
+                    {/* Right-clicking the empty parts of the area offers the same
+                        creation actions as the "New" menu, acting on the folder
+                        currently open. Wraps the header too: its empty band reads
+                        as part of the same surface, and its controls are already
+                        excluded — as is the table's own header row, which will
+                        become interactive once columns are sortable. Items keep
+                        the browser's own menu — see MainAreaContextMenu. */}
                     <MainAreaContextMenu
                       disabled={!canCreate}
                       onCreateFolder={() => setIsCreateFolderDialogOpen(true)}
                       onImportFiles={handleFileSelect}
                       onImportFromUrl={() => setIsUrlDialogOpen(true)}
                     >
+                      <StickyHeader $compact={isHeaderCompact}>
+                        <TitleRow>
+                          <Typography variant="alpha" tag="h1">
+                            {pageHeaderTitle}
+                          </Typography>
+                          {canCreate && (
+                            <SimpleMenu
+                              popoverPlacement="bottom-end"
+                              variant="default"
+                              endIcon={<ChevronDown />}
+                              label={formatMessage({
+                                id: getTranslationKey('new'),
+                                defaultMessage: 'New',
+                              })}
+                            >
+                              <MenuItem
+                                onSelect={() => setIsCreateFolderDialogOpen(true)}
+                                startIcon={<FolderIcon />}
+                              >
+                                {formatMessage({
+                                  id: getTranslationKey('folder.create.title'),
+                                  defaultMessage: 'New folder',
+                                })}
+                              </MenuItem>
+                              <MenuItem onSelect={handleFileSelect} startIcon={<Files />}>
+                                {formatMessage({
+                                  id: getTranslationKey('import-files'),
+                                  defaultMessage: 'File upload',
+                                })}
+                              </MenuItem>
+                              <MenuItem
+                                onSelect={() => setIsUrlDialogOpen(true)}
+                                startIcon={<Link />}
+                              >
+                                {formatMessage({
+                                  id: getTranslationKey('import-from-url'),
+                                  defaultMessage: 'File upload from URL',
+                                })}
+                              </MenuItem>
+                            </SimpleMenu>
+                          )}
+                        </TitleRow>
+
+                        <Toolbar $compact={isHeaderCompact}>
+                          <FilterSearchGroup>
+                            <Box>
+                              <FilterMenu listFilters={listFilters} />
+                            </Box>
+                            <SearchSlot>
+                              <AssetsSearchInput />
+                            </SearchSlot>
+                          </FilterSearchGroup>
+                          <SortToggleGroup>
+                            <Box>
+                              <SortMenu sort={listSort} showFoldersGroup={!isGridView} />
+                            </Box>
+                            <StyledToggleGroup
+                              type="single"
+                              value={isGridView ? 'grid' : 'table'}
+                              onValueChange={(value) =>
+                                value &&
+                                setView(value === 'grid' ? viewOptions.GRID : viewOptions.TABLE)
+                              }
+                              aria-label={formatMessage({
+                                id: getTranslationKey('view.switch.label'),
+                                defaultMessage: 'View options',
+                              })}
+                            >
+                              <StyledToggleItem
+                                value="table"
+                                aria-label={formatMessage({
+                                  id: getTranslationKey('view.table'),
+                                  defaultMessage: 'Table view',
+                                })}
+                              >
+                                <List />
+                                <ToggleLabel>
+                                  {formatMessage({
+                                    id: getTranslationKey('view.table'),
+                                    defaultMessage: 'Table view',
+                                  })}
+                                </ToggleLabel>
+                              </StyledToggleItem>
+                              <StyledToggleItem
+                                value="grid"
+                                aria-label={formatMessage({
+                                  id: getTranslationKey('view.grid'),
+                                  defaultMessage: 'Grid view',
+                                })}
+                              >
+                                <GridIcon />
+                                <ToggleLabel>
+                                  {formatMessage({
+                                    id: getTranslationKey('view.grid'),
+                                    defaultMessage: 'Grid view',
+                                  })}
+                                </ToggleLabel>
+                              </StyledToggleItem>
+                            </StyledToggleGroup>
+                          </SortToggleGroup>
+                        </Toolbar>
+
+                        <FilterBadges listFilters={listFilters} compact={isHeaderCompact} />
+                      </StickyHeader>
+
                       <Layouts.Content>
                         <BetaNotice />
                         {/* Renders nothing — keeps every loaded page's query subscribed

--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -50,6 +50,7 @@ import { FilterMenu } from './components/FilterMenu';
 import { FolderFormDialog } from './components/FolderFormDialog';
 import { FolderTree } from './components/FolderTree/FolderTree';
 import { ImportFromUrlDialog } from './components/ImportFromUrlDialog';
+import { MainAreaContextMenu } from './components/MainAreaContextMenu';
 import { SortMenu } from './components/SortMenu';
 import { localStorageKeys, viewOptions } from './constants';
 import { useAssetSearch } from './hooks/useAssetSearch';
@@ -459,6 +460,24 @@ const SearchSlot = styled(Box)`
   }
 `;
 
+// The main column normally ends with its content, which left the right-click
+// area stopping at the last row — the one place the gesture is most natural.
+// These two give the column a height to hand down to `MainAreaContextMenu`.
+// `min-height`, never `height`, so a long list still grows past the fold; and
+// if the percentage can't resolve, the chain degrades to `auto` and the layout
+// is exactly what it was.
+const FullHeightMain = styled(Page.Main)`
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+`;
+
+const PageBody = styled(Box)`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+`;
+
 // Toggle labels are hidden below desktop — icons only (buttons keep aria-label).
 const ToggleLabel = styled.span`
   display: none;
@@ -712,8 +731,8 @@ export const AssetsPage = () => {
                   />
                 }
               >
-                <Page.Main>
-                  <Box ref={uploadDropZoneRef}>
+                <FullHeightMain>
+                  <PageBody ref={uploadDropZoneRef}>
                     <VisuallyHidden>
                       <input type="file" ref={fileInputRef} onChange={handleFileChange} multiple />
                     </VisuallyHidden>
@@ -828,41 +847,52 @@ export const AssetsPage = () => {
                       <FilterBadges listFilters={listFilters} compact={isHeaderCompact} />
                     </StickyHeader>
 
-                    <Layouts.Content>
-                      <BetaNotice />
-                      {/* Renders nothing — keeps every loaded page's query subscribed
-                      so a rename/delete refreshes the whole list. */}
-                      {assetPageSubscribers}
-                      <DropZoneWithOverlay>
-                        <DropFilesMessage
-                          uploadDropZoneRef={uploadDropZoneRef}
-                          folderName={title}
-                        />
-                        <AssetsView
-                          view={view}
-                          folders={folders}
-                          isLoadingFolders={isLoadingFolders}
-                          assets={assets}
-                          isLoadingAssets={isLoadingAssets}
-                          isFetchingMore={isFetchingMore}
-                          hasNextPage={hasNextPage}
-                          fetchNextPage={fetchNextPage}
-                          error={assetsError}
-                          locations={itemLocations}
-                          searchQuery={searchQuery}
-                          assetsSort={listSort.assetsSort}
-                          foldersPosition={listSort.foldersPosition}
-                          hasActiveFilters={listFilters.filters.length > 0}
-                          onClearFilters={listFilters.clearFilters}
-                          onAssetItemClick={openDetails}
-                          onAddAssets={handleFileSelect}
-                          canAddAssets={canCreate}
-                          onClearSearch={clearSearch}
-                        />
-                      </DropZoneWithOverlay>
-                    </Layouts.Content>
-                  </Box>
-                </Page.Main>
+                    {/* Right-clicking the empty parts of the list offers the same
+                        creation actions as the "New" menu above, acting on the
+                        folder currently open. Items keep the browser's own menu —
+                        see MainAreaContextMenu. */}
+                    <MainAreaContextMenu
+                      disabled={!canCreate}
+                      onCreateFolder={() => setIsCreateFolderDialogOpen(true)}
+                      onImportFiles={handleFileSelect}
+                      onImportFromUrl={() => setIsUrlDialogOpen(true)}
+                    >
+                      <Layouts.Content>
+                        <BetaNotice />
+                        {/* Renders nothing — keeps every loaded page's query subscribed
+                            so a rename/delete refreshes the whole list. */}
+                        {assetPageSubscribers}
+                        <DropZoneWithOverlay>
+                          <DropFilesMessage
+                            uploadDropZoneRef={uploadDropZoneRef}
+                            folderName={title}
+                          />
+                          <AssetsView
+                            view={view}
+                            folders={folders}
+                            isLoadingFolders={isLoadingFolders}
+                            assets={assets}
+                            isLoadingAssets={isLoadingAssets}
+                            isFetchingMore={isFetchingMore}
+                            hasNextPage={hasNextPage}
+                            fetchNextPage={fetchNextPage}
+                            error={assetsError}
+                            locations={itemLocations}
+                            searchQuery={searchQuery}
+                            assetsSort={listSort.assetsSort}
+                            foldersPosition={listSort.foldersPosition}
+                            hasActiveFilters={listFilters.filters.length > 0}
+                            onClearFilters={listFilters.clearFilters}
+                            onAssetItemClick={openDetails}
+                            onAddAssets={handleFileSelect}
+                            canAddAssets={canCreate}
+                            onClearSearch={clearSearch}
+                          />
+                        </DropZoneWithOverlay>
+                      </Layouts.Content>
+                    </MainAreaContextMenu>
+                  </PageBody>
+                </FullHeightMain>
               </Layouts.Root>
             </AssetsDndProvider>
           </BusyAssetsProvider>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
@@ -232,6 +232,9 @@ const FolderCard = ({ folder, orderedItemKeys }: FolderCardProps) => {
       }}
       role="listitem"
       tabIndex={0}
+      // Right-clicking an item is not the background gesture: the folder keeps
+      // the browser's own menu. See MainAreaContextMenu.
+      data-native-context-menu
     >
       {canUpdate && (
         <Flex onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}>
@@ -475,6 +478,9 @@ const AssetCard = ({ asset, orderedItemKeys, onAssetItemClick }: AssetCardProps)
       $isSelected={selected}
       tabIndex={0}
       role="listitem"
+      // Right-clicking an item is not the background gesture: the card keeps
+      // the browser's own menu. See MainAreaContextMenu.
+      data-native-context-menu
       onDragStart={(e) => e.preventDefault()}
       onClick={handleCardClick}
       onKeyDown={handleKeyDown}

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
@@ -326,6 +326,9 @@ const AssetRow = ({ asset, orderedItemKeys, onAssetItemClick }: AssetRowProps) =
       $isSelected={selected}
       tabIndex={0}
       role="row"
+      // Right-clicking an item is not the background gesture: the row keeps the
+      // browser's own menu. See MainAreaContextMenu.
+      data-native-context-menu
       onDragStart={(e) => e.preventDefault()}
       onClick={handleRowClick}
       onKeyDown={handleKeyDown}
@@ -504,6 +507,9 @@ const FolderRow = ({ folder, orderedItemKeys }: FolderRowProps) => {
       $isSelected={isSelected(key)}
       tabIndex={0}
       role="row"
+      // Right-clicking an item is not the background gesture: the row keeps the
+      // browser's own menu. See MainAreaContextMenu.
+      data-native-context-menu
       onDragStart={(e: React.DragEvent) => {
         if (isEventFromWithin(e)) {
           e.preventDefault();

--- a/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
@@ -382,6 +382,9 @@ export const BulkActionsBar = ({
         $isStacked={isAiMetadataEnabled}
         tag="section"
         role="region"
+        // The bar floats over the list but is not part of its background: a
+        // right-click on it keeps the browser's own menu. See MainAreaContextMenu.
+        data-native-context-menu
         aria-label={formatMessage({
           id: getTranslationKey('list.bulk-actions.label'),
           defaultMessage: 'Bulk actions',

--- a/packages/core/upload/admin/src/future/pages/Assets/components/MainAreaContextMenu.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/MainAreaContextMenu.tsx
@@ -187,13 +187,13 @@ export const MainAreaContextMenu = ({
             <Menu.Item onSelect={onImportFiles} startIcon={<Files />}>
               {formatMessage({
                 id: getTranslationKey('import-files'),
-                defaultMessage: 'Import files',
+                defaultMessage: 'File upload',
               })}
             </Menu.Item>
             <Menu.Item onSelect={onImportFromUrl} startIcon={<Link />}>
               {formatMessage({
                 id: getTranslationKey('import-from-url'),
-                defaultMessage: 'Import from URL',
+                defaultMessage: 'File upload from URL',
               })}
             </Menu.Item>
           </ActionsMenuContent>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/MainAreaContextMenu.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/MainAreaContextMenu.tsx
@@ -1,0 +1,204 @@
+import { useState, type CSSProperties, type MouseEvent, type ReactNode } from 'react';
+
+import { Menu } from '@strapi/design-system';
+import { Files, Folder as FolderIcon, Link } from '@strapi/icons';
+import { useIntl } from 'react-intl';
+import { styled } from 'styled-components';
+
+import { isEventFromWithin } from '../../../utils/isEventFromWithin';
+import { getTranslationKey } from '../../../utils/translations';
+
+import { ActionsMenuContent } from './ActionsMenuContent';
+
+/**
+ * Subtrees that keep the browser's own context menu instead of opening the
+ * create menu.
+ *
+ * `data-native-context-menu` is the explicit opt-out carried by the list items
+ * themselves (asset cards, folder cards, table rows) and by the bulk actions
+ * bar — right-clicking one of those must behave exactly as it does today. The
+ * rest are the generic cases where the native menu is the useful one: links,
+ * buttons and anything the user can type into or select text in.
+ *
+ * `thead` covers the table's header row, which is chrome rather than empty
+ * background even though it carries no `data-native-context-menu` item.
+ */
+const NATIVE_CONTEXT_MENU_SELECTOR = [
+  '[data-native-context-menu]',
+  'thead',
+  'a',
+  'button',
+  'input',
+  'textarea',
+  'select',
+  '[contenteditable="true"]',
+].join(', ');
+
+/**
+ * Fills the main column so the empty space below the last row still belongs to
+ * the menu's hit area — right-clicking under a short list is the whole point of
+ * the gesture. `flex: 1` only bites once an ancestor has a height to give; when
+ * it doesn't, this collapses to its content and the area is just the list, as
+ * it was before.
+ */
+const ContextMenuArea = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+`;
+
+/**
+ * The menu is anchored to a zero-sized element parked at the cursor, because
+ * the design system's `Menu` is a dropdown: it positions its content against a
+ * trigger, and there is no real trigger for a right-click on empty space.
+ *
+ * Inline styles rather than a `styled` wrapper — the trigger renders a design
+ * system `Button`, and losing the specificity race with its own class would put
+ * a stray button on the page.
+ */
+const CURSOR_ANCHOR_STYLE: CSSProperties = {
+  position: 'fixed',
+  width: 0,
+  height: 0,
+  minWidth: 0,
+  minHeight: 0,
+  padding: 0,
+  border: 0,
+  opacity: 0,
+  overflow: 'hidden',
+  pointerEvents: 'none',
+};
+
+interface CursorPosition {
+  x: number;
+  y: number;
+}
+
+interface MainAreaContextMenuProps {
+  children: ReactNode;
+  /** Opens the "new folder" dialog in the folder currently on screen. */
+  onCreateFolder: () => void;
+  /** Opens the native file picker — same entry point as the header "New" menu. */
+  onImportFiles: () => void;
+  /** Opens the "import from URL" dialog. */
+  onImportFromUrl: () => void;
+  /**
+   * RBAC gate — without `assets.create` there is nothing to offer, so the
+   * right-click falls through to the browser. Required (not defaulted) so a
+   * permission gate can't silently regress to permissive.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Drive/Dropbox-style right-click on the empty parts of the assets area: the
+ * same creation actions the header "New" menu offers, acting on the folder
+ * currently open.
+ *
+ * Deliberately background-only. Right-clicking an asset, a folder or a table
+ * row is left alone — those carry `data-native-context-menu` and keep the
+ * browser's menu (which is what you want over a thumbnail or a filename).
+ * Item-level context menus would be a separate feature; the "..." menus are
+ * the row-scoped affordance today.
+ */
+export const MainAreaContextMenu = ({
+  children,
+  onCreateFolder,
+  onImportFiles,
+  onImportFromUrl,
+  disabled,
+}: MainAreaContextMenuProps) => {
+  const { formatMessage } = useIntl();
+  const [position, setPosition] = useState<CursorPosition | null>(null);
+
+  const handleContextMenu = (event: MouseEvent<HTMLDivElement>) => {
+    if (disabled) {
+      return;
+    }
+
+    // Portaled content (this menu, the dialogs a row's "..." menu opens) bubbles
+    // through the React tree without ever being a DOM descendant. Same guard the
+    // cards and rows use for their own handlers.
+    if (!isEventFromWithin(event)) {
+      return;
+    }
+
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+
+    if (event.target.closest(NATIVE_CONTEXT_MENU_SELECTOR)) {
+      return;
+    }
+
+    event.preventDefault();
+    // A right-click while the menu is open reaches Radix's dismiss listener
+    // first, which closes it; re-anchoring here reopens it under the new cursor
+    // rather than leaving the user with a menu that just vanished.
+    setPosition({ x: event.clientX, y: event.clientY });
+  };
+
+  return (
+    <ContextMenuArea onContextMenu={handleContextMenu} data-testid="assets-context-menu-area">
+      {children}
+      {/* Non-modal, like the row-level menus: a right-click elsewhere is both
+          "close this" and "open that", which a modal layer would swallow.
+          Skipped entirely without the permission — the anchor is a real
+          (if invisible) button, and one that can never open is noise in the
+          accessibility tree. */}
+      {!disabled && (
+        <Menu.Root
+          modal={false}
+          open={position !== null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setPosition(null);
+            }
+          }}
+        >
+          <Menu.Trigger
+            tabIndex={-1}
+            // No visible content, so the name has to come from `aria-label` —
+            // the trigger's `label` prop renders as button text, which would
+            // defeat the point of an invisible anchor. Radix points the menu's
+            // `aria-labelledby` at this element, so it names the menu too.
+            endIcon={null}
+            aria-label={formatMessage({
+              id: getTranslationKey('list.context-menu.label'),
+              defaultMessage: 'Media library actions',
+            })}
+            style={{ ...CURSOR_ANCHOR_STYLE, top: position?.y ?? 0, left: position?.x ?? 0 }}
+          />
+          <ActionsMenuContent
+            popoverPlacement="bottom-start"
+            zIndex={2}
+            minWidth="22rem"
+            // The anchor is invisible and sits wherever the cursor was, so
+            // handing focus back to it on close would be a focus ring nobody can
+            // see. Let it fall to the body instead.
+            onCloseAutoFocus={(event) => event.preventDefault()}
+          >
+            <Menu.Item onSelect={onCreateFolder} startIcon={<FolderIcon />}>
+              {formatMessage({
+                id: getTranslationKey('folder.create.title'),
+                defaultMessage: 'New folder',
+              })}
+            </Menu.Item>
+            <Menu.Item onSelect={onImportFiles} startIcon={<Files />}>
+              {formatMessage({
+                id: getTranslationKey('import-files'),
+                defaultMessage: 'Import files',
+              })}
+            </Menu.Item>
+            <Menu.Item onSelect={onImportFromUrl} startIcon={<Link />}>
+              {formatMessage({
+                id: getTranslationKey('import-from-url'),
+                defaultMessage: 'Import from URL',
+              })}
+            </Menu.Item>
+          </ActionsMenuContent>
+        </Menu.Root>
+      )}
+    </ContextMenuArea>
+  );
+};

--- a/packages/core/upload/admin/src/future/pages/Assets/components/MainAreaContextMenu.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/MainAreaContextMenu.tsx
@@ -1,14 +1,21 @@
-import { useState, type CSSProperties, type MouseEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useState, type CSSProperties } from 'react';
 
 import { Menu } from '@strapi/design-system';
 import { Files, Folder as FolderIcon, Link } from '@strapi/icons';
 import { useIntl } from 'react-intl';
-import { styled } from 'styled-components';
 
-import { isEventFromWithin } from '../../../utils/isEventFromWithin';
 import { getTranslationKey } from '../../../utils/translations';
 
 import { ActionsMenuContent } from './ActionsMenuContent';
+
+/**
+ * The admin layout marks the element that scrolls the main column. Listening on
+ * it rather than a wrapper of our own is what makes the whole column part of the
+ * hit area: it carries a responsive `padding-bottom` (16 / 24 / 40px) that no
+ * descendant can cover, and that strip is exactly where a right-click "below the
+ * list" lands.
+ */
+const SCROLL_ROOT_SELECTOR = '[data-strapi-main-content]';
 
 /**
  * Subtrees that keep the browser's own context menu instead of opening the
@@ -35,19 +42,6 @@ const NATIVE_CONTEXT_MENU_SELECTOR = [
 ].join(', ');
 
 /**
- * Fills the main column so the empty space below the last row still belongs to
- * the menu's hit area — right-clicking under a short list is the whole point of
- * the gesture. `flex: 1` only bites once an ancestor has a height to give; when
- * it doesn't, this collapses to its content and the area is just the list, as
- * it was before.
- */
-const ContextMenuArea = styled.div`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-`;
-
-/**
  * The menu is anchored to a zero-sized element parked at the cursor, because
  * the design system's `Menu` is a dropdown: it positions its content against a
  * trigger, and there is no real trigger for a right-click on empty space.
@@ -69,13 +63,14 @@ const CURSOR_ANCHOR_STYLE: CSSProperties = {
   pointerEvents: 'none',
 };
 
+const LOCATOR_STYLE: CSSProperties = { height: 0 };
+
 interface CursorPosition {
   x: number;
   y: number;
 }
 
 interface MainAreaContextMenuProps {
-  children: ReactNode;
   /** Opens the "new folder" dialog in the folder currently on screen. */
   onCreateFolder: () => void;
   /** Opens the native file picker — same entry point as the header "New" menu. */
@@ -95,14 +90,14 @@ interface MainAreaContextMenuProps {
  * same creation actions the header "New" menu offers, acting on the folder
  * currently open.
  *
+ * Renders no wrapper — it finds the scrolling column and listens there, so the
+ * hit area is the whole column including the padding below the list.
+ *
  * Deliberately background-only. Right-clicking an asset, a folder or a table
  * row is left alone — those carry `data-native-context-menu` and keep the
  * browser's menu (which is what you want over a thumbnail or a filename).
- * Item-level context menus would be a separate feature; the "..." menus are
- * the row-scoped affordance today.
  */
 export const MainAreaContextMenu = ({
-  children,
   onCreateFolder,
   onImportFiles,
   onImportFromUrl,
@@ -110,37 +105,41 @@ export const MainAreaContextMenu = ({
 }: MainAreaContextMenuProps) => {
   const { formatMessage } = useIntl();
   const [position, setPosition] = useState<CursorPosition | null>(null);
+  const [locator, setLocator] = useState<HTMLElement | null>(null);
 
-  const handleContextMenu = (event: MouseEvent<HTMLDivElement>) => {
-    if (disabled) {
+  const anchorRef = useCallback((node: HTMLElement | null) => setLocator(node), []);
+
+  useEffect(() => {
+    const container = locator?.closest<HTMLElement>(SCROLL_ROOT_SELECTOR);
+
+    if (!container || disabled) {
       return;
     }
 
-    // Portaled content (this menu, the dialogs a row's "..." menu opens) bubbles
-    // through the React tree without ever being a DOM descendant. Same guard the
-    // cards and rows use for their own handlers.
-    if (!isEventFromWithin(event)) {
-      return;
-    }
+    const handleContextMenu = (event: MouseEvent) => {
+      if (!(event.target instanceof Element)) {
+        return;
+      }
 
-    if (!(event.target instanceof Element)) {
-      return;
-    }
+      if (event.target.closest(NATIVE_CONTEXT_MENU_SELECTOR)) {
+        return;
+      }
 
-    if (event.target.closest(NATIVE_CONTEXT_MENU_SELECTOR)) {
-      return;
-    }
+      event.preventDefault();
+      // A right-click while the menu is open reaches Radix's dismiss listener
+      // first, which closes it; re-anchoring here reopens it under the new
+      // cursor rather than leaving the user with a menu that just vanished.
+      setPosition({ x: event.clientX, y: event.clientY });
+    };
 
-    event.preventDefault();
-    // A right-click while the menu is open reaches Radix's dismiss listener
-    // first, which closes it; re-anchoring here reopens it under the new cursor
-    // rather than leaving the user with a menu that just vanished.
-    setPosition({ x: event.clientX, y: event.clientY });
-  };
+    container.addEventListener('contextmenu', handleContextMenu);
+
+    return () => container.removeEventListener('contextmenu', handleContextMenu);
+  }, [locator, disabled]);
 
   return (
-    <ContextMenuArea onContextMenu={handleContextMenu} data-testid="assets-context-menu-area">
-      {children}
+    <>
+      <div ref={anchorRef} style={LOCATOR_STYLE} aria-hidden />
       {/* Non-modal, like the row-level menus: a right-click elsewhere is both
           "close this" and "open that", which a modal layer would swallow.
           Skipped entirely without the permission — the anchor is a real
@@ -199,6 +198,6 @@ export const MainAreaContextMenu = ({
           </ActionsMenuContent>
         </Menu.Root>
       )}
-    </ContextMenuArea>
+    </>
   );
 };

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/MainAreaContextMenu.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/MainAreaContextMenu.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, waitFor, fireEvent } from '@tests/utils';
+
+import { MainAreaContextMenu } from '../MainAreaContextMenu';
+
+const onCreateFolder = jest.fn();
+const onImportFiles = jest.fn();
+const onImportFromUrl = jest.fn();
+
+const setup = (props: Partial<React.ComponentProps<typeof MainAreaContextMenu>> = {}) =>
+  render(
+    <MainAreaContextMenu
+      disabled={false}
+      onCreateFolder={onCreateFolder}
+      onImportFiles={onImportFiles}
+      onImportFromUrl={onImportFromUrl}
+      {...props}
+    >
+      <div data-testid="background">
+        {/* Stands in for an asset card / folder card / table row. */}
+        <div data-testid="item" data-native-context-menu>
+          asset.png
+        </div>
+        <button type="button">Add assets</button>
+      </div>
+    </MainAreaContextMenu>
+  );
+
+const rightClick = (element: Element) =>
+  fireEvent.contextMenu(element, { clientX: 120, clientY: 240 });
+
+describe('MainAreaContextMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders its children with no menu open', () => {
+    setup();
+
+    expect(screen.getByTestId('background')).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  // The design system's Menu is a dropdown, so the popover needs a trigger to
+  // hang off. A right-click on empty space has none — this is the stand-in.
+  it('anchors the menu to a named, invisible, unfocusable element at the cursor', () => {
+    setup();
+
+    const anchor = screen.getByRole('button', { name: 'Media library actions' });
+
+    expect(anchor).toHaveAttribute('tabindex', '-1');
+    expect(anchor).toHaveStyle({
+      position: 'fixed',
+      width: '0px',
+      height: '0px',
+      opacity: '0',
+      pointerEvents: 'none',
+    });
+
+    rightClick(screen.getByTestId('background'));
+
+    expect(anchor).toHaveStyle({ top: '240px', left: '120px' });
+  });
+
+  it('mounts no anchor at all without the create permission', () => {
+    setup({ disabled: true });
+
+    expect(screen.queryByRole('button', { name: 'Media library actions' })).not.toBeInTheDocument();
+  });
+
+  it('opens the create actions when the empty area is right-clicked', async () => {
+    setup();
+
+    rightClick(screen.getByTestId('background'));
+
+    const items = await screen.findAllByRole('menuitem');
+    expect(items.map((item) => item.textContent)).toEqual([
+      'New folder',
+      'Import files',
+      'Import from URL',
+    ]);
+  });
+
+  it('suppresses the browser menu only when it opens its own', () => {
+    setup();
+
+    const opened = fireEvent.contextMenu(screen.getByTestId('background'), {
+      clientX: 10,
+      clientY: 10,
+    });
+    // fireEvent returns false once a listener called preventDefault().
+    expect(opened).toBe(false);
+
+    const passedThrough = fireEvent.contextMenu(screen.getByTestId('item'), {
+      clientX: 10,
+      clientY: 10,
+    });
+    expect(passedThrough).toBe(true);
+  });
+
+  it('leaves items marked `data-native-context-menu` to the browser', async () => {
+    setup();
+
+    rightClick(screen.getByTestId('item'));
+
+    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+  });
+
+  it('leaves buttons in the background to the browser', async () => {
+    setup();
+
+    rightClick(screen.getByRole('button', { name: 'Add assets' }));
+
+    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+  });
+
+  it('stays shut without the create permission', async () => {
+    setup({ disabled: true });
+
+    const event = fireEvent.contextMenu(screen.getByTestId('background'), {
+      clientX: 10,
+      clientY: 10,
+    });
+
+    expect(event).toBe(true);
+    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+  });
+
+  it.each([
+    ['New folder', () => onCreateFolder],
+    ['Import files', () => onImportFiles],
+    ['Import from URL', () => onImportFromUrl],
+  ])('runs %s and closes', async (label, getHandler) => {
+    const { user } = setup();
+
+    rightClick(screen.getByTestId('background'));
+    await user.click(await screen.findByRole('menuitem', { name: label }));
+
+    expect(getHandler()).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+  });
+
+  it('dismisses on Escape', async () => {
+    const { user } = setup();
+
+    rightClick(screen.getByTestId('background'));
+    await screen.findAllByRole('menuitem');
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+    expect(onCreateFolder).not.toHaveBeenCalled();
+  });
+
+  it('dismisses when the pointer goes down elsewhere', async () => {
+    const { user } = setup();
+
+    rightClick(screen.getByTestId('background'));
+    await screen.findAllByRole('menuitem');
+
+    await user.click(document.body);
+
+    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+  });
+
+  it('re-anchors instead of vanishing when the background is right-clicked again', async () => {
+    setup();
+
+    rightClick(screen.getByTestId('background'));
+    await screen.findAllByRole('menuitem');
+
+    fireEvent.contextMenu(screen.getByTestId('background'), { clientX: 400, clientY: 80 });
+
+    // Radix dismisses on the right-click's `pointerdown` before our handler
+    // re-opens it — the menu must survive that round trip.
+    await waitFor(() => expect(screen.getAllByRole('menuitem')).toHaveLength(3));
+  });
+});

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/MainAreaContextMenu.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/MainAreaContextMenu.test.tsx
@@ -6,15 +6,14 @@ const onCreateFolder = jest.fn();
 const onImportFiles = jest.fn();
 const onImportFromUrl = jest.fn();
 
+/**
+ * Mirrors the admin layout: the column marked `data-strapi-main-content` is what
+ * scrolls and what the menu listens on. `scroll-root` stands in for the strip of
+ * that column which no descendant covers — its own bottom padding.
+ */
 const setup = (props: Partial<React.ComponentProps<typeof MainAreaContextMenu>> = {}) =>
   render(
-    <MainAreaContextMenu
-      disabled={false}
-      onCreateFolder={onCreateFolder}
-      onImportFiles={onImportFiles}
-      onImportFromUrl={onImportFromUrl}
-      {...props}
-    >
+    <div data-strapi-main-content data-testid="scroll-root">
       <div data-testid="background">
         {/* Stands in for an asset card / folder card / table row. */}
         <div data-testid="item" data-native-context-menu>
@@ -22,7 +21,14 @@ const setup = (props: Partial<React.ComponentProps<typeof MainAreaContextMenu>> 
         </div>
         <button type="button">Add assets</button>
       </div>
-    </MainAreaContextMenu>
+      <MainAreaContextMenu
+        disabled={false}
+        onCreateFolder={onCreateFolder}
+        onImportFiles={onImportFiles}
+        onImportFromUrl={onImportFromUrl}
+        {...props}
+      />
+    </div>
   );
 
 const rightClick = (element: Element) =>
@@ -33,11 +39,21 @@ describe('MainAreaContextMenu', () => {
     jest.clearAllMocks();
   });
 
-  it('renders its children with no menu open', () => {
+  it('starts with no menu open', () => {
     setup();
 
-    expect(screen.getByTestId('background')).toBeInTheDocument();
     expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  // The column carries a bottom padding no descendant can cover, and that strip
+  // is where a right-click below a full list lands. Listening on the column is
+  // what puts it in reach.
+  it('opens when the scrolling column itself is right-clicked', async () => {
+    setup();
+
+    rightClick(screen.getByTestId('scroll-root'));
+
+    expect(await screen.findAllByRole('menuitem')).toHaveLength(3);
   });
 
   // The design system's Menu is a dropdown, so the popover needs a trigger to

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/MainAreaContextMenu.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/MainAreaContextMenu.test.tsx
@@ -75,8 +75,8 @@ describe('MainAreaContextMenu', () => {
     const items = await screen.findAllByRole('menuitem');
     expect(items.map((item) => item.textContent)).toEqual([
       'New folder',
-      'Import files',
-      'Import from URL',
+      'File upload',
+      'File upload from URL',
     ]);
   });
 
@@ -127,8 +127,8 @@ describe('MainAreaContextMenu', () => {
 
   it.each([
     ['New folder', () => onCreateFolder],
-    ['Import files', () => onImportFiles],
-    ['Import from URL', () => onImportFromUrl],
+    ['File upload', () => onImportFiles],
+    ['File upload from URL', () => onImportFromUrl],
   ])('runs %s and closes', async (label, getHandler) => {
     const { user } = setup();
 

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
@@ -183,6 +183,17 @@ describe('AssetsGrid', () => {
       setup({ assets: [], folders: [] });
       expect(screen.queryByTestId('assets-grid')).not.toBeInTheDocument();
     });
+
+    // The page's background context menu reads this attribute to tell an item
+    // apart from empty space — see MainAreaContextMenu.
+    it('opts every card out of the background context menu', () => {
+      setup({ assets: [mockAssets[0]], folders: [createMockFolder(1, 'Photos')] });
+
+      const cards = screen.getAllByRole('listitem');
+
+      expect(cards).toHaveLength(2);
+      cards.forEach((card) => expect(card).toHaveAttribute('data-native-context-menu'));
+    });
   });
 
   describe('AssetCard', () => {

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, server, waitFor } from '@tests/utils';
+import { act, fireEvent, render, screen, server, waitFor } from '@tests/utils';
 import { http, HttpResponse } from 'msw';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -611,6 +611,105 @@ describe('AssetsPage search', () => {
       expect(await screen.findByRole('option', { name: 'Media Library' })).toBeInTheDocument();
       expect(screen.queryByRole('option', { name: 'A' })).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('AssetsPage main-area context menu', () => {
+  const rightClickBackground = () =>
+    fireEvent.contextMenu(screen.getByTestId('assets-context-menu-area'), {
+      clientX: 200,
+      clientY: 300,
+    });
+
+  /**
+   * The menu is gated on `assets.create`, which is `false` until the RBAC check
+   * settles — the "New" menu appearing is the signal that it has.
+   */
+  const waitForCreatePermission = () => screen.findByRole('button', { name: 'New' });
+
+  it('offers the same creation actions as the New menu', async () => {
+    respondWithAssets([createAsset(1, 'image.png')]);
+
+    renderPage();
+    await waitForCreatePermission();
+
+    rightClickBackground();
+
+    const items = await screen.findAllByRole('menuitem');
+    expect(items.map((item) => item.textContent)).toEqual([
+      'New folder',
+      'Import files',
+      'Import from URL',
+    ]);
+  });
+
+  it('creates the folder inside the folder currently open', async () => {
+    respondWithAssets([createAsset(1, 'image.png')]);
+    respondWithFolders([]);
+    server.use(
+      http.get('*/upload/folders/:id', () =>
+        HttpResponse.json({ data: { id: 1, name: 'Photos', pathId: 1, path: '/1', parent: null } })
+      )
+    );
+
+    const { user } = renderPage('?folder=1');
+    await waitForCreatePermission();
+
+    rightClickBackground();
+    await user.click(await screen.findByRole('menuitem', { name: 'New folder' }));
+
+    expect(await screen.findByText('New folder in Photos')).toBeInTheDocument();
+  });
+
+  it('opens the file picker from Import files', async () => {
+    respondWithAssets([createAsset(1, 'image.png')]);
+
+    const { user } = renderPage();
+    await waitForCreatePermission();
+
+    // The hidden input the header "New > Import files" also clicks.
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const click = jest.spyOn(fileInput, 'click').mockImplementation(() => {});
+
+    rightClickBackground();
+    await user.click(await screen.findByRole('menuitem', { name: 'Import files' }));
+
+    expect(click).toHaveBeenCalled();
+    click.mockRestore();
+  });
+
+  it('leaves an asset card to the browser', async () => {
+    respondWithAssets([createAsset(1, 'image.png')]);
+
+    renderPage();
+    await waitForCreatePermission();
+
+    const card = (await screen.findByText('image.png')).closest('[data-native-context-menu]');
+    const event = fireEvent.contextMenu(card!, { clientX: 20, clientY: 20 });
+
+    // Nothing called preventDefault, so the browser's own menu still opens.
+    expect(event).toBe(true);
+    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+  });
+
+  it('stays shut without assets.create', async () => {
+    respondWithAssets([createAsset(1, 'image.png')]);
+
+    render(<AssetsPage />, {
+      initialEntries: ['/'],
+      providerOptions: {
+        permissions: (defaults: Array<{ action: string }>) =>
+          defaults.filter((permission) => permission.action !== 'plugin::upload.assets.create'),
+      },
+    });
+    await findHeading();
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
+    );
+
+    rightClickBackground();
+
+    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
   });
 });
 

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
@@ -615,11 +615,18 @@ describe('AssetsPage search', () => {
 });
 
 describe('AssetsPage main-area context menu', () => {
-  const rightClickBackground = () =>
-    fireEvent.contextMenu(screen.getByTestId('assets-context-menu-area'), {
-      clientX: 200,
-      clientY: 300,
-    });
+  // The menu listens on the scrolling column the admin layout marks, so this is
+  // also the strip below the list that no descendant of the page covers.
+  const rightClickBackground = () => {
+    // eslint-disable-next-line testing-library/no-node-access
+    const column = document.querySelector('[data-strapi-main-content]');
+
+    if (!column) {
+      throw new Error('the admin layout did not render its main column');
+    }
+
+    fireEvent.contextMenu(column, { clientX: 200, clientY: 300 });
+  };
 
   /**
    * The menu is gated on `assets.create`, which is `false` until the RBAC check

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsPage.test.tsx
@@ -638,9 +638,49 @@ describe('AssetsPage main-area context menu', () => {
     const items = await screen.findAllByRole('menuitem');
     expect(items.map((item) => item.textContent)).toEqual([
       'New folder',
-      'Import files',
-      'Import from URL',
+      'File upload',
+      'File upload from URL',
     ]);
+  });
+
+  it('reaches the page header band, whose empty space is part of the same surface', async () => {
+    respondWithAssets([createAsset(1, 'image.png')]);
+
+    renderPage();
+    await waitForCreatePermission();
+
+    // The heading is inert, so a press on it is background rather than a
+    // control. The header used to sit outside the wrapped area entirely, which
+    // made its whole band a dead zone.
+    fireEvent.contextMenu(screen.getByRole('heading', { level: 1 }), {
+      clientX: 200,
+      clientY: 40,
+    });
+
+    expect(await screen.findAllByRole('menuitem')).toHaveLength(3);
+  });
+
+  it('leaves the table header row to the browser, since sorting will make it interactive', async () => {
+    respondWithAssets([createAsset(1, 'image.png')]);
+    // Grid is the default view, and only the table has a header row.
+    window.localStorage.setItem('STRAPI_UPLOAD_LIBRARY_VIEW', '1');
+
+    try {
+      renderPage();
+      await waitForCreatePermission();
+
+      // Wrapping the header brought `thead` inside the hit area, so the explicit
+      // `thead` exclusion is now what keeps it out.
+      const table = await screen.findByRole('grid');
+      // eslint-disable-next-line testing-library/no-node-access
+      const columnHeader = table.querySelector('thead th') as HTMLElement;
+
+      fireEvent.contextMenu(columnHeader, { clientX: 200, clientY: 120 });
+
+      expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+    } finally {
+      window.localStorage.removeItem('STRAPI_UPLOAD_LIBRARY_VIEW');
+    }
   });
 
   it('creates the folder inside the folder currently open', async () => {
@@ -661,18 +701,18 @@ describe('AssetsPage main-area context menu', () => {
     expect(await screen.findByText('New folder in Photos')).toBeInTheDocument();
   });
 
-  it('opens the file picker from Import files', async () => {
+  it('opens the file picker from File upload', async () => {
     respondWithAssets([createAsset(1, 'image.png')]);
 
     const { user } = renderPage();
     await waitForCreatePermission();
 
-    // The hidden input the header "New > Import files" also clicks.
+    // The hidden input the header "New > File upload" also clicks.
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
     const click = jest.spyOn(fileInput, 'click').mockImplementation(() => {});
 
     rightClickBackground();
-    await user.click(await screen.findByRole('menuitem', { name: 'Import files' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'File upload' }));
 
     expect(click).toHaveBeenCalled();
     click.mockRestore();

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsTable.test.tsx
@@ -133,6 +133,19 @@ describe('AssetsTable', () => {
       expect(screen.getByText('image2.png')).toBeInTheDocument();
       expect(screen.getByText('image3.png')).toBeInTheDocument();
     });
+
+    // The page's background context menu reads this attribute to tell an item
+    // apart from empty space — see MainAreaContextMenu. The header row is not
+    // marked: it is matched by the `thead` half of the same rule.
+    it('opts every item row out of the background context menu', () => {
+      setup({ assets: [mockAssets[0]], folders: [createMockFolder(1, 'Photos')] });
+
+      const [headerRow, ...itemRows] = screen.getAllByRole('row');
+
+      expect(headerRow).not.toHaveAttribute('data-native-context-menu');
+      expect(itemRows).toHaveLength(2);
+      itemRows.forEach((row) => expect(row).toHaveAttribute('data-native-context-menu'));
+    });
   });
 
   describe('AssetPreviewCell', () => {

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -339,6 +339,7 @@
   "list.table.row.select": "Select {name}",
   "list.table.row.metadata-missing": "This asset is missing metadata (caption or alternative text).",
   "list.table.content.empty-label": "This field is empty",
+  "list.context-menu.label": "Media library actions",
   "list.bulk-actions.label": "Bulk actions",
   "list.bulk-actions.selected-count": "{count, plural, =1 {# item selected} other {# items selected}}",
   "list.bulk-actions.select-all": "Select all",


### PR DESCRIPTION
### What does it do?

Adds a right-click context menu to the empty parts of the Media Library assets area, offering the same creation actions as the header **New** menu, acting on the folder currently open:

- **New folder**
- **File upload**
- **File upload from URL**

The hit area is the **whole scrolling main column** — the list, the empty space below the last row, the page header band, and the padding around all of it. Interactive controls inside it (the New menu, search, filters, sort, the view toggle, filter badges) keep the browser's own menu, as do links, buttons, inputs and anything selectable.

**Items keep the browser menu.** Asset cards, folder cards and table rows carry a `data-native-context-menu` opt-out, so right-clicking one behaves exactly as it does today. Giving items their own actions menu is [CMS-1708](https://linear.app/strapi/issue/CMS-1708/right-clicking-an-asset-or-folder-should-open-its-actions-menu), raised from this review.

**The table's column-header row is also excluded.** It isn't interactive today, but it will be once columns are sortable, so it opts out now rather than later. The whole column is in the hit area, so that exclusion is load-bearing — removing it fails a test.

The design system's `Menu` is a dropdown, so the menu is anchored to a zero-sized element parked at the cursor. Gated on `assets.create`: without the permission no anchor is mounted at all.

### How the hit area works, after QA

The first implementation wrapped the page content in a flex container (`FullHeightMain` / `PageBody` / `ContextMenuArea`) and listened on it. @mathildeleg found the flaw in QA: right-clicking below the last row did nothing in a folder with enough assets to scroll, while working fine in a small folder.

The cause is that `[data-strapi-main-content]` — the column the admin layout scrolls — carries a responsive `padding-bottom` of 16 / 24 / **40px**, and that strip belongs to the column, *outside* `Page.Main`. No descendant can cover it, so `min-height: 100%` could never reach it. With a short list there was enough empty wrapper above the strip that you'd hit it by aiming slightly higher; with a full list the row went right up to the strip, so every reachable point near the bottom either did nothing or was an item (correctly showing the browser menu).

So the component now **renders no wrapper at all**. It drops a zero-height locator, resolves `closest('[data-strapi-main-content]')`, and attaches a native `contextmenu` listener there:

```ts
const container = locator?.closest<HTMLElement>(SCROLL_ROOT_SELECTOR);
container.addEventListener('contextmenu', handleContextMenu);
```

That made three things unnecessary, all now deleted:

- `FullHeightMain` and `PageBody` in `AssetsPage` — they existed only to give the wrapper a height. Back to plain `Page.Main` / `Box`.
- `ContextMenuArea` and its `flex: 1`.
- `isEventFromWithin` — portaled menus and dialogs land on `body`, so they can no longer bubble into the column. The guard had nothing left to guard.

It also means no spacing constant is duplicated out of `@strapi/admin`; the hit area is defined by the column itself rather than by a value we'd have to keep in sync.

### Why is it needed?

The Media Library should support the fast, mouse-driven creation gestures people expect from a desktop file manager (Finder, Drive, Dropbox). Previously the only way to create a folder or upload was the header **New** menu, with no affordance on the area itself.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

1. Open the Media Library and right-click the empty background of the list — the menu appears with **New folder**, **File upload** and **File upload from URL**.
2. **The QA case:** in a folder with enough assets to scroll, scroll to the bottom and right-click just below the last row, right down to the bottom edge of the column. The menu appears everywhere in that strip. Repeat in a folder with one or two items.
3. Repeat both in grid and table view, and at a narrow window width (the padding is 16px there rather than 40px).
4. Right-click the empty space in the **page header band**, beside the title. Same menu.
5. Right-click an asset card, a folder card, a table row, and the bulk-actions bar — the browser's own menu appears, unchanged.
6. Right-click the **table's column headers** (NAME / CREATION DATE / …) — browser menu, deliberately.
7. Right-click the search field, the New button, the filter and sort menus — browser menu, so copy/paste still works in the search box.
8. Each action acts on the folder currently open: create a folder from inside a subfolder and confirm it lands there.
9. As a user without `assets.create`, right-clicking the background falls through to the browser menu with nothing offered.

Automated:

```bash
yarn nx test:front @strapi/upload   # 154 suites / 1346 tests
```

15 tests on `MainAreaContextMenu` plus page-level coverage: the permission gate, the opt-out selector, Escape and pointer-down dismissal, re-anchoring on a second right-click, `preventDefault` firing only when the menu actually opens, the header band responding, and the table header row not. The page-level tests now right-click the real `[data-strapi-main-content]` element rendered by `Layouts.Root`.

New since QA: `opens when the scrolling column itself is right-clicked` — the regression test for the reported bug, which the wrapper design could not express.

### Verified in a browser, because the tests cannot

jsdom has no layout engine, so the geometry was measured in Chrome rather than asserted.

`elementFromPoint` down the bottom of the column, with the old wrapper and with the listener on the column:

```
long list, viewport 700, column ends at 700, wrapper ended at 660
  y=698  hit=column   before: nothing   after: menu
  y=680  hit=column   before: nothing   after: menu
  y=661  hit=column   before: nothing   after: menu
  y=655  hit=row      before: menu      after: menu
```

Confirmed at both list lengths, so the strip goes from dead to live and everything above it is unchanged.

A keyboard-invoked context menu was also checked: Chrome reports the focused element's centre (`clientX: 400, clientY: 220`, `button: -1`), not `0,0`, so the menu anchors near focus. `Shift+F10` was inconclusive under Playwright and Firefox was not available locally.

### For QA

Since @mathildeleg's pass, the hit-area mechanism has been **replaced**, not patched — step 2 above is the case that regressed and the one worth most attention, and steps 3–7 confirm nothing else moved with it.

Two things reviewers may want to weigh in on:

- @MarionLemaire reported that a fast right-click within ~220px of the right edge opens the **New folder** dialog directly, without the menu appearing. Still open — waiting on a video to reproduce it.
- Rebased onto develop after #27449 and #27509 merged. The bulk-actions bar's new bottom spacer is inert background with no opt-out, so right-clicking it opens the create menu. That reads correct to me, but it is new behaviour nobody has seen.

Also note this branch and #27449 both drop a zero-height locator to resolve the same `[data-strapi-main-content]`. Harmless, but worth consolidating into one shared hook as a follow-up — it would also give a single place to notice if the admin layout ever drops that marker, since both features fail silently rather than loudly if it does.

### Related issue(s)/PR(s)

fix CMS-1532

- CMS-1708 — right-clicking an asset or folder to get its own actions menu, raised from this review.
