### PR TITLE
fix(content-manager): prevent relations pagination reset on modal close

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -50,6 +50,7 @@ import {
   useGetRelationsQuery,
   useLazySearchRelationsQuery,
   RelationResult,
+  relationsApi,
 } from '../../../../../services/relations';
 import { type MainField } from '../../../../../utils/attributes';
 import { setIn } from '../../../../../utils/objects';
@@ -165,28 +166,11 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
   ({ disabled, label, ...props }, ref) => {
     const { currentDocument, currentDocumentMeta } = useDocumentContext('RelationsField');
 
-    const [currentPage, setCurrentPage] = React.useState(1);
-
     // Use the documentId from the actual document, not the params (meta)
     const documentId = currentDocument.document?.documentId;
 
-    const { formatMessage } = useIntl();
-
-    const isMorph = props.attribute.relation.toLowerCase().includes('morph');
-    const isDisabled = isMorph || disabled;
-    // @ts-expect-error – `targetModel` exists on supported non-morph relations (morph is disabled).
-    const targetModel = props.attribute.targetModel;
-
     const componentId = useComponent('RelationsField', (state) => state.id);
     const componentUID = useComponent('RelationsField', (state) => state.uid);
-
-    const isSubmitting = useForm('RelationsList', (state) => state.isSubmitting);
-
-    React.useEffect(() => {
-      setCurrentPage(1);
-    }, [isSubmitting]);
-
-    const component = componentUID ? currentDocument.components[componentUID] : undefined;
 
     /**
      * We'll always have a documentId in a created entry, so we look for a componentId first.
@@ -203,6 +187,43 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
      * individual components. Therefore we split the string and take the last item.
      */
     const [targetField] = props.name.split('.').slice(-1);
+
+    const queryState = relationsApi.endpoints.getRelations.useQueryState(
+      {
+        model,
+        targetField,
+        id,
+        params: {
+          ...currentDocumentMeta.params,
+          pageSize: RELATIONS_TO_DISPLAY,
+          page: 1, // Any page works because serializeQueryArgs ignores it
+        },
+      },
+      {
+        skip: !id,
+      }
+    );
+
+    const [currentPage, setCurrentPage] = React.useState(queryState.data?.pagination?.page || 1);
+
+    const { formatMessage } = useIntl();
+
+    const isMorph = props.attribute.relation.toLowerCase().includes('morph');
+    const isDisabled = isMorph || disabled;
+    // @ts-expect-error – `targetModel` exists on supported non-morph relations (morph is disabled).
+    const targetModel = props.attribute.targetModel;
+
+
+
+    const isSubmitting = useForm('RelationsList', (state) => state.isSubmitting);
+
+    React.useEffect(() => {
+      if (isSubmitting) {
+        setCurrentPage(1);
+      }
+    }, [isSubmitting]);
+
+    const component = componentUID ? currentDocument.components[componentUID] : undefined;
 
     const schemaAttributes = component
       ? (component.attributes ?? {})

--- a/packages/core/content-manager/admin/src/services/relations.ts
+++ b/packages/core/content-manager/admin/src/services/relations.ts
@@ -194,5 +194,5 @@ const prepareTempKeys = (relations: RelResult[], existingRelations: RelationResu
 
 const { useGetRelationsQuery, useLazySearchRelationsQuery } = relationsApi;
 
-export { useGetRelationsQuery, useLazySearchRelationsQuery };
+export { useGetRelationsQuery, useLazySearchRelationsQuery, relationsApi };
 export type { RelationResult };


### PR DESCRIPTION
### What does it do?

1. **Persists `currentPage` state:** Uses `relationsApi.endpoints.getRelations.useQueryState` to securely retrieve the current `pagination.page` directly from the RTK query cache instead of defaulting to `1`.
2. **Hardens Form Submit Effect:** Narrows the `isSubmitting` effect in `RelationsField` so that the pagination resets strictly when the state changes to `true` (i.e. explicitly on submit) rather than triggering on initial mount.

### Why is it needed?

This resolves an issue where the `RelationsField` component was losing its local `currentPage` state when it re-renders following a `triggerRefetchDocument` on modal close. Due to the component state loss, RTK Query would inadvertently refetch `page: 1`, which intentionally wipes the accumulated cache (causing it to fall back to a 5-item limit and breaking "Load More" functionality). 

### How to test it?

1. Create a collection type with more than 5 entries.
2. Create another collection with a Relation field (e.g. ManyToMany) tied to the first collection.
3. Link more than 5 items into the Relation field, save the document, and reload the page.
4. Click "Load More" until all items are visible.
5. Open an entry's relation modal, and simply close it.
6. Verify that the relations list remains intact with all items visible, and doesn't get abruptly wiped back to the first 5 entries.

### Related issue(s)/PR(s)

Fixes #27199
