### PR TITLE
future(upload): select all in the bulk action bar

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -246,7 +246,7 @@ const AssetsView = ({
           assets: the AI metadata action needs their mime types to know what
           the provider can handle. `position: fixed` keeps it visually anchored
           regardless of where it sits in the tree. */}
-      <BulkActionsBar assets={assets} locations={locations} />
+      <BulkActionsBar assets={assets} folders={folders} locations={locations} />
     </>
   );
 };

--- a/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/AssetsPage.tsx
@@ -64,6 +64,7 @@ import { useListSort, type FoldersPosition } from './hooks/useListSort';
 import { buildAssetFilters } from './utils/buildAssetFilters';
 import { getListQueryKey } from './utils/listQueryKey';
 import { mergeMixedList } from './utils/mergeMixedList';
+import { buildRenderedKeys } from './utils/renderedKeys';
 
 import type { File, UploadFileInfo } from '../../../../../shared/contracts/files';
 import type { Folder } from '../../../../../shared/contracts/folders';
@@ -177,6 +178,10 @@ const AssetsView = ({
     [foldersPosition, isGridView, folders, assets, assetsSort, hasNextPage]
   );
 
+  // Derived once here so the table, the grid and the bulk bar all agree on what
+  // is on screen — in mixed mode that is not simply every folder.
+  const renderedKeys = buildRenderedKeys({ folders, assets, mixedItems });
+
   const loadMoreRef = useInfiniteScrollSentinel({
     hasNextPage,
     isFetchingMore,
@@ -222,12 +227,18 @@ const AssetsView = ({
   return (
     <>
       {isGridView ? (
-        <AssetsGrid folders={folders} assets={assets} onAssetItemClick={onAssetItemClick} />
+        <AssetsGrid
+          folders={folders}
+          assets={assets}
+          renderedKeys={renderedKeys}
+          onAssetItemClick={onAssetItemClick}
+        />
       ) : (
         <AssetsTable
           assets={assets}
           folders={folders}
           mixedItems={mixedItems}
+          renderedKeys={renderedKeys}
           onAssetItemClick={onAssetItemClick}
         />
       )}
@@ -246,7 +257,7 @@ const AssetsView = ({
           assets: the AI metadata action needs their mime types to know what
           the provider can handle. `position: fixed` keeps it visually anchored
           regardless of where it sits in the tree. */}
-      <BulkActionsBar assets={assets} folders={folders} locations={locations} />
+      <BulkActionsBar assets={assets} renderedKeys={renderedKeys} locations={locations} />
     </>
   );
 };

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
@@ -13,6 +13,7 @@ import { getTranslationKey } from '../../../utils/translations';
 import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useBusyAssetsOptional } from '../hooks/useBusyAssets';
 import { useFolderNavigation } from '../hooks/useFolderNavigation';
+import { buildRenderedKeys } from '../utils/renderedKeys';
 import { assetKey, folderKey, type ItemKey } from '../utils/selection';
 
 import { AssetActionsMenu } from './AssetActionsMenu';
@@ -530,18 +531,22 @@ const AssetCard = ({ asset, orderedItemKeys, onAssetItemClick }: AssetCardProps)
 interface AssetsGridProps {
   assets: File[];
   folders?: Folder[];
+  /** Keys of the rendered items, in render order. Owned by the view. */
+  renderedKeys?: ItemKey[];
   onAssetItemClick: (assetId: number) => void;
 }
 
-export const AssetsGrid = ({ assets, folders = [], onAssetItemClick }: AssetsGridProps) => {
+export const AssetsGrid = ({
+  assets,
+  folders = [],
+  renderedKeys,
+  onAssetItemClick,
+}: AssetsGridProps) => {
   const totalItems = folders.length + assets.length;
 
   // Render order: folders always on top in the grid (mixing is table-only) —
   // range selection follows it.
-  const orderedItemKeys: ItemKey[] = [
-    ...folders.map((folder) => folderKey(folder.id)),
-    ...assets.map((asset) => assetKey(asset.id)),
-  ];
+  const orderedItemKeys: ItemKey[] = renderedKeys ?? buildRenderedKeys({ folders, assets });
 
   // The empty state is owned by the page (`AssetsView` renders `EmptyState`) — an
   // empty grid renders nothing at all.

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
@@ -29,6 +29,7 @@ import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useBusyAssetsOptional } from '../hooks/useBusyAssets';
 import { useFolderNavigation } from '../hooks/useFolderNavigation';
 import { type MixedItem } from '../utils/mergeMixedList';
+import { buildRenderedKeys } from '../utils/renderedKeys';
 import { assetKey, folderKey, getSelectAllState, type ItemKey } from '../utils/selection';
 
 import { AssetActionsMenu } from './AssetActionsMenu';
@@ -591,6 +592,8 @@ interface AssetsTableProps {
    * order instead of folders-first. Range selection follows the same order.
    */
   mixedItems?: MixedItem[] | null;
+  /** Keys of the rendered rows, in render order. Owned by the view. */
+  renderedKeys?: ItemKey[];
   onAssetItemClick: (assetId: number) => void;
 }
 
@@ -598,6 +601,7 @@ export const AssetsTable = ({
   assets,
   folders = [],
   mixedItems = null,
+  renderedKeys,
   onAssetItemClick,
 }: AssetsTableProps) => {
   const isDesktop = useIsDesktop();
@@ -622,14 +626,8 @@ export const AssetsTable = ({
 
   // Render order — folders first by default, or the interleaved mixed order.
   // Range selection follows it.
-  const orderedItemKeys: ItemKey[] = mixedItems
-    ? mixedItems.map((item) =>
-        item.kind === 'folder' ? folderKey(item.folder.id) : assetKey(item.asset.id)
-      )
-    : [
-        ...folders.map((folder) => folderKey(folder.id)),
-        ...assets.map((asset) => assetKey(asset.id)),
-      ];
+  const orderedItemKeys: ItemKey[] =
+    renderedKeys ?? buildRenderedKeys({ folders, assets, mixedItems });
   const { allSelected, isIndeterminate } = getSelectAllState(selectedKeys, orderedItemKeys);
 
   const handleSelectAll = () => {

--- a/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
@@ -28,13 +28,12 @@ import { getTranslationKey } from '../../../utils/translations';
 import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useFolderNavigation } from '../hooks/useFolderNavigation';
 import { useIsAssetDetailsOpen } from '../hooks/useIsAssetDetailsOpen';
-import { assetKey, folderKey, type ItemKey } from '../utils/selection';
+import { type ItemKey } from '../utils/selection';
 
 import { BulkMoveDialog } from './BulkMoveDialog';
 import { DeleteItemsDialog } from './DeleteItemsDialog';
 
 import type { File } from '../../../../../../shared/contracts/files';
-import type { Folder } from '../../../../../../shared/contracts/folders';
 
 /**
  * Bulk action bar for the future Media Library. Mobile: docked full-bleed to the
@@ -152,14 +151,18 @@ interface BulkActionsBarProps {
    * everything, which falls back to the folder currently open.
    */
   locations?: ItemLocations;
-  /** Folders currently rendered, so select-all covers them as well as assets. */
-  folders?: Folder[];
+  /**
+   * Keys of the items on screen, in render order. Owned by the view so
+   * select-all covers exactly what the user can see — in mixed mode that is not
+   * every folder.
+   */
+  renderedKeys?: ItemKey[];
 }
 
 export const BulkActionsBar = ({
   assets = [],
   locations = emptyItemLocations,
-  folders = [],
+  renderedKeys = [],
 }: BulkActionsBarProps) => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
@@ -181,13 +184,6 @@ export const BulkActionsBar = ({
   const [isDeleting, setIsDeleting] = useState(false);
 
   const count = selectedIds.size + selectedFolderIds.size;
-
-  // Order is irrelevant here — unlike range selection, select-all only needs the
-  // set — so folders and assets are enough, whichever way the view arranges them.
-  const renderedKeys: ItemKey[] = useMemo(
-    () => [...folders.map((folder) => folderKey(folder.id)), ...assets.map((a) => assetKey(a.id))],
-    [folders, assets]
-  );
 
   const handleSelectAll = () => {
     trackUsage('didSelectAllMediaLibraryElements');
@@ -361,7 +357,7 @@ export const BulkActionsBar = ({
         )}
       </Typography>
 
-      <TextButton onClick={handleSelectAll} marginRight={4}>
+      <TextButton onClick={handleSelectAll} marginRight={4} disabled={isBusy}>
         {formatMessage({
           id: getTranslationKey('list.bulk-actions.select-all'),
           defaultMessage: 'Select all',

--- a/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
@@ -62,26 +62,29 @@ const Bar = styled(Flex)<{ $isDrawerOpen: boolean; $isStacked: boolean }>`
 
   /* Mobile with the metadata action present: the labelled button plus the icons
      no longer fit beside the count on one line, so the count takes a row of its
-     own and every button drops to the next. Children in source order: count,
-     action cluster, divider, clear. */
+     own and every button drops to the next.
+
+     Addressed by slot rather than by position: these rules used to use
+     nth-child, which silently retargeted the moment a control was inserted
+     into the row. */
   ${({ $isStacked }) =>
     $isStacked &&
     css`
       flex-wrap: wrap;
       justify-content: space-between;
 
-      > :first-child {
+      > [data-bar-slot='count'] {
         flex-basis: 100%;
         margin-right: 0;
       }
 
-      > :nth-child(2) {
+      > [data-bar-slot='actions'] {
         margin-left: 0;
       }
 
       /* The divider only existed to set the clear action apart from the rest;
          with the row spread it would hang in mid-air between them. */
-      > :nth-child(3) {
+      > [data-bar-slot='divider'] {
         display: none;
       }
     `}
@@ -108,15 +111,15 @@ const Bar = styled(Flex)<{ $isDrawerOpen: boolean; $isStacked: boolean }>`
     /* One line again from tablet up, where it fits. */
     flex-wrap: nowrap;
 
-    > :first-child {
+    > [data-bar-slot='count'] {
       flex-basis: auto;
     }
 
-    > :nth-child(2) {
+    > [data-bar-slot='actions'] {
       margin-left: auto;
     }
 
-    > :nth-child(3) {
+    > [data-bar-slot='divider'] {
       display: block;
     }
   }
@@ -347,7 +350,7 @@ export const BulkActionsBar = ({
         defaultMessage: 'Bulk actions',
       })}
     >
-      <Typography fontWeight="bold" textColor="neutral800" marginRight={4}>
+      <Typography data-bar-slot="count" fontWeight="bold" textColor="neutral800" marginRight={4}>
         {formatMessage(
           {
             id: getTranslationKey('list.bulk-actions.selected-count'),
@@ -366,7 +369,7 @@ export const BulkActionsBar = ({
 
       {/* Past the early return the user always has `assets.update`, so the
           individual actions no longer re-check it. */}
-      <ActionCluster>
+      <ActionCluster data-bar-slot="actions">
         {isAiMetadataEnabled && (
           <Tooltip label={metadataDisabledReason}>
             {/* Wrapped so the tooltip still receives pointer events while the
@@ -431,7 +434,7 @@ export const BulkActionsBar = ({
         />
       </ActionCluster>
 
-      <VerticalDivider aria-hidden />
+      <VerticalDivider data-bar-slot="divider" aria-hidden />
 
       <IconButton
         variant="ghost"

--- a/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
@@ -1,7 +1,15 @@
 import { useMemo, useState } from 'react';
 
 import { useNotification } from '@strapi/admin/strapi-admin';
-import { Box, Button, Flex, IconButton, Tooltip, Typography } from '@strapi/design-system';
+import {
+  Box,
+  Button,
+  Flex,
+  IconButton,
+  TextButton,
+  Tooltip,
+  Typography,
+} from '@strapi/design-system';
 import { ArrowRight, Cross, Sparkle, Trash } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { css, styled } from 'styled-components';
@@ -12,6 +20,7 @@ import {
 } from '../../../../../../shared/constants';
 import { useAIMetadataEnabled } from '../../../hooks/useAIMetadataEnabled';
 import { useMediaLibraryPermissions } from '../../../hooks/useMediaLibraryPermissions';
+import { useTracking } from '../../../hooks/useTracking';
 import { useGenerateAiMetadataMutation } from '../../../services/assets';
 import { buildDragSetFromSelection } from '../../../utils/buildDragSetFromSelection';
 import { emptyItemLocations, type ItemLocations } from '../../../utils/itemLocations';
@@ -19,11 +28,13 @@ import { getTranslationKey } from '../../../utils/translations';
 import { useAssetSelection } from '../hooks/useAssetSelection';
 import { useFolderNavigation } from '../hooks/useFolderNavigation';
 import { useIsAssetDetailsOpen } from '../hooks/useIsAssetDetailsOpen';
+import { assetKey, folderKey, type ItemKey } from '../utils/selection';
 
 import { BulkMoveDialog } from './BulkMoveDialog';
 import { DeleteItemsDialog } from './DeleteItemsDialog';
 
 import type { File } from '../../../../../../shared/contracts/files';
+import type { Folder } from '../../../../../../shared/contracts/folders';
 
 /**
  * Bulk action bar for the future Media Library. Mobile: docked full-bleed to the
@@ -141,11 +152,14 @@ interface BulkActionsBarProps {
    * everything, which falls back to the folder currently open.
    */
   locations?: ItemLocations;
+  /** Folders currently rendered, so select-all covers them as well as assets. */
+  folders?: Folder[];
 }
 
 export const BulkActionsBar = ({
   assets = [],
   locations = emptyItemLocations,
+  folders = [],
 }: BulkActionsBarProps) => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
@@ -155,7 +169,8 @@ export const BulkActionsBar = ({
   // Every bulk action (move, delete, metadata) is an `assets.update` mutation
   // server-side — one flag gates the whole cluster.
   const { canUpdate } = useMediaLibraryPermissions();
-  const { selectedIds, selectedFolderIds, clear } = useAssetSelection();
+  const { selectedIds, selectedFolderIds, selectAll, clear } = useAssetSelection();
+  const { trackUsage } = useTracking();
   const { currentFolderId } = useFolderNavigation();
   const isDetailsDrawerOpen = useIsAssetDetailsOpen();
   const [generateAiMetadata, { isLoading: isGeneratingMetadata }] = useGenerateAiMetadataMutation();
@@ -166,6 +181,18 @@ export const BulkActionsBar = ({
   const [isDeleting, setIsDeleting] = useState(false);
 
   const count = selectedIds.size + selectedFolderIds.size;
+
+  // Order is irrelevant here — unlike range selection, select-all only needs the
+  // set — so folders and assets are enough, whichever way the view arranges them.
+  const renderedKeys: ItemKey[] = useMemo(
+    () => [...folders.map((folder) => folderKey(folder.id)), ...assets.map((a) => assetKey(a.id))],
+    [folders, assets]
+  );
+
+  const handleSelectAll = () => {
+    trackUsage('didSelectAllMediaLibraryElements');
+    selectAll(renderedKeys);
+  };
   const isBusy = isDeleting || isGeneratingMetadata;
 
   // Stable identity: the move dialog memoizes its destination walk on it. Each
@@ -333,6 +360,13 @@ export const BulkActionsBar = ({
           { count }
         )}
       </Typography>
+
+      <TextButton onClick={handleSelectAll} marginRight={4}>
+        {formatMessage({
+          id: getTranslationKey('list.bulk-actions.select-all'),
+          defaultMessage: 'Select all',
+        })}
+      </TextButton>
 
       {/* Past the early return the user always has `assets.update`, so the
           individual actions no longer re-check it. */}

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/BulkActionsBar.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/BulkActionsBar.test.tsx
@@ -5,9 +5,11 @@ import { AssetSelectionProvider, useAssetSelection } from '../../hooks/useAssetS
 import { BulkActionsBar } from '../BulkActionsBar';
 
 import type { File } from '../../../../../../../shared/contracts/files';
+import type { Folder } from '../../../../../../../shared/contracts/folders';
 
 const mockToggleNotification = jest.fn();
 const mockAIAvailability = jest.fn(() => false);
+const mockTrackUsage = jest.fn();
 let mockAiMetadataEnabled = false;
 
 jest.mock('../../../../hooks/useAIMetadataEnabled', () => ({
@@ -25,6 +27,11 @@ jest.mock('@strapi/admin/strapi-admin/ee', () => ({
   useAIAvailability: () => mockAIAvailability(),
 }));
 
+jest.mock('../../../../hooks/useTracking', () => ({
+  ...jest.requireActual('../../../../hooks/useTracking'),
+  useTracking: () => ({ trackUsage: mockTrackUsage }),
+}));
+
 jest.mock('../../hooks/useFolderNavigation', () => ({
   useFolderNavigation: () => ({ currentFolderId: null }),
 }));
@@ -39,7 +46,9 @@ const mockAssets: File[] = [
  * "the selection survives" is genuinely asserted rather than faked by a
  * static mock.
  */
-const Harness = () => {
+const mockFolders = [{ id: 9, name: 'reports' }] as Folder[];
+
+const Harness = ({ folders = [] as Folder[] }: { folders?: Folder[] }) => {
   const { toggle } = useAssetSelection();
   const [, setQuery] = useQueryParams<{ assetId?: string }>();
 
@@ -49,15 +58,16 @@ const Harness = () => {
       <button onClick={() => toggle('asset:2')}>Toggle asset 2</button>
       <button onClick={() => setQuery({ assetId: '1' }, 'push', true)}>Open drawer</button>
       <button onClick={() => setQuery({ assetId: undefined }, 'remove', true)}>Close drawer</button>
-      <BulkActionsBar assets={mockAssets} />
+      <button onClick={() => toggle('folder:9')}>Toggle folder 9</button>
+      <BulkActionsBar assets={mockAssets} folders={folders} />
     </>
   );
 };
 
-const setup = (initialEntries?: string[]) =>
+const setup = (initialEntries?: string[], folders?: Folder[]) =>
   render(
     <AssetSelectionProvider>
-      <Harness />
+      <Harness folders={folders} />
     </AssetSelectionProvider>,
     { initialEntries }
   );
@@ -164,5 +174,52 @@ describe('BulkActionsBar', () => {
     await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
 
     expect(await screen.findByRole('region', { name: 'Bulk actions' })).toBeInTheDocument();
+  });
+
+  describe('select all', () => {
+    it('selects every rendered item, folders included', async () => {
+      const { user } = setup(undefined, mockFolders);
+
+      await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+      await user.click(await screen.findByRole('button', { name: 'Select all' }));
+
+      // 2 assets + 1 folder
+      expect(await screen.findByText('3 items selected')).toBeInTheDocument();
+    });
+
+    it('keeps reading Select all once everything is selected', async () => {
+      const { user } = setup(undefined, mockFolders);
+
+      await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+      await user.click(await screen.findByRole('button', { name: 'Select all' }));
+
+      expect(await screen.findByText('3 items selected')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Select all' })).toBeInTheDocument();
+    });
+
+    it('lets the clear button deselect a select-all selection', async () => {
+      const { user } = setup(undefined, mockFolders);
+
+      await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+      await user.click(await screen.findByRole('button', { name: 'Select all' }));
+      expect(await screen.findByText('3 items selected')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Clear selection' }));
+
+      await waitFor(() =>
+        expect(screen.queryByRole('region', { name: 'Bulk actions' })).not.toBeInTheDocument()
+      );
+    });
+
+    it('tracks the select-all action', async () => {
+      const { user } = setup(undefined, mockFolders);
+
+      await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+      expect(mockTrackUsage).not.toHaveBeenCalled();
+
+      await user.click(await screen.findByRole('button', { name: 'Select all' }));
+
+      expect(mockTrackUsage).toHaveBeenCalledWith('didSelectAllMediaLibraryElements');
+    });
   });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/BulkActionsBar.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/BulkActionsBar.test.tsx
@@ -2,10 +2,10 @@ import { useQueryParams } from '@strapi/admin/strapi-admin';
 import { render, screen, waitFor } from '@tests/utils';
 
 import { AssetSelectionProvider, useAssetSelection } from '../../hooks/useAssetSelection';
+import { type ItemKey } from '../../utils/selection';
 import { BulkActionsBar } from '../BulkActionsBar';
 
 import type { File } from '../../../../../../../shared/contracts/files';
-import type { Folder } from '../../../../../../../shared/contracts/folders';
 
 const mockToggleNotification = jest.fn();
 const mockAIAvailability = jest.fn(() => false);
@@ -32,6 +32,13 @@ jest.mock('../../../../hooks/useTracking', () => ({
   useTracking: () => ({ trackUsage: mockTrackUsage }),
 }));
 
+let mockIsGeneratingMetadata = false;
+
+jest.mock('../../../../services/assets', () => ({
+  ...jest.requireActual('../../../../services/assets'),
+  useGenerateAiMetadataMutation: () => [jest.fn(), { isLoading: mockIsGeneratingMetadata }],
+}));
+
 jest.mock('../../hooks/useFolderNavigation', () => ({
   useFolderNavigation: () => ({ currentFolderId: null }),
 }));
@@ -46,9 +53,14 @@ const mockAssets: File[] = [
  * "the selection survives" is genuinely asserted rather than faked by a
  * static mock.
  */
-const mockFolders = [{ id: 9, name: 'reports' }] as Folder[];
+/**
+ * What the view says is on screen. Passed in rather than derived from the asset
+ * and folder lists, mirroring the real wiring: in mixed mode not every folder is
+ * rendered, so only the view can say.
+ */
+const renderedWithFolder: ItemKey[] = ['folder:9', 'asset:1', 'asset:2'];
 
-const Harness = ({ folders = [] as Folder[] }: { folders?: Folder[] }) => {
+const Harness = ({ renderedKeys }: { renderedKeys?: ItemKey[] }) => {
   const { toggle } = useAssetSelection();
   const [, setQuery] = useQueryParams<{ assetId?: string }>();
 
@@ -59,15 +71,15 @@ const Harness = ({ folders = [] as Folder[] }: { folders?: Folder[] }) => {
       <button onClick={() => setQuery({ assetId: '1' }, 'push', true)}>Open drawer</button>
       <button onClick={() => setQuery({ assetId: undefined }, 'remove', true)}>Close drawer</button>
       <button onClick={() => toggle('folder:9')}>Toggle folder 9</button>
-      <BulkActionsBar assets={mockAssets} folders={folders} />
+      <BulkActionsBar assets={mockAssets} renderedKeys={renderedKeys} />
     </>
   );
 };
 
-const setup = (initialEntries?: string[], folders?: Folder[]) =>
+const setup = (initialEntries?: string[], renderedKeys?: ItemKey[]) =>
   render(
     <AssetSelectionProvider>
-      <Harness folders={folders} />
+      <Harness renderedKeys={renderedKeys} />
     </AssetSelectionProvider>,
     { initialEntries }
   );
@@ -76,6 +88,7 @@ describe('BulkActionsBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAiMetadataEnabled = false;
+    mockIsGeneratingMetadata = false;
   });
 
   it('is visible with a selection and no details param', async () => {
@@ -178,7 +191,7 @@ describe('BulkActionsBar', () => {
 
   describe('select all', () => {
     it('selects every rendered item, folders included', async () => {
-      const { user } = setup(undefined, mockFolders);
+      const { user } = setup(undefined, renderedWithFolder);
 
       await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
       await user.click(await screen.findByRole('button', { name: 'Select all' }));
@@ -188,7 +201,7 @@ describe('BulkActionsBar', () => {
     });
 
     it('keeps reading Select all once everything is selected', async () => {
-      const { user } = setup(undefined, mockFolders);
+      const { user } = setup(undefined, renderedWithFolder);
 
       await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
       await user.click(await screen.findByRole('button', { name: 'Select all' }));
@@ -198,7 +211,7 @@ describe('BulkActionsBar', () => {
     });
 
     it('lets the clear button deselect a select-all selection', async () => {
-      const { user } = setup(undefined, mockFolders);
+      const { user } = setup(undefined, renderedWithFolder);
 
       await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
       await user.click(await screen.findByRole('button', { name: 'Select all' }));
@@ -211,8 +224,17 @@ describe('BulkActionsBar', () => {
       );
     });
 
+    it('is disabled while the bar is busy', async () => {
+      mockIsGeneratingMetadata = true;
+      const { user } = setup(undefined, renderedWithFolder);
+
+      await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+
+      expect(await screen.findByRole('button', { name: 'Select all' })).toBeDisabled();
+    });
+
     it('tracks the select-all action', async () => {
-      const { user } = setup(undefined, mockFolders);
+      const { user } = setup(undefined, renderedWithFolder);
 
       await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
       expect(mockTrackUsage).not.toHaveBeenCalled();

--- a/packages/core/upload/admin/src/future/pages/Assets/utils/renderedKeys.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/utils/renderedKeys.ts
@@ -1,0 +1,33 @@
+import { assetKey, folderKey, type ItemKey } from './selection';
+
+import type { MixedItem } from './mergeMixedList';
+import type { File } from '../../../../../../shared/contracts/files';
+import type { Folder } from '../../../../../../shared/contracts/folders';
+
+/**
+ * The keys of the items actually on screen, in render order.
+ *
+ * Single source for every consumer of the rendered set — range selection,
+ * select-all and the bulk action bar. Derived once so they cannot disagree:
+ * in "Folders: Mixed with files" the rows come from `mergeMixedList`, which
+ * withholds folders sorting after the last loaded asset, so `folders` is not
+ * the rendered folder set.
+ */
+export const buildRenderedKeys = ({
+  folders,
+  assets,
+  mixedItems,
+}: {
+  folders: Folder[];
+  assets: File[];
+  /** The interleaved rows, when the table is in mixed mode. */
+  mixedItems?: MixedItem[] | null;
+}): ItemKey[] =>
+  mixedItems
+    ? mixedItems.map((item) =>
+        item.kind === 'folder' ? folderKey(item.folder.id) : assetKey(item.asset.id)
+      )
+    : [
+        ...folders.map((folder) => folderKey(folder.id)),
+        ...assets.map((asset) => assetKey(asset.id)),
+      ];

--- a/packages/core/upload/admin/src/future/pages/Assets/utils/tests/renderedKeys.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/utils/tests/renderedKeys.test.ts
@@ -1,0 +1,69 @@
+import { mergeMixedList } from '../mergeMixedList';
+import { buildRenderedKeys } from '../renderedKeys';
+
+import type { File } from '../../../../../../../shared/contracts/files';
+import type { Folder } from '../../../../../../../shared/contracts/folders';
+
+const folder = (id: number, name: string, updatedAt: string) =>
+  ({ id, name, updatedAt }) as unknown as Folder;
+
+const asset = (id: number, name: string, updatedAt: string) =>
+  ({ id, name, updatedAt }) as unknown as File;
+
+describe('buildRenderedKeys', () => {
+  const folders = [
+    folder(1, 'alpha', '2024-05-01T00:00:00.000Z'),
+    folder(2, 'beta', '2024-01-01T00:00:00.000Z'),
+  ];
+  const assets = [
+    asset(10, 'a.png', '2024-04-01T00:00:00.000Z'),
+    asset(11, 'b.png', '2024-03-01T00:00:00.000Z'),
+  ];
+
+  it('puts folders before assets when the rows are not interleaved', () => {
+    expect(buildRenderedKeys({ folders, assets })).toEqual([
+      'folder:1',
+      'folder:2',
+      'asset:10',
+      'asset:11',
+    ]);
+  });
+
+  it('follows the interleaved order in mixed mode', () => {
+    const mixedItems = mergeMixedList({
+      folders,
+      assets,
+      sort: 'updatedAt:DESC',
+      hasNextPage: false,
+    });
+
+    expect(buildRenderedKeys({ folders, assets, mixedItems })).toEqual([
+      'folder:1',
+      'asset:10',
+      'asset:11',
+      'folder:2',
+    ]);
+  });
+
+  it('leaves out folders the mixed list is still withholding', () => {
+    // With pages left to load, `mergeMixedList` only places folders that sort at
+    // or before the last loaded asset — the rest belong further down the list
+    // and are not on screen. Selecting them would act on rows the user cannot
+    // see, and folder deletes cascade.
+    const mixedItems = mergeMixedList({
+      folders,
+      assets,
+      sort: 'updatedAt:DESC',
+      hasNextPage: true,
+    });
+
+    const keys = buildRenderedKeys({ folders, assets, mixedItems });
+
+    expect(keys).toEqual(['folder:1', 'asset:10', 'asset:11']);
+    expect(keys).not.toContain('folder:2');
+  });
+
+  it('treats an empty mixed list as no rendered rows', () => {
+    expect(buildRenderedKeys({ folders, assets, mixedItems: [] })).toEqual([]);
+  });
+});

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -341,6 +341,7 @@
   "list.table.content.empty-label": "This field is empty",
   "list.bulk-actions.label": "Bulk actions",
   "list.bulk-actions.selected-count": "{count, plural, =1 {# item selected} other {# items selected}}",
+  "list.bulk-actions.select-all": "Select all",
   "list.bulk-actions.clear": "Clear selection",
   "list.bulk-actions.create-metadata": "Create metadata",
   "list.bulk-actions.create-metadata.success": "{count, plural, =1 {Metadata generated for # asset} other {Metadata generated for # assets}}",


### PR DESCRIPTION
### What does it do?

Adds a **Select all** action to the bulk action bar in the new Media Library, next to the selected-count label.

<img width="580" height="84" alt="Screenshot 2026-08-25 at 09 47 53" src="https://github.com/user-attachments/assets/10c150b5-7d40-4d26-8de7-2434e9223fb4" />


- `BulkActionsBar` takes a new `folders` prop and builds the set of currently rendered items as `[...folderKeys, ...assetKeys]`.
- `allSelected` comes from the existing `getSelectAllState` helper — the same one the table view's header checkbox uses, so the two controls agree on what "all" means.
- **Select all** selects every rendered item of the displayed list.
- Tracks `didSelectAllMediaLibraryElements` on select only, not on clear — mirroring `AssetsTable`, so the grid and table views emit the same event.

Per the ticket, it only selects what is **currently rendered** — folders included. The library paginates by infinite scroll, so items below the scroll boundary are not loaded and are deliberately not selected; scrolling further and pressing the button again extends the selection (same behaviour as the select all checkbox on the table view).

Two things follow from where the control lives, both worth a look:

- **It only appears once at least one item is already selected.** The bar itself early-returns on an empty selection (`BulkActionsBar.tsx:289`), which matches the design — the bar is selection-triggered — but it does mean there is no zero-state select-all the way the table's header checkbox offers one. Reachable in practice by selecting any single item first.
- **It inherits the bar's `canUpdate` gate.** Pre-existing for the whole bar, not added here; a read-only user never sees the bar and so never sees this button.

Closing the bulk bar clears the whole selection, which drops the count to zero and dismisses the bar.

### Why is it needed?

Selecting many items meant clicking each one. The table view already had a select-all affordance via its header checkbox; the grid view had nothing equivalent, so the same task was materially slower depending on which view you happened to be in. This closes that gap and keeps the semantics identical between the two.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

1. Open the Media Library in **grid** view, in a folder holding both subfolders and assets.
2. Select one item — the bulk action bar appears with **Select all**.
3. Press it. Every rendered item is selected, folders included, and the count matches what is on screen.
4. Deselect a single item while everything is selected.
5. Click **Select all** — all items should be selected again.
6. Scroll to load another page, then press **Select all** again — the newly loaded items join the selection.
7. Compare against **table** view: the header checkbox behaves the same way, folders and all.
8. Check the tracking payload contains `didSelectAllMediaLibraryElements` on select, and nothing on unselect.

Automated:

```bash
yarn nx test:front @strapi/upload      # 146 suites / 1208 tests
yarn nx test:ts:front @strapi/upload
```

### Related issue(s)/PR(s)

fix CMS-1606

- CMS-1582 — parent bulk-actions work this was split out of.

 🚀