### PR TITLE
fix(graphql): custom resolvers losing draft-and-publish relations

### DIFF
--- a/packages/plugins/graphql/server/src/services/content-api/index.ts
+++ b/packages/plugins/graphql/server/src/services/content-api/index.ts
@@ -101,15 +101,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     // eg: removes registered subscriptions if they're disabled in the config)
     const prunedNexusSchema = pruneSchema(wrappedNexusSchema);
 
-    // Populate builtInQueryFields set for use by resolvers to avoid runtime schema builds
-    try {
-      const queryType = prunedNexusSchema.getQueryType();
-      const fields = queryType ? Object.keys(queryType.getFields() || {}) : [];
-      builtInQueryFields = new Set(fields);
-    } catch {
-      // ignore; leave set empty
-    }
-
     return prunedNexusSchema;
   };
 
@@ -119,6 +110,13 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     builtInQueryFields.has(fieldName) || fieldName.endsWith('_connection');
 
   const buildMergedSchema = ({ registry }: { registry: TypeRegistry }) => {
+    // Capture the built-in (shadow CRUD) query fields from a schema built with only the
+    // registry's own types, before any extension-registered types/typeDefs are merged in,
+    // so isBuiltInQueryField can tell shadow CRUD fields apart from custom extension resolvers.
+    const shadowCRUDSchema = makeSchema({ types: [registry.definitions] });
+    const shadowCRUDQueryFields = shadowCRUDSchema.getQueryType()?.getFields() ?? {};
+    builtInQueryFields = new Set(Object.keys(shadowCRUDQueryFields));
+
     // Here we extract types, plugins & typeDefs from a temporary generated
     // extension since there won't be any addition allowed after schemas generation
     const { types, typeDefs = [] } = extensionService.generate({ typeRegistry: registry });

--- a/tests/api/plugins/graphql/custom-resolver-dp-relations.test.api.js
+++ b/tests/api/plugins/graphql/custom-resolver-dp-relations.test.api.js
@@ -1,0 +1,208 @@
+'use strict';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let graphqlQuery;
+
+const authorModel = {
+  attributes: {
+    name: { type: 'string' },
+  },
+  draftAndPublish: true,
+  singularName: 'author',
+  pluralName: 'authors',
+  displayName: 'Author',
+  description: '',
+  collectionName: '',
+};
+
+const categoryModel = {
+  attributes: {
+    name: { type: 'string' },
+  },
+  draftAndPublish: false,
+  singularName: 'category',
+  pluralName: 'categories',
+  displayName: 'Category',
+  description: '',
+  collectionName: '',
+};
+
+const articleModel = {
+  attributes: {
+    title: { type: 'string' },
+    author: {
+      type: 'relation',
+      relation: 'manyToOne',
+      target: 'api::author.author',
+    },
+    category: {
+      type: 'relation',
+      relation: 'manyToOne',
+      target: 'api::category.category',
+    },
+  },
+  draftAndPublish: true,
+  singularName: 'article',
+  pluralName: 'articles',
+  displayName: 'Article',
+  description: '',
+  collectionName: '',
+};
+
+describe('Test Graphql custom resolvers returning Document Service results', () => {
+  const data = { article: null };
+
+  beforeAll(async () => {
+    await builder
+      .addContentType(authorModel)
+      .addContentType(categoryModel)
+      .addContentType(articleModel)
+      .build();
+
+    strapi = await createStrapiInstance({
+      bootstrap({ strapi: instance }) {
+        instance
+          .plugin('graphql')
+          .service('extension')
+          .use({
+            typeDefs: /* GraphQL */ `
+              type ArticleResponse {
+                data: [Article]
+              }
+              type Query {
+                articleByDocumentId(documentId: ID!): Article
+                allArticles: ArticleResponse
+              }
+            `,
+            resolvers: {
+              Query: {
+                async articleByDocumentId(_parent, args) {
+                  return instance
+                    .documents('api::article.article')
+                    .findFirst({ filters: { documentId: args.documentId } });
+                },
+                async allArticles() {
+                  const articleData = await instance
+                    .documents('api::article.article')
+                    .findMany({ populate: { author: true, category: true } });
+                  return { data: articleData };
+                },
+              },
+            },
+          });
+      },
+    });
+    rq = await createAuthRequest({ strapi });
+
+    graphqlQuery = (body) => rq({ url: '/graphql', method: 'POST', body });
+
+    const author = await strapi.documents('api::author.author').create({
+      data: { name: 'Alice' },
+    });
+    await strapi.documents('api::author.author').publish({ documentId: author.documentId });
+
+    const category = await strapi.documents('api::category.category').create({
+      data: { name: 'News' },
+    });
+
+    const article = await strapi.documents('api::article.article').create({
+      data: { title: 'Hello', author: author.documentId, category: category.documentId },
+    });
+    await strapi.documents('api::article.article').publish({ documentId: article.documentId });
+
+    data.article = article;
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('Built-in single query resolves the draft-and-publish relation (control)', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query Article($documentId: ID!) {
+          article(documentId: $documentId) {
+            documentId
+            title
+            author {
+              documentId
+              name
+            }
+            category {
+              documentId
+              name
+            }
+          }
+        }
+      `,
+      variables: { documentId: data.article.documentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.article.author).not.toBeNull();
+    expect(res.body.data.article.category).not.toBeNull();
+  });
+
+  test('Custom resolver returning a findFirst() result resolves the draft-and-publish relation', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query Article($documentId: ID!) {
+          articleByDocumentId(documentId: $documentId) {
+            documentId
+            title
+            author {
+              documentId
+              name
+            }
+            category {
+              documentId
+              name
+            }
+          }
+        }
+      `,
+      variables: { documentId: data.article.documentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.articleByDocumentId.category).not.toBeNull();
+    expect(res.body.data.articleByDocumentId.author).not.toBeNull();
+  });
+
+  test('Custom resolver returning a findMany() result with explicit populate resolves the draft-and-publish relation', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        {
+          allArticles {
+            data {
+              documentId
+              title
+              author {
+                documentId
+                name
+              }
+              category {
+                documentId
+                name
+              }
+            }
+          }
+        }
+      `,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const article = res.body.data.allArticles.data.find(
+      (a) => a.documentId === data.article.documentId
+    );
+    expect(article.category).not.toBeNull();
+    expect(article.author).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes draft-and-publish relations coming back `null` when a custom GraphQL resolver returns a Document Service result directly.

## Root Cause

`isBuiltInQueryField()` in the content-api service was checking against a `builtInQueryFields` set captured from the schema after custom extension resolvers were merged in, so it couldn't tell a shadow CRUD query apart from a custom one.

This caused the relation resolver to wrongly inherit a published status filter for relations reached through custom resolvers, filtering out validly-linked draft targets.

## Changes

- `packages/plugins/graphql/server/src/services/content-api/index.ts`
  - Capture `builtInQueryFields` from the schema built purely from shadow CRUD registry types, before extension types/typeDefs are merged in.
- Added `tests/api/plugins/graphql/custom-resolver-dp-relations.test.api.js`
  - Covers a custom resolver returning `findFirst`/`findMany` results directly.

## Testing

- `yarn test:api --testPathPattern="custom-resolver-dp-relations"` — passing
- `yarn test:api --testPathPattern="plugins/graphql"` — full suite passing, no regressions
- `yarn nx run @strapi/plugin-graphql:test:ts:back` — passing

## Manual Verification

1. Register a custom GraphQL resolver returning `strapi.documents(uid).findFirst()`/`findMany()` results for a content type with a draft-and-publish relation.
2. Query the relation through the custom resolver — it resolves instead of returning `null`.
3. Confirm the built-in auto-generated query for the same content type still resolves the relation correctly (no regression).

## Related Issue

Closes #27447