### PR TITLE
fix(admin): keep role conditions from custom categories when applying

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ConditionsModal.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ConditionsModal.tsx
@@ -84,22 +84,14 @@ const ConditionsModal = ({
   }, [isReadOnly, actionsToDisplay, modifiedData, arrayOfOptionsGroupedByCategory]);
 
   const handleChange = React.useCallback(
-    (name: string, values: ConditionForm) => {
+    (name: string, values: Record<string, ConditionForm>) => {
       if (isReadOnly === true) {
         return;
       }
 
       setState(
         produce((draft) => {
-          if (draft[name] === undefined) {
-            draft[name] = {};
-          }
-
-          if (draft[name].default === undefined) {
-            draft[name].default = {};
-          }
-
-          draft[name].default = values;
+          draft[name] = values;
         })
       );
     },
@@ -266,7 +258,7 @@ interface ActionRowProps {
   isReadOnly?: boolean;
   label: string;
   name: string;
-  onChange?: (name: string, values: Record<string, boolean>) => void;
+  onChange?: (name: string, values: Record<string, ConditionForm>) => void;
   value: Record<string, ConditionForm>;
 }
 
@@ -398,13 +390,14 @@ const getNewStateFromChangedValues = (
   options: ActionRowProps['arrayOfOptionsGroupedByCategory'],
   changedValues: string[]
 ) =>
-  options
-    .map(([, values]) => values)
-    .flat()
-    .reduce<Record<string, boolean>>(
+  options.reduce<Record<string, ConditionForm>>((acc, [categoryName, values]) => {
+    acc[categoryName] = values.reduce<ConditionForm>(
       (acc, curr) => ({ [curr.id]: changedValues.includes(curr.id), ...acc }),
       {}
     );
+
+    return acc;
+  }, {});
 
 export { ConditionsModal };
 export type { ConditionsModalProps };

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ConditionsModal.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ConditionsModal.tsx
@@ -391,10 +391,11 @@ const getNewStateFromChangedValues = (
   changedValues: string[]
 ) =>
   options.reduce<Record<string, ConditionForm>>((acc, [categoryName, values]) => {
-    acc[categoryName] = values.reduce<ConditionForm>(
-      (acc, curr) => ({ [curr.id]: changedValues.includes(curr.id), ...acc }),
-      {}
-    );
+    acc[categoryName] = values.reduce<ConditionForm>((acc, current) => {
+      acc[current.id] = changedValues.includes(current.id);
+
+      return acc;
+    }, {});
 
     return acc;
   }, {});

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/tests/ConditionsModal.test.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/tests/ConditionsModal.test.tsx
@@ -1,0 +1,90 @@
+import { Modal } from '@strapi/design-system';
+import { render, screen } from '@tests/utils';
+
+import { PermissionsDataManagerProvider } from '../../hooks/usePermissionsDataManager';
+import { ConditionsModal } from '../ConditionsModal';
+
+const AVAILABLE_CONDITIONS = [
+  {
+    id: 'admin::is-creator',
+    displayName: 'Is creator',
+    category: 'default',
+  },
+  {
+    id: 'admin::my-condition',
+    displayName: 'My condition',
+    category: 'my category',
+  },
+];
+
+const ACTIONS = [
+  {
+    actionId: 'plugin::content-manager.explorer.read',
+    label: 'Read',
+    isDisplayed: true,
+    hasAllActionsSelected: true,
+    pathToConditionsObject: ['collectionTypes', 'api::address.address', 'read'],
+  },
+];
+
+const renderModal = (onChangeConditions: jest.Mock, conditions: Record<string, boolean> = {}) =>
+  render(
+    <Modal.Root defaultOpen>
+      <ConditionsModal actions={ACTIONS} />
+    </Modal.Root>,
+    {
+      renderOptions: {
+        wrapper: ({ children }) => (
+          <PermissionsDataManagerProvider
+            availableConditions={AVAILABLE_CONDITIONS}
+            modifiedData={{
+              collectionTypes: {
+                'api::address.address': {
+                  read: { properties: { enabled: true }, conditions },
+                },
+              },
+              singleTypes: {},
+              plugins: {},
+              settings: {},
+            }}
+            onChangeConditions={onChangeConditions}
+            onChangeSimpleCheckbox={jest.fn()}
+            onChangeParentCheckbox={jest.fn()}
+            onChangeCollectionTypeLeftActionRowCheckbox={jest.fn()}
+            onChangeCollectionTypeGlobalActionCheckbox={jest.fn()}
+          >
+            {children}
+          </PermissionsDataManagerProvider>
+        ),
+      },
+    }
+  );
+
+describe('ConditionsModal', () => {
+  it('should apply a condition belonging to a custom category', async () => {
+    const onChangeConditions = jest.fn();
+    const { user } = renderModal(onChangeConditions);
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: 'My condition' }));
+    await user.keyboard('[Escape]');
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(onChangeConditions).toHaveBeenCalledWith({
+      'collectionTypes..api::address.address..read': {
+        'admin::is-creator': false,
+        'admin::my-condition': true,
+      },
+    });
+  });
+
+  it('should not count a selected condition twice', async () => {
+    const { user } = renderModal(jest.fn(), { 'admin::my-condition': true });
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: 'Is creator' }));
+    await user.keyboard('[Escape]');
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('2 currently selected');
+  });
+});


### PR DESCRIPTION
### What does it do?

`getNewStateFromChangedValues` now returns the selected conditions grouped by category, and the conditions modal stores that object as-is instead of writing everything into the `default` bucket.

### Why is it needed?

The modal keeps one bucket of conditions per category, but every change was written into `default` only. On apply the buckets are merged in insertion order, so the untouched bucket of a custom category overwrote the values the user had just picked and the condition was dropped from the payload. The same flattening also counted a condition twice when it was set in both buckets, so the select could report more selected conditions than there were ticked checkboxes.

### How to test it?

In `examples/getstarted`, register a condition with a custom `category` (see the issue for a snippet), then grant a permission to a role, tick that condition in *Define conditions*, apply and save. The condition is kept after a reload. `yarn test:front` covers both cases in `ConditionsModal.test.tsx`.

### Related issue(s)/PR(s)

Fix #27461
