### PR TITLE
fix(content-type-builder): remove unused runtime import of @strapi/types

### DIFF
--- a/packages/core/content-type-builder/server/src/index.ts
+++ b/packages/core/content-type-builder/server/src/index.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@strapi/types';
-
 import config from './config';
 import bootstrap from './bootstrap';
 import services from './services';


### PR DESCRIPTION
### What does it do?

Removes the side-effect import `import '@strapi/types'` (and its `eslint-disable-next-line import/no-extraneous-dependencies` comment) from the Content-Type Builder server entry point.

### Why is it needed?

That import compiled to `require('@strapi/types')` in the published `dist/server/index.js`, but `@strapi/types` was only declared in `devDependencies`. A production install had no nested copy, so Node had to walk up the tree to find some other `node_modules/@strapi/types` — a resolution that only happens to succeed today because of hoisting. Any package manager or dependency graph that doesn't hoist `@strapi/types` next to Content-Type Builder throws `Cannot find module '@strapi/types'` at boot.

`@strapi/types` ([`packages/core/types/src/index.ts`](https://github.com/strapi/strapi/blob/develop/packages/core/types/src/index.ts)) only re-exports `type`s plus one `declare global` block — no runtime code. Every other reference to it inside Content-Type Builder already uses `import type`, which TypeScript erases at compile time. This one file was the sole exception, left over since the [2023 TypeScript migration](https://github.com/strapi/strapi/pull/18155). Deleting it removes the runtime dependency on `@strapi/types` entirely rather than papering over it by moving the package to `dependencies`.

### How to test it?

- `yarn nx run @strapi/content-type-builder:build:code` — confirm `dist/server/index.js` no longer contains a `require('@strapi/types')` call.
- `yarn nx run @strapi/content-type-builder:test:ts:back`, `:lint`, `:test:unit` — all pass unchanged.
- Functionally: boot a Strapi app with Content-Type Builder enabled and confirm the plugin loads normally.

### Related issues / PRs

[#27249](https://github.com/strapi/strapi/pull/27249) declares several other implicit/hoisting-dependent dependencies across the monorepo (surfaced via a pnpm-linker experiment) but does not touch this particular `@strapi/types` require — this PR is complementary, not a duplicate.

---
_AI assisted_