### PR TITLE
fix(upload): various fixes and adjustments of new media library

### DIFF
--- a/packages/core/upload/admin/src/future/components/Drawer.tsx
+++ b/packages/core/upload/admin/src/future/components/Drawer.tsx
@@ -147,6 +147,17 @@ const CollapsibleContent = styled(Box)<CollapsibleContentProps>`
     overflow: hidden;
     min-height: 0;
   }
+
+  /* The scroll area wraps its children in a div styled inline as
+     display: table, min-width: 100%. A table box grows to its content, so a
+     single unbreakable string (a long file name) widens it past the scrollport
+     and the panel gains a horizontal scrollbar — with nothing left to clamp the
+     row, the name never truncates. Overriding to a block box makes the
+     scrollport the width again, which is what the vertical-only list wants.
+     Inline styles, hence the important. */
+  [data-radix-scroll-area-viewport] > div {
+    display: block !important;
+  }
 `;
 
 const CloseIconButton = styled(IconButton)`

--- a/packages/core/upload/admin/src/future/components/UploadProgressDialog.tsx
+++ b/packages/core/upload/admin/src/future/components/UploadProgressDialog.tsx
@@ -32,6 +32,7 @@ import {
 import { getTranslationKey } from '../utils/translations';
 
 import { Drawer } from './Drawer';
+import { TruncatedText } from './TruncatedText';
 
 import type { FileMetadataStatus, FileProgress, FileProgressStatus } from '../store/uploadProgress';
 import type { MessageDescriptor } from 'react-intl';
@@ -489,6 +490,27 @@ const IndeterminateBar = () => {
   );
 };
 
+/**
+ * Without a floor of zero the row is as wide as its longest filename, which
+ * pushes past the panel and gives the dialog a second, horizontal scrollbar
+ * instead of truncating.
+ *
+ * The floor belongs to the name alone: the icon carries its size in SVG
+ * attributes, which flex is free to override, so letting it shrink squashes it
+ * against a long name instead of truncating the name.
+ */
+const FileRowName = styled(Flex)`
+  min-width: 0;
+
+  > :first-child {
+    flex-shrink: 0;
+  }
+
+  > :last-child {
+    min-width: 0;
+  }
+`;
+
 const FileRow = ({
   icon,
   fileName,
@@ -500,12 +522,12 @@ const FileRow = ({
 }) => {
   return (
     <Flex direction="column" alignItems="stretch" justifyContent="center" gap={1} width="100%">
-      <Flex gap={2}>
+      <FileRowName gap={2}>
         {icon}
-        <Typography variant="omega" fontWeight="semiBold" ellipsis>
+        <TruncatedText variant="omega" fontWeight="semiBold">
           {fileName}
-        </Typography>
-      </Flex>
+        </TruncatedText>
+      </FileRowName>
       {children}
     </Flex>
   );

--- a/packages/core/upload/admin/src/future/components/UploadProgressDialog.tsx
+++ b/packages/core/upload/admin/src/future/components/UploadProgressDialog.tsx
@@ -50,7 +50,14 @@ const HeaderStatusMessage = ({
   metadataSubtitle?: string;
 }) => {
   return (
-    <Flex direction="column" alignItems="flex-start" paddingLeft={2}>
+    <Flex
+      direction="column"
+      alignItems="flex-start"
+      paddingLeft={2}
+      paddingRight={2}
+      paddingTop={1}
+      paddingBottom={1}
+    >
       <Drawer.Title>
         <Typography variant="omega">{title}</Typography>
       </Drawer.Title>
@@ -69,6 +76,7 @@ const HeaderStatusMessage = ({
 };
 
 const HeaderStatusIcon = styled(Flex)`
+  align-self: stretch;
   padding: ${({ theme }) => theme.spaces[3]};
   border-radius: ${({ theme }) => `${theme.borderRadius} 0 0 ${theme.borderRadius}`};
 

--- a/packages/core/upload/admin/src/future/components/tests/UploadProgressDialog.test.tsx
+++ b/packages/core/upload/admin/src/future/components/tests/UploadProgressDialog.test.tsx
@@ -64,6 +64,45 @@ describe('UploadProgressDialog', () => {
     jest.clearAllMocks();
   });
 
+  describe('Long file names', () => {
+    const longName = `${'a'.repeat(200)}.png`;
+
+    it('ellipsizes the name instead of widening the row', () => {
+      setup(
+        createMockState({
+          isVisible: true,
+          files: [createMockFile(0, longName, 'uploading')],
+        })
+      );
+
+      // An unconstrained row grows to the width of its longest name, which pushes
+      // past the fixed-width panel and gives the dialog a horizontal scrollbar
+      // on top of the vertical one.
+      const name = screen.getByText(longName);
+
+      expect(window.getComputedStyle(name).textOverflow).toBe('ellipsis');
+      // The floor belongs to the name, so it is what gives way.
+      expect(window.getComputedStyle(name).minWidth).toBe('0');
+    });
+
+    it('keeps the status icon at full size next to a truncated name', () => {
+      setup(
+        createMockState({
+          isVisible: true,
+          files: [createMockFile(0, longName, 'uploading')],
+        })
+      );
+
+      // The icon sizes itself through SVG attributes, which flex may override —
+      // so without a shrink guard a long name squashes it instead of truncating.
+      // eslint-disable-next-line testing-library/no-node-access
+      const icon = screen.getByText(longName).previousElementSibling;
+
+      expect(icon).toBeInTheDocument();
+      expect(window.getComputedStyle(icon as Element).flexShrink).toBe('0');
+    });
+  });
+
   describe('Dialog visibility', () => {
     it('renders the dialog when isVisible is true', () => {
       setup(createMockState({ isVisible: true }));

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetDetailsDrawer.tsx
@@ -1177,6 +1177,19 @@ export const AssetDetails = ({ asset, closeDetails }: AssetDetailsProps) => {
  * DrawerHeader
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * The icon's size lives in SVG attributes, which flex is free to override, so a
+ * long asset name would squash it. Matches the grid and table rows, where the
+ * file-type icon is shrink-proof and the name is what truncates.
+ */
+const HeaderIcon = styled(Flex)`
+  flex-shrink: 0;
+`;
+
+const HeaderTitle = styled(Typography)`
+  min-width: 0;
+`;
+
 interface DrawerHeaderProps {
   asset: AssetWithPopulatedCreatedBy;
   closeDetails: () => void;
@@ -1195,11 +1208,13 @@ const DrawerHeader = ({ asset, closeDetails }: DrawerHeaderProps) => {
       borderStyle="solid"
       borderWidth="0 0 1px 0"
     >
-      <DocIcon width={20} height={20} />
+      <HeaderIcon>
+        <DocIcon width={20} height={20} />
+      </HeaderIcon>
       <Drawer.Title asChild>
-        <Typography variant="omega" fontWeight="semiBold" overflow="hidden" ellipsis tag="h2">
+        <HeaderTitle variant="omega" fontWeight="semiBold" overflow="hidden" ellipsis tag="h2">
           {asset.name}
-        </Typography>
+        </HeaderTitle>
       </Drawer.Title>
       <Box marginLeft="auto">
         <Drawer.CloseButton onClose={closeDetails}>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsGrid.tsx
@@ -58,6 +58,7 @@ const StyledCard = styled(Card)<{
     ${({ theme, $isSelected }) => ($isSelected ? theme.colors.primary600 : theme.colors.neutral200)};
   border-radius: 8px;
   overflow: hidden;
+  isolation: isolate;
   cursor: ${({ $isMovePending, $isBusy }) => ($isMovePending || $isBusy ? 'wait' : 'pointer')};
   opacity: ${({ $isDragging }) => ($isDragging ? 0.4 : 1)};
   /* No opacity change while busy — the overlay does the dimming, and stacking

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetsTable.tsx
@@ -47,26 +47,15 @@ const StyledTable = styled(RawTable)`
   border-radius: 4px;
   overflow: hidden;
 
-  /* Below desktop only the name column remains. A fixed layout makes a long
-     name ellipsize instead of widening the table past the viewport — the
-     checkbox (first) and actions (last) columns keep a fixed width and the name
-     takes the rest. Desktop keeps the content-sized auto layout. */
-  table-layout: fixed;
+  /* An auto layout lets every column but the name size itself to its content,
+     so the dates never wrap. The name cell is what absorbs the leftover and
+     ellipsizes — see NameTd. */
+  table-layout: auto;
 
   & td:last-child,
   & th:last-child {
     width: 5.6rem;
     white-space: nowrap;
-  }
-
-  ${({ theme }) => theme.breakpoints.large} {
-    table-layout: auto;
-
-    & td:last-child,
-    & th:last-child {
-      width: auto;
-      white-space: normal;
-    }
   }
 `;
 
@@ -78,15 +67,48 @@ const StyledThead = styled(RawThead)`
   }
 `;
 
-const StyledTh = styled(RawTh)`
+/**
+ * Column sizing, applied to the header and body cells alike.
+ *
+ * `hug` shrinks a column to its content: `width: 1%` is a floor the content
+ * overrides, and `nowrap` stops a date breaking across lines.
+ *
+ * `flex` claims everything left over. `width: 100%` asks for all of it and
+ * `max-width: 0` is what allows the cell to be narrower than its content, which
+ * is what lets the name inside ellipsize instead of widening the table.
+ */
+const hugColumn = css`
+  width: 1%;
+  white-space: nowrap;
+`;
+
+const flexColumn = css`
+  width: 100%;
+  max-width: 0;
+  overflow: hidden;
+`;
+
+const StyledTh = styled(RawTh)<{ $flex?: boolean }>`
   height: 40px;
   padding: 0 ${({ theme }) => theme.spaces[4]};
   text-align: left;
+
+  ${({ $flex }) => ($flex ? flexColumn : hugColumn)}
 `;
 
 const StyledTd = styled(RawTd)`
   padding: 0 ${({ theme }) => theme.spaces[4]};
   border-bottom: 1px solid ${({ theme }) => theme.colors.neutral150};
+`;
+
+/** The name column: takes whatever the others leave and ellipsizes. */
+const NameTd = styled(StyledTd)`
+  ${flexColumn}
+`;
+
+/** Every other column: as wide as its content, never wrapping. */
+const HugTd = styled(StyledTd)`
+  ${hugColumn}
 `;
 
 const StyledTr = styled.tr<{
@@ -331,7 +353,7 @@ const AssetRow = ({ asset, orderedItemKeys, onAssetItemClick }: AssetRowProps) =
           </Flex>
         </CheckboxTd>
       )}
-      <StyledTd>
+      <NameTd>
         <Flex alignItems="center" justifyContent="space-between" gap={2} minWidth={0}>
           <Flex gap={3} alignItems="center" minWidth={0}>
             {/* The row is dimmed and inert while busy; the spinner in place of the
@@ -363,24 +385,24 @@ const AssetRow = ({ asset, orderedItemKeys, onAssetItemClick }: AssetRowProps) =
             </Tooltip>
           )}
         </Flex>
-      </StyledTd>
+      </NameTd>
       {isDesktop && (
         <>
-          <StyledTd>
+          <HugTd>
             <Typography textColor="neutral600">
               {asset.createdAt ? formatDate(new Date(asset.createdAt), { dateStyle: 'long' }) : '-'}
             </Typography>
-          </StyledTd>
-          <StyledTd>
+          </HugTd>
+          <HugTd>
             <Typography textColor="neutral600">
               {asset.updatedAt ? formatDate(new Date(asset.updatedAt), { dateStyle: 'long' }) : '-'}
             </Typography>
-          </StyledTd>
-          <StyledTd>
+          </HugTd>
+          <HugTd>
             <Typography textColor="neutral600">
               {asset.size ? formatBytes(asset.size, 1) : '-'}
             </Typography>
-          </StyledTd>
+          </HugTd>
         </>
       )}
       {/* The row owns click, Enter and Space; none of them should reach it from
@@ -511,7 +533,7 @@ const FolderRow = ({ folder, orderedItemKeys }: FolderRowProps) => {
           </Flex>
         </CheckboxTd>
       )}
-      <StyledTd>
+      <NameTd>
         <Flex gap={3} alignItems="center" minWidth={0}>
           <Flex
             justifyContent="center"
@@ -528,26 +550,26 @@ const FolderRow = ({ folder, orderedItemKeys }: FolderRowProps) => {
             {folder.name}
           </TruncatedText>
         </Flex>
-      </StyledTd>
+      </NameTd>
       {isDesktop && (
         <>
-          <StyledTd>
+          <HugTd>
             <Typography textColor="neutral600">
               {folder.createdAt
                 ? formatDate(new Date(folder.createdAt), { dateStyle: 'long' })
                 : '-'}
             </Typography>
-          </StyledTd>
-          <StyledTd>
+          </HugTd>
+          <HugTd>
             <Typography textColor="neutral600">
               {folder.updatedAt
                 ? formatDate(new Date(folder.updatedAt), { dateStyle: 'long' })
                 : '-'}
             </Typography>
-          </StyledTd>
-          <StyledTd>
+          </HugTd>
+          <HugTd>
             <Typography textColor="neutral600">-</Typography>
-          </StyledTd>
+          </HugTd>
         </>
       )}
       {/* The row owns click, Enter and Space; none of them should reach it from
@@ -650,7 +672,7 @@ export const AssetsTable = ({
 
             if (isVisuallyHidden) {
               return (
-                <StyledTh key={header.name}>
+                <StyledTh key={header.name} $flex={header.name === 'name'}>
                   <VisuallyHidden>
                     {formatMessage({
                       id: getTranslationKey('table.header.actions'),
@@ -662,7 +684,7 @@ export const AssetsTable = ({
             }
 
             return (
-              <StyledTh key={header.name}>
+              <StyledTh key={header.name} $flex={header.name === 'name'}>
                 <Typography textColor="neutral600" variant="sigma">
                   {tableHeaderLabel}
                 </Typography>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/BulkActionsBar.tsx
@@ -4,7 +4,7 @@ import { useNotification } from '@strapi/admin/strapi-admin';
 import { Box, Button, Flex, IconButton, Tooltip, Typography } from '@strapi/design-system';
 import { ArrowRight, Cross, Sparkle, Trash } from '@strapi/icons';
 import { useIntl } from 'react-intl';
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 
 import {
   AI_METADATA_MAX_FILES,
@@ -30,7 +30,7 @@ import type { File } from '../../../../../../shared/contracts/files';
  * bottom edge (no radius, top border only). Desktop (medium+): a floating,
  * centered pill.
  */
-const Bar = styled(Flex)`
+const Bar = styled(Flex)<{ $isDrawerOpen: boolean; $isStacked: boolean }>`
   position: fixed;
   z-index: ${({ theme }) => theme.zIndices.popover};
   left: 0;
@@ -46,13 +46,69 @@ const Bar = styled(Flex)`
   border-radius: 0;
   box-shadow: ${({ theme }) => theme.shadows.popupShadow};
 
+  /* Docked full-bleed at the bottom on mobile, which is exactly where the open
+     drawer keeps its own actions — so it steps aside there, and only there. */
+  display: ${({ $isDrawerOpen }) => ($isDrawerOpen ? 'none' : 'flex')};
+
+  /* Mobile with the metadata action present: the labelled button plus the icons
+     no longer fit beside the count on one line, so the count takes a row of its
+     own and every button drops to the next. Children in source order: count,
+     action cluster, divider, clear. */
+  ${({ $isStacked }) =>
+    $isStacked &&
+    css`
+      flex-wrap: wrap;
+      justify-content: space-between;
+
+      > :first-child {
+        flex-basis: 100%;
+        margin-right: 0;
+      }
+
+      > :nth-child(2) {
+        margin-left: 0;
+      }
+
+      /* The divider only existed to set the clear action apart from the rest;
+         with the row spread it would hang in mid-air between them. */
+      > :nth-child(3) {
+        display: none;
+      }
+    `}
+
   ${({ theme }) => theme.breakpoints.medium} {
+    display: flex;
     left: 50%;
     right: auto;
     bottom: ${({ theme }) => theme.spaces[4]};
     transform: translateX(-50%);
     border: 1px solid ${({ theme }) => theme.colors.neutral150};
     border-radius: ${({ theme }) => theme.borderRadius};
+    /* Sized by its content, capped so the pill can never span the whole
+       viewport. The nowrap is what lets the content set that width — without it
+       the labels wrap and the bar reads as narrow and tall. Inherited, so it
+       covers every label inside.
+
+       Deliberately not applied on mobile: there the bar is full-bleed and
+       cannot grow, so refusing to wrap would clip the last action on a narrow
+       phone rather than widen anything. */
+    white-space: nowrap;
+    max-width: 90%;
+
+    /* One line again from tablet up, where it fits. */
+    flex-wrap: nowrap;
+
+    > :first-child {
+      flex-basis: auto;
+    }
+
+    > :nth-child(2) {
+      margin-left: auto;
+    }
+
+    > :nth-child(3) {
+      display: block;
+    }
   }
 `;
 
@@ -248,18 +304,19 @@ export const BulkActionsBar = ({
   // rather than show a count + "Clear selection" over no actions (mirrors the
   // drawer footer, which hides when no permitted action survives).
   //
-  // The details drawer owns the bottom of the screen while it is open. It is
-  // fixed to `bottom: 0` too, and its z-index of 200 is pinned below the
-  // overlay token on purpose, so the bar (popover, 500) covers the drawer's own
-  // footer actions — and, because the drawer is non-modal, keeps taking clicks
-  // through it. The selection itself is untouched: the bar returns unchanged
-  // when the drawer closes.
-  if (count === 0 || !canUpdate || isDetailsDrawerOpen) {
+  // With the drawer open the bar is hidden on mobile only, in CSS: there the two
+  // are stacked at `bottom: 0` and the bar (popover, 500) would cover the
+  // drawer's footer actions, since the drawer sits below the overlay token at
+  // 200. From `medium` up the drawer is a side panel and the bar is a centered
+  // pill, so they no longer collide.
+  if (count === 0 || !canUpdate) {
     return null;
   }
 
   return (
     <Bar
+      $isDrawerOpen={isDetailsDrawerOpen}
+      $isStacked={isAiMetadataEnabled}
       tag="section"
       role="region"
       aria-label={formatMessage({

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/BulkActionsBar.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/BulkActionsBar.test.tsx
@@ -8,6 +8,12 @@ import type { File } from '../../../../../../../shared/contracts/files';
 
 const mockToggleNotification = jest.fn();
 const mockAIAvailability = jest.fn(() => false);
+let mockAiMetadataEnabled = false;
+
+jest.mock('../../../../hooks/useAIMetadataEnabled', () => ({
+  ...jest.requireActual('../../../../hooks/useAIMetadataEnabled'),
+  useAIMetadataEnabled: () => mockAiMetadataEnabled,
+}));
 
 jest.mock('@strapi/admin/strapi-admin', () => ({
   ...jest.requireActual('@strapi/admin/strapi-admin'),
@@ -59,6 +65,7 @@ const setup = (initialEntries?: string[]) =>
 describe('BulkActionsBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAiMetadataEnabled = false;
   });
 
   it('is visible with a selection and no details param', async () => {
@@ -71,7 +78,8 @@ describe('BulkActionsBar', () => {
     expect(screen.getByText('2 items selected')).toBeInTheDocument();
   });
 
-  it('is hidden while the details drawer is open', async () => {
+  // jsdom matches no breakpoint, so the base (mobile) rules are what applies here.
+  it('is hidden on mobile while the details drawer is open', async () => {
     const { user } = setup();
 
     await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
@@ -83,6 +91,40 @@ describe('BulkActionsBar', () => {
     await waitFor(() =>
       expect(screen.queryByRole('region', { name: 'Bulk actions' })).not.toBeInTheDocument()
     );
+  });
+
+  // jsdom matches no breakpoint, so these read the mobile rules.
+  describe('mobile layout with the metadata action', () => {
+    const openBar = async () => {
+      const { user } = setup();
+
+      await user.click(screen.getByRole('button', { name: 'Toggle asset 1' }));
+      await user.click(screen.getByRole('button', { name: 'Toggle asset 2' }));
+
+      return screen.findByRole('region', { name: 'Bulk actions' });
+    };
+
+    it('drops the buttons to their own line when Create metadata is offered', async () => {
+      mockAiMetadataEnabled = true;
+
+      const bar = await openBar();
+
+      // The labelled button plus the icons no longer fit beside the count, so
+      // the count takes a full row and the buttons wrap under it, spread across it.
+      const style = window.getComputedStyle(bar);
+
+      expect(style.flexWrap).toBe('wrap');
+      expect(style.justifyContent).toBe('space-between');
+    });
+
+    it('keeps everything on one line without it', async () => {
+      const bar = await openBar();
+
+      const style = window.getComputedStyle(bar);
+
+      expect(style.flexWrap).not.toBe('wrap');
+      expect(style.justifyContent).not.toBe('space-between');
+    });
   });
 
   it('returns with the selection intact once the drawer closes', async () => {

--- a/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/tests/AssetsGrid.test.tsx
@@ -151,6 +151,26 @@ describe('AssetsGrid', () => {
     jest.clearAllMocks();
   });
 
+  describe('Card stacking', () => {
+    it('keeps the card overlays from painting over the page header', () => {
+      setup();
+
+      // The checkbox and busy overlays carry their own z-index. Without a
+      // stacking context on the card they compete with the page's sticky header
+      // and, being later in document order, win — so a busy card's spinner
+      // draws over the header as the card scrolls under it.
+      // Reading the compiled CSS: `toHaveStyleRule` is not typed in this suite,
+      // and the rule under test is on the styled component rather than an
+      // attribute of the rendered node.
+      // eslint-disable-next-line testing-library/no-node-access
+      const css = Array.from(document.querySelectorAll('style'))
+        .map((style) => style.textContent ?? '')
+        .join('\n');
+
+      expect(css).toContain('isolation:isolate');
+    });
+  });
+
   describe('Grid rendering', () => {
     it('renders asset cards in a grid', () => {
       setup();


### PR DESCRIPTION
Six small Media Library fixes from the beta blitz, one commit each so they can be reviewed — or dropped — independently.

### What does it do?

**1. Card overlays no longer paint over the assets list header** (`83cfae3275`)

<img width="307" height="222" alt="Screenshot 2026-08-26 at 17 55 47" src="https://github.com/user-attachments/assets/ccc81efc-8d1d-49d8-90e9-39e988cd18b6" />


A busy card's spinner drew over the page's sticky header while the card scrolled beneath it. The header is `z-index: 2` and the card's busy overlay is `z-index: 2`, and equal values in the same stacking context are broken by document order — which the grid wins.

The card's internal order is deliberate (the busy overlay has to sit above the selection checkbox at 1), and the design-system scale has nothing below `navigation: 100`, so raising the header would have meant inventing a number. Instead the card isolates its own stacking context: children keep their relative order and can no longer escape above anything outside the card. No z-index values touched.

The table view needed nothing — `BusyOverlay` has only two callers, the grid and the details drawer, and the table has no sticky header of its own.

**2. The asset drawer header icon stops being squashed** (`fa4b2665b7`)

<img width="361" height="95" alt="image" src="https://github.com/user-attachments/assets/aa59dd92-e06c-4a6a-9618-646f40fac896" />


The file-type icon carried its size in SVG attributes with no box constraint, so as a plain flex sibling of the name it gave up width to a long name and rendered narrower. It now sits in a shrink-proof wrapper and the title can shrink below its content width, so the name truncates instead — matching how the grid and table rows already pair an icon with a truncating name.

**3. The upload dialog header gets padding** (`80a4ccf0ff`)

<img width="410" height="339" alt="image" src="https://github.com/user-attachments/assets/c157293a-4a18-46fd-b991-03e2d3d98a3f" />


The header contributed none of its own, so its status message sat flush against the dialog edges while the file list below was padded on all four sides. The padding goes on the message block, and the status tile — rounded on its left corners only, so meant to meet the header's edges — now stretches to the header's full height.

**4. Long file names truncate in the upload dialog** (`c3905abe24`)

<img width="384" height="309" alt="Screenshot 2026-08-12 at 12 26 12" src="https://github.com/user-attachments/assets/48cb9cb6-95e4-4c66-b910-0cd6fdc8bc95" />


The reported symptom was two scrollbars and free two-axis panning. The cause turned out to be one layer up from the row: Radix's `ScrollArea` wraps its children in a div styled inline as `min-width: 100%; display: table`. A table box grows to its content, so a single unbreakable filename widened it past the scrollport — and because the row then inherited the *table's* width rather than the panel's, `width: 100%` clamped nothing and the name had no reason to truncate.

Overriding that wrapper to a block box inside the drawer makes the scrollport the width again. On top of that the row's name is now a `TruncatedText` (tooltip on hover, reusing the existing component) with the shrink floor on the name only — the status icon is explicitly shrink-proof, since it sizes itself through SVG attributes too.

**Note:** the wrapper override lives on `Drawer.CollapsibleContent`, so it also applies to the asset details drawer, the other consumer. Content there will now clamp to the panel width instead of scrolling horizontally. That is the intended behaviour for both, but it is a wider blast radius than the ticket implies and the crop editor deserves a look.

**5. The bulk actions bar comes back on tablet and desktop with the drawer open** (`8534b61fda`)

The bar was dropped outright whenever the details drawer was open. That rule exists for mobile, where both dock at the bottom and the bar covers the drawer's own footer actions; on wider screens the drawer is a side panel and the bar a centered pill, so they never collide and hiding it read as a bug. The bar now stays mounted and steps aside in CSS below the `medium` breakpoint, so it follows the viewport with no resize listener.

**Beyond the ticket**, two layout changes on the same bar:
- Content-sized with `white-space: nowrap` and `max-width: 90%`, so labels stay on one line and the pill can never span the viewport. Scoped to tablet and up: on mobile the bar is full-bleed and cannot grow, so refusing to wrap would clip the last action on a narrow phone.
- On mobile **with** the Create metadata action present, the count takes a row of its own and the buttons drop below it, spread with `space-between`. The labelled button plus the icons no longer fit beside the count. The vertical divider is hidden in that mode — its only job was setting the clear action apart, which the spacing now does, and it would otherwise hang in mid-air.

**6. Long names truncate in the table on desktop** (`e23321634c`)

Below desktop the table already truncated. From the large breakpoint up it used an auto layout, where an unbreakable filename sizes its own column and nothing caps it, so the table grew past the viewport.

The table now sizes every column but the name to its content (`width: 1%` + `nowrap`, a floor the content overrides) and gives the name cell `width: 100%; max-width: 0; overflow: hidden`. `max-width: 0` is the load-bearing part: it lets the cell be narrower than its content, which is what allows the name to ellipsize rather than widen the table. The name absorbs all the leftover, and the dates no longer wrap onto two lines.

Names already carried a tooltip through `TruncatedText`, in the table and the folder rows alike, so the hover half of that report needed no change.

### Why is it needed?

All six are visible defects in the beta Media Library, reported during the blitz session: a spinner floating in the header, an icon that changes size depending on a filename, a cramped dialog header, a compact upload widget that pans on two axes, a bulk bar that vanishes for no visible reason on desktop, and a table that overflows the viewport instead of truncating.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

1. **Card overlay** — with AI metadata enabled, start a Replace on a card in the first row, then scroll so the busy card passes under the sticky header. The header covers it, spinner included.
2. **Drawer icon** — open an asset with a short name, then one with a long name. The file-type icon is the same size in both; the name truncates.
3. **Dialog header** — upload a file and look at the header: the status message has room on all sides and the coloured tile meets the header's edges.
4. **Long file name** — upload a file whose name exceeds the panel width. One scrollbar, vertical only; the name ellipsizes with the full value on hover; the status icon keeps its size.
5. **Bulk bar** — select items, open an asset's details drawer. On desktop and tablet the bar stays; on a phone-width viewport it steps aside. With AI metadata on, at phone width the count sits on its own line above the buttons.
6. **Table names** — in table view at desktop width, a very long name truncates and the table stays within the viewport. Widen the window: the name column grows and takes the space, the dates stay on one line.

Automated:

```bash
yarn nx test:front @strapi/upload      # 147 suites / 1234 tests
yarn nx test:ts:front @strapi/upload
```

Each behavioural fix was checked against a deliberately broken version — never stacking the mobile bar, forcing it always, dropping the folder scope, reverting the icon shrink guard, removing the truncation. Every one fails a test.

**What the unit tests cannot cover, and how it was verified instead:** jsdom has no layout engine and matches no media query, so the geometry was measured in real Chrome via Playwright rather than asserted:

- Upload dialog: the Radix table wrapper at **822px inside a 648px scrollport** before, 648px after — with the name truncating only after.
- Row icon: **16×16 squashed to 10.8×16** before the shrink guard, 16×16 after.
- Table: an auto layout pushes a 900px table to **1761px**; the new sizing holds it at 100% and the name column scales 216 → 1368px between 768px and 1920px, dates never wrapping.
- Bulk bar: stacked to two rows below 768px, one row (47px tall) above, nothing clipped from 320px up.

Two rules are consequently **not** covered by any test — the `medium`-breakpoint resets on the bulk bar, and the paint order in fix 1. Both were verified in the browser; a regression there would not fail CI. If that matters, they belong in `tests/e2e` as Playwright assertions and I am happy to add them.

### Related issue(s)/PR(s)

fix CMS-1620
fix CMS-1618
fix CMS-1617
fix CMS-1622
fix CMS-1688
fix CMS-1690

- #27453 also touches `BulkActionsBar` (the Select all action). Expect a small conflict whichever lands second.

🚀