### PR TITLE
fix(content-type-builder): default new private fields to not searchable

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/tests/toCTB.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/tests/toCTB.test.ts
@@ -1,4 +1,4 @@
-import { transformChatToCTB } from '../toCTB';
+import { transformAttributesFromChatToCTB, transformChatToCTB } from '../toCTB';
 
 import type { ContentType, Component } from '../../../../../../types';
 import type { Schema } from '../../../types/schema';
@@ -44,6 +44,78 @@ describe('transformChatToCTB', () => {
       const result = transformChatToCTB(schema) as ContentType;
 
       expect(result).toMatchObject({ options: { draftAndPublish: true } });
+    });
+  });
+
+  describe('private search default', () => {
+    it.each([
+      {
+        action: 'create' as const,
+        oldSchema: undefined,
+        status: 'NEW' as const,
+      },
+      {
+        action: 'update' as const,
+        oldSchema: {
+          ...(transformChatToCTB(makeSchema()) as ContentType),
+          status: 'UNCHANGED',
+          attributes: [{ name: 'secret', type: 'text', status: 'UNCHANGED' }],
+        } satisfies ContentType,
+        status: 'CHANGED' as const,
+      },
+    ])(
+      'defaults private searchable scalar attributes during AI $action transforms',
+      ({ action, oldSchema, status }) => {
+        const attributes = transformAttributesFromChatToCTB(
+          makeSchema({
+            action,
+            attributes: { secret: { type: 'text', private: true } },
+          }),
+          oldSchema
+        );
+
+        expect(attributes).toEqual([
+          {
+            name: 'secret',
+            type: 'text',
+            private: true,
+            searchable: false,
+            status,
+          },
+        ]);
+      }
+    );
+
+    it.each([true, false])('preserves explicit searchable: %s from AI', (searchable) => {
+      const attributes = transformAttributesFromChatToCTB(
+        makeSchema({
+          attributes: { secret: { type: 'text', private: true, searchable } },
+        })
+      );
+
+      expect(attributes[0]).toMatchObject({ private: true, searchable });
+    });
+
+    it.each([
+      ['json', { type: 'json' }],
+      [
+        'relation',
+        {
+          type: 'relation',
+          relation: 'oneWay',
+          target: 'api::category.category',
+        },
+      ],
+    ] as const)('does not add searchable to private AI-created %s attributes', (_type, data) => {
+      const attributes = transformAttributesFromChatToCTB(
+        makeSchema({
+          attributes: {
+            secret: { ...data, private: true } as Schema['attributes'][string],
+          },
+        })
+      );
+
+      expect(attributes[0]).not.toHaveProperty('searchable');
     });
   });
 

--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/toCTB.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/toCTB.ts
@@ -2,6 +2,8 @@ import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import pluralize from 'pluralize';
 
+import { applyPrivateSearchDefault } from '../../../../../utils/applyPrivateSearchDefault';
+
 import type { ContentType, Component, AnyAttribute } from '../../../../../types';
 import type { Schema, SchemaAttribute } from '../../types/schema';
 import type { Struct, UID } from '@strapi/types';
@@ -42,7 +44,7 @@ const createAttributeWithStatus = (
   status: AnyAttribute['status']
 ): AnyAttribute =>
   ({
-    ...attributeData,
+    ...applyPrivateSearchDefault(attributeData),
     name,
     status,
   }) as AnyAttribute;

--- a/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
@@ -2,6 +2,7 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
 
+import { applyPrivateSearchDefault } from '../../utils/applyPrivateSearchDefault';
 import { getRelationType } from '../../utils/getRelationType';
 import { makeUnique } from '../../utils/makeUnique';
 
@@ -212,14 +213,6 @@ const getNewStatus = (oldStatus: Status | undefined, newStatus: Status) => {
 
 const setAttributeStatus = (attribute: { status?: Status }, status: Status) => {
   attribute.status = getNewStatus(attribute.status, status);
-};
-
-const applyPrivateSearchDefault = <T extends Record<string, unknown>>(attribute: T): T => {
-  if (attribute.private === true && attribute.searchable === undefined) {
-    return { ...attribute, searchable: false };
-  }
-
-  return attribute;
 };
 
 const createAttribute = (properties: Record<string, unknown>): AnyAttribute => {

--- a/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/reducer.ts
@@ -214,9 +214,17 @@ const setAttributeStatus = (attribute: { status?: Status }, status: Status) => {
   attribute.status = getNewStatus(attribute.status, status);
 };
 
+const applyPrivateSearchDefault = <T extends Record<string, unknown>>(attribute: T): T => {
+  if (attribute.private === true && attribute.searchable === undefined) {
+    return { ...attribute, searchable: false };
+  }
+
+  return attribute;
+};
+
 const createAttribute = (properties: Record<string, unknown>): AnyAttribute => {
   return {
-    ...properties,
+    ...applyPrivateSearchDefault(properties),
     status: 'NEW',
   } as AnyAttribute;
 };
@@ -227,7 +235,7 @@ const setAttributeAt = (type: ContentType | Component, index: number, attribute:
   const newStatus = getNewStatus(previousAttribute.status, 'CHANGED');
 
   type.attributes[index] = {
-    ...attribute,
+    ...applyPrivateSearchDefault(attribute),
     status: newStatus,
   };
 

--- a/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerAddAttributeAction.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerAddAttributeAction.test.ts
@@ -86,6 +86,77 @@ describe.each<{ forTarget: Struct.ModelType; targetUid: string }>([
         attributes: [{ name: 'name', type, ...opts, status: 'NEW' }],
       });
     });
+
+    it('marks a new private scalar attribute as not searchable by default', () => {
+      const initializedState = init();
+
+      const state = reducer(
+        initializedState,
+        actions.addAttribute({
+          attributeToSet: { type: 'text', name: 'secret', private: true },
+          forTarget,
+          targetUid,
+        })
+      );
+
+      expect(getType(state, { forTarget, targetUid })).toMatchObject({
+        attributes: [
+          {
+            name: 'secret',
+            type: 'text',
+            private: true,
+            searchable: false,
+            status: 'NEW',
+          },
+        ],
+      });
+    });
+
+    it.each([true, false])(
+      'preserves searchable: %s for a new private scalar attribute',
+      (searchable) => {
+        const initializedState = init();
+
+        const state = reducer(
+          initializedState,
+          actions.addAttribute({
+            attributeToSet: { type: 'text', name: 'secret', private: true, searchable },
+            forTarget,
+            targetUid,
+          })
+        );
+
+        expect(getType(state, { forTarget, targetUid })).toMatchObject({
+          attributes: [
+            {
+              name: 'secret',
+              type: 'text',
+              private: true,
+              searchable,
+              status: 'NEW',
+            },
+          ],
+        });
+      }
+    );
+
+    it('does not add searchable to a new non-private scalar attribute', () => {
+      const initializedState = init();
+
+      const state = reducer(
+        initializedState,
+        actions.addAttribute({
+          attributeToSet: { type: 'text', name: 'title' },
+          forTarget,
+          targetUid,
+        })
+      );
+
+      const [attribute] = getType(state, { forTarget, targetUid }).attributes;
+
+      expect(attribute).toEqual({ name: 'title', type: 'text', status: 'NEW' });
+      expect(attribute).not.toHaveProperty('searchable');
+    });
   });
 
   it('Should throw id content type does not exist', () => {

--- a/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerAddAttributeAction.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerAddAttributeAction.test.ts
@@ -9,6 +9,38 @@ const relatedContentType = initCT('relationship', {});
 const baseComponent = initCompo('test', {});
 type AddAttributePayload = Parameters<typeof actions.addAttribute>[0];
 
+const SEARCHABLE_SCALAR_TYPES = [
+  'string',
+  'text',
+  'uid',
+  'email',
+  'enumeration',
+  'richtext',
+  'biginteger',
+  'integer',
+  'decimal',
+  'float',
+] as const;
+
+const NON_SEARCHABLE_PRIVATE_ATTRIBUTES = [
+  { type: 'password' },
+  { type: 'boolean' },
+  { type: 'blocks' },
+  { type: 'json' },
+  { type: 'date' },
+  { type: 'time' },
+  { type: 'datetime' },
+  { type: 'timestamp' },
+  { type: 'media', multiple: false },
+  { type: 'component', component: 'default.test', repeatable: false },
+  { type: 'dynamiczone', components: ['default.test'] },
+  {
+    type: 'relation',
+    relation: 'oneWay',
+    target: 'api::relationship.relationship',
+  },
+] as const;
+
 const init = () => {
   return initUtils({
     components: {
@@ -87,30 +119,59 @@ describe.each<{ forTarget: Struct.ModelType; targetUid: string }>([
       });
     });
 
-    it('marks a new private scalar attribute as not searchable by default', () => {
-      const initializedState = init();
+    it.each(SEARCHABLE_SCALAR_TYPES)(
+      'marks a new private %s attribute as not searchable by default',
+      (type) => {
+        const initializedState = init();
 
-      const state = reducer(
-        initializedState,
-        actions.addAttribute({
-          attributeToSet: { type: 'text', name: 'secret', private: true },
-          forTarget,
-          targetUid,
-        })
-      );
+        const state = reducer(
+          initializedState,
+          actions.addAttribute({
+            attributeToSet: {
+              type,
+              name: 'secret',
+              private: true,
+            } as AddAttributePayload['attributeToSet'],
+            forTarget,
+            targetUid,
+          })
+        );
 
-      expect(getType(state, { forTarget, targetUid })).toMatchObject({
-        attributes: [
-          {
-            name: 'secret',
-            type: 'text',
-            private: true,
-            searchable: false,
-            status: 'NEW',
-          },
-        ],
-      });
-    });
+        expect(getType(state, { forTarget, targetUid })).toMatchObject({
+          attributes: [
+            {
+              name: 'secret',
+              type,
+              private: true,
+              searchable: false,
+              status: 'NEW',
+            },
+          ],
+        });
+      }
+    );
+
+    it.each(NON_SEARCHABLE_PRIVATE_ATTRIBUTES)(
+      'does not add searchable to a new private $type attribute',
+      (properties) => {
+        const initializedState = init();
+        const attributeToSet = {
+          ...properties,
+          name: 'secret',
+          private: true,
+        } as AddAttributePayload['attributeToSet'];
+
+        const state = reducer(
+          initializedState,
+          actions.addAttribute({ attributeToSet, forTarget, targetUid })
+        );
+
+        const [attribute] = getType(state, { forTarget, targetUid }).attributes;
+
+        expect(attribute).toEqual({ ...attributeToSet, status: 'NEW' });
+        expect(attribute).not.toHaveProperty('searchable');
+      }
+    );
 
     it.each([true, false])(
       'preserves searchable: %s for a new private scalar attribute',

--- a/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerEditAttributeAction.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/tests/reducerEditAttributeAction.test.ts
@@ -6,6 +6,100 @@ import type { AttributeConditions } from '../../../types';
 
 describe('CTB | components | DataManagerProvider | reducer | EDIT_ATTRIBUTE', () => {
   describe('Editing a common attribute (string, integer, json, media, ...)', () => {
+    it('marks a scalar attribute as not searchable when it becomes private', () => {
+      const contentType = initCT('test', {
+        attributes: [{ name: 'secret', type: 'text' }],
+      });
+      const initializedState = init({
+        contentTypes: { [contentType.uid]: contentType },
+      });
+
+      const state = reducer(
+        initializedState,
+        actions.editAttribute({
+          attributeToSet: { name: 'secret', type: 'text', private: true },
+          forTarget: 'contentType',
+          targetUid: contentType.uid,
+          name: 'secret',
+        })
+      );
+
+      expect(state.current.contentTypes[contentType.uid]).toMatchObject({
+        attributes: [
+          {
+            name: 'secret',
+            type: 'text',
+            private: true,
+            searchable: false,
+            status: 'CHANGED',
+          },
+        ],
+      });
+    });
+
+    it.each([true, false])(
+      'preserves searchable: %s when editing a private scalar attribute',
+      (searchable) => {
+        const contentType = initCT('test', {
+          attributes: [{ name: 'secret', type: 'text' }],
+        });
+        const initializedState = init({
+          contentTypes: { [contentType.uid]: contentType },
+        });
+
+        const state = reducer(
+          initializedState,
+          actions.editAttribute({
+            attributeToSet: { name: 'secret', type: 'text', private: true, searchable },
+            forTarget: 'contentType',
+            targetUid: contentType.uid,
+            name: 'secret',
+          })
+        );
+
+        expect(state.current.contentTypes[contentType.uid]).toMatchObject({
+          attributes: [
+            {
+              name: 'secret',
+              type: 'text',
+              private: true,
+              searchable,
+              status: 'CHANGED',
+            },
+          ],
+        });
+      }
+    );
+
+    it('does not force searchable when privacy is disabled', () => {
+      const contentType = initCT('test', {
+        attributes: [{ name: 'secret', type: 'text', private: true, searchable: false }],
+      });
+      const initializedState = init({
+        contentTypes: { [contentType.uid]: contentType },
+      });
+
+      const state = reducer(
+        initializedState,
+        actions.editAttribute({
+          attributeToSet: { name: 'secret', type: 'text', private: false },
+          forTarget: 'contentType',
+          targetUid: contentType.uid,
+          name: 'secret',
+        })
+      );
+
+      const [attribute] = state.current.contentTypes[contentType.uid].attributes;
+
+      expect(attribute).toEqual({
+        name: 'secret',
+        type: 'text',
+        private: false,
+        status: 'CHANGED',
+      });
+      expect(attribute).not.toHaveProperty('searchable');
+    });
+
     it('Should edit the attribute correctly and preserve the order of the attributes for a content type', () => {
       const contentType = initCT('test', {
         attributes: [

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/attributeOptions.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/attributeOptions.ts
@@ -50,7 +50,8 @@ export const attributeOptions = {
     },
     description: {
       id: getTrad('form.attribute.item.privateField.description'),
-      defaultMessage: 'This field will not show up in the API response',
+      defaultMessage:
+        'This field will not show up in the API response. New private fields are also excluded from search.',
     },
   },
   regex: {

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/tests/attributeOptions.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/tests/attributeOptions.test.ts
@@ -1,0 +1,15 @@
+import en from '../../../../translations/en.json';
+import { attributeOptions } from '../attributeOptions';
+
+const PRIVATE_FIELD_DESCRIPTION =
+  'This field will not show up in the API response. New private fields are also excluded from search.';
+
+describe('attributeOptions', () => {
+  it('keeps the registered English private-field description aligned with the fallback copy', () => {
+    const registeredMessage = en['form.attribute.item.privateField.description'];
+    const fallbackMessage = attributeOptions.private.description.defaultMessage;
+
+    expect(registeredMessage).toBe(PRIVATE_FIELD_DESCRIPTION);
+    expect(registeredMessage).toBe(fallbackMessage);
+  });
+});

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -102,7 +102,7 @@
   "form.attribute.item.number.type.float": "float (ex: 3.33333333)",
   "form.attribute.item.number.type.integer": "integer (ex: 10)",
   "form.attribute.item.privateField": "Private field",
-  "form.attribute.item.privateField.description": "This field will not show up in the API response",
+  "form.attribute.item.privateField.description": "This field will not show up in the API response. New private fields are also excluded from search.",
   "form.attribute.item.requiredField": "Required field",
   "form.attribute.item.requiredField.description": "You won't be able to create an entry if this field is empty",
   "form.attribute.item.text.regex": "RegExp pattern",

--- a/packages/core/content-type-builder/admin/src/utils/applyPrivateSearchDefault.ts
+++ b/packages/core/content-type-builder/admin/src/utils/applyPrivateSearchDefault.ts
@@ -1,0 +1,32 @@
+const SEARCHABLE_ATTRIBUTE_TYPES = new Set([
+  'string',
+  'text',
+  'uid',
+  'email',
+  'enumeration',
+  'richtext',
+  'biginteger',
+  'integer',
+  'decimal',
+  'float',
+]);
+
+type Attribute = {
+  type?: unknown;
+  private?: unknown;
+  searchable?: unknown;
+};
+
+// Mirrors the scalar types used by database search without importing server code into the admin.
+export const applyPrivateSearchDefault = <T extends Attribute>(attribute: T): T => {
+  if (
+    attribute.private === true &&
+    attribute.searchable === undefined &&
+    typeof attribute.type === 'string' &&
+    SEARCHABLE_ATTRIBUTE_TYPES.has(attribute.type)
+  ) {
+    return { ...attribute, searchable: false };
+  }
+
+  return attribute;
+};

--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/schema.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/schema.test.ts
@@ -56,6 +56,33 @@ describe('Schema', () => {
       },
     });
 
+    const schemaWithSearchable = (searchable?: boolean | null) => ({
+      data: {
+        contentTypes: [
+          {
+            action: 'create',
+            uid: 'api::article.article',
+            displayName: 'Article',
+            draftAndPublish: false,
+            singularName: 'article',
+            pluralName: 'articles',
+            kind: 'collectionType',
+            attributes: [
+              {
+                action: 'create',
+                name: 'secret',
+                properties: {
+                  type: 'text',
+                  private: true,
+                  ...(searchable === undefined ? {} : { searchable }),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
     test('reports a missing schema', () => {
       expect(() => validateUpdateSchema(undefined)).toThrow('Schema is required');
     });
@@ -87,6 +114,61 @@ describe('Schema', () => {
           contentTypes: [{ options: {}, pluginOptions: {} }],
         },
       });
+    });
+
+    test('retains searchable when a private attribute explicitly disables search', () => {
+      expect(validateUpdateSchema(schemaWithSearchable(false))).toMatchObject({
+        data: {
+          contentTypes: [
+            {
+              attributes: [
+                {
+                  properties: { type: 'text', private: true, searchable: false },
+                },
+              ],
+            },
+          ],
+        },
+      });
+    });
+
+    test('retains searchable when a private attribute explicitly enables search', () => {
+      expect(validateUpdateSchema(schemaWithSearchable(true))).toMatchObject({
+        data: {
+          contentTypes: [
+            {
+              attributes: [
+                {
+                  properties: { type: 'text', private: true, searchable: true },
+                },
+              ],
+            },
+          ],
+        },
+      });
+    });
+
+    test('accepts an absent searchable property', () => {
+      const schema = validateUpdateSchema(schemaWithSearchable());
+
+      expect(schema).toMatchObject({
+        data: {
+          contentTypes: [
+            {
+              attributes: [
+                {
+                  properties: { type: 'text', private: true },
+                },
+              ],
+            },
+          ],
+        },
+      });
+      expect(schema).not.toHaveProperty('data.contentTypes.0.attributes.0.properties.searchable');
+    });
+
+    test('rejects a null searchable property', () => {
+      expect(() => validateUpdateSchema(schemaWithSearchable(null))).toThrow();
     });
   });
 

--- a/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
@@ -265,6 +265,7 @@ const basePropertiesSchema = z.object({
   ]),
   configurable: z.boolean().nullish(),
   private: z.boolean().nullish(),
+  searchable: z.boolean().optional(),
   pluginOptions: z.record(z.string(), z.unknown()).optional(),
   conditions: z.preprocess((val) => {
     return val;

--- a/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
@@ -265,6 +265,7 @@ const basePropertiesSchema = z.object({
   ]),
   configurable: z.boolean().nullish(),
   private: z.boolean().nullish(),
+  // Keep null invalid so searchability is always an explicit boolean when provided.
   searchable: z.boolean().optional(),
   pluginOptions: z.record(z.string(), z.unknown()).optional(),
   conditions: z.preprocess((val) => {


### PR DESCRIPTION
### What does it do?

Makes newly created or edited private fields safer by default in Content-Type Builder. When a CTB attribute is private and has no explicit `searchable` value, CTB records `searchable: false`. Explicit searchability decisions remain unchanged, server validation preserves optional boolean values while rejecting `null`, and the English private-field help text explains that new private fields are excluded from search.

This deliberately does not change runtime `_q` field selection, migrate existing schemas, or modify manually authored schemas.

### Why is it needed?

CTB previously emitted private attributes without a searchability setting, and server validation stripped an explicitly supplied setting. Under the current runtime contract, an omitted value allows private-field contents to participate in `_q` searches. This could expose private values through search matches even though the values themselves are omitted from response payloads.

### How to test it?

  1. Start a development Strapi application and open Content-Type Builder.
  2. Create a content type or component with a scalar field, open the field's advanced settings, enable **Private field**, and save the field and schema.
  3. Inspect the generated schema attribute and verify it contains both `private: true` and `searchable: false`.
  4. Edit an existing scalar field, enable **Private field**, save, and verify the same generated properties.
  5. Verify the private-field help text states that new private fields are excluded from search.
  6. If a schema explicitly provides `searchable: true` or `searchable: false`, save it through CTB and verify the explicit value is preserved.
  7. Disable privacy on an existing field and verify CTB does not synthesize `searchable: true`.
  8. For an existing private field created before this change, verify that no automatic migration occurs; resave it through CTB or explicitly set `searchable: false` to adopt the safer behavior.
