### PR TITLE
fix(upload): show each asset as soon as its upload completes

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.eviction.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.eviction.test.ts
@@ -36,6 +36,8 @@ jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useDispatch: () => mockDispatch,
   useStore: () => ({ getState: () => mockState }),
+  // No <Provider> here, so selectors read the same stand-in state as `useStore`.
+  useSelector: (selector: (state: unknown) => unknown) => selector(mockState),
 }));
 
 const key = (folder: number, page: number) =>

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
@@ -12,6 +12,15 @@ jest.mock('../../../../services/assets', () => ({
   useGetAssetsQuery: (...args: unknown[]) => mockUseGetAssetsQuery(...args),
 }));
 
+let mockCompletedUploads: File[] = [];
+
+// Only the selector is stubbed: `services/api` imports the rest of this module,
+// so replacing it wholesale would break the hook's own import graph.
+jest.mock('../../../../store/uploadProgress', () => ({
+  ...jest.requireActual('../../../../store/uploadProgress'),
+  selectCompletedUploads: () => mockCompletedUploads,
+}));
+
 const createMockAsset = (id: number): File => ({
   id,
   name: `asset-${id}.png`,
@@ -120,6 +129,7 @@ const renderWithFolder = () => {
 describe('useInfiniteAssets', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCompletedUploads = [];
   });
 
   it('returns first page of assets on initial load', () => {
@@ -755,5 +765,82 @@ describe('useInfiniteAssets', () => {
     const { result } = renderHook(() => useInfiniteAssets());
 
     expect(result.current.error).toBe(mockError);
+  });
+});
+
+describe('useInfiniteAssets — assets uploaded during the batch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCompletedUploads = [];
+  });
+
+  const justUploaded = (overrides: Partial<File> = {}): File => ({
+    ...createMockAsset(999),
+    name: 'just-uploaded.png',
+    // Newer than anything `createMockAsset` produces, so the default sort puts
+    // it at the top of the list.
+    updatedAt: '2030-01-01T00:00:00.000Z',
+    folder: null,
+    ...overrides,
+  });
+
+  it('shows an asset as soon as its own upload finishes', () => {
+    mockUseGetAssetsQuery.mockReturnValue(createMockPage(1, 1, 20));
+    mockCompletedUploads = [justUploaded()];
+
+    const { result } = renderHook(() => useInfiniteAssets());
+
+    expect(result.current.assets[0].name).toBe('just-uploaded.png');
+    expect(result.current.assets).toHaveLength(PAGE_SIZE + 1);
+  });
+
+  it('leaves the list alone while a search is active', () => {
+    mockUseGetAssetsQuery.mockReturnValue(createMockPage(1, 1, 20));
+    mockCompletedUploads = [justUploaded()];
+
+    const { result } = renderHook(() => useInfiniteAssets({ search: 'report' }));
+
+    // Whether an upload matches the query is the server's call, so a searched
+    // list waits for the end-of-batch refetch.
+    expect(result.current.assets).toHaveLength(PAGE_SIZE);
+  });
+
+  it('leaves the list alone while list filters are active', () => {
+    mockUseGetAssetsQuery.mockReturnValue(createMockPage(1, 1, 20));
+    mockCompletedUploads = [justUploaded()];
+
+    const { result } = renderHook(() =>
+      useInfiniteAssets({ filters: [{ mime: { $contains: 'image' } }] })
+    );
+
+    expect(result.current.assets).toHaveLength(PAGE_SIZE);
+  });
+
+  it('ignores an upload that landed in another folder', () => {
+    mockUseGetAssetsQuery.mockReturnValue(createMockPage(1, 1, 20));
+    mockCompletedUploads = [justUploaded({ folder: 42 })];
+
+    const { result } = renderHook(() => useInfiniteAssets({ folder: 7 }));
+
+    expect(result.current.assets).toHaveLength(PAGE_SIZE);
+  });
+
+  it('shows an upload that landed in the folder being viewed', () => {
+    mockUseGetAssetsQuery.mockReturnValue(createMockPage(1, 1, 20));
+    mockCompletedUploads = [justUploaded({ folder: 7 })];
+
+    const { result } = renderHook(() => useInfiniteAssets({ folder: 7 }));
+
+    expect(result.current.assets[0].name).toBe('just-uploaded.png');
+  });
+
+  it('matches the populated folder relation the list returns', () => {
+    mockUseGetAssetsQuery.mockReturnValue(createMockPage(1, 1, 20));
+    // A refetched asset carries `folder` as the populated object rather than an id.
+    mockCompletedUploads = [justUploaded({ folder: { id: 7 } as unknown as number })];
+
+    const { result } = renderHook(() => useInfiniteAssets({ folder: 7 }));
+
+    expect(result.current.assets[0].name).toBe('just-uploaded.png');
   });
 });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/tests/useInfiniteAssets.test.ts
@@ -12,7 +12,7 @@ jest.mock('../../../../services/assets', () => ({
   useGetAssetsQuery: (...args: unknown[]) => mockUseGetAssetsQuery(...args),
 }));
 
-let mockCompletedUploads: File[] = [];
+let mockCompletedUploads: Array<{ asset: File; completedAt: number }> = [];
 
 // Only the selector is stubbed: `services/api` imports the rest of this module,
 // so replacing it wholesale would break the hook's own import graph.
@@ -774,14 +774,17 @@ describe('useInfiniteAssets — assets uploaded during the batch', () => {
     mockCompletedUploads = [];
   });
 
-  const justUploaded = (overrides: Partial<File> = {}): File => ({
-    ...createMockAsset(999),
-    name: 'just-uploaded.png',
-    // Newer than anything `createMockAsset` produces, so the default sort puts
-    // it at the top of the list.
-    updatedAt: '2030-01-01T00:00:00.000Z',
-    folder: null,
-    ...overrides,
+  const justUploaded = (overrides: Partial<File> = {}, completedAt = 2_000) => ({
+    asset: {
+      ...createMockAsset(999),
+      name: 'just-uploaded.png',
+      // Newer than anything `createMockAsset` produces, so the default sort puts
+      // it at the top of the list.
+      updatedAt: '2030-01-01T00:00:00.000Z',
+      folder: null,
+      ...overrides,
+    } as File,
+    completedAt,
   });
 
   it('shows an asset as soon as its own upload finishes', () => {
@@ -830,6 +833,70 @@ describe('useInfiniteAssets — assets uploaded during the batch', () => {
     mockCompletedUploads = [justUploaded({ folder: 7 })];
 
     const { result } = renderHook(() => useInfiniteAssets({ folder: 7 }));
+
+    expect(result.current.assets[0].name).toBe('just-uploaded.png');
+  });
+
+  /**
+   * A response that the server produced after the upload was stored. Past this
+   * point the list knows about the asset, so its absence means it is genuinely
+   * gone (deleted) or elsewhere (moved) — not that the list is behind.
+   */
+  const answeredAfterUpload = (completedAt: number) => ({
+    ...createMockPage(1, 1, 20),
+    startedTimeStamp: completedAt + 1,
+    fulfilledTimeStamp: completedAt + 2,
+  });
+
+  it('stops bridging once the list has answered on that upload', () => {
+    mockUseGetAssetsQuery.mockReturnValue(answeredAfterUpload(2_000));
+    mockCompletedUploads = [justUploaded({}, 2_000)];
+
+    const { result } = renderHook(() => useInfiniteAssets());
+
+    // The asset is not in the refetched page — deleted after the batch settled.
+    // Re-inserting it would resurrect a row whose asset no longer exists.
+    expect(result.current.assets).toHaveLength(PAGE_SIZE);
+  });
+
+  it('keeps bridging an upload that finished after the loaded response', () => {
+    mockUseGetAssetsQuery.mockReturnValue(answeredAfterUpload(1_000));
+    // Completed after that response was requested, so the list cannot know it yet.
+    mockCompletedUploads = [justUploaded({}, 5_000)];
+
+    const { result } = renderHook(() => useInfiniteAssets());
+
+    expect(result.current.assets[0].name).toBe('just-uploaded.png');
+  });
+
+  it('keeps bridging when the loaded response was requested before the upload', () => {
+    // Requested at 1000, delivered at 3000, upload stored at 2000: the server was
+    // asked before the asset existed, so its absence says nothing. Comparing
+    // against the delivery time instead would settle here and hide the asset —
+    // exactly the gap this bridging exists to cover.
+    mockUseGetAssetsQuery.mockReturnValue({
+      ...createMockPage(1, 1, 20),
+      startedTimeStamp: 1_000,
+      fulfilledTimeStamp: 3_000,
+    });
+    mockCompletedUploads = [justUploaded({}, 2_000)];
+
+    const { result } = renderHook(() => useInfiniteAssets());
+
+    expect(result.current.assets[0].name).toBe('just-uploaded.png');
+  });
+
+  it('keeps bridging while a refetch is still in flight', () => {
+    // `fulfilledTimeStamp` still belongs to the previous response, so the loaded
+    // data predates the upload even though a newer request has started.
+    mockUseGetAssetsQuery.mockReturnValue({
+      ...createMockPage(1, 1, 20),
+      startedTimeStamp: 3_000,
+      fulfilledTimeStamp: 1_000,
+    });
+    mockCompletedUploads = [justUploaded({}, 2_000)];
+
+    const { result } = renderHook(() => useInfiniteAssets());
 
     expect(result.current.assets[0].name).toBe('just-uploaded.png');
   });

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
@@ -144,14 +144,15 @@ const useInfiniteAssets = ({
     setPageState({ queryKey, page: 1 });
   }
 
-  const { currentData, isLoading, isFetching, error } = useGetAssetsQuery(
-    {
-      ...queryArgs,
-      page,
-      pageSize: PAGE_SIZE,
-    },
-    { skip: !enabled }
-  );
+  const { currentData, isLoading, isFetching, error, startedTimeStamp, fulfilledTimeStamp } =
+    useGetAssetsQuery(
+      {
+        ...queryArgs,
+        page,
+        pageSize: PAGE_SIZE,
+      },
+      { skip: !enabled }
+    );
 
   const isSameQuery = accumulated.queryKey === queryKey;
 
@@ -278,18 +279,46 @@ const useInfiniteAssets = ({
   // end-of-batch invalidation, as they did before.
   const canPlaceUploads = !search && (filters?.length ?? 0) === 0;
 
+  // When the loaded data came back from a request that started after a given
+  // upload — i.e. the server had already stored it when asked. Past that point
+  // the list is the authority on whether the asset is there at all, so bridging
+  // must stop: otherwise a later delete or move, which refetches without it,
+  // would have it re-inserted.
+  const listAnsweredAfter =
+    fulfilledTimeStamp !== undefined &&
+    startedTimeStamp !== undefined &&
+    // A refetch in flight leaves `fulfilledTimeStamp` on the previous response,
+    // which predates this request — so only settled data counts.
+    fulfilledTimeStamp > startedTimeStamp
+      ? startedTimeStamp
+      : undefined;
+
   const assets = useMemo(() => {
     if (!canPlaceUploads || completedUploads.length === 0) {
       return loadedAssets;
     }
 
+    const bridging = completedUploads.filter(
+      ({ asset, completedAt }) =>
+        getRelationId(asset.folder) === folder &&
+        (listAnsweredAfter === undefined || completedAt > listAnsweredAfter)
+    );
+
     return mergeUploadedAssets({
       assets: loadedAssets,
-      uploaded: completedUploads.filter((asset) => getRelationId(asset.folder) === folder),
+      uploaded: bridging.map(({ asset }) => asset),
       sort,
       hasNextPage,
     });
-  }, [canPlaceUploads, completedUploads, loadedAssets, folder, sort, hasNextPage]);
+  }, [
+    canPlaceUploads,
+    completedUploads,
+    loadedAssets,
+    folder,
+    sort,
+    hasNextPage,
+    listAnsweredAfter,
+  ]);
   const isFetchingMore = isFetching && page > 1;
 
   const fetchNextPage = useCallback(() => {

--- a/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/hooks/useInfiniteAssets.ts
@@ -4,6 +4,10 @@ import { useDispatch, useStore } from 'react-redux';
 
 import { uploadApi } from '../../../services/api';
 import { useGetAssetsQuery } from '../../../services/assets';
+import { useTypedSelector } from '../../../store/hooks';
+import { selectCompletedUploads } from '../../../store/uploadProgress';
+import { getRelationId } from '../../../utils/getRelationId';
+import { mergeUploadedAssets } from '../utils/mergeUploadedAssets';
 
 import type { File, Pagination } from '../../../../../../shared/contracts/files';
 
@@ -257,7 +261,7 @@ const useInfiniteAssets = ({
   // of the outgoing folder's assets under the incoming folder's header.
   const isChangingList = accumulated.listKey !== listKey;
 
-  const assets = useMemo(
+  const loadedAssets = useMemo(
     () => (isChangingList ? [] : flattenPages(accumulated.pages)),
     [isChangingList, accumulated.pages]
   );
@@ -265,6 +269,27 @@ const useInfiniteAssets = ({
   // Deliberately the live value, not the stale-tolerant one below: paging must
   // never be driven by a total that belongs to the previous query.
   const hasNextPage = currentData ? page < currentData.pagination.pageCount : false;
+
+  const completedUploads = useTypedSelector(selectCompletedUploads);
+
+  // Only an unfiltered, unsearched list can place an upload locally: deciding
+  // whether an asset satisfies a filter means reimplementing the server's
+  // filter semantics client-side. Filtered views still refresh on the
+  // end-of-batch invalidation, as they did before.
+  const canPlaceUploads = !search && (filters?.length ?? 0) === 0;
+
+  const assets = useMemo(() => {
+    if (!canPlaceUploads || completedUploads.length === 0) {
+      return loadedAssets;
+    }
+
+    return mergeUploadedAssets({
+      assets: loadedAssets,
+      uploaded: completedUploads.filter((asset) => getRelationId(asset.folder) === folder),
+      sort,
+      hasNextPage,
+    });
+  }, [canPlaceUploads, completedUploads, loadedAssets, folder, sort, hasNextPage]);
   const isFetchingMore = isFetching && page > 1;
 
   const fetchNextPage = useCallback(() => {

--- a/packages/core/upload/admin/src/future/pages/Assets/utils/mergeUploadedAssets.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/utils/mergeUploadedAssets.ts
@@ -1,0 +1,108 @@
+/**
+ * Merges just-uploaded assets into the loaded asset list so each one appears as
+ * soon as its own upload finishes, rather than when the whole batch settles.
+ *
+ * The upload is one mutation per batch, so its cache invalidation fires once at
+ * the end. These helpers bridge that gap purely client-side: the completed
+ * uploads already sit in the progress store as full `File` objects, so they can
+ * be placed into the list at their sort position with no extra request.
+ *
+ * The server list stays authoritative — merging never reorders it, and an id it
+ * already contains wins over the local copy, so the end-of-batch refetch
+ * silently takes over.
+ */
+
+import type { File } from '../../../../../../shared/contracts/files';
+
+type SortField = 'createdAt' | 'updatedAt' | 'name' | 'size';
+
+const SORT_FIELDS: SortField[] = ['createdAt', 'updatedAt', 'name', 'size'];
+
+const isSortField = (value: string): value is SortField =>
+  (SORT_FIELDS as string[]).includes(value);
+
+const DEFAULT_RULE = 'updatedAt:DESC';
+
+const compareByField = (field: SortField, a: File, b: File): number => {
+  if (field === 'size') {
+    return (a.size ?? 0) - (b.size ?? 0);
+  }
+
+  if (field === 'name') {
+    return a.name.localeCompare(b.name);
+  }
+
+  // `createdAt` / `updatedAt` are ISO-8601, which sorts correctly as text.
+  return (a[field] ?? '').localeCompare(b[field] ?? '');
+};
+
+/**
+ * Comparator matching a `<field>:<ASC|DESC>` sort rule, as sent to the API.
+ *
+ * Ties break on id so the order is total: without it, two files sharing a
+ * timestamp could swap places between renders.
+ */
+export const getAssetComparator = (rule: string = DEFAULT_RULE) => {
+  const [field, requestedDirection] = rule.split(':');
+  // An unrecognised field discards the direction too: half-applying a rule we
+  // cannot read would order the list differently from the default it stands in for.
+  const isKnownField = isSortField(field);
+  const sortField: SortField = isKnownField ? field : 'updatedAt';
+  const direction = isKnownField ? requestedDirection : 'DESC';
+  const sign = direction === 'ASC' ? 1 : -1;
+
+  return (a: File, b: File): number => {
+    const byField = compareByField(sortField, a, b);
+
+    return byField !== 0 ? sign * byField : sign * (a.id - b.id);
+  };
+};
+
+/**
+ * Places `uploaded` into `assets` at their sort position.
+ *
+ * An upload that sorts past everything loaded is dropped unless the list is
+ * fully loaded: it belongs on a page the user has not reached, and appending it
+ * would show it adjacent to the last loaded item instead of at its real place.
+ */
+export const mergeUploadedAssets = ({
+  assets,
+  uploaded,
+  sort,
+  hasNextPage,
+}: {
+  assets: File[];
+  uploaded: File[];
+  sort?: string;
+  /** Whether more pages remain, i.e. the tail of the list is not loaded. */
+  hasNextPage: boolean;
+}): File[] => {
+  if (uploaded.length === 0) {
+    return assets;
+  }
+
+  const loadedIds = new Set(assets.map((asset) => asset.id));
+  const compare = getAssetComparator(sort);
+  const fresh = uploaded.filter((asset) => !loadedIds.has(asset.id)).sort(compare);
+
+  if (fresh.length === 0) {
+    return assets;
+  }
+
+  const merged = [...assets];
+
+  for (const asset of fresh) {
+    const at = merged.findIndex((loaded) => compare(asset, loaded) < 0);
+
+    if (at === -1) {
+      if (hasNextPage) {
+        continue;
+      }
+      merged.push(asset);
+    } else {
+      merged.splice(at, 0, asset);
+    }
+  }
+
+  return merged;
+};

--- a/packages/core/upload/admin/src/future/pages/Assets/utils/tests/mergeUploadedAssets.test.ts
+++ b/packages/core/upload/admin/src/future/pages/Assets/utils/tests/mergeUploadedAssets.test.ts
@@ -1,0 +1,201 @@
+import { getAssetComparator, mergeUploadedAssets } from '../mergeUploadedAssets';
+
+import type { File } from '../../../../../../../shared/contracts/files';
+
+const asset = (id: number, overrides: Partial<File> = {}): File => ({
+  id,
+  name: `asset-${id}.png`,
+  hash: `hash_${id}`,
+  ext: '.png',
+  mime: 'image/png',
+  size: id,
+  url: `http://example.com/asset-${id}.png`,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const names = (assets: File[]) => assets.map(({ name }) => name);
+
+describe('getAssetComparator', () => {
+  it('orders newest first for the default rule', () => {
+    const older = asset(1, { updatedAt: '2024-01-01T00:00:00.000Z' });
+    const newer = asset(2, { updatedAt: '2024-06-01T00:00:00.000Z' });
+
+    expect([older, newer].sort(getAssetComparator('updatedAt:DESC'))).toEqual([newer, older]);
+  });
+
+  it('orders oldest first for an ascending date rule', () => {
+    const older = asset(1, { createdAt: '2024-01-01T00:00:00.000Z' });
+    const newer = asset(2, { createdAt: '2024-06-01T00:00:00.000Z' });
+
+    expect([newer, older].sort(getAssetComparator('createdAt:ASC'))).toEqual([older, newer]);
+  });
+
+  it('orders by name and by size', () => {
+    const a = asset(1, { name: 'apple.png', size: 900 });
+    const b = asset(2, { name: 'banana.png', size: 100 });
+
+    expect(names([b, a].sort(getAssetComparator('name:ASC')))).toEqual(['apple.png', 'banana.png']);
+    expect(names([a, b].sort(getAssetComparator('name:DESC')))).toEqual([
+      'banana.png',
+      'apple.png',
+    ]);
+    expect(names([a, b].sort(getAssetComparator('size:ASC')))).toEqual(['banana.png', 'apple.png']);
+    expect(names([b, a].sort(getAssetComparator('size:DESC')))).toEqual([
+      'apple.png',
+      'banana.png',
+    ]);
+  });
+
+  it('breaks ties on id so the order is total', () => {
+    const first = asset(1);
+    const second = asset(2);
+
+    // Same timestamp on both: without a tie-break the comparator returns 0 and
+    // the pair could swap between renders.
+    expect(getAssetComparator('updatedAt:DESC')(first, second)).toBeGreaterThan(0);
+    expect(getAssetComparator('createdAt:ASC')(first, second)).toBeLessThan(0);
+  });
+
+  it('falls back to newest-first when the rule is missing or unknown', () => {
+    const older = asset(1, { updatedAt: '2024-01-01T00:00:00.000Z' });
+    const newer = asset(2, { updatedAt: '2024-06-01T00:00:00.000Z' });
+
+    expect([older, newer].sort(getAssetComparator())).toEqual([newer, older]);
+    expect([older, newer].sort(getAssetComparator('bogus:ASC'))).toEqual([newer, older]);
+  });
+});
+
+describe('mergeUploadedAssets', () => {
+  const loaded = [
+    asset(3, { name: 'c.png', updatedAt: '2024-03-01T00:00:00.000Z' }),
+    asset(2, { name: 'b.png', updatedAt: '2024-02-01T00:00:00.000Z' }),
+    asset(1, { name: 'a.png', updatedAt: '2024-01-01T00:00:00.000Z' }),
+  ];
+
+  it('places an upload at its sort position, not at the end', () => {
+    const fresh = asset(9, { name: 'fresh.png', updatedAt: '2024-02-15T00:00:00.000Z' });
+
+    const merged = mergeUploadedAssets({
+      assets: loaded,
+      uploaded: [fresh],
+      sort: 'updatedAt:DESC',
+      hasNextPage: false,
+    });
+
+    expect(names(merged)).toEqual(['c.png', 'fresh.png', 'b.png', 'a.png']);
+  });
+
+  it('places the newest upload at the top under the default sort', () => {
+    const fresh = asset(9, { name: 'fresh.png', updatedAt: '2024-12-01T00:00:00.000Z' });
+
+    const merged = mergeUploadedAssets({
+      assets: loaded,
+      uploaded: [fresh],
+      sort: 'updatedAt:DESC',
+      hasNextPage: true,
+    });
+
+    expect(names(merged)).toEqual(['fresh.png', 'c.png', 'b.png', 'a.png']);
+  });
+
+  it('keeps the server copy once the list has caught up', () => {
+    const server = asset(2, { name: 'b-renamed.png', updatedAt: '2024-02-01T00:00:00.000Z' });
+    const stale = asset(2, { name: 'b.png', updatedAt: '2024-02-01T00:00:00.000Z' });
+
+    const merged = mergeUploadedAssets({
+      assets: [server],
+      uploaded: [stale],
+      sort: 'updatedAt:DESC',
+      hasNextPage: false,
+    });
+
+    expect(names(merged)).toEqual(['b-renamed.png']);
+  });
+
+  it('drops an upload that sorts past the loaded tail while pages remain', () => {
+    const fresh = asset(9, { name: 'fresh.png', updatedAt: '2020-01-01T00:00:00.000Z' });
+
+    const merged = mergeUploadedAssets({
+      assets: loaded,
+      uploaded: [fresh],
+      sort: 'updatedAt:DESC',
+      hasNextPage: true,
+    });
+
+    // Its real place is on a page the user has not loaded, so showing it right
+    // after the last loaded item would put it in the wrong position.
+    expect(names(merged)).toEqual(['c.png', 'b.png', 'a.png']);
+  });
+
+  it('appends that same upload once the whole list is loaded', () => {
+    const fresh = asset(9, { name: 'fresh.png', updatedAt: '2020-01-01T00:00:00.000Z' });
+
+    const merged = mergeUploadedAssets({
+      assets: loaded,
+      uploaded: [fresh],
+      sort: 'updatedAt:DESC',
+      hasNextPage: false,
+    });
+
+    expect(names(merged)).toEqual(['c.png', 'b.png', 'a.png', 'fresh.png']);
+  });
+
+  it('places several uploads in order, in one pass', () => {
+    const merged = mergeUploadedAssets({
+      assets: loaded,
+      uploaded: [
+        asset(8, { name: 'oldest-fresh.png', updatedAt: '2024-01-15T00:00:00.000Z' }),
+        asset(9, { name: 'newest-fresh.png', updatedAt: '2024-12-01T00:00:00.000Z' }),
+      ],
+      sort: 'updatedAt:DESC',
+      hasNextPage: false,
+    });
+
+    expect(names(merged)).toEqual([
+      'newest-fresh.png',
+      'c.png',
+      'b.png',
+      'oldest-fresh.png',
+      'a.png',
+    ]);
+  });
+
+  it('respects a non-default sort', () => {
+    const fresh = asset(9, { name: 'bb.png' });
+
+    const merged = mergeUploadedAssets({
+      assets: [
+        asset(1, { name: 'a.png' }),
+        asset(2, { name: 'b.png' }),
+        asset(3, { name: 'c.png' }),
+      ],
+      uploaded: [fresh],
+      sort: 'name:ASC',
+      hasNextPage: false,
+    });
+
+    expect(names(merged)).toEqual(['a.png', 'b.png', 'bb.png', 'c.png']);
+  });
+
+  it('returns the original list untouched when there is nothing to place', () => {
+    expect(
+      mergeUploadedAssets({
+        assets: loaded,
+        uploaded: [],
+        sort: 'updatedAt:DESC',
+        hasNextPage: false,
+      })
+    ).toBe(loaded);
+
+    expect(
+      mergeUploadedAssets({
+        assets: loaded,
+        uploaded: [loaded[1]],
+        sort: 'updatedAt:DESC',
+        hasNextPage: false,
+      })
+    ).toBe(loaded);
+  });
+});

--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -182,6 +182,18 @@ const METADATA_STATUS_BY_RESULT: Record<GenerateAIMetadata.FileStatus, FileMetad
 };
 
 /**
+ * Re-attaches the folder an upload targeted.
+ *
+ * The create response is built from `db.query().create()` with no populate, so
+ * it comes back without the folder relation it was just given. The list needs
+ * it to tell whether a freshly uploaded asset belongs to the folder on screen.
+ */
+const withTargetFolder = (
+  file: UploadedFile,
+  folder: number | string | null | undefined
+): UploadedFile => (file.folder != null ? file : { ...file, folder: folder ?? null });
+
+/**
  * Kicks off AI metadata generation for a freshly uploaded file.
  *
  * Deliberately fire-and-forget — the caller must NOT await it:
@@ -298,7 +310,9 @@ const runUploadPool = async ({
       );
       batcher.cancel();
       uploaded.push(file);
-      dispatch(setFileComplete({ index, file, uploadId }));
+      dispatch(
+        setFileComplete({ index, file: withTargetFolder(file, entry.fileInfo?.folder), uploadId })
+      );
 
       // Not awaited: overlaps with the next file's upload and can't fail the batch.
       maybeGenerateMetadata({
@@ -484,11 +498,13 @@ const processSSEStream = async ({
   dispatch,
   uploadId,
   generateAiMetadata,
+  folderId,
 }: {
   response: Response;
   dispatch: Dispatch;
   uploadId: number;
   generateAiMetadata: boolean;
+  folderId?: number | null;
 }): Promise<CreateFilesStream.Response | null> => {
   const reader = response.body!.getReader();
   const decoder = new TextDecoder();
@@ -534,7 +550,13 @@ const processSSEStream = async ({
         }
         case 'file:complete': {
           const payload = parsed as CreateFilesStreamEvents.FileCompleteEvent;
-          dispatch(setFileComplete({ index, file: payload.file, uploadId }));
+          dispatch(
+            setFileComplete({
+              index,
+              file: withTargetFolder(payload.file, folderId),
+              uploadId,
+            })
+          );
 
           // Same fire-and-forget semantics as the file flow.
           maybeGenerateMetadata({
@@ -843,6 +865,7 @@ const uploadApi = adminApi
               dispatch,
               uploadId,
               generateAiMetadata,
+              folderId,
             });
 
             unregisterAbortController(uploadId);

--- a/packages/core/upload/admin/src/future/services/api.ts
+++ b/packages/core/upload/admin/src/future/services/api.ts
@@ -311,7 +311,12 @@ const runUploadPool = async ({
       batcher.cancel();
       uploaded.push(file);
       dispatch(
-        setFileComplete({ index, file: withTargetFolder(file, entry.fileInfo?.folder), uploadId })
+        setFileComplete({
+          index,
+          file: withTargetFolder(file, entry.fileInfo?.folder),
+          uploadId,
+          completedAt: Date.now(),
+        })
       );
 
       // Not awaited: overlaps with the next file's upload and can't fail the batch.
@@ -555,6 +560,7 @@ const processSSEStream = async ({
               index,
               file: withTargetFolder(payload.file, folderId),
               uploadId,
+              completedAt: Date.now(),
             })
           );
 

--- a/packages/core/upload/admin/src/future/services/tests/uploadFolderScope.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadFolderScope.test.ts
@@ -76,14 +76,14 @@ describe('uploaded assets carry the folder they targeted', () => {
     const result = setup(5);
 
     await waitFor(() => expect(result.current.completed).toHaveLength(1));
-    expect(result.current.completed[0].folder).toBe(5);
+    expect(result.current.completed[0].asset.folder).toBe(5);
   });
 
   it('leaves a root upload at the root', async () => {
     const result = setup(null);
 
     await waitFor(() => expect(result.current.completed).toHaveLength(1));
-    expect(result.current.completed[0].folder).toBeNull();
+    expect(result.current.completed[0].asset.folder).toBeNull();
   });
 
   it('keeps a folder the response did provide', async () => {
@@ -92,6 +92,6 @@ describe('uploaded assets carry the folder they targeted', () => {
     const result = setup(5);
 
     await waitFor(() => expect(result.current.completed).toHaveLength(1));
-    expect(result.current.completed[0].folder).toBe(9);
+    expect(result.current.completed[0].asset.folder).toBe(9);
   });
 });

--- a/packages/core/upload/admin/src/future/services/tests/uploadFolderScope.test.ts
+++ b/packages/core/upload/admin/src/future/services/tests/uploadFolderScope.test.ts
@@ -1,0 +1,97 @@
+import { adminApi } from '@strapi/admin/strapi-admin';
+import { renderHook, act, waitFor } from '@tests/utils';
+
+import { useTypedSelector } from '../../store/hooks';
+import { selectCompletedUploads, uploadProgressReducer } from '../../store/uploadProgress';
+import { useUploadFilesMutation } from '../api';
+import { uploadFileViaXHR } from '../uploadFileViaXHR';
+
+/**
+ * The create response is built without populating the folder relation, so an
+ * uploaded asset comes back with no folder at all. The list needs one to tell
+ * whether a fresh upload belongs to the folder on screen, so the upload
+ * re-attaches the folder it targeted.
+ *
+ * Its own file rather than joining the pool suite: the upload registry is module
+ * state while each test gets a fresh store, so ids collide across tests.
+ */
+
+jest.mock('../uploadFileViaXHR', () => ({
+  ...jest.requireActual('../uploadFileViaXHR'),
+  uploadFileViaXHR: jest.fn(),
+}));
+
+const mockUploadFileViaXHR = uploadFileViaXHR as jest.MockedFunction<typeof uploadFileViaXHR>;
+
+// The harness store has no `uploadProgress` slice (the plugin registers it via
+// `app.addReducers` at runtime), and overriding `reducer` replaces the whole
+// map — so the default slices must be re-declared alongside it.
+const storeConfig = {
+  reducer: {
+    [adminApi.reducerPath]: adminApi.reducer,
+    admin_app: (state = { token: 'test-token' }) => state,
+    uploadProgress: uploadProgressReducer,
+  },
+};
+
+const buildFormData = (folder: number | null) => {
+  const formData = new FormData();
+  formData.append('files', new File(['content'], 'file.png', { type: 'image/png' }));
+  formData.append(
+    'fileInfo',
+    JSON.stringify([{ name: 'file.png', caption: null, alternativeText: null, folder }])
+  );
+
+  return formData;
+};
+
+const setup = (folder: number | null) => {
+  const { result } = renderHook(
+    () => ({
+      upload: useUploadFilesMutation(),
+      completed: useTypedSelector(selectCompletedUploads),
+    }),
+    { providerOptions: { storeConfig } }
+  );
+
+  act(() => {
+    result.current.upload[0]({
+      formData: buildFormData(folder),
+      totalFiles: 1,
+      generateAiMetadata: false,
+    });
+  });
+
+  return result;
+};
+
+describe('uploaded assets carry the folder they targeted', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // What the server actually answers: the created file, with no folder on it.
+    mockUploadFileViaXHR.mockResolvedValue({ id: 1, name: 'file.png' } as never);
+  });
+
+  it('re-attaches the target folder the response left out', async () => {
+    const result = setup(5);
+
+    await waitFor(() => expect(result.current.completed).toHaveLength(1));
+    expect(result.current.completed[0].folder).toBe(5);
+  });
+
+  it('leaves a root upload at the root', async () => {
+    const result = setup(null);
+
+    await waitFor(() => expect(result.current.completed).toHaveLength(1));
+    expect(result.current.completed[0].folder).toBeNull();
+  });
+
+  it('keeps a folder the response did provide', async () => {
+    mockUploadFileViaXHR.mockResolvedValue({ id: 1, name: 'file.png', folder: 9 } as never);
+
+    const result = setup(5);
+
+    await waitFor(() => expect(result.current.completed).toHaveLength(1));
+    expect(result.current.completed[0].folder).toBe(9);
+  });
+});

--- a/packages/core/upload/admin/src/future/store/tests/uploadProgress.test.ts
+++ b/packages/core/upload/admin/src/future/store/tests/uploadProgress.test.ts
@@ -104,6 +104,7 @@ describe('uploadProgress slice', () => {
         setFileComplete({
           uploadId: 1,
           index: 0,
+          completedAt: 1000,
           file: { id: 5, name: 'a.png', hash: 'h' } as never,
         })
       );
@@ -526,7 +527,7 @@ describe('uploadProgress slice', () => {
         );
         state = uploadProgressReducer(
           state,
-          setFileComplete({ uploadId: 1, index, file: { id: index } as never })
+          setFileComplete({ uploadId: 1, index, file: { id: index } as never, completedAt: 1000 })
         );
         state = uploadProgressReducer(state, setFileMetadataGenerating({ index, uploadId: 1 }));
         observe();
@@ -566,7 +567,7 @@ describe('uploadProgress slice', () => {
         );
         state = uploadProgressReducer(
           state,
-          setFileComplete({ uploadId: 1, index, file: { id: index } as never })
+          setFileComplete({ uploadId: 1, index, file: { id: index } as never, completedAt: 1000 })
         );
         state = uploadProgressReducer(state, setFileMetadataGenerating({ index, uploadId: 1 }));
         outcomes.push(metadataOutcome(state));
@@ -699,7 +700,12 @@ describe('uploadProgress slice', () => {
 
       const completed = uploadProgressReducer(
         second,
-        setFileComplete({ index: 0, file: { id: 1 } as never, uploadId: first.uploadId })
+        setFileComplete({
+          index: 0,
+          file: { id: 1 } as never,
+          uploadId: first.uploadId,
+          completedAt: 1000,
+        })
       );
       expect(completed.files[0].status).toBe('pending');
 
@@ -737,11 +743,20 @@ describe('uploadProgress slice', () => {
 describe('selectCompletedUploads', () => {
   const uploaded = (id: number) => ({ id, name: `file-${id}.png`, hash: `hash_${id}` });
 
-  it('returns the assets of rows whose upload has finished', () => {
+  it('returns the assets of rows whose upload has finished, with their completion time', () => {
     const state = makeState([makeFile(0, 'complete', 100, 100), makeFile(1, 'uploading', 100, 50)]);
     state.files[0].file = uploaded(7);
+    state.files[0].completedAt = 1000;
 
-    expect(completedUploads(state)).toEqual([uploaded(7)]);
+    expect(completedUploads(state)).toEqual([{ asset: uploaded(7), completedAt: 1000 }]);
+  });
+
+  it('ignores a row with no completion time', () => {
+    // Nothing to compare a list response against, so it cannot be settled.
+    const state = makeState([makeFile(0, 'complete', 100, 100)]);
+    state.files[0].file = uploaded(7);
+
+    expect(completedUploads(state)).toStrictEqual([]);
   });
 
   it('ignores a complete row that carries no asset', () => {
@@ -755,7 +770,9 @@ describe('selectCompletedUploads', () => {
   it('ignores rows that failed or were cancelled', () => {
     const state = makeState([makeFile(0, 'error', 100), makeFile(1, 'cancelled', 100)]);
     state.files[0].file = uploaded(1);
+    state.files[0].completedAt = 1000;
     state.files[1].file = uploaded(2);
+    state.files[1].completedAt = 1000;
 
     expect(completedUploads(state)).toStrictEqual([]);
   });

--- a/packages/core/upload/admin/src/future/store/tests/uploadProgress.test.ts
+++ b/packages/core/upload/admin/src/future/store/tests/uploadProgress.test.ts
@@ -13,6 +13,7 @@ import {
   setUploadFailed,
   retryCancelledFiles,
   selectAggregateProgress,
+  selectCompletedUploads,
   selectMetadataProgress,
   selectIsGeneratingMetadata,
   selectMetadataOutcome,
@@ -54,6 +55,9 @@ const isGenerating = (state: UploadProgressState) =>
 
 const metadataOutcome = (state: UploadProgressState) =>
   selectMetadataOutcome({ uploadProgress: state });
+
+const completedUploads = (state: UploadProgressState) =>
+  selectCompletedUploads({ uploadProgress: state });
 
 describe('uploadProgress slice', () => {
   describe('openUploadProgress', () => {
@@ -727,5 +731,38 @@ describe('uploadProgress slice', () => {
     it('is true when any row is still going', () => {
       expect(isUploadInFlight([{ status: 'complete' }, { status: 'uploading' }])).toBe(true);
     });
+  });
+});
+
+describe('selectCompletedUploads', () => {
+  const uploaded = (id: number) => ({ id, name: `file-${id}.png`, hash: `hash_${id}` });
+
+  it('returns the assets of rows whose upload has finished', () => {
+    const state = makeState([makeFile(0, 'complete', 100, 100), makeFile(1, 'uploading', 100, 50)]);
+    state.files[0].file = uploaded(7);
+
+    expect(completedUploads(state)).toEqual([uploaded(7)]);
+  });
+
+  it('ignores a complete row that carries no asset', () => {
+    // Nothing to place: the row is only complete once the server has answered
+    // with the created file.
+    const state = makeState([makeFile(0, 'complete', 100, 100)]);
+
+    expect(completedUploads(state)).toStrictEqual([]);
+  });
+
+  it('ignores rows that failed or were cancelled', () => {
+    const state = makeState([makeFile(0, 'error', 100), makeFile(1, 'cancelled', 100)]);
+    state.files[0].file = uploaded(1);
+    state.files[1].file = uploaded(2);
+
+    expect(completedUploads(state)).toStrictEqual([]);
+  });
+
+  it('returns nothing when the slice is not registered yet', () => {
+    // The plugin adds the reducer in `register()`; before that the state has no
+    // upload slice at all and reading through it must not throw.
+    expect(selectCompletedUploads({})).toStrictEqual([]);
   });
 });

--- a/packages/core/upload/admin/src/future/store/uploadProgress.ts
+++ b/packages/core/upload/admin/src/future/store/uploadProgress.ts
@@ -26,6 +26,8 @@ export interface FileProgress {
   size: number;
   uploadedBytes: number;
   file?: File;
+  /** When the server confirmed the upload. Set with the row's asset. */
+  completedAt?: number;
   error?: string;
   metadataStatus?: FileMetadataStatus;
 }
@@ -142,14 +144,18 @@ const uploadProgressSlice = createSlice({
         file.uploadedBytes = Math.min(bytes, file.size);
       }
     },
-    setFileComplete(state, action: PayloadAction<{ index: number; file: File; uploadId: number }>) {
-      const { index, file, uploadId } = action.payload;
+    setFileComplete(
+      state,
+      action: PayloadAction<{ index: number; file: File; uploadId: number; completedAt: number }>
+    ) {
+      const { index, file, uploadId, completedAt } = action.payload;
       if (uploadId !== state.uploadId) {
         return;
       }
       if (state.files[index]) {
         state.files[index].status = 'complete';
         state.files[index].file = file;
+        state.files[index].completedAt = completedAt;
         // Reflect completion in the aggregate even if the final progress event was throttled.
         state.files[index].uploadedBytes = state.files[index].size;
       }
@@ -269,14 +275,20 @@ const uploadProgressSlice = createSlice({
  */
 const NO_FILES: FileProgress[] = [];
 
+/** An uploaded asset, with the moment the server confirmed it. */
+export interface CompletedUpload {
+  asset: File;
+  completedAt: number;
+}
+
 export const selectCompletedUploads = createSelector(
   // The plugin registers this slice in `register()`, so a host that has not
   // reached that point has no upload state — and therefore nothing to place.
   (state: Partial<RootState>) => state.uploadProgress?.files ?? NO_FILES,
-  (files): File[] =>
-    files.reduce<File[]>((completed, row) => {
-      if (row.status === 'complete' && row.file) {
-        completed.push(row.file);
+  (files): CompletedUpload[] =>
+    files.reduce<CompletedUpload[]>((completed, row) => {
+      if (row.status === 'complete' && row.file && row.completedAt !== undefined) {
+        completed.push({ asset: row.file, completedAt: row.completedAt });
       }
 
       return completed;

--- a/packages/core/upload/admin/src/future/store/uploadProgress.ts
+++ b/packages/core/upload/admin/src/future/store/uploadProgress.ts
@@ -260,6 +260,30 @@ const uploadProgressSlice = createSlice({
 });
 
 /**
+ * Assets whose own upload has already finished, newest batch only.
+ *
+ * The list behind the upload dialog uses these to show each asset the moment it
+ * lands, instead of waiting for the batch mutation to invalidate the cache. Rows
+ * only carry a `file` once the server has created it, so every entry here is a
+ * real, persisted asset.
+ */
+const NO_FILES: FileProgress[] = [];
+
+export const selectCompletedUploads = createSelector(
+  // The plugin registers this slice in `register()`, so a host that has not
+  // reached that point has no upload state — and therefore nothing to place.
+  (state: Partial<RootState>) => state.uploadProgress?.files ?? NO_FILES,
+  (files): File[] =>
+    files.reduce<File[]>((completed, row) => {
+      if (row.status === 'complete' && row.file) {
+        completed.push(row.file);
+      }
+
+      return completed;
+    }, [])
+);
+
+/**
  * Byte-weighted aggregate progress across the whole batch: `sum(uploadedBytes) / sum(size)`.
  *
  * Falls back to count-based progress (settled files / total files) when all sizes are


### PR DESCRIPTION
### What does it do?

Makes each uploaded asset appear in the grid/table as soon as **its own** upload finishes, instead of the whole batch appearing at once when the last file settles.

No extra requests are involved. Completed uploads are already in the progress store as full `File` objects — `setFileComplete` stores the server's response on the row — so they are merged into the loaded list client-side, at their correct sort position.

- **`utils/mergeUploadedAssets.ts`** (new, pure) — `getAssetComparator(rule)` for the six sort rules the list can request, and `mergeUploadedAssets` which inserts uploads into the loaded array by sort position.
- **`store/uploadProgress.ts`** — `selectCompletedUploads`, the rows whose upload finished and that carry a created asset.
- **`hooks/useInfiniteAssets.ts`** — merges those into the returned `assets`, scoped to the current view.
- **`services/api.ts`** — re-attaches the folder each upload targeted (see below).

The existing batch-level `{Asset, LIST}` / `{Folder, LIST}` invalidation is **unchanged**. It stops being the only refresh and becomes the reconcile step: the server list always wins, since the merge skips any id the list already holds. That also settles the inconsistency the ticket notes, where the grid only refreshed incrementally when AI metadata generation happened to be enabled.

Three decisions inside this, all deliberate:

- **Only unfiltered, unsearched lists place uploads locally.** Deciding whether a new asset satisfies an active filter means reimplementing the server's filter semantics in the client, which is not worth the divergence. Filtered and searched views behave exactly as they do today and refresh on the end-of-batch invalidation.
- **An upload that sorts past the loaded tail is dropped while more pages remain.** Under `name:ASC` with two pages loaded, a freshly uploaded `zebra.png` belongs on a page the user has not reached; appending it would render it directly after the last loaded item, i.e. in the wrong place. Once the list is fully loaded (`hasNextPage === false`) it appends normally.
- **An unrecognised sort rule falls back to the whole default rule**, field and direction. Keeping the requested direction while substituting the field would order the list differently from the default it is standing in for.

**Beyond the ticket:** the upload response had to be corrected before folder scoping could work at all. `POST /upload/files` builds its body from `strapi.db.query().create()` with no populate (`server/src/services/upload.ts:565`), so an uploaded asset comes back with **no `folder`** — only `GET /upload/files` populates it (`server/src/controllers/admin-file.ts:17`). Without re-attaching the target folder, the scope check matched nothing and no upload would ever have appeared. `withTargetFolder` fixes that at both completion sites, which meant threading `folderId` into `processSSEStream` for the upload-from-URL flow.

Reading the folder back off an asset reuses the existing `getRelationId` helper, which already exists for this contract-versus-wire mismatch.

### Why is it needed?

Uploading a batch left the list behind the dialog frozen. Files that had finished were already stored and visible to the API, but the grid did not reflect them until the slowest file in the batch completed — so twenty files, or one large file among small ones, meant staring at a stale list.

A naive fix (invalidate the list per completed file) would have been expensive here: `useInfiniteAssets` deliberately keeps *every* loaded page subscribed, so one `{Asset, LIST}` invalidation refetches one request **per loaded page**. Twenty files with five pages scrolled is a hundred requests against a filtered, paginated endpoint. Placing the asset client-side avoids that entirely — zero additional requests for the same result.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

Clearer with AI metadata generation **off** and network throttling on, so uploads take visible time.

1. Open the Media Library on a folder, plain view (no search, no filters).
2. Upload several images at once, ideally mixed sizes so some finish well before others.
3. Watch the grid behind the upload dialog: each asset should appear as its own upload completes, newest first, rather than all at the end.
4. Let the batch finish. The list reconciles on the end-of-batch refetch — no duplicated rows, no flicker, no reordering.
5. Repeat in **table** view.
6. Sort by **Name (A-Z)** and upload a file whose name sorts into the middle of what is loaded — it should land in the right place, not at the end.
7. Scroll to load a second page, then upload. The existing rows must not jump or be re-fetched.
8. Upload into folder A, then navigate to folder B while it runs. Nothing from A may appear in B.
9. With a **search** active, or a **type filter** applied: behaviour is unchanged from today — the list updates when the batch finishes.
10. Upload **from URL** (the SSE flow) and confirm the same incremental appearance.

Automated:

```bash
yarn nx test:front @strapi/upload      # 148 suites / 1230 tests
yarn nx test:ts:front @strapi/upload
```

26 new tests across three levels: the comparator and merge semantics as pure units, the selector against slice state, the view gating (search / filters / folder, both `folder` shapes) at hook level, and the folder re-attachment through the real upload mutation with a store.

All ten were checked against deliberately broken versions — never merging, ignoring the search/filter gate, dropping folder scoping, appending instead of inserting, preferring the local copy over the server's, appending a past-the-tail upload anyway, both selector guards, dropping the folder re-attachment, and overwriting a folder the response did provide. Each fails one to four tests. One assertion initially survived its mutation (`expect([undefined]).toEqual([])` passes in Jest) and was tightened to `toStrictEqual`.

### Related issue(s)/PR(s)

fix CMS-1619

🚀