### PR TITLE
chore: replace lodash keys/values/entries/concat/filter/find with native and ban them

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "@swc/core": "1.13.5",
     "@swc/helpers": "0.5.17",
     "@swc/jest": "0.2.39",
+    "@types/eslint": "8.56.12",
     "@types/fs-extra": "11.0.4",
     "@types/git-url-parse": "9.0.3",
     "@types/prompts": "2.4.9",

--- a/packages/core/admin/server/src/controllers/admin.ts
+++ b/packages/core/admin/server/src/controllers/admin.ts
@@ -2,7 +2,7 @@ import type { Context } from 'koa';
 
 import path from 'path';
 
-import { map, values, sumBy, pipe, flatMap, propEq } from 'lodash/fp';
+import { map, sumBy, pipe, flatMap, propEq } from 'lodash/fp';
 import _ from 'lodash';
 import { exists } from 'fs-extra';
 import { env } from '@strapi/utils';
@@ -119,7 +119,7 @@ export default {
     const getNumberOfDynamicZones = () => {
       return pipe(
         map('attributes'),
-        flatMap(values),
+        flatMap(Object.values),
         // @ts-expect-error lodash types
         sumBy(propEq('type', 'dynamiczone'))
       )(strapi.contentTypes as any);

--- a/packages/core/admin/server/src/domain/action/index.ts
+++ b/packages/core/admin/server/src/domain/action/index.ts
@@ -1,6 +1,6 @@
 import type { Utils } from '@strapi/types';
 
-import { curry, pipe, merge, set, pick, omit, includes, isArray, prop } from 'lodash/fp';
+import { curry, pipe, merge, set, pick, omit, includes, prop } from 'lodash/fp';
 
 export interface ActionAlias {
   /**
@@ -174,7 +174,7 @@ const appliesToProperty = curry((property: string, action: Action): boolean => {
  * Check if an action applies to a subject
  */
 const appliesToSubject = curry((subject: string, action: Action): boolean => {
-  return isArray(action.subjects) && includes(subject, action.subjects);
+  return Array.isArray(action.subjects) && includes(subject, action.subjects);
 });
 
 /**

--- a/packages/core/admin/server/src/domain/permission/index.ts
+++ b/packages/core/admin/server/src/domain/permission/index.ts
@@ -1,20 +1,7 @@
 import type { Utils } from '@strapi/types';
 
 import { providerFactory } from '@strapi/utils';
-import {
-  pipe,
-  set,
-  pick,
-  eq,
-  omit,
-  remove,
-  get,
-  uniq,
-  isArray,
-  map,
-  curry,
-  merge,
-} from 'lodash/fp';
+import { pipe, set, pick, eq, omit, remove, get, uniq, map, curry, merge } from 'lodash/fp';
 import { Permission } from '../../../../shared/contracts/shared';
 import { SanitizedPermission } from '../../../../shared/contracts/roles';
 
@@ -130,7 +117,7 @@ export const create = (attributes: CreatePermissionPayload) => {
  */
 export const sanitizeConditions = curry(
   (provider: Provider, permission: Permission): Permission => {
-    if (!isArray(permission.conditions)) {
+    if (!Array.isArray(permission.conditions)) {
       return permission;
     }
 
@@ -153,7 +140,7 @@ function toPermission<T extends CreatePermissionPayload>(payload: T): Permission
 function toPermission<T extends CreatePermissionPayload>(
   payload: T[] | T
 ): Permission[] | Permission {
-  if (isArray(payload)) {
+  if (Array.isArray(payload)) {
     return map((value) => create(value), payload);
   }
 

--- a/packages/core/admin/server/src/index.ts
+++ b/packages/core/admin/server/src/index.ts
@@ -27,7 +27,7 @@ let admin = {
 };
 
 const mergeRoutes = (a: any, b: any, key: string) => {
-  return _.isArray(a) && _.isArray(b) && key === 'routes' ? a.concat(b) : undefined;
+  return Array.isArray(a) && Array.isArray(b) && key === 'routes' ? a.concat(b) : undefined;
 };
 
 if (strapi.EE) {

--- a/packages/core/admin/server/src/policies/hasPermissions.ts
+++ b/packages/core/admin/server/src/policies/hasPermissions.ts
@@ -10,7 +10,7 @@ const inputModifiers = [
     transform: (action: any) => ({ action }),
   },
   {
-    check: _.isArray,
+    check: Array.isArray,
     transform: (arr: any) => ({ action: arr[0], subject: arr[1] }),
   },
   {

--- a/packages/core/admin/server/src/services/__tests__/role.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/role.test.ts
@@ -75,7 +75,9 @@ describe('Role', () => {
         name: 'super_admin',
         description: "Have all permissions. Can't be delete",
       };
-      const dbFindOne = jest.fn(({ where: { id } }) => Promise.resolve(_.find([role], { id })));
+      const dbFindOne = jest.fn(({ where: { id } }) =>
+        Promise.resolve([role].find((candidate) => candidate.id === id))
+      );
 
       global.strapi = {
         ...strapiMock,
@@ -96,7 +98,7 @@ describe('Role', () => {
         usersCount: 0,
       };
       const dbFindOne = jest.fn(({ where: { id } }) =>
-        Promise.resolve(_.find([_.omit(role, ['usersCount'])], { id }))
+        Promise.resolve([_.omit(role, ['usersCount'])].find((candidate) => candidate.id === id))
       );
       const dbCount = jest.fn(() => Promise.resolve(0));
       global.strapi = {

--- a/packages/core/admin/server/src/services/api-token.ts
+++ b/packages/core/admin/server/src/services/api-token.ts
@@ -5,7 +5,6 @@ import {
   isNil,
   isEmpty,
   map,
-  isArray,
   uniq,
   isNumber,
   differenceWith,
@@ -138,7 +137,7 @@ const assertCustomTokenPermissionsValidity = (
   }
 
   // Custom type tokens should always have permissions attached to them
-  if (type === constants.API_TOKEN_TYPE.CUSTOM && !isArray(permissions)) {
+  if (type === constants.API_TOKEN_TYPE.CUSTOM && !Array.isArray(permissions)) {
     throw new ValidationError('Missing permissions attribute for custom token');
   }
 
@@ -591,7 +590,7 @@ const syncApiTokenPermissionsForRole = async (roleId: Data.ID): Promise<void> =>
  * Flatten a token's database permissions objects to an array of strings
  */
 const flattenTokenPermissions = (permissions: { action: string }[] | undefined): string[] => {
-  return isArray(permissions) ? map('action', permissions) : [];
+  return Array.isArray(permissions) ? map('action', permissions) : [];
 };
 
 type WhereParams = {

--- a/packages/core/admin/server/src/services/permission/engine.ts
+++ b/packages/core/admin/server/src/services/permission/engine.ts
@@ -1,4 +1,4 @@
-import { curry, isArray, isEmpty, difference } from 'lodash/fp';
+import { curry, isEmpty, difference } from 'lodash/fp';
 import { engine } from '@strapi/permissions';
 import type { Ability } from '@casl/ability';
 import permissionDomain from '../../domain/permission';
@@ -56,7 +56,7 @@ export default (params: { providers: engine.EngineParams['providers'] }) => {
     .on('after-format::validate.permission', ({ permission }) => {
       const { fields } = permission.properties;
 
-      if (isArray(fields) && isEmpty(fields)) {
+      if (Array.isArray(fields) && isEmpty(fields)) {
         return false;
       }
     });

--- a/packages/core/admin/server/src/services/permission/permissions-manager/query-builders.ts
+++ b/packages/core/admin/server/src/services/permission/permissions-manager/query-builders.ts
@@ -34,10 +34,10 @@ const buildStrapiQuery = (caslQuery: unknown) => {
 };
 
 const unwrapDeep = (obj: any): unknown => {
-  if (!_.isPlainObject(obj) && !_.isArray(obj)) {
+  if (!_.isPlainObject(obj) && !Array.isArray(obj)) {
     return obj;
   }
-  if (_.isArray(obj)) {
+  if (Array.isArray(obj)) {
     return obj.map((v: unknown) => unwrapDeep(v));
   }
 
@@ -52,7 +52,7 @@ const unwrapDeep = (obj: any): unknown => {
         } else {
           _.setWith(acc, key, unwrapDeep(v));
         }
-      } else if (_.isArray(v)) {
+      } else if (Array.isArray(v)) {
         // prettier-ignore
         _.setWith(acc, key, v.map(v => unwrapDeep(v)));
       } else {

--- a/packages/core/admin/server/src/services/permission/permissions-manager/sanitize.ts
+++ b/packages/core/admin/server/src/services/permission/permissions-manager/sanitize.ts
@@ -2,7 +2,6 @@ import { subject as asSubject } from '@casl/ability';
 import {
   defaults,
   omit,
-  isArray,
   isEmpty,
   uniq,
   intersection,
@@ -202,7 +201,7 @@ export default ({ action, ability, model }: any) => {
     const { getPermissionFields } = createPermissionFieldsCache(ability);
 
     const wrappedSanitize = async (data: unknown, options = {} as any): Promise<unknown> => {
-      if (isArray(data)) {
+      if (Array.isArray(data)) {
         return Promise.all(data.map((entity: unknown) => wrappedSanitize(entity, options)));
       }
 

--- a/packages/core/admin/server/src/services/permission/permissions-manager/validate.ts
+++ b/packages/core/admin/server/src/services/permission/permissions-manager/validate.ts
@@ -1,5 +1,5 @@
 import { subject as asSubject } from '@casl/ability';
-import { defaults, omit, isArray, isEmpty, uniq, intersection, getOr, isObject } from 'lodash/fp';
+import { defaults, omit, isEmpty, uniq, intersection, getOr, isObject } from 'lodash/fp';
 
 import {
   contentTypes,
@@ -161,7 +161,7 @@ export default ({ action, ability, model }: any) => {
     // TODO
     // @ts-expect-error define the correct return type
     const wrappedValidate = async (data, options = {}): Promise<unknown> => {
-      if (isArray(data)) {
+      if (Array.isArray(data)) {
         return Promise.all(data.map((entity: unknown) => wrappedValidate(entity, options)));
       }
 

--- a/packages/core/admin/server/src/services/permission/queries.ts
+++ b/packages/core/admin/server/src/services/permission/queries.ts
@@ -1,4 +1,4 @@
-import { isNil, isArray, prop, xor, eq, differenceWith } from 'lodash/fp';
+import { isNil, prop, xor, eq, differenceWith } from 'lodash/fp';
 import pmap from 'p-map';
 import type { Data } from '@strapi/types';
 import { getService } from '../../utils';
@@ -110,8 +110,10 @@ const filterPermissionsToRemove = async (permissions: Permission[]) => {
     );
 
     const isRegisteredAction = actionProvider.has(permission.action);
-    const hasInvalidProperties = isArray(applyToProperties) && invalidProperties.every(eq(true));
-    const isInvalidSubject = isArray(subjects) && !subjects.includes(permission.subject as string);
+    const hasInvalidProperties =
+      Array.isArray(applyToProperties) && invalidProperties.every(eq(true));
+    const isInvalidSubject =
+      Array.isArray(subjects) && !subjects.includes(permission.subject as string);
     // On an api token permission, nil properties mean "everything", not "invalid"
     const hasApiToken = !isNil(prop('apiToken', permission));
 

--- a/packages/core/admin/server/src/services/role.ts
+++ b/packages/core/admin/server/src/services/role.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */ // TODO: TS - Use database parameters interface when they are ready
 /* eslint-disable @typescript-eslint/default-param-last */
 import _ from 'lodash';
-import { set, omit, pick, prop, isArray, differenceWith, differenceBy, isEqual } from 'lodash/fp';
+import { set, omit, pick, prop, differenceWith, differenceBy, isEqual } from 'lodash/fp';
 
 import { dates, arrays, hooks as hooksUtils, errors } from '@strapi/utils';
 import type { Data } from '@strapi/types';
@@ -431,7 +431,7 @@ const resetSuperAdminPermissions = async () => {
   const otherPermissions = otherActions.reduce((acc, action) => {
     const { actionId, subjects } = action;
 
-    if (isArray(subjects)) {
+    if (Array.isArray(subjects)) {
       acc.push(
         ...subjects.map((subject) => permissionDomain.create({ action: actionId, subject }))
       );

--- a/packages/core/admin/server/src/services/transfer/token.ts
+++ b/packages/core/admin/server/src/services/transfer/token.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import assert from 'assert';
-import { map, isArray, omit, uniq, isNil, difference, isEmpty, isNumber } from 'lodash/fp';
+import { map, omit, uniq, isNil, difference, isEmpty, isNumber } from 'lodash/fp';
 import { errors } from '@strapi/utils';
 import '@strapi/types';
 import constants from '../constants';
@@ -331,7 +331,7 @@ const flattenTokenPermissions = (token: DatabaseTransferToken): TransferToken =>
 
   return {
     ...token,
-    permissions: isArray(token.permissions)
+    permissions: Array.isArray(token.permissions)
       ? map('action', token.permissions as TransferTokenPermission[])
       : token.permissions,
   };

--- a/packages/core/admin/server/src/validation/common-validators.ts
+++ b/packages/core/admin/server/src/validation/common-validators.ts
@@ -1,6 +1,6 @@
 import { yup } from '@strapi/utils';
 import _ from 'lodash';
-import { isEmpty, has, isNil, isArray } from 'lodash/fp';
+import { isEmpty, has, isNil } from 'lodash/fp';
 import { getService } from '../utils';
 import actionDomain, { type Action } from '../domain/action';
 import { checkFieldsAreCorrectlyNested, checkFieldsDontHaveDuplicates } from './common-functions';
@@ -138,7 +138,7 @@ export const permission = yup
             return isNil(subject);
           }
 
-          if (isArray(action.subjects) && !isNil(subject)) {
+          if (Array.isArray(action.subjects) && !isNil(subject)) {
             return action.subjects.includes(subject);
           }
 
@@ -166,7 +166,7 @@ export const permission = yup
 
           const { applyToProperties } = action.options;
 
-          if (!isArray(applyToProperties)) {
+          if (!Array.isArray(applyToProperties)) {
             return false;
           }
 

--- a/packages/core/admin/server/src/validation/policies/hasPermissions.ts
+++ b/packages/core/admin/server/src/validation/policies/hasPermissions.ts
@@ -5,7 +5,7 @@ const hasPermissionsSchema = yup.object({
   actions: yup.array().of(
     // @ts-expect-error yup types
     yup.lazy((val) => {
-      if (_.isArray(val)) {
+      if (Array.isArray(val)) {
         return yup.array().of(yup.string()).min(1).max(2);
       }
 

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -1,4 +1,4 @@
-import { prop, uniq, uniqBy, concat, flow, isEmpty } from 'lodash/fp';
+import { prop, uniq, uniqBy, flow, isEmpty } from 'lodash/fp';
 
 import { isOperatorOfType, contentTypes, relations, errors } from '@strapi/utils';
 import type { Data, Modules, UID } from '@strapi/types';
@@ -509,7 +509,7 @@ export default {
     });
 
     // NOTE: the order is very important to make sure sanitized relations are kept in priority
-    const relationsUnion = uniqBy('id', concat(sanitizedRes.results, res.results));
+    const relationsUnion = uniqBy('id', [...sanitizedRes.results, ...res.results]);
 
     ctx.body = {
       pagination: res.pagination || {

--- a/packages/core/content-releases/server/src/migrations/index.ts
+++ b/packages/core/content-releases/server/src/migrations/index.ts
@@ -2,7 +2,7 @@ import type { Schema, UID } from '@strapi/types';
 import { contentTypes as contentTypesUtils, async } from '@strapi/utils';
 import isEqual from 'lodash/isEqual';
 
-import { difference, keys } from 'lodash';
+import { difference } from 'lodash';
 import { RELEASE_ACTION_MODEL_UID, RELEASE_MODEL_UID } from '../constants';
 import { getDraftEntryValidStatus, getService } from '../utils';
 import { Release } from '../../../shared/contracts/releases';
@@ -43,7 +43,8 @@ export async function deleteActionsOnDisableDraftAndPublish({
 }
 
 export async function deleteActionsOnDeleteContentType({ oldContentTypes, contentTypes }: Input) {
-  const deletedContentTypes = difference(keys(oldContentTypes), keys(contentTypes)) ?? [];
+  const deletedContentTypes =
+    difference(Object.keys(oldContentTypes), Object.keys(contentTypes)) ?? [];
 
   if (deletedContentTypes.length) {
     await async.map(deletedContentTypes, async (deletedContentTypeUID: unknown) => {

--- a/packages/core/content-type-builder/server/src/controllers/validation/common.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/common.ts
@@ -85,7 +85,7 @@ export const isValidDefaultJSON: CommonTestConfig = {
       return true;
     }
 
-    if (_.isNumber(val) || _.isNull(val) || _.isObject(val) || _.isArray(val)) {
+    if (_.isNumber(val) || _.isNull(val) || _.isObject(val) || Array.isArray(val)) {
       return true;
     }
 

--- a/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod/v4';
 import { strings, validateZodSchema, contentTypes } from '@strapi/utils';
 import type { Struct, UID } from '@strapi/types';
-import { isArray, isNil, isNull, isNumber, isObject, isUndefined, snakeCase } from 'lodash/fp';
+import { isNil, isNull, isNumber, isObject, isUndefined, snakeCase } from 'lodash/fp';
 
 import { isReservedAttributeName, isReservedModelName } from '../../services/builder';
 import { coreUids, typeKinds, VALID_UID_TARGETS } from '../../services/constants';
@@ -416,7 +416,7 @@ const jsonSchema = basePropertiesSchema.extend({
         return true;
       }
 
-      if (isNumber(value) || isNull(value) || isObject(value) || isArray(value)) {
+      if (isNumber(value) || isNull(value) || isObject(value) || Array.isArray(value)) {
         return true;
       }
 

--- a/packages/core/core/src/middlewares/session.ts
+++ b/packages/core/core/src/middlewares/session.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isArray } from 'lodash/fp';
+import { isEmpty } from 'lodash/fp';
 import { type SessionOptions, createSession } from 'koa-session';
 import type { Core } from '@strapi/types';
 
@@ -20,7 +20,7 @@ export const session: Core.MiddlewareFactory<Partial<SessionOptions>> = (
   { strapi }
 ) => {
   const { keys } = strapi.server.app;
-  if (!isArray(keys) || isEmpty(keys) || keys.some(isEmpty)) {
+  if (!Array.isArray(keys) || isEmpty(keys) || keys.some(isEmpty)) {
     throw new Error(
       `App keys are required. Please set app.keys in config/server.js (ex: keys: ['myKeyA', 'myKeyB'])`
     );

--- a/packages/core/core/src/services/config.ts
+++ b/packages/core/core/src/services/config.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import { get, set, has, isString, isNumber, isArray, type PropertyPath } from 'lodash';
+import { get, set, has, isString, isNumber, type PropertyPath } from 'lodash';
 
 type State = {
   config: Config;
@@ -35,7 +35,7 @@ export const createConfigProvider = (
     if (isString(path)) {
       return transformPathString(path);
     }
-    if (isArray(path)) {
+    if (Array.isArray(path)) {
       // if the path is not joinable, we won't apply our deprecation support
       if (path.some((part) => !(isString(part) || isNumber(part)))) {
         return path;

--- a/packages/core/core/src/services/entity-validator/index.ts
+++ b/packages/core/core/src/services/entity-validator/index.ts
@@ -3,7 +3,7 @@
  * Module that will validate input data for entity creation or edition
  */
 
-import { uniqBy, castArray, isNil, isArray, mergeWith } from 'lodash';
+import { uniqBy, castArray, isNil, mergeWith } from 'lodash';
 import { has, prop, isObject, isEmpty } from 'lodash/fp';
 import jsonLogic from 'json-logic-js';
 import * as strapiUtils from '@strapi/utils';
@@ -710,7 +710,7 @@ const buildRelationsStore = <TUID extends UID.Schema>({
                 data: componentValue as Record<string, unknown>,
               }),
               (objValue, srcValue) => {
-                if (isArray(objValue)) {
+                if (Array.isArray(objValue)) {
                   return objValue.concat(srcValue);
                 }
               }
@@ -733,7 +733,7 @@ const buildRelationsStore = <TUID extends UID.Schema>({
                 data: value,
               }),
               (objValue, srcValue) => {
-                if (isArray(objValue)) {
+                if (Array.isArray(objValue)) {
                   return objValue.concat(srcValue);
                 }
               }

--- a/packages/core/core/src/services/server/middleware.ts
+++ b/packages/core/core/src/services/server/middleware.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { isArray } from 'lodash/fp';
 import { importDefault } from '@strapi/utils';
 import type { Core } from '@strapi/types';
 
@@ -21,7 +20,7 @@ const instantiateMiddleware = (
 const resolveRouteMiddlewares = (route: Core.Route, strapi: Core.Strapi) => {
   const middlewaresConfig = route?.config?.middlewares ?? [];
 
-  if (!isArray(middlewaresConfig)) {
+  if (!Array.isArray(middlewaresConfig)) {
     throw new Error('Route middlewares config must be an array');
   }
 

--- a/packages/core/core/src/services/utils/conditional-fields.ts
+++ b/packages/core/core/src/services/utils/conditional-fields.ts
@@ -1,4 +1,4 @@
-import { map, values, sumBy, pipe, flatMap } from 'lodash/fp';
+import { map, sumBy, pipe, flatMap } from 'lodash/fp';
 import type { Schema, UID } from '@strapi/types';
 
 const getNumberOfConditionalFields = () => {
@@ -10,7 +10,7 @@ const getNumberOfConditionalFields = () => {
   ) => {
     return pipe(
       map('attributes'),
-      flatMap(values),
+      flatMap(Object.values),
       sumBy((attribute: Schema.Attribute.AnyAttribute) => {
         if (attribute.conditions && typeof attribute.conditions === 'object') {
           return 1;

--- a/packages/core/core/src/services/utils/dynamic-zones.ts
+++ b/packages/core/core/src/services/utils/dynamic-zones.ts
@@ -1,4 +1,4 @@
-import { map, values, sumBy, pipe, flatMap } from 'lodash/fp';
+import { map, sumBy, pipe, flatMap } from 'lodash/fp';
 import type { Schema, UID } from '@strapi/types';
 
 const getNumberOfDynamicZones = () => {
@@ -6,7 +6,7 @@ const getNumberOfDynamicZones = () => {
 
   return pipe(
     map('attributes'),
-    flatMap(values),
+    flatMap(Object.values),
     sumBy((item) => {
       if (item.type === 'dynamiczone') {
         return 1;

--- a/packages/core/data-transfer/src/engine/validation/schemas/index.ts
+++ b/packages/core/data-transfer/src/engine/validation/schemas/index.ts
@@ -1,5 +1,5 @@
 import type { Struct } from '@strapi/types';
-import { isArray, isObject, reject } from 'lodash/fp';
+import { isObject, reject } from 'lodash/fp';
 import type { Diff } from '../../../utils/json';
 import * as utils from '../../../utils';
 
@@ -27,7 +27,7 @@ const isOptionalAdminType = (diff: Diff) => {
   }
 
   // modified
-  if ('values' in diff && isArray(diff.values) && isObject(diff.values[0])) {
+  if ('values' in diff && Array.isArray(diff.values) && isObject(diff.values[0])) {
     const name = (diff?.values[0] as Struct.ContentTypeSchema)?.info?.singularName;
     return (OPTIONAL_CONTENT_TYPES as ReadonlyArray<string | undefined>).includes(name);
   }

--- a/packages/core/data-transfer/src/strapi/queries/entity.ts
+++ b/packages/core/data-transfer/src/strapi/queries/entity.ts
@@ -1,4 +1,4 @@
-import { assign, isArray, isEmpty, isObject, map, omit, size } from 'lodash/fp';
+import { assign, isEmpty, isObject, map, omit, size } from 'lodash/fp';
 
 import type { Core, UID, Data, Struct } from '@strapi/types';
 import * as componentsService from '../../utils/components';
@@ -92,11 +92,11 @@ const createEntityQuery = (strapi: Core.Strapi): any => {
           const component = strapi.getModel(attribute.component);
           const subPopulate = getDeepPopulateComponentLikeQuery(component, params);
 
-          if ((isArray(subPopulate) || isObject(subPopulate)) && size(subPopulate) > 0) {
+          if ((Array.isArray(subPopulate) || isObject(subPopulate)) && size(subPopulate) > 0) {
             populate[key] = { ...params, populate: subPopulate };
           }
 
-          if (isArray(subPopulate) && isEmpty(subPopulate)) {
+          if (Array.isArray(subPopulate) && isEmpty(subPopulate)) {
             populate[key] = { ...params };
           }
         }
@@ -110,11 +110,11 @@ const createEntityQuery = (strapi: Core.Strapi): any => {
             const component = strapi.getModel(componentUID);
             const subPopulate = getDeepPopulateComponentLikeQuery(component, params);
 
-            if ((isArray(subPopulate) || isObject(subPopulate)) && size(subPopulate) > 0) {
+            if ((Array.isArray(subPopulate) || isObject(subPopulate)) && size(subPopulate) > 0) {
               on[componentUID] = { ...params, populate: subPopulate };
             }
 
-            if (isArray(subPopulate) && isEmpty(subPopulate)) {
+            if (Array.isArray(subPopulate) && isEmpty(subPopulate)) {
               on[componentUID] = { ...params };
             }
           }

--- a/packages/core/data-transfer/src/utils/json.ts
+++ b/packages/core/data-transfer/src/utils/json.ts
@@ -1,4 +1,4 @@
-import { isArray, isObject, zip, isEqual, uniq } from 'lodash/fp';
+import { isObject, zip, isEqual, uniq } from 'lodash/fp';
 
 const createContext = (): Context => ({ path: [] });
 
@@ -38,7 +38,7 @@ export const diff = (a: unknown, b: unknown, ctx: Context = createContext()): Di
     return diffs;
   };
 
-  if (isArray(a) && isArray(b)) {
+  if (Array.isArray(a) && Array.isArray(b)) {
     let k = 0;
 
     for (const [aItem, bItem] of zip(a, b)) {

--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -4,7 +4,6 @@ import {
   difference,
   differenceWith,
   has,
-  isArray,
   isEmpty,
   isEqual,
   isInteger,
@@ -148,7 +147,7 @@ type Assocs =
 
 const toAssocs = (data: Assocs) => {
   if (
-    isArray(data) ||
+    Array.isArray(data) ||
     isString(data) ||
     isNumber(data) ||
     isNull(data) ||
@@ -379,7 +378,7 @@ export const createEntityManager = (db: Database): EntityManager => {
       const metadata = db.metadata.get(uid);
       const { data } = params;
 
-      if (!isArray(data)) {
+      if (!Array.isArray(data)) {
         throw new Error('CreateMany expects data to be an array');
       }
 

--- a/packages/core/database/src/lifecycles/subscribers/timestamps.ts
+++ b/packages/core/database/src/lifecycles/subscribers/timestamps.ts
@@ -21,7 +21,7 @@ export const timestampsLifecyclesSubscriber: Subscriber = {
     const { data } = event.params;
 
     const now = new Date();
-    if (_.isArray(data)) {
+    if (Array.isArray(data)) {
       data.forEach((data) => _.defaults(data, { createdAt: now, updatedAt: now }));
     }
   },
@@ -45,7 +45,7 @@ export const timestampsLifecyclesSubscriber: Subscriber = {
     const { data } = event.params;
 
     const now = new Date();
-    if (_.isArray(data)) {
+    if (Array.isArray(data)) {
       data.forEach((data) => _.assign(data, { updatedAt: now }));
     }
   },

--- a/packages/core/database/src/query/helpers/transform.ts
+++ b/packages/core/database/src/query/helpers/transform.ts
@@ -91,7 +91,7 @@ function toRow(meta: Meta, data: Rec | Rec[] | null): Row | Row[] | null {
     return data;
   }
 
-  if (_.isArray(data)) {
+  if (Array.isArray(data)) {
     return data.map((datum) => toSingleRow(meta, datum));
   }
 

--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { isArray, castArray, isPlainObject } from 'lodash/fp';
+import { castArray, isPlainObject } from 'lodash/fp';
 import type { Knex } from 'knex';
 
 import { isOperator, isOperatorOfType } from '@strapi/utils';
@@ -60,7 +60,7 @@ const processSingleAttributeWhere = (
 };
 
 const processAttributeWhere = (attribute: Attribute | null, where: unknown, operator = '$eq') => {
-  if (isArray(where)) {
+  if (Array.isArray(where)) {
     return where.map((sub) => processSingleAttributeWhere(attribute, sub, operator));
   }
 
@@ -118,11 +118,11 @@ function processWhere(
   where: Record<string, unknown> | Record<string, unknown>[],
   ctx: WhereCtx
 ): Record<string, unknown> | Record<string, unknown>[] {
-  if (!isArray(where) && !isRecord(where)) {
+  if (!Array.isArray(where) && !isRecord(where)) {
     throw new Error('Where must be an array or an object');
   }
 
-  if (isArray(where)) {
+  if (Array.isArray(where)) {
     return where.map((sub) => processWhere(sub, ctx));
   }
 
@@ -430,11 +430,11 @@ type Where =
   | Array<Where>;
 
 const applyWhere = (qb: Knex.QueryBuilder, where: Where): Knex.QueryBuilder | undefined => {
-  if (!isArray(where) && !isRecord(where)) {
+  if (!Array.isArray(where) && !isRecord(where)) {
     throw new Error('Where must be an array or an object');
   }
 
-  if (isArray(where)) {
+  if (Array.isArray(where)) {
     return qb.where((subQB: Knex.QueryBuilder) =>
       where.forEach((subWhere) => applyWhere(subQB, subWhere))
     );

--- a/packages/core/database/src/query/query-builder.ts
+++ b/packages/core/database/src/query/query-builder.ts
@@ -558,7 +558,7 @@ const createQueryBuilder = (
 
       if (this.shouldUseDistinct()) {
         const joinsOrderByColumns = state.joins.flatMap((join) => {
-          return _.keys(join.orderBy).map((key) => this.aliasColumn(key, join.alias));
+          return Object.keys(join.orderBy ?? {}).map((key) => this.aliasColumn(key, join.alias));
         });
         // Only include column-based orderBy entries here (raw expressions are handled below)
         const orderByColumns = state.orderBy

--- a/packages/core/database/src/schema/diff.ts
+++ b/packages/core/database/src/schema/diff.ts
@@ -451,7 +451,7 @@ export default (db: Database) => {
           .filter((table: PersistedTable) => {
             const dependsOn = table?.dependsOn;
 
-            if (!_.isArray(dependsOn)) {
+            if (!Array.isArray(dependsOn)) {
               return;
             }
 

--- a/packages/core/permissions/src/engine/hooks.ts
+++ b/packages/core/permissions/src/engine/hooks.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, has, isArray } from 'lodash/fp';
+import { cloneDeep, has } from 'lodash/fp';
 import { hooks } from '@strapi/utils';
 
 import * as domain from '../domain';
@@ -72,7 +72,7 @@ const createWillRegisterContext = ({ permission, options }: WillRegisterContextP
         permission.condition = { $and: [] };
       }
 
-      if (isArray(permission.condition.$and)) {
+      if (Array.isArray(permission.condition.$and)) {
         permission.condition.$and.push(rawConditionObject);
       }
 
@@ -84,7 +84,7 @@ const createWillRegisterContext = ({ permission, options }: WillRegisterContextP
         permission.condition = { $and: [] };
       }
 
-      if (isArray(permission.condition.$and)) {
+      if (Array.isArray(permission.condition.$and)) {
         const orClause = permission.condition.$and.find(has('$or'));
 
         if (orClause) {

--- a/packages/core/permissions/src/engine/index.ts
+++ b/packages/core/permissions/src/engine/index.ts
@@ -119,10 +119,10 @@ const newEngine = (params: EngineParams): Engine => {
     const resolveConditions = (ids: string[]): (Condition | undefined)[] =>
       ids.map((id) => providers.condition.get(id) as Condition | undefined);
 
-    const removeInvalidConditions = _.filter(
-      (condition: Condition | undefined): condition is Condition =>
-        condition != null && _.isFunction(condition.handler)
-    );
+    const removeInvalidConditions = (conditions: (Condition | undefined)[]): Condition[] =>
+      conditions.filter(
+        (condition): condition is Condition => condition != null && _.isFunction(condition.handler)
+      );
 
     const evaluateConditions = (conditions: Condition[]) => {
       return Promise.all(
@@ -135,9 +135,8 @@ const newEngine = (params: EngineParams): Engine => {
       );
     };
 
-    const removeInvalidResults = _.filter(
-      ({ result }) => _.isBoolean(result) || _.isObject(result)
-    );
+    const removeInvalidResults = <T extends { result: unknown }>(results: T[]): T[] =>
+      results.filter(({ result }) => _.isBoolean(result) || _.isObject(result));
 
     const evaluatedConditions = await Promise.resolve(conditions)
       .then(resolveConditions)

--- a/packages/core/review-workflows/server/src/migrations/handle-deleted-ct-in-workflows.ts
+++ b/packages/core/review-workflows/server/src/migrations/handle-deleted-ct-in-workflows.ts
@@ -1,4 +1,4 @@
-import { difference, keys } from 'lodash/fp';
+import { difference } from 'lodash/fp';
 import { async } from '@strapi/utils';
 import { WORKFLOW_MODEL_UID } from '../constants/workflows';
 import { getWorkflowContentTypeFilter } from '../utils/review-workflows';
@@ -7,7 +7,8 @@ import { getWorkflowContentTypeFilter } from '../utils/review-workflows';
  * Remove CT references from workflows if the CT is deleted
  */
 async function migrateDeletedCTInWorkflows({ oldContentTypes, contentTypes }: any) {
-  const deletedContentTypes = difference(keys(oldContentTypes), keys(contentTypes)) ?? [];
+  const deletedContentTypes =
+    difference(Object.keys(oldContentTypes), Object.keys(contentTypes)) ?? [];
 
   if (deletedContentTypes.length) {
     await async.map(deletedContentTypes, async (deletedContentTypeUID: unknown) => {

--- a/packages/core/review-workflows/server/src/migrations/multiple-workflows.ts
+++ b/packages/core/review-workflows/server/src/migrations/multiple-workflows.ts
@@ -1,4 +1,4 @@
-import { get, keys, pickBy, pipe } from 'lodash/fp';
+import { get, pickBy, pipe } from 'lodash/fp';
 import { WORKFLOW_MODEL_UID } from '../constants/workflows';
 
 async function migrateWorkflowsContentTypes({ oldContentTypes, contentTypes }: any) {
@@ -12,7 +12,9 @@ async function migrateWorkflowsContentTypes({ oldContentTypes, contentTypes }: a
     await strapi.db.query(WORKFLOW_MODEL_UID).updateMany({ data: { contentTypes: [] } });
 
     // Find Content Types which were using Review Workflow before
-    const contentTypes = pipe([pickBy(get('options.reviewWorkflows')), keys])(oldContentTypes);
+    const contentTypes = pipe([pickBy(get('options.reviewWorkflows')), Object.keys])(
+      oldContentTypes
+    );
 
     if (contentTypes.length) {
       // Update only one workflow with the contentTypes

--- a/packages/core/review-workflows/server/src/register.ts
+++ b/packages/core/review-workflows/server/src/register.ts
@@ -1,4 +1,4 @@
-import { defaultsDeep, filter, pipe } from 'lodash/fp';
+import { defaultsDeep, pipe } from 'lodash/fp';
 
 import type { Core, UID } from '@strapi/types';
 
@@ -86,7 +86,7 @@ function persistRWOnDowngrade({ strapi }: { strapi: Core.Strapi }) {
 
     const enabledRWContentTypes = pipe([
       getVisibleContentTypesUID,
-      filter((uid: UID.ContentType) => hasStageAttribute(contentTypes[uid])),
+      (uids: UID.ContentType[]) => uids.filter((uid) => hasStageAttribute(contentTypes[uid])),
     ])(contentTypes);
 
     // Remove previously created join tables and persist the new ones

--- a/packages/core/review-workflows/server/src/utils/review-workflows.ts
+++ b/packages/core/review-workflows/server/src/utils/review-workflows.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import { getOr, keys, pickBy, pipe, has, clamp } from 'lodash/fp';
+import { getOr, pickBy, pipe, has, clamp } from 'lodash/fp';
 import {
   ENTITY_STAGE_ATTRIBUTE,
   MAX_WORKFLOWS,
@@ -14,7 +14,7 @@ export const getVisibleContentTypesUID = pipe([
       !getOr(false, 'options.noStageAttribute', value)
   ),
   // Get UIDs
-  keys,
+  Object.keys,
 ]);
 
 export const hasStageAttribute = has(['attributes', ENTITY_STAGE_ATTRIBUTE]);

--- a/packages/core/strapi/src/cli/utils/helpers.ts
+++ b/packages/core/strapi/src/cli/utils/helpers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import chalk from 'chalk';
-import { has, isString, isArray } from 'lodash/fp';
+import { has, isString } from 'lodash/fp';
 import boxen from 'boxen';
 import type { Command } from 'commander';
 import { getInquirer } from './get-inquirer';
@@ -95,7 +95,7 @@ const exitWith = (code: number, message?: string | string[], options: ExitWithOp
 
   if (isString(message)) {
     log(message);
-  } else if (isArray(message)) {
+  } else if (Array.isArray(message)) {
     message.forEach((msg) => log(msg));
   }
 

--- a/packages/core/utils/src/content-types.ts
+++ b/packages/core/utils/src/content-types.ts
@@ -241,7 +241,7 @@ const getNonVisibleAttributes = (model: Model) => {
 };
 
 const getVisibleAttributes = (model: Model) => {
-  return _.difference(_.keys(model.attributes), getNonVisibleAttributes(model));
+  return _.difference(Object.keys(model.attributes), getNonVisibleAttributes(model));
 };
 
 const isVisibleAttribute = (model: Model, attributeName: string) => {
@@ -338,7 +338,7 @@ const getStoredPrivateAttributes = (model: Model) =>
 const getPrivateAttributes = (model: Model) => {
   return _.union(
     getStoredPrivateAttributes(model),
-    _.keys(_.pickBy(model.attributes, (attr) => !!attr.private))
+    Object.keys(_.pickBy(model.attributes, (attr) => !!attr.private))
   );
 };
 

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -6,17 +6,7 @@
  */
 
 import _ from 'lodash';
-import {
-  cloneDeep,
-  get,
-  isArray,
-  isEmpty,
-  isInteger,
-  isNil,
-  isObject,
-  isString,
-  toNumber,
-} from 'lodash/fp';
+import { cloneDeep, get, isEmpty, isInteger, isNil, isObject, isString, toNumber } from 'lodash/fp';
 import {
   constants,
   hasDraftAndPublish,
@@ -193,7 +183,7 @@ const convertOrderingQueryParams = (ordering: unknown) => {
 };
 
 const isStringArray = (value: unknown): value is string[] =>
-  isArray(value) && value.every(isString);
+  Array.isArray(value) && value.every(isString);
 
 interface TransformerOptions {
   getModel: (uid: string) => Model | undefined;

--- a/packages/core/utils/src/primitives/objects.ts
+++ b/packages/core/utils/src/primitives/objects.ts
@@ -3,10 +3,6 @@ import _ from 'lodash';
 const keysDeep = (obj: object, path: string[] = []): string[] =>
   !_.isObject(obj)
     ? [path.join('.')]
-    : _.reduce(
-        obj,
-        (acc, next, key) => _.concat(acc, keysDeep(next, [...path, key])),
-        [] as string[]
-      );
+    : _.reduce(obj, (acc, next, key) => acc.concat(keysDeep(next, [...path, key])), [] as string[]);
 
 export { keysDeep };

--- a/packages/core/utils/src/sanitize/index.ts
+++ b/packages/core/utils/src/sanitize/index.ts
@@ -1,5 +1,5 @@
 import { CurriedFunction1 } from 'lodash';
-import { isArray, cloneDeep, omit, pick } from 'lodash/fp';
+import { cloneDeep, omit, pick } from 'lodash/fp';
 import type { z } from 'zod/v4';
 
 import { constants, getNonWritableAttributes } from '../content-types';
@@ -75,7 +75,7 @@ const createAPISanitizers = (opts: APIOptions) => {
     if (!schema) {
       throw new Error('Missing schema in sanitizeInput');
     }
-    if (isArray(data)) {
+    if (Array.isArray(data)) {
       return Promise.all(
         data.map((entry) => sanitizeInput(entry, schema, { auth, strictParams, route }))
       );
@@ -155,7 +155,7 @@ const createAPISanitizers = (opts: APIOptions) => {
     if (!schema) {
       throw new Error('Missing schema in sanitizeOutput');
     }
-    if (isArray(data)) {
+    if (Array.isArray(data)) {
       const res: unknown[] = Array.from({ length: data.length });
       for (let i = 0; i < data.length; i += 1) {
         res[i] = await sanitizeOutput(data[i], schema, { auth });
@@ -243,7 +243,7 @@ const createAPISanitizers = (opts: APIOptions) => {
     if (!schema) {
       throw new Error('Missing schema in sanitizeFilters');
     }
-    if (isArray(filters)) {
+    if (Array.isArray(filters)) {
       return Promise.all(filters.map((filter) => sanitizeFilters(filter, schema, { auth })));
     }
 

--- a/packages/core/utils/src/sanitize/sanitizers.ts
+++ b/packages/core/utils/src/sanitize/sanitizers.ts
@@ -1,4 +1,4 @@
-import { curry, isEmpty, isNil, isArray, isPlainObject } from 'lodash/fp';
+import { curry, isEmpty, isNil, isPlainObject } from 'lodash/fp';
 
 import { pipe as pipeAsync } from '../async';
 import traverseEntity from '../traverse-entity';
@@ -88,7 +88,7 @@ const defaultSanitizeFilters = curry((ctx: Context, filters: unknown) => {
     // enumerable keys (Date, RegExp, boxed primitives, etc.) are "empty" and would wrongly drop valid operands.
     traverseQueryFilters(({ key, value }, { remove }) => {
       const isEmptyPlainObject = isPlainObject(value) && isEmpty(value);
-      const isEmptyArrayOperand = isArray(value) && isEmpty(value);
+      const isEmptyArrayOperand = Array.isArray(value) && isEmpty(value);
       if (isEmptyPlainObject || isEmptyArrayOperand) {
         remove(key);
       }
@@ -160,7 +160,7 @@ const defaultSanitizeFields = curry((ctx: Context, fields: unknown) => {
     // Remove password fields
     traverseQueryFields(removePassword, ctx),
     // Remove nil values from fields array
-    (value) => (isArray(value) ? value.filter((field) => !isNil(field)) : value)
+    (value) => (Array.isArray(value) ? value.filter((field) => !isNil(field)) : value)
   )(fields);
 });
 

--- a/packages/core/utils/src/sanitize/visitors/remove-disallowed-fields.ts
+++ b/packages/core/utils/src/sanitize/visitors/remove-disallowed-fields.ts
@@ -1,4 +1,4 @@
-import { isArray, isNil, isString, toPath } from 'lodash/fp';
+import { isNil, isString, toPath } from 'lodash/fp';
 import type { Visitor } from '../../traverse/factory';
 
 export default (allowedFields: string[] | null = null): Visitor =>
@@ -9,7 +9,7 @@ export default (allowedFields: string[] | null = null): Visitor =>
     }
 
     // Throw on invalid formats
-    if (!(isArray(allowedFields) && allowedFields.every(isString))) {
+    if (!(Array.isArray(allowedFields) && allowedFields.every(isString))) {
       throw new TypeError(
         `Expected array of strings for allowedFields but got "${typeof allowedFields}"`
       );

--- a/packages/core/utils/src/sanitize/visitors/remove-restricted-fields.ts
+++ b/packages/core/utils/src/sanitize/visitors/remove-restricted-fields.ts
@@ -1,4 +1,4 @@
-import { isArray, isString } from 'lodash/fp';
+import { isString } from 'lodash/fp';
 import type { Visitor } from '../../traverse/factory';
 
 export default (restrictedFields: string[] | null = null): Visitor =>
@@ -10,7 +10,7 @@ export default (restrictedFields: string[] | null = null): Visitor =>
     }
 
     // Throw on invalid formats
-    if (!(isArray(restrictedFields) && restrictedFields.every(isString))) {
+    if (!(Array.isArray(restrictedFields) && restrictedFields.every(isString))) {
       throw new TypeError(
         `Expected array of strings for restrictedFields but got "${typeof restrictedFields}"`
       );

--- a/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
+++ b/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
@@ -1,4 +1,4 @@
-import { isArray, isObject } from 'lodash/fp';
+import { isObject } from 'lodash/fp';
 import * as contentTypeUtils from '../../content-types';
 import type { Visitor } from '../../traverse/factory';
 import { RelationOrderingOptions } from '../../types';
@@ -98,7 +98,7 @@ const visitRelationAttribute = async (
   const handleMorphElements = async (elements: any[]) => {
     const allowedElements: Record<string, unknown>[] = [];
 
-    if (!isArray(elements)) {
+    if (!Array.isArray(elements)) {
       return allowedElements;
     }
 

--- a/packages/core/utils/src/traverse-entity.ts
+++ b/packages/core/utils/src/traverse-entity.ts
@@ -1,4 +1,4 @@
-import { clone, isObject, isArray, isNil, curry } from 'lodash/fp';
+import { clone, isObject, isNil, curry } from 'lodash/fp';
 
 import type { Attribute, AnyAttribute, Model, Data } from './types';
 import { isRelationalAttribute, isMediaAttribute } from './content-types';
@@ -213,7 +213,7 @@ const traverseEntity = async (
         ? traverseMorphRelationTarget
         : traverseRelationTarget(getModel(attribute.target!));
 
-      if (isArray(value)) {
+      if (Array.isArray(value)) {
         // Process array items in parallel with ordered error handling
         copy[key] = await parallelWithOrderedErrors(
           value.map((item, i) => {
@@ -236,7 +236,7 @@ const traverseEntity = async (
     if (isMediaAttribute(attribute)) {
       parent = { schema, key, attribute, path: newPath };
 
-      if (isArray(value)) {
+      if (Array.isArray(value)) {
         // Process media array items in parallel with ordered error handling
         copy[key] = await parallelWithOrderedErrors(
           value.map((item, i) => {
@@ -260,7 +260,7 @@ const traverseEntity = async (
       parent = { schema, key, attribute, path: newPath };
       const targetSchema = getModel(attribute.component);
 
-      if (isArray(value)) {
+      if (Array.isArray(value)) {
         // Process component array items in parallel with ordered error handling
         copy[key] = await parallelWithOrderedErrors(
           value.map((item, i) => {
@@ -280,7 +280,7 @@ const traverseEntity = async (
       continue;
     }
 
-    if (attribute.type === 'dynamiczone' && isArray(value)) {
+    if (attribute.type === 'dynamiczone' && Array.isArray(value)) {
       parent = { schema, key, attribute, path: newPath };
 
       // Process dynamic zone items in parallel with ordered error handling

--- a/packages/core/utils/src/traverse/query-fields.ts
+++ b/packages/core/utils/src/traverse/query-fields.ts
@@ -1,9 +1,9 @@
-import { curry, isArray, isString, eq, trim, constant } from 'lodash/fp';
+import { curry, isString, eq, trim, constant } from 'lodash/fp';
 
 import traverseFactory from './factory';
 
 const isStringArray = (value: unknown): value is string[] => {
-  return isArray(value) && value.every(isString);
+  return Array.isArray(value) && value.every(isString);
 };
 
 const fields = traverseFactory()

--- a/packages/core/utils/src/traverse/query-filters.ts
+++ b/packages/core/utils/src/traverse/query-filters.ts
@@ -1,4 +1,4 @@
-import { curry, isObject, isEmpty, isArray, isNil, cloneDeep, omit } from 'lodash/fp';
+import { curry, isObject, isEmpty, isNil, cloneDeep, omit } from 'lodash/fp';
 
 import { isScalarAttribute } from '../content-types';
 import { isOperator } from '../operators';
@@ -14,7 +14,7 @@ const isFilterLikeObject = (value: Record<string, unknown>, schema?: Model) =>
 const filters = traverseFactory()
   .intercept(
     // Intercept filters arrays and apply the traversal to each one individually
-    isArray,
+    Array.isArray,
     async (visitor, options, filters, { recurse }) => {
       return Promise.all(
         filters.map((filter, i) => {
@@ -74,7 +74,7 @@ const filters = traverseFactory()
         isOperator(key) &&
         key !== '$not' &&
         isObj(value) &&
-        !isArray(value) &&
+        !Array.isArray(value) &&
         !isFilterLikeObject(value, schema)
       ) {
         set(key, value);
@@ -139,7 +139,7 @@ const filters = traverseFactory()
   // Scalar fields: recurse into operator maps (e.g. { $contains: 'x' }) so visitors see nested keys.
   .onAttribute(
     ({ attribute, value }) =>
-      Boolean(isScalarAttribute(attribute)) && isObj(value) && !isArray(value),
+      Boolean(isScalarAttribute(attribute)) && isObj(value) && !Array.isArray(value),
     async ({ key, visitor, path, value, schema, getModel, attribute }, { set, recurse }) => {
       const parent: Parent = { key, path, schema, attribute };
 

--- a/packages/core/utils/src/traverse/query-populate.ts
+++ b/packages/core/utils/src/traverse/query-populate.ts
@@ -1,7 +1,6 @@
 import {
   curry,
   isString,
-  isArray,
   isEmpty,
   split,
   isObject,
@@ -26,7 +25,7 @@ const DEFAULT_QS_ARRAY_LIMIT = 100;
  * produces when indexed array notation exceeds `arrayLimit` (see #25632).
  */
 const isQsArrayLimitPopulateObject = (value: unknown): value is Record<string, string> => {
-  if (!isObject(value) || isArray(value)) {
+  if (!isObject(value) || Array.isArray(value)) {
     return false;
   }
 
@@ -65,7 +64,7 @@ const isPopulateString = (value: unknown): value is string => {
 };
 
 const isStringArray = (value: unknown): value is string[] =>
-  isArray(value) && value.every(isString);
+  Array.isArray(value) && value.every(isString);
 
 const isObj = (value: unknown): value is Record<string, unknown> => isObject(value);
 

--- a/packages/core/utils/src/validate/index.ts
+++ b/packages/core/utils/src/validate/index.ts
@@ -1,5 +1,5 @@
 import { CurriedFunction1 } from 'lodash';
-import { isArray, isObject } from 'lodash/fp';
+import { isObject } from 'lodash/fp';
 import type { z } from 'zod/v4';
 
 import { getNonWritableAttributes, constants } from '../content-types';
@@ -75,7 +75,7 @@ const createAPIValidators = (opts: APIOptions) => {
       throw new Error('Missing schema in validateInput');
     }
 
-    if (isArray(data)) {
+    if (Array.isArray(data)) {
       await Promise.all(data.map((entry) => validateInput(entry, schema, options)));
       return;
     }
@@ -233,7 +233,7 @@ const createAPIValidators = (opts: APIOptions) => {
     if (!schema) {
       throw new Error('Missing schema in validateFilters');
     }
-    if (isArray(filters)) {
+    if (Array.isArray(filters)) {
       await Promise.all(filters.map((filter) => validateFilters(filter, schema, { auth })));
       return;
     }

--- a/packages/core/utils/src/validate/visitors/throw-disallowed-fields.ts
+++ b/packages/core/utils/src/validate/visitors/throw-disallowed-fields.ts
@@ -1,4 +1,4 @@
-import { isArray, isNil, isString, toPath } from 'lodash/fp';
+import { isNil, isString, toPath } from 'lodash/fp';
 import type { Visitor } from '../../traverse/factory';
 import { throwInvalidKey } from '../utils';
 
@@ -10,7 +10,7 @@ export default (allowedFields: string[] | null = null): Visitor =>
     }
 
     // Throw on invalid formats
-    if (!(isArray(allowedFields) && allowedFields.every(isString))) {
+    if (!(Array.isArray(allowedFields) && allowedFields.every(isString))) {
       throw new TypeError(
         `Expected array of strings for allowedFields but got "${typeof allowedFields}"`
       );

--- a/packages/core/utils/src/validate/visitors/throw-restricted-fields.ts
+++ b/packages/core/utils/src/validate/visitors/throw-restricted-fields.ts
@@ -1,4 +1,4 @@
-import { isArray, isString } from 'lodash/fp';
+import { isString } from 'lodash/fp';
 import type { Visitor } from '../../traverse/factory';
 import { throwInvalidKey } from '../utils';
 
@@ -10,7 +10,7 @@ export default (restrictedFields: string[] | null = null): Visitor =>
     }
 
     // Throw on invalid formats
-    if (!(isArray(restrictedFields) && restrictedFields.every(isString))) {
+    if (!(Array.isArray(restrictedFields) && restrictedFields.every(isString))) {
       throw new TypeError(
         `Expected array of strings for restrictedFields but got "${typeof restrictedFields}"`
       );

--- a/packages/core/utils/src/validate/visitors/throw-restricted-relations.ts
+++ b/packages/core/utils/src/validate/visitors/throw-restricted-relations.ts
@@ -1,4 +1,4 @@
-import { isArray, isObject } from 'lodash/fp';
+import { isObject } from 'lodash/fp';
 import * as contentTypeUtils from '../../content-types';
 import { throwInvalidKey } from '../utils';
 import type { Visitor } from '../../traverse/factory';
@@ -62,7 +62,7 @@ export default (auth: unknown): Visitor =>
     };
 
     const handleMorphElements = async (elements: any[]) => {
-      if (!isArray(elements)) {
+      if (!Array.isArray(elements)) {
         throwInvalidKey({ key, path: path.attribute });
       }
 

--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { isEmpty, mergeWith, isArray, isObject, isFunction } from 'lodash/fp';
+import { isEmpty, mergeWith, isObject, isFunction } from 'lodash/fp';
 import { ApolloServer, type ApolloServerPlugin, type ApolloServerOptions } from '@apollo/server';
 import {
   ApolloServerPluginLandingPageLocalDefault,
@@ -16,7 +16,7 @@ import type { BaseContext, DefaultContextExtends, DefaultStateExtends } from 'ko
 import { formatGraphqlError } from './format-graphql-error';
 
 const merge = mergeWith((a, b) => {
-  if (isArray(a) && isArray(b)) {
+  if (Array.isArray(a) && Array.isArray(b)) {
     return a.concat(b);
   }
 });

--- a/packages/plugins/graphql/server/src/services/builders/type.ts
+++ b/packages/plugins/graphql/server/src/services/builders/type.ts
@@ -1,4 +1,4 @@
-import { isArray, isString, isUndefined, constant } from 'lodash/fp';
+import { isString, isUndefined, constant } from 'lodash/fp';
 import { nonNull, list, objectType } from 'nexus';
 import { contentTypes } from '@strapi/utils';
 import type { Struct } from '@strapi/types';
@@ -214,7 +214,7 @@ export default (context: Context) => {
     }
 
     // If the target is an array of string, resolve the associated morph type and use it
-    else if (isArray(target) && target.every(isString)) {
+    else if (Array.isArray(target) && target.every(isString)) {
       const type = naming.getMorphRelationTypeName(contentType, attributeName);
 
       builder.field(attributeName, { type, resolve });

--- a/packages/plugins/graphql/server/src/services/builders/utils.ts
+++ b/packages/plugins/graphql/server/src/services/builders/utils.ts
@@ -1,4 +1,4 @@
-import { entries, mapValues, omit } from 'lodash/fp';
+import { mapValues, omit } from 'lodash/fp';
 import { idArg, nonNull } from 'nexus';
 import { hasSort, pagination } from '@strapi/utils';
 import type { Core, Struct } from '@strapi/types';
@@ -96,7 +96,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     getUniqueScalarAttributes(attributes: Struct.SchemaAttributes) {
       const { isStrapiScalar } = getService('utils').attributes;
 
-      const uniqueAttributes = entries(attributes).filter(
+      const uniqueAttributes = Object.entries(attributes).filter(
         ([, attribute]) => isStrapiScalar(attribute) && 'unique' in attribute && attribute.unique
       );
 

--- a/packages/plugins/i18n/server/src/services/content-types.ts
+++ b/packages/plugins/i18n/server/src/services/content-types.ts
@@ -1,4 +1,4 @@
-import { pick, pipe, has, prop, isNil, cloneDeep, isArray } from 'lodash/fp';
+import { pick, pipe, has, prop, isNil, cloneDeep } from 'lodash/fp';
 import { errors, contentTypes as contentTypeUtils } from '@strapi/utils';
 import type { Struct } from '@strapi/types';
 import { getService } from '../utils';
@@ -85,7 +85,7 @@ const removeIdsMut = (
 
   for (const [attrName, attr] of Object.entries(model.attributes)) {
     const value = entry[attrName];
-    if (attr.type === 'dynamiczone' && isArray(value)) {
+    if (attr.type === 'dynamiczone' && Array.isArray(value)) {
       value.forEach((compo) => {
         if (has('__component', compo)) {
           const model = strapi.components[compo.__component];
@@ -94,7 +94,7 @@ const removeIdsMut = (
       });
     } else if (attr.type === 'component') {
       const model = strapi.components[attr.component];
-      if (isArray(value)) {
+      if (Array.isArray(value)) {
         value.forEach((compo) => removeIdsMut(model, compo));
       } else {
         removeIdsMut(model, value);

--- a/packages/plugins/i18n/server/src/services/fill-from-locale.ts
+++ b/packages/plugins/i18n/server/src/services/fill-from-locale.ts
@@ -1,4 +1,3 @@
-import { isArray } from 'lodash/fp';
 import { contentTypes } from '@strapi/utils';
 import type { UID, Schema, Core } from '@strapi/types';
 
@@ -104,7 +103,7 @@ const incrementInitialTempKey = (key?: string): string => {
  * Normalizes a value to an array: arrays pass through, single values become [value], null/undefined become [].
  */
 const normalizeToArray = (value: unknown): unknown[] => {
-  if (isArray(value)) return value;
+  if (Array.isArray(value)) return value;
   if (value) return [value];
   return [];
 };
@@ -238,14 +237,14 @@ const collectRelationsByUid = (
         const compSchema = (components[attribute.component] ?? {
           attributes: {},
         }) as Schema.Component;
-        if (attribute.repeatable && isArray(value)) {
+        if (attribute.repeatable && Array.isArray(value)) {
           for (const item of value as Record<string, unknown>[]) {
             collect(item, compSchema);
           }
         } else if (value) {
           collect(value as Record<string, unknown>, compSchema);
         }
-      } else if (attribute.type === 'dynamiczone' && isArray(value)) {
+      } else if (attribute.type === 'dynamiczone' && Array.isArray(value)) {
         for (const item of value as Record<string, unknown>[]) {
           const compUid = (item as any)?.__component as string;
           const compSchema = (components[compUid] ?? { attributes: {} }) as Schema.Component;
@@ -475,7 +474,7 @@ const processDocumentData = async (
       const compSchema = (components[attribute.component] || {
         attributes: {},
       }) as Schema.Component;
-      if (attribute.repeatable && isArray(value)) {
+      if (attribute.repeatable && Array.isArray(value)) {
         const tempKeys = generateInitialTempKeys(value.length);
         result[key] = await Promise.all(
           value.map(async (item: Record<string, unknown>, index: number) => {
@@ -497,7 +496,7 @@ const processDocumentData = async (
       continue;
     }
 
-    if (attribute.type === 'dynamiczone' && isArray(value)) {
+    if (attribute.type === 'dynamiczone' && Array.isArray(value)) {
       const tempKeys = generateInitialTempKeys(value.length);
       result[key] = await Promise.all(
         value.map(async (item: Record<string, unknown>, index: number) => {

--- a/packages/plugins/i18n/server/src/services/permissions/actions.ts
+++ b/packages/plugins/i18n/server/src/services/permissions/actions.ts
@@ -1,4 +1,4 @@
-import { isArray, getOr, prop } from 'lodash/fp';
+import { getOr, prop } from 'lodash/fp';
 import { getService } from '../../utils';
 
 const actions = [
@@ -51,12 +51,12 @@ const addLocalesPropertyIfNeeded = ({ value: action }: any) => {
   }
 
   // If the 'locales' property is already declared within the applyToProperties array, then ignore the next steps
-  if (isArray(applyToProperties) && applyToProperties.includes('locales')) {
+  if (Array.isArray(applyToProperties) && applyToProperties.includes('locales')) {
     return;
   }
 
   // Add the 'locales' property to the applyToProperties array (create it if necessary)
-  action.options.applyToProperties = isArray(applyToProperties)
+  action.options.applyToProperties = Array.isArray(applyToProperties)
     ? applyToProperties.concat('locales')
     : ['locales'];
 };

--- a/packages/plugins/users-permissions/server/src/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/src/bootstrap/index.js
@@ -42,7 +42,7 @@ const initGrant = async (pluginStore) => {
 
   if (!prevGrantConfig || !_.isEqual(prevGrantConfig, grantConfig)) {
     // merge with the previous provider config.
-    _.keys(grantConfig).forEach((key) => {
+    Object.keys(grantConfig).forEach((key) => {
       if (key in prevGrantConfig) {
         grantConfig[key] = _.merge(grantConfig[key], prevGrantConfig[key]);
       }

--- a/packages/plugins/users-permissions/server/src/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/src/controllers/auth.js
@@ -9,7 +9,7 @@
 /* eslint-disable no-useless-escape */
 const crypto = require('crypto');
 const _ = require('lodash');
-const { concat, compact } = require('lodash/fp');
+const { compact } = require('lodash/fp');
 const utils = require('@strapi/utils');
 const { getService } = require('../utils');
 const { buildRefreshCookieOptions } = require('../utils/refresh-cookie-options');
@@ -545,12 +545,10 @@ module.exports = ({ strapi }) => ({
     const alwaysAllowedKeys = ['username', 'password', 'email'];
 
     // Note that we intentionally do not filter allowedFields to allow a project to explicitly accept private or other Strapi field on registration
-    const allowedKeys = compact(
-      concat(
-        alwaysAllowedKeys,
-        Array.isArray(register?.allowedFields) ? register.allowedFields : []
-      )
-    );
+    const allowedKeys = compact([
+      ...alwaysAllowedKeys,
+      ...(Array.isArray(register?.allowedFields) ? register.allowedFields : []),
+    ]);
 
     // Check if there are any keys in requestBody that are not in allowedKeys
     const invalidKeys = Object.keys(ctx.request.body).filter((key) => !allowedKeys.includes(key));

--- a/packages/plugins/users-permissions/server/src/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/src/controllers/auth.js
@@ -9,7 +9,7 @@
 /* eslint-disable no-useless-escape */
 const crypto = require('crypto');
 const _ = require('lodash');
-const { concat, compact, isArray } = require('lodash/fp');
+const { concat, compact } = require('lodash/fp');
 const utils = require('@strapi/utils');
 const { getService } = require('../utils');
 const { buildRefreshCookieOptions } = require('../utils/refresh-cookie-options');
@@ -546,7 +546,10 @@ module.exports = ({ strapi }) => ({
 
     // Note that we intentionally do not filter allowedFields to allow a project to explicitly accept private or other Strapi field on registration
     const allowedKeys = compact(
-      concat(alwaysAllowedKeys, isArray(register?.allowedFields) ? register.allowedFields : [])
+      concat(
+        alwaysAllowedKeys,
+        Array.isArray(register?.allowedFields) ? register.allowedFields : []
+      )
     );
 
     // Check if there are any keys in requestBody that are not in allowedKeys

--- a/packages/plugins/users-permissions/server/src/controllers/permissions.js
+++ b/packages/plugins/users-permissions/server/src/controllers/permissions.js
@@ -11,7 +11,7 @@ module.exports = {
   },
 
   async getPolicies(ctx) {
-    const policies = _.keys(strapi.plugin('users-permissions').policies);
+    const policies = Object.keys(strapi.plugin('users-permissions').policies);
 
     ctx.send({
       policies: _.without(policies, 'permissions'),

--- a/packages/plugins/users-permissions/server/src/services/providers.js
+++ b/packages/plugins/users-permissions/server/src/services/providers.js
@@ -67,7 +67,7 @@ module.exports = ({ strapi }) => {
       .store({ type: 'plugin', name: 'users-permissions', key: 'advanced' })
       .get();
 
-    const user = _.find(users, { provider });
+    const user = users.find((candidate) => candidate.provider === provider);
 
     if (_.isEmpty(user) && !advancedSettings.allow_register) {
       throw new Error('Register action is actually not available.');

--- a/packages/plugins/users-permissions/server/src/services/users-permissions.js
+++ b/packages/plugins/users-permissions/server/src/services/users-permissions.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const { filter, map, pipe, prop } = require('lodash/fp');
+const { map, pipe, prop } = require('lodash/fp');
 const urlJoin = require('url-join');
 const {
   template: { createStrictInterpolationRegExp },
@@ -164,7 +164,7 @@ module.exports = ({ strapi }) => ({
 
     const appActions = _.flatMap(strapi.apis, (api, apiName) => {
       return _.flatMap(api.controllers, (controller, controllerName) => {
-        return _.keys(controller).map((actionName) => {
+        return Object.keys(controller).map((actionName) => {
           return `api::${apiName}.${controllerName}.${actionName}`;
         });
       });
@@ -172,7 +172,7 @@ module.exports = ({ strapi }) => ({
 
     const pluginsActions = _.flatMap(strapi.plugins, (plugin, pluginName) => {
       return _.flatMap(plugin.controllers, (controller, controllerName) => {
-        return _.keys(controller).map((actionName) => {
+        return Object.keys(controller).map((actionName) => {
           return `plugin::${pluginName}.${controllerName}.${actionName}`;
         });
       });
@@ -194,7 +194,8 @@ module.exports = ({ strapi }) => ({
       // create default permissions
       for (const role of roles) {
         const toCreate = pipe(
-          filter(({ roleType }) => roleType === role.type || roleType === null),
+          (permissions) =>
+            permissions.filter(({ roleType }) => roleType === role.type || roleType === null),
           map(prop('action'))
         )(DEFAULT_PERMISSIONS);
 

--- a/packages/utils/api-tests/agent.js
+++ b/packages/utils/api-tests/agent.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { clone, has, concat, isNil } = require('lodash/fp');
+const { clone, has, isNil } = require('lodash/fp');
 const qs = require('qs');
 const request = require('supertest');
 const { createUtils } = require('./utils');
@@ -71,7 +71,7 @@ const createAgent = (strapi, initialState = {}) => {
     const { method, url, body, formData, qs: queryString, headers } = options;
     const supertestAgent = request.agent(strapi.server.httpServer);
 
-    const fullUrl = concat(state.urlPrefix, url).join('');
+    const fullUrl = [state.urlPrefix, url].join('');
 
     const rq = supertestAgent[method.toLowerCase()](fullUrl);
 

--- a/packages/utils/eslint-config-custom/back/index.js
+++ b/packages/utils/eslint-config-custom/back/index.js
@@ -1,6 +1,10 @@
 // @ts-check
 
-/** @type {import('eslint').Linter.Config} */
+/** @import { Linter } from 'eslint' */
+
+const { noRestrictedImports, noRestrictedSyntax } = require('../lodash');
+
+/** @type {Linter.Config} */
 const config = {
   extends: '@strapi/eslint-config/back/javascript',
   parserOptions: {
@@ -43,6 +47,8 @@ const config = {
         props: false,
       },
     ],
+    'no-restricted-imports': noRestrictedImports(),
+    'no-restricted-syntax': noRestrictedSyntax(),
   },
 };
 

--- a/packages/utils/eslint-config-custom/back/index.js
+++ b/packages/utils/eslint-config-custom/back/index.js
@@ -2,7 +2,7 @@
 
 /** @import { Linter } from 'eslint' */
 
-const { noRestrictedImports, noRestrictedSyntax } = require('../lodash');
+const { noRestrictedImports, noRestrictedSyntax } = require('lint-policy/lodash');
 
 /** @type {Linter.Config} */
 const config = {

--- a/packages/utils/eslint-config-custom/back/typescript.js
+++ b/packages/utils/eslint-config-custom/back/typescript.js
@@ -1,6 +1,8 @@
 // @ts-check
 
-/** @type {import('eslint').Linter.Config} */
+/** @import { Linter } from 'eslint' */
+
+/** @type {Linter.Config} */
 const config = {
   root: true,
   extends: [

--- a/packages/utils/eslint-config-custom/front/index.js
+++ b/packages/utils/eslint-config-custom/front/index.js
@@ -1,6 +1,10 @@
 // @ts-check
 
-/** @type {import('eslint').Linter.Config} */
+/** @import { Linter } from 'eslint' */
+
+const { noRestrictedImports, noRestrictedSyntax } = require('../lodash');
+
+/** @type {Linter.Config} */
 const config = {
   parser: '@babel/eslint-parser',
   extends: ['@strapi/eslint-config/front/javascript'],
@@ -50,17 +54,13 @@ const config = {
         alphabetize: { order: 'asc', caseInsensitive: true },
       },
     ],
-    'no-restricted-imports': [
-      'error',
+    'no-restricted-imports': noRestrictedImports([
       {
-        paths: [
-          {
-            name: 'lodash',
-            message: 'Please use import [method] from lodash/[method]',
-          },
-        ],
+        name: 'lodash',
+        message: 'Please use import [method] from lodash/[method]',
       },
-    ],
+    ]),
+    'no-restricted-syntax': noRestrictedSyntax(),
     'no-restricted-globals': [
       'error',
       {

--- a/packages/utils/eslint-config-custom/front/index.js
+++ b/packages/utils/eslint-config-custom/front/index.js
@@ -2,7 +2,7 @@
 
 /** @import { Linter } from 'eslint' */
 
-const { noRestrictedImports, noRestrictedSyntax } = require('../lodash');
+const { noRestrictedImports, noRestrictedSyntax } = require('lint-policy/lodash');
 
 /** @type {Linter.Config} */
 const config = {

--- a/packages/utils/eslint-config-custom/front/typescript.js
+++ b/packages/utils/eslint-config-custom/front/typescript.js
@@ -2,7 +2,7 @@
 
 /** @import { Linter } from 'eslint' */
 
-const { noRestrictedImports, noRestrictedSyntax } = require('../lodash');
+const { noRestrictedImports, noRestrictedSyntax } = require('lint-policy/lodash');
 
 /** @type {Linter.Config} */
 const config = {

--- a/packages/utils/eslint-config-custom/front/typescript.js
+++ b/packages/utils/eslint-config-custom/front/typescript.js
@@ -1,6 +1,10 @@
 // @ts-check
 
-/** @type {import('eslint').Linter.Config} */
+/** @import { Linter } from 'eslint' */
+
+const { noRestrictedImports, noRestrictedSyntax } = require('../lodash');
+
+/** @type {Linter.Config} */
 const config = {
   root: true,
   extends: ['@strapi/eslint-config/front/typescript'],
@@ -33,17 +37,13 @@ const config = {
      */
     'import/no-named-as-default-member': 'off',
     'import/no-extraneous-dependencies': 'error',
-    'no-restricted-imports': [
-      'error',
+    'no-restricted-imports': noRestrictedImports([
       {
-        paths: [
-          {
-            name: 'lodash',
-            message: 'Please use import [method] from lodash/[method]',
-          },
-        ],
+        name: 'lodash',
+        message: 'Please use import [method] from lodash/[method]',
       },
-    ],
+    ]),
+    'no-restricted-syntax': noRestrictedSyntax(),
     'no-restricted-globals': [
       'error',
       {

--- a/packages/utils/eslint-config-custom/jsconfig.json
+++ b/packages/utils/eslint-config-custom/jsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6"
+    "target": "es6",
+    "strict": true
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/utils/eslint-config-custom/lodash.js
+++ b/packages/utils/eslint-config-custom/lodash.js
@@ -1,0 +1,102 @@
+// @ts-check
+
+/** @import { Linter } from 'eslint' */
+
+/**
+ * Shared lodash policy for the monorepo.
+ *
+ * Each banned member has a native equivalent, so importing it only costs a module and hides the
+ * standard API. The rules below ban every way of reaching one — ESM named imports, deep submodule
+ * imports, CommonJS `require`, and namespace member access (`_.isArray`) — because a single
+ * `no-restricted-imports` entry misses most of them.
+ *
+ * Named imports are matched via `no-restricted-syntax` rather than `no-restricted-imports`
+ * `importNames`, because the latter also rejects `import * as _ from 'lodash'` outright; the
+ * namespace itself is fine, only the member access is not.
+ */
+
+/**
+ * A single `no-restricted-imports` `paths` entry.
+ *
+ * @typedef {{ name: string; importNames?: string[]; message?: string }} RestrictedImportPath
+ */
+
+/**
+ * A single `no-restricted-syntax` entry.
+ *
+ * @typedef {{ selector: string; message?: string }} RestrictedSyntax
+ */
+
+/** Local identifiers conventionally bound to a lodash namespace. */
+const LODASH_NAMESPACES = '(_|lodash|fp)';
+
+/** Members banned everywhere, with the native replacement to reach for instead. */
+const BANNED_MEMBERS = [
+  {
+    name: 'isArray',
+    message:
+      'Use the native `Array.isArray` instead of lodash `isArray` (lodash re-exports the native function).',
+  },
+  {
+    name: 'forEach',
+    message:
+      'Use native iteration instead of lodash `forEach` — `for...of`, `Array.prototype.forEach`, or `Object.entries`/`Object.values` for objects.',
+  },
+];
+
+/** `no-restricted-imports` patterns: `import isArray from 'lodash/isArray'`. */
+const restrictedImportPatterns = BANNED_MEMBERS.map(({ name, message }) => ({
+  group: [`lodash/${name}`, `lodash/fp/${name}`],
+  message,
+}));
+
+/**
+ * `no-restricted-syntax` entries, covering the forms `no-restricted-imports` cannot express.
+ *
+ * @type {RestrictedSyntax[]}
+ */
+const restrictedSyntax = BANNED_MEMBERS.flatMap(({ name, message }) => [
+  {
+    // `import { isArray } from 'lodash'` / `'lodash/fp'`
+    selector: `ImportDeclaration[source.value=/^lodash(\\/fp)?$/] > ImportSpecifier[imported.name='${name}']`,
+    message,
+  },
+  {
+    // `_.isArray(x)`, `lodash.isArray(x)`, `fp.isArray(x)`
+    selector: `MemberExpression[object.name=/^${LODASH_NAMESPACES}$/][property.name='${name}']`,
+    message,
+  },
+  {
+    // `const { isArray } = require('lodash')` / `require('lodash/fp')`
+    selector: `VariableDeclarator[init.callee.name='require'][init.arguments.0.value=/^lodash(\\/fp)?$/] > ObjectPattern > Property[key.name='${name}']`,
+    message,
+  },
+  {
+    // `require('lodash/isArray')`
+    selector: `CallExpression[callee.name='require'][arguments.0.value=/^lodash(\\/fp)?\\/${name}$/]`,
+    message,
+  },
+]);
+
+/**
+ * Builds the `no-restricted-imports` value, appending the lodash patterns to any package-specific
+ * paths.
+ *
+ * @param {RestrictedImportPath[]} [paths]
+ * @returns {Linter.RuleEntry<[{ paths: RestrictedImportPath[]; patterns: typeof restrictedImportPatterns }]>}
+ */
+const noRestrictedImports = (paths = []) => [
+  'error',
+  { paths, patterns: restrictedImportPatterns },
+];
+
+/**
+ * Builds the `no-restricted-syntax` value, appending the lodash selectors to any package-specific
+ * ones.
+ *
+ * @param {RestrictedSyntax[]} [selectors]
+ * @returns {Linter.RuleEntry<RestrictedSyntax[]>}
+ */
+const noRestrictedSyntax = (selectors = []) => ['error', ...selectors, ...restrictedSyntax];
+
+module.exports = { noRestrictedImports, noRestrictedSyntax };

--- a/packages/utils/eslint-config-custom/package.json
+++ b/packages/utils/eslint-config-custom/package.json
@@ -1,5 +1,8 @@
 {
   "name": "eslint-config-custom",
   "version": "5.52.1",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "lint-policy": "5.52.1"
+  }
 }

--- a/packages/utils/eslint-config-custom/package.json
+++ b/packages/utils/eslint-config-custom/package.json
@@ -1,6 +1,5 @@
 {
   "name": "eslint-config-custom",
   "version": "5.52.1",
-  "private": true,
-  "main": "index.js"
+  "private": true
 }

--- a/packages/utils/lint-policy/jsconfig.json
+++ b/packages/utils/lint-policy/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "strict": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/utils/lint-policy/lodash.js
+++ b/packages/utils/lint-policy/lodash.js
@@ -1,24 +1,33 @@
 // @ts-check
 
-/** @import { Linter } from 'eslint' */
-
 /**
- * Shared lodash policy for the monorepo.
+ * Shared lodash policy, consumed by both linters.
+ *
+ * ESLint (`eslint-config-custom`) and OxLint (`oxlint-config`) enforce the same bans, and both
+ * accept the same `[severity, ...options]` rule-value shape, so the two builders below are used
+ * verbatim by each. Only the rule *key* differs: OxLint has no native `no-restricted-syntax` and
+ * takes it from `oxlint-plugin-eslint` under the `eslint-js/` prefix.
  *
  * Each banned member has a native equivalent, so importing it only costs a module and hides the
- * standard API. The rules below ban every way of reaching one — ESM named imports, deep submodule
- * imports, CommonJS `require`, and namespace member access (`_.isArray`) — because a single
+ * standard API. Every way of reaching one is covered — ESM named imports, deep submodule imports,
+ * CommonJS `require`, and namespace member access (`_.isArray`) — because a single
  * `no-restricted-imports` entry misses most of them.
  *
  * Named imports are matched via `no-restricted-syntax` rather than `no-restricted-imports`
- * `importNames`, because the latter also rejects `import * as _ from 'lodash'` outright; the
- * namespace itself is fine, only the member access is not.
+ * `importNames`, because the latter also rejects `import * as _ from 'lodash'` outright in both
+ * linters; the namespace binding itself is fine, only the member access is not.
  */
 
 /**
  * A single `no-restricted-imports` `paths` entry.
  *
  * @typedef {{ name: string; importNames?: string[]; message?: string }} RestrictedImportPath
+ */
+
+/**
+ * A single `no-restricted-imports` `patterns` entry.
+ *
+ * @typedef {{ group: string[]; message?: string }} RestrictedImportPattern
  */
 
 /**
@@ -44,7 +53,11 @@ const BANNED_MEMBERS = [
   },
 ];
 
-/** `no-restricted-imports` patterns: `import isArray from 'lodash/isArray'`. */
+/**
+ * `no-restricted-imports` patterns: `import isArray from 'lodash/isArray'`.
+ *
+ * @type {RestrictedImportPattern[]}
+ */
 const restrictedImportPatterns = BANNED_MEMBERS.map(({ name, message }) => ({
   group: [`lodash/${name}`, `lodash/fp/${name}`],
   message,
@@ -79,11 +92,14 @@ const restrictedSyntax = BANNED_MEMBERS.flatMap(({ name, message }) => [
 ]);
 
 /**
- * Builds the `no-restricted-imports` value, appending the lodash patterns to any package-specific
+ * Builds the `no-restricted-imports` value, appending the lodash patterns to any consumer-specific
  * paths.
  *
+ * The concrete tuple return type matters: ESLint's `Linter.RuleEntry` makes the options element
+ * optional, which OxLint's stricter `no-restricted-imports` type rejects.
+ *
  * @param {RestrictedImportPath[]} [paths]
- * @returns {Linter.RuleEntry<[{ paths: RestrictedImportPath[]; patterns: typeof restrictedImportPatterns }]>}
+ * @returns {['error', { paths: RestrictedImportPath[]; patterns: RestrictedImportPattern[] }]}
  */
 const noRestrictedImports = (paths = []) => [
   'error',
@@ -91,11 +107,11 @@ const noRestrictedImports = (paths = []) => [
 ];
 
 /**
- * Builds the `no-restricted-syntax` value, appending the lodash selectors to any package-specific
- * ones.
+ * Builds the `no-restricted-syntax` value, appending the lodash selectors to any
+ * consumer-specific ones.
  *
  * @param {RestrictedSyntax[]} [selectors]
- * @returns {Linter.RuleEntry<RestrictedSyntax[]>}
+ * @returns {['error', ...RestrictedSyntax[]]}
  */
 const noRestrictedSyntax = (selectors = []) => ['error', ...selectors, ...restrictedSyntax];
 

--- a/packages/utils/lint-policy/lodash.js
+++ b/packages/utils/lint-policy/lodash.js
@@ -51,6 +51,33 @@ const BANNED_MEMBERS = [
     message:
       'Use native iteration instead of lodash `forEach` — `for...of`, `Array.prototype.forEach`, or `Object.entries`/`Object.values` for objects.',
   },
+  {
+    name: 'keys',
+    message: 'Use the native `Object.keys` instead of lodash `keys`.',
+  },
+  {
+    name: 'values',
+    message: 'Use the native `Object.values` instead of lodash `values`.',
+  },
+  {
+    name: 'entries',
+    message: 'Use the native `Object.entries` instead of lodash `entries`.',
+  },
+  {
+    name: 'concat',
+    message:
+      'Use the native `Array.prototype.concat` or an array spread instead of lodash `concat`.',
+  },
+  {
+    name: 'filter',
+    message:
+      'Use the native `Array.prototype.filter` instead of lodash `filter` (iterate `Object.entries`/`Object.values` for objects).',
+  },
+  {
+    name: 'find',
+    message:
+      'Use the native `Array.prototype.find` instead of lodash `find` — expand matcher shorthand (`{ id }`) into an explicit predicate.',
+  },
 ];
 
 /**

--- a/packages/utils/lint-policy/lodash.js
+++ b/packages/utils/lint-policy/lodash.js
@@ -39,7 +39,30 @@
 /** Local identifiers conventionally bound to a lodash namespace. */
 const LODASH_NAMESPACES = '(_|lodash|fp)';
 
-/** Members banned everywhere, with the native replacement to reach for instead. */
+/**
+ * Builds a banned member whose message points at its native replacement.
+ *
+ * @param {string} name
+ * @param {string} replacement
+ * @param {string} [note]
+ * @returns {{ name: string; message: string }}
+ */
+const banned = (name, replacement, note) => ({
+  name,
+  message: `Use ${replacement} instead of lodash \`${name}\`.${note ? ` ${note}` : ''}`,
+});
+
+/**
+ * Members banned everywhere, with the native replacement to reach for instead.
+ *
+ * The list is deliberately wider than what the codebase currently imports: a member with an exact
+ * native equivalent is banned whether or not it has a call site today, so the next one is caught by
+ * the linter rather than by review. Members whose lodash semantics differ from the closest native
+ * API are left out on purpose — `assignIn` copies inherited properties, `lowerCase` splits words
+ * rather than lowercasing, `min`/`max` return `undefined` for an empty array where `Math.min`/
+ * `Math.max` return infinities, and the `isMap`/`isRegExp` family survives cross-realm values that
+ * `instanceof` does not.
+ */
 const BANNED_MEMBERS = [
   {
     name: 'isArray',
@@ -78,6 +101,55 @@ const BANNED_MEMBERS = [
     message:
       'Use the native `Array.prototype.find` instead of lodash `find` — expand matcher shorthand (`{ id }`) into an explicit predicate.',
   },
+
+  // Array
+  banned('head', '`array[0]` or `Array.prototype.at`'),
+  banned('nth', '`Array.prototype.at`'),
+  banned('fill', '`Array.prototype.fill`'),
+  banned('indexOf', '`Array.prototype.indexOf`'),
+  banned('lastIndexOf', '`Array.prototype.lastIndexOf`'),
+  banned('findIndex', '`Array.prototype.findIndex`'),
+  banned('findLastIndex', '`Array.prototype.findLastIndex`'),
+  banned('flattenDeep', '`Array.prototype.flat(Infinity)`'),
+  banned(
+    'reduceRight',
+    '`Array.prototype.reduceRight`',
+    'Iterate `Object.entries`/`Object.values` for objects.'
+  ),
+  banned('toArray', '`Array.from` (or `Object.values` for objects)'),
+
+  // Object
+  banned('toPairs', '`Object.entries`'),
+  banned('fromPairs', '`Object.fromEntries`'),
+
+  // String
+  banned('endsWith', '`String.prototype.endsWith`'),
+  banned('repeat', '`String.prototype.repeat`'),
+  banned('padStart', '`String.prototype.padStart`'),
+  banned('trimStart', '`String.prototype.trimStart`'),
+  banned('parseInt', '`Number.parseInt`'),
+
+  // Number
+  banned('isSafeInteger', '`Number.isSafeInteger`'),
+
+  // Math and comparison
+  banned('add', 'the `+` operator'),
+  banned('subtract', 'the `-` operator'),
+  banned('multiply', 'the `*` operator'),
+  banned('divide', 'the `/` operator'),
+  banned('gt', 'the `>` operator'),
+  banned('gte', 'the `>=` operator'),
+  banned('lt', 'the `<` operator'),
+  banned('lte', 'the `<=` operator'),
+
+  // Function
+  banned('now', '`Date.now`'),
+  banned('noop', '`() => {}`'),
+  banned('stubTrue', '`() => true`'),
+  banned('stubFalse', '`() => false`'),
+  banned('stubArray', '`() => []`'),
+  banned('stubObject', '`() => ({})`'),
+  banned('stubString', "`() => ''`"),
 ];
 
 /**

--- a/packages/utils/lint-policy/lodash.js
+++ b/packages/utils/lint-policy/lodash.js
@@ -64,45 +64,24 @@ const banned = (name, replacement, note) => ({
  * `instanceof` does not.
  */
 const BANNED_MEMBERS = [
-  {
-    name: 'isArray',
-    message:
-      'Use the native `Array.isArray` instead of lodash `isArray` (lodash re-exports the native function).',
-  },
-  {
-    name: 'forEach',
-    message:
-      'Use native iteration instead of lodash `forEach` — `for...of`, `Array.prototype.forEach`, or `Object.entries`/`Object.values` for objects.',
-  },
-  {
-    name: 'keys',
-    message: 'Use the native `Object.keys` instead of lodash `keys`.',
-  },
-  {
-    name: 'values',
-    message: 'Use the native `Object.values` instead of lodash `values`.',
-  },
-  {
-    name: 'entries',
-    message: 'Use the native `Object.entries` instead of lodash `entries`.',
-  },
-  {
-    name: 'concat',
-    message:
-      'Use the native `Array.prototype.concat` or an array spread instead of lodash `concat`.',
-  },
-  {
-    name: 'filter',
-    message:
-      'Use the native `Array.prototype.filter` instead of lodash `filter` (iterate `Object.entries`/`Object.values` for objects).',
-  },
-  {
-    name: 'find',
-    message:
-      'Use the native `Array.prototype.find` instead of lodash `find` — expand matcher shorthand (`{ id }`) into an explicit predicate.',
-  },
-
   // Array
+  banned('isArray', '`Array.isArray`', 'lodash re-exports the native function.'),
+  banned(
+    'forEach',
+    '`for...of` or `Array.prototype.forEach`',
+    'Iterate `Object.entries`/`Object.values` for objects.'
+  ),
+  banned(
+    'filter',
+    '`Array.prototype.filter`',
+    'Iterate `Object.entries`/`Object.values` for objects.'
+  ),
+  banned(
+    'find',
+    '`Array.prototype.find`',
+    'Expand matcher shorthand (`{ id }`) into an explicit predicate.'
+  ),
+  banned('concat', '`Array.prototype.concat` or an array spread'),
   banned('head', '`array[0]` or `Array.prototype.at`'),
   banned('nth', '`Array.prototype.at`'),
   banned('fill', '`Array.prototype.fill`'),
@@ -119,6 +98,9 @@ const BANNED_MEMBERS = [
   banned('toArray', '`Array.from` (or `Object.values` for objects)'),
 
   // Object
+  banned('keys', '`Object.keys`'),
+  banned('values', '`Object.values`'),
+  banned('entries', '`Object.entries`'),
   banned('toPairs', '`Object.entries`'),
   banned('fromPairs', '`Object.fromEntries`'),
 

--- a/packages/utils/lint-policy/package.json
+++ b/packages/utils/lint-policy/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "lint-policy",
+  "version": "5.52.1",
+  "private": true,
+  "license": "SEE LICENSE IN LICENSE",
+  "exports": {
+    "./lodash": "./lodash.js"
+  }
+}

--- a/packages/utils/oxlint-config/base.ts
+++ b/packages/utils/oxlint-config/base.ts
@@ -1,5 +1,7 @@
 import type { OxlintConfig } from 'oxlint';
 
+import { noRestrictedImports, noRestrictedSyntax } from 'lint-policy/lodash';
+
 /**
  * Shared baseline applied to every file in the monorepo.
  *
@@ -19,6 +21,8 @@ import type { OxlintConfig } from 'oxlint';
  */
 export const base = {
   plugins: ['typescript', 'react', 'import', 'unicorn'],
+  // ESLint's own rule implementations, for rules OxLint has no native equivalent of.
+  jsPlugins: [{ name: 'eslint-js', specifier: 'oxlint-plugin-eslint' }],
   categories: {
     // Phase 1: correctness only (definitely-wrong code, lowest noise).
     // TODO @Nico Phase 2 — port the ESLint/Airbnb policy surface here
@@ -32,6 +36,11 @@ export const base = {
     'unicorn/no-thenable': 'off',
     // Behavioral / intentional deps; revisit when enabling broader react-hooks.
     'react/exhaustive-deps': 'off',
+    // Lodash policy shared verbatim with ESLint — see lint-policy/lodash.js.
+    // `no-restricted-syntax` is not native to OxLint; it comes from the `eslint-js`
+    // JS plugin declared above, which is why this key carries the plugin prefix.
+    'no-restricted-imports': noRestrictedImports(),
+    'eslint-js/no-restricted-syntax': noRestrictedSyntax(),
   },
   ignorePatterns: [
     '**/dist/**',

--- a/packages/utils/oxlint-config/package.json
+++ b/packages/utils/oxlint-config/package.json
@@ -15,7 +15,9 @@
     "./tests": "./tests.ts"
   },
   "devDependencies": {
+    "lint-policy": "5.52.1",
     "oxlint": "1.72.0",
+    "oxlint-plugin-eslint": "1.72.0",
     "tsconfig": "5.52.1"
   },
   "scripts": {

--- a/packages/utils/oxlint-config/tsconfig.json
+++ b/packages/utils/oxlint-config/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "tsconfig/base.json",
   "compilerOptions": {
     "noEmit": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "allowJs": true
   },
   "include": ["*.ts"],
   "exclude": ["node_modules"]

--- a/packages/utils/typescript/src/generators/common/models/utils.ts
+++ b/packages/utils/typescript/src/generators/common/models/utils.ts
@@ -9,7 +9,6 @@ import {
   isString,
   isNumber,
   isDate,
-  isArray,
   isBoolean,
   propEq,
 } from 'lodash/fp';
@@ -114,7 +113,7 @@ export const toTypeLiteral = (data: any): any => {
     return data ? factory.createTrue() : factory.createFalse();
   }
 
-  if (isArray(data)) {
+  if (Array.isArray(data)) {
     return factory.createTupleTypeNode(data.map((item) => toTypeLiteral(item)));
   }
 

--- a/packages/utils/typescript/src/generators/components/index.ts
+++ b/packages/utils/typescript/src/generators/components/index.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { pipe, values, sortBy, map } from 'lodash/fp';
+import { pipe, sortBy, map } from 'lodash/fp';
 
 import { models } from '../common';
 import { emitDefinitions, format, generateSharedExtensionDefinition } from '../utils';
@@ -23,7 +23,7 @@ export const generateComponentsDefinitions = async (
   const { components } = strapi;
 
   const componentsDefinitions = pipe(
-    values,
+    Object.values,
     sortBy('uid'),
     map((component: any) => ({
       uid: component.uid,

--- a/packages/utils/typescript/src/generators/content-types/index.ts
+++ b/packages/utils/typescript/src/generators/content-types/index.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { values, pipe, map, sortBy } from 'lodash/fp';
+import { pipe, map, sortBy } from 'lodash/fp';
 
 import { models } from '../common';
 import { emitDefinitions, format, generateSharedExtensionDefinition } from '../utils';
@@ -23,7 +23,7 @@ export const generateContentTypesDefinitions = async (
   const { contentTypes } = strapi;
 
   const contentTypesDefinitions = pipe(
-    values,
+    Object.values,
     sortBy('uid'),
     map((contentType: any) => ({
       uid: contentType.uid,

--- a/tests/api/core/strapi/api/sanitize/sanitize-input.test.api.js
+++ b/tests/api/core/strapi/api/sanitize/sanitize-input.test.api.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { values } = require('lodash/fp');
-
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
 const resources = require('../validate/resources');
@@ -13,11 +11,11 @@ describe('Core API - Sanitize Input', () => {
   let strapi;
 
   const addSchemas = () => {
-    for (const component of values(schemas.components)) {
+    for (const component of Object.values(schemas.components)) {
       builder.addComponent(component);
     }
 
-    builder.addContentTypes(values(schemas['content-types']));
+    builder.addContentTypes(Object.values(schemas['content-types']));
   };
 
   const addFixtures = () => {

--- a/tests/api/core/strapi/api/validate/validate-input.test.api.js
+++ b/tests/api/core/strapi/api/validate/validate-input.test.api.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { values } = require('lodash/fp');
-
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
 const { createAuthRequest } = require('api-tests/request');
@@ -16,11 +14,11 @@ let rq;
 let data;
 
 const addSchemas = () => {
-  for (const component of values(schemas.components)) {
+  for (const component of Object.values(schemas.components)) {
     builder.addComponent(component);
   }
 
-  builder.addContentTypes(values(schemas['content-types']));
+  builder.addContentTypes(Object.values(schemas['content-types']));
 };
 
 const addFixtures = () => {

--- a/tests/api/core/strapi/api/validate/validate-query.test.api.js
+++ b/tests/api/core/strapi/api/validate/validate-query.test.api.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { values, zip, symmetricDifference } = require('lodash/fp');
+const { zip, symmetricDifference } = require('lodash/fp');
 
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
@@ -17,11 +17,11 @@ let rq;
 let publicRq;
 
 const addSchemas = () => {
-  for (const component of values(schemas.components)) {
+  for (const component of Object.values(schemas.components)) {
     builder.addComponent(component);
   }
 
-  builder.addContentTypes(values(schemas['content-types']));
+  builder.addContentTypes(Object.values(schemas['content-types']));
 };
 
 const addFixtures = () => {

--- a/tests/api/core/strapi/api/validate/validate-with-exported-zod.test.api.js
+++ b/tests/api/core/strapi/api/validate/validate-with-exported-zod.test.api.js
@@ -5,7 +5,6 @@
  * are used and validated/sanitized correctly throughout the content API pipeline.
  * Covers happy paths and error cases for extra query and body params.
  */
-const { values } = require('lodash/fp');
 
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
@@ -23,11 +22,11 @@ let rq;
 let data;
 
 const addSchemas = () => {
-  for (const component of values(schemas.components)) {
+  for (const component of Object.values(schemas.components)) {
     builder.addComponent(component);
   }
 
-  builder.addContentTypes(values(schemas['content-types']));
+  builder.addContentTypes(Object.values(schemas['content-types']));
 };
 
 const addFixtures = () => {

--- a/tests/api/utils/builder-helper.ts
+++ b/tests/api/utils/builder-helper.ts
@@ -1,7 +1,5 @@
 import type { Core } from '@strapi/types';
 
-import { values } from 'lodash/fp';
-
 import { createTestBuilder } from 'api-tests/builder';
 import { createStrapiInstance } from 'api-tests/strapi';
 import { createAuthRequest } from 'api-tests/request';
@@ -26,11 +24,11 @@ export type BuilderResources = {
 };
 
 const addSchemasToBuilder = (schemas, builder) => {
-  for (const component of values(schemas.components)) {
+  for (const component of Object.values(schemas.components)) {
     builder.addComponent(component);
   }
 
-  builder.addContentTypes(values(schemas['content-types']));
+  builder.addContentTypes(Object.values(schemas['content-types']));
 };
 
 const bootstrapBuilder = ({ fixtures, schemas, locales }: BuilderResources, builder: Builder) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10987,6 +10987,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint@npm:8.56.12":
+  version: 8.56.12
+  resolution: "@types/eslint@npm:8.56.12"
+  dependencies:
+    "@types/estree": "npm:*"
+    "@types/json-schema": "npm:*"
+  checksum: 10c0/e4ca426abe9d55f82b69a3250bec78b6d340ad1e567f91c97ecc59d3b2d6a1d8494955ac62ad0ea14b97519db580611c02be8277cbea370bdfb0f96aa2910504
+  languageName: node
+  linkType: hard
+
 "@types/estree-jsx@npm:^1.0.0":
   version: 1.0.5
   resolution: "@types/estree-jsx@npm:1.0.5"
@@ -11226,7 +11236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -28162,6 +28172,7 @@ __metadata:
     "@swc/core": "npm:1.13.5"
     "@swc/helpers": "npm:0.5.17"
     "@swc/jest": "npm:0.2.39"
+    "@types/eslint": "npm:8.56.12"
     "@types/fs-extra": "npm:11.0.4"
     "@types/git-url-parse": "npm:9.0.3"
     "@types/prompts": "npm:2.4.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17007,6 +17007,8 @@ __metadata:
 "eslint-config-custom@npm:5.52.1, eslint-config-custom@workspace:packages/utils/eslint-config-custom":
   version: 0.0.0-use.local
   resolution: "eslint-config-custom@workspace:packages/utils/eslint-config-custom"
+  dependencies:
+    lint-policy: "npm:5.52.1"
   languageName: unknown
   linkType: soft
 
@@ -22007,6 +22009,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lint-policy@npm:5.52.1, lint-policy@workspace:packages/utils/lint-policy":
+  version: 0.0.0-use.local
+  resolution: "lint-policy@workspace:packages/utils/lint-policy"
+  languageName: unknown
+  linkType: soft
+
 "lint-staged@npm:16.4.0":
   version: 16.4.0
   resolution: "lint-staged@npm:16.4.0"
@@ -24570,10 +24578,19 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "oxlint-config@workspace:packages/utils/oxlint-config"
   dependencies:
+    lint-policy: "npm:5.52.1"
     oxlint: "npm:1.72.0"
+    oxlint-plugin-eslint: "npm:1.72.0"
     tsconfig: "npm:5.52.1"
   languageName: unknown
   linkType: soft
+
+"oxlint-plugin-eslint@npm:1.72.0":
+  version: 1.72.0
+  resolution: "oxlint-plugin-eslint@npm:1.72.0"
+  checksum: 10c0/98eeb6f01285c7fd8617571a482b6fb744f166ac3ed0fef917a722fdcbe7e03e3438e67369ca1adbbe2186d78f37569f442922742e9a7b652661b4acc3caa9b1
+  languageName: node
+  linkType: hard
 
 "oxlint@npm:1.72.0":
   version: 1.72.0


### PR DESCRIPTION
### What does it do?

Continues the lodash reduction started in #27409 and #27454, this time for the six collection helpers that native JavaScript already covers:

| lodash | native replacement | call sites |
| --- | --- | --- |
| `keys` | `Object.keys` | 9 |
| `values` | `Object.values` | 10 |
| `entries` | `Object.entries` | 1 |
| `concat` | array spread / `Array.prototype.concat` | 4 |
| `filter` | `Array.prototype.filter` | 4 |
| `find` | `Array.prototype.find` | 3 |

The six members are then added to `BANNED_MEMBERS` in `packages/utils/lint-policy/lodash.js`, so both ESLint and OxLint reject every way of reaching them — named imports from `lodash` / `lodash/fp`, `lodash/<name>` deep paths, `require` destructuring, and namespace member access (`_.keys`).

Two call sites needed more than a mechanical swap:

- `_.find(users, { provider })` used lodash's matcher shorthand, which has no native equivalent — expanded into an explicit predicate.
- Curried `lodash/fp` `filter(pred)` inside a `pipe` chain became a plain arrow function; the type guard on the permissions engine's `removeInvalidConditions` is preserved so the `Condition | undefined` narrowing still holds.

One behaviour difference worth calling out: `_.keys(join.orderBy)` in the query builder became `Object.keys(join.orderBy ?? {})`. `Join['orderBy']` is optional, and lodash `keys(undefined)` returns `[]` where `Object.keys(undefined)` throws — the nullish fallback keeps the original semantics.

A second commit widens the policy past the members this PR touches: every lodash member with an exact native equivalent is banned now, whether or not it has a call site, so the next one is caught by the linter rather than by review — array (`head`, `nth`, `fill`, `indexOf`, `lastIndexOf`, `findIndex`, `findLastIndex`, `flattenDeep`, `reduceRight`, `toArray`), object (`toPairs`, `fromPairs`), string (`endsWith`, `repeat`, `padStart`, `trimStart`, `parseInt`), `isSafeInteger`, the math and comparison operators (`add`, `subtract`, `multiply`, `divide`, `gt`, `gte`, `lt`, `lte`), and `now`/`noop`/`stub*`. None of them are imported today, so that commit changes no source files.

A third commit routes every entry — the ones added here and the ones added in #27454 — through a `banned(name, replacement, note)` helper and groups the list by the API the replacement belongs to, so all 41 messages share one shape and a new ban is one line. Message prose shifts slightly for `isArray`, `forEach`, `keys`, `values`, `entries`, `concat`, `filter`, and `find`; the members banned and the selectors generated are unchanged.

Members whose lodash semantics differ from the closest native API are deliberately left out and documented in the policy module: `assignIn`/`extend` walk the prototype chain, `lowerCase`/`upperCase` split words rather than changing case, `min`/`max` return `undefined` for an empty array where `Math.min`/`Math.max` return infinities, and the `isMap`/`isSet`/`isRegExp` family survives cross-realm values that `instanceof` does not.

### Why is it needed?

These six are the largest remaining group of lodash imports that native JavaScript covers exactly. Removing them cuts module surface, makes the code read as standard JS, and — for anyone eventually evaluating `es-toolkit` — moves the codebase off members that only exist in `es-toolkit/compat`, never in the root package.

The lint rules keep them from coming back, using the shared policy module so ESLint and OxLint cannot drift apart.

### How to test it?

```bash
yarn test:ts     # 37 projects
yarn test:unit   # 22 projects
yarn lint        # 38 projects
yarn prettier:check
```

To confirm the bans are live, add `import { keys } from 'lodash';` (or `_.find(...)`) to any linted file — both linters should fail with the message pointing at the native replacement.

`yarn lint:oxlint` reports 4 errors, all pre-existing on `develop` and untouched by this PR.

### Related issue(s)/PR(s)

Stacked on #27454 — the first three commits here belong to that PR and will disappear from the diff once it merges. The three new commits are:

1. `chore: replace lodash collection helpers with native equivalents` — the migration and the six bans
2. `chore(lint): ban lodash members with exact native equivalents` — the preventive bans, no source changes
3. `chore(lint): build every lodash ban message through the shared helper` — policy-module cleanup only

Because commit 3 touches the `isArray` and `forEach` messages introduced in #27454, this branch needs a rebase if those strings change there.

Follows #27409.

