### PR TITLE
fix(types): defer recursive expansion in filters ObjectNotation

### DIFF
--- a/packages/core/types/src/modules/documents/params/filters/index.ts
+++ b/packages/core/types/src/modules/documents/params/filters/index.ts
@@ -72,6 +72,8 @@ type AttributeCondition<
  * Tree representation of a Strapi filter for a given schema UID
  */
 export type ObjectNotation<TSchemaUID extends UID.Schema> = {
+  // The recursive references below go through `extends infer` so that TypeScript defers them instead
+  // of expanding the whole filter tree while TSchemaUID is still unresolved
   [TIter in Operator.Group]?: (ObjectNotation<TSchemaUID> extends infer TNested
     ? TNested
     : never)[];
@@ -95,9 +97,9 @@ export type ObjectNotation<TSchemaUID extends UID.Schema> = {
         },
         // Generic representation of the filter object tree in case we don't have access to the attributes' list
         {
-          [TKey in string]?: NestedAttributeCondition<TSchemaUID, never> extends infer TNested
-            ? AttributeCondition<TSchemaUID, never> | TNested
-            : never;
+          [TKey in string]?:
+            | AttributeCondition<TSchemaUID, never>
+            | (NestedAttributeCondition<TSchemaUID, never> extends infer TNested ? TNested : never);
         }
       >
     : never);

--- a/packages/core/types/src/modules/documents/params/filters/index.ts
+++ b/packages/core/types/src/modules/documents/params/filters/index.ts
@@ -72,9 +72,11 @@ type AttributeCondition<
  * Tree representation of a Strapi filter for a given schema UID
  */
 export type ObjectNotation<TSchemaUID extends UID.Schema> = {
-  [TIter in Operator.Group]?: ObjectNotation<TSchemaUID>[];
+  [TIter in Operator.Group]?: (ObjectNotation<TSchemaUID> extends infer TNested
+    ? TNested
+    : never)[];
 } & {
-  [TIter in Operator.Logical]?: ObjectNotation<TSchemaUID>;
+  [TIter in Operator.Logical]?: ObjectNotation<TSchemaUID> extends infer TNested ? TNested : never;
 } & ([AttributeUtils.GetScalarKeys<TSchemaUID>, AttributeUtils.GetNestedKeys<TSchemaUID>] extends [
     infer TScalarKeys extends AttributeUtils.GetScalarKeys<TSchemaUID>,
     infer TNestedKeys extends AttributeUtils.GetNestedKeys<TSchemaUID>,
@@ -87,13 +89,15 @@ export type ObjectNotation<TSchemaUID extends UID.Schema> = {
         {
           [TIter in IDKey | DocumentIDKey | TScalarKeys]?: AttributeCondition<TSchemaUID, TIter>;
         } & {
-          [TIter in TNestedKeys]?: NestedAttributeCondition<TSchemaUID, TIter>;
+          [TIter in TNestedKeys]?: NestedAttributeCondition<TSchemaUID, TIter> extends infer TNested
+            ? TNested
+            : never;
         },
         // Generic representation of the filter object tree in case we don't have access to the attributes' list
         {
-          [TKey in string]?:
-            | AttributeCondition<TSchemaUID, never>
-            | NestedAttributeCondition<TSchemaUID, never>;
+          [TKey in string]?: NestedAttributeCondition<TSchemaUID, never> extends infer TNested
+            ? AttributeCondition<TSchemaUID, never> | TNested
+            : never;
         }
       >
     : never);


### PR DESCRIPTION
### What does it do?

Routes the recursive references inside `Filters.ObjectNotation` through an `extends infer` indirection, so the compiler defers them instead of expanding the whole filter tree up front. For every resolved schema UID the type comes out identical to what `develop` produces.

### Why is it needed?

`ObjectNotation` refers back to itself through the `$and` / `$or` / `$not` operators and through relation attributes. While the schema UID is still an unresolved type parameter, TypeScript walks all of those branches eagerly, so nesting a few filter groups is enough to hit `TS2589` or to stall the compiler outright.

On `develop` the snippet below runs for about 30 seconds and then exits with a heap out of memory error. After the change it type checks in roughly a second. The flat case from the issue does compile on `develop`, but it costs a few hundred thousand extra instantiations; with the change it lands within a couple of percent of a program that never mentions the type at all. The absolute counts depend on how many content types the project has, so measure with `--extendedDiagnostics` rather than trusting mine.

There is one trade-off. Code that is generic over the schema UID and reads a nested sub-filter back out, such as `f.$and` or `f.$not`, now sees an opaque deferred type and needs an explicit annotation. Constraining the `infer` restores that, but it brings the eager expansion straight back and measured worse than `develop`, so I left the references deferred. Writing filters is unaffected, and so is anything at a concrete UID.

### How to test it?

From `examples/getstarted`, drop this into a `.ts` file and run `npx tsc --noEmit --extendedDiagnostics` on it:

```ts
import type { UID, Modules } from '@strapi/types';

declare function filterEntries<const TSchemaUID extends UID.ContentType>(args: {
  name: TSchemaUID;
  params: {
    filters?: Modules.Documents.Params.Filters.ObjectNotation<TSchemaUID>;
    populate?: Modules.Documents.Params.Populate.Any<TSchemaUID>;
  };
}): void;

filterEntries({
  name: 'api::article.article' as UID.ContentType,
  params: {
    filters: {
      $or: [
        { $and: [{ $or: [{ slug: { $notNull: true } }] }] },
        { $not: { $and: [{ $or: [{ slug: { $contains: 'a' } }] }] } },
      ],
    },
  },
});
```

### Related issue(s)/PR(s)

Fixes #27476
