### PR TITLE
fix(utils): stop traverseEntity leaking sibling parent context (#27474)

### DIFF
--- a/packages/core/utils/src/__tests__/traverse-entity.test.ts
+++ b/packages/core/utils/src/__tests__/traverse-entity.test.ts
@@ -809,6 +809,66 @@ describe('traverse-entity', () => {
     });
   });
 
+  describe('Sibling parent context (#27474)', () => {
+    // Reproduces the "Invalid key __component at blocks" error: a dynamic-zone
+    // entry whose component/relational key is ordered before __component. The
+    // sibling key must not leak its parent onto the special __component key.
+    const buildDynamicZoneEntity = () => {
+      const mediaComponentSchema = createComponentSchema({
+        authorImage: { type: 'media' },
+      });
+      // schema of the dynamic-zone component entry (shared.quote)
+      const quoteComponentSchema: Model = {
+        ...createComponentSchema({
+          authorImage: { type: 'component', component: 'shared.media' },
+        }),
+        uid: 'shared.quote',
+      };
+      const mediaEntrySchema: Model = {
+        ...createComponentSchema({ image: { type: 'media' } }),
+        uid: 'shared.media',
+      };
+      const rootSchema = createBaseSchema({
+        blocks: { type: 'dynamiczone', components: ['shared.quote'] },
+      });
+      const getModel = (uid: string): Model => {
+        if (uid === 'shared.quote') return quoteComponentSchema;
+        if (uid === 'shared.media') return mediaEntrySchema;
+        return mediaComponentSchema;
+      };
+      // Component key (authorImage) precedes __component: the failing order.
+      const entity = {
+        blocks: [{ authorImage: { image: { id: 1 } }, __component: 'shared.quote' }],
+      };
+      return { rootSchema, getModel, entity };
+    };
+
+    test('__component sees the dynamic-zone parent, not a preceding sibling parent', async () => {
+      const { rootSchema, getModel, entity } = buildDynamicZoneEntity();
+
+      await traverseEntity(mockVisitor, { schema: rootSchema, getModel }, entity);
+
+      const componentCall = mockVisitor.mock.calls.find((c) => c[0].key === '__component');
+      expect(componentCall).toBeDefined();
+      // Before the fix this was the leaked authorImage (component) parent, so
+      // the dynamic-zone key check in validators failed and threw.
+      expect(componentCall[0].parent?.attribute?.type).toBe('dynamiczone');
+    });
+
+    test('the real throwUnrecognizedFields visitor accepts __component after a component sibling', async () => {
+      // End to end against the actual validator that produced
+      // "Invalid key __component at blocks" in the bug report.
+      const throwUnrecognizedFields = (
+        await import('../validate/visitors/throw-unrecognized-fields')
+      ).default;
+      const { rootSchema, getModel, entity } = buildDynamicZoneEntity();
+
+      await expect(
+        traverseEntity(throwUnrecognizedFields, { schema: rootSchema, getModel }, entity)
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe('Curried function export', () => {
     test('should work with curried syntax', async () => {
       const schema = createBaseSchema({

--- a/packages/core/utils/src/traverse-entity.ts
+++ b/packages/core/utils/src/traverse-entity.ts
@@ -71,6 +71,13 @@ const traverseEntity = async (
     allowedExtraRootKeys,
   } = options;
 
+  // The parent of every direct key of `entity` is fixed for the whole call:
+  // it is `options.parent`. Keep a stable reference for the visitor so that
+  // visiting one relational/component/dynamic-zone key cannot leak its own
+  // parent context onto the sibling keys that follow it. The mutable `parent`
+  // below is only used to drive recursion into a key's own children. (#27474)
+  const nodeParent = options.parent;
+
   let parent = options.parent;
 
   const traverseMorphRelationTarget = async (visitor: Visitor, path: Path, entry: Data) => {
@@ -182,7 +189,7 @@ const traverseEntity = async (
       attribute,
       path: newPath,
       getModel,
-      parent,
+      parent: nodeParent,
       allowedExtraRootKeys,
     };
 


### PR DESCRIPTION
### What does it do?

`traverseEntity` walks an entity's keys in a loop and, for each relational, component, media, or dynamic-zone key, reassigns a function-scoped `parent` binding before recursing into that key's children. The same binding was also handed to the visitor for the current key. Because it is shared across iterations, a key visited after one of those attributes received the previous sibling's parent rather than its own.

The parent of every direct key of a node is fixed for the whole call, so the visitor now reads a stable reference (`options.parent`) while the mutable binding continues to drive recursion into a key's own children. The change is two lines of behaviour plus a comment.

### Why is it needed?

It fixes the order-dependent "Invalid key __component at blocks" error in #27474. A dynamic-zone entry is traversed as a component whose parent is the dynamic-zone attribute. `throwUnrecognizedFields` allows the special `__component` key only when it can see that dynamic-zone parent. When a component or relation key appeared before `__component` in the same entry, the leaked parent was that sibling's component attribute, the dynamic-zone check failed, and a valid update was rejected. The reporter noticed the error disappears when `__component` is ordered first, which is the signature of this leak.

### How to test it?

Unit tests are added to `packages/core/utils/src/__tests__/traverse-entity.test.ts`. One asserts that `__component`, when it follows a component sibling, still sees a dynamic-zone parent. The other runs the real `throwUnrecognizedFields` visitor over the same shape and asserts it no longer throws.

Both tests fail on the current code and pass with the fix. Reverting only the source change makes the second test reject with the exact `Invalid key __component at blocks` error from the report. The full `@strapi/utils` unit suite passes (611 tests), and `test:ts` for the package is clean.

### Related issue(s)/PR(s)

Fixes #27474
