### PR TITLE
fix(i18n): keep shared components whose relations are missing in a locale

### DIFF
--- a/packages/plugins/i18n/server/src/services/__tests__/localizations.test.ts
+++ b/packages/plugins/i18n/server/src/services/__tests__/localizations.test.ts
@@ -64,6 +64,7 @@ global.strapi = {
       },
     },
   },
+  log: { warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
   db: {
     dialect: {
       client: 'sqlite',
@@ -118,6 +119,126 @@ describe('localizations service', () => {
           where: { documentId: 'Doc1', locale: { $eq: 'fr' }, publishedAt: null },
         })
       );
+    });
+
+    test('Leaves a shared component alone when its relation cannot be resolved in the target locale', async () => {
+      const componentSchema = {
+        uid: 'shared.block',
+        attributes: {
+          mode: { type: 'string' },
+          tag: { type: 'relation', relation: 'oneToOne', target: 'api::tag.tag' },
+        },
+      };
+
+      const modelWithSharedBlocks = {
+        uid: 'test-model',
+        pluginOptions: { i18n: { localized: true } },
+        attributes: {
+          title: { type: 'string', pluginOptions: { i18n: { localized: true } } },
+          blocks: {
+            type: 'component',
+            repeatable: true,
+            component: 'shared.block',
+            pluginOptions: { i18n: { localized: false } },
+          },
+        },
+      };
+
+      const updateComponents = jest.fn(() => ({}));
+      const previousComponents = global.strapi.components;
+      const previousGetModel = global.strapi.getModel;
+      const previousDocuments = global.strapi.documents;
+
+      global.strapi.components = { 'shared.block': componentSchema } as any;
+      global.strapi.getModel = jest.fn(() => componentSchema) as any;
+      global.strapi.documents = Object.assign(
+        () => ({ updateComponents, omitComponentData: jest.fn(() => ({})) }),
+        {
+          utils: {
+            // The tag has no entry in `fr`, so the transform resolves it to an empty set.
+            transformData: jest.fn(async () => ({
+              blocks: [{ mode: 'a', tag: { set: [] } }],
+            })),
+          },
+        }
+      ) as any;
+
+      const entry = {
+        id: 1,
+        documentId: 'Doc1',
+        locale: defaultLocale,
+        blocks: [{ mode: 'a', tag: { documentId: 'Tag1' } }],
+      };
+
+      await syncNonLocalizedAttributes(entry, modelWithSharedBlocks as any);
+
+      expect(updateComponents).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.not.objectContaining({ blocks: expect.anything() })
+      );
+
+      global.strapi.components = previousComponents;
+      global.strapi.getModel = previousGetModel;
+      global.strapi.documents = previousDocuments;
+    });
+
+    test('Still syncs a shared component whose relation resolves in the target locale', async () => {
+      const componentSchema = {
+        uid: 'shared.block',
+        attributes: {
+          mode: { type: 'string' },
+          tag: { type: 'relation', relation: 'oneToOne', target: 'api::tag.tag' },
+        },
+      };
+
+      const modelWithSharedBlocks = {
+        uid: 'test-model',
+        pluginOptions: { i18n: { localized: true } },
+        attributes: {
+          blocks: {
+            type: 'component',
+            repeatable: true,
+            component: 'shared.block',
+            pluginOptions: { i18n: { localized: false } },
+          },
+        },
+      };
+
+      const updateComponents = jest.fn(() => ({}));
+      const previousComponents = global.strapi.components;
+      const previousGetModel = global.strapi.getModel;
+      const previousDocuments = global.strapi.documents;
+
+      global.strapi.components = { 'shared.block': componentSchema } as any;
+      global.strapi.getModel = jest.fn(() => componentSchema) as any;
+      global.strapi.documents = Object.assign(
+        () => ({ updateComponents, omitComponentData: jest.fn(() => ({})) }),
+        {
+          utils: {
+            transformData: jest.fn(async () => ({
+              blocks: [{ mode: 'a', tag: { set: [{ id: 7 }] } }],
+            })),
+          },
+        }
+      ) as any;
+
+      const entry = {
+        id: 1,
+        documentId: 'Doc1',
+        locale: defaultLocale,
+        blocks: [{ mode: 'a', tag: { documentId: 'Tag1' } }],
+      };
+
+      await syncNonLocalizedAttributes(entry, modelWithSharedBlocks as any);
+
+      expect(updateComponents).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ blocks: [{ mode: 'a', tag: { set: [{ id: 7 }] } }] })
+      );
+
+      global.strapi.components = previousComponents;
+      global.strapi.getModel = previousGetModel;
+      global.strapi.documents = previousDocuments;
     });
   });
 });

--- a/packages/plugins/i18n/server/src/services/localizations.ts
+++ b/packages/plugins/i18n/server/src/services/localizations.ts
@@ -64,6 +64,70 @@ const normalizeMediaIds = (
   return data;
 };
 
+const hasTarget = (value: unknown): boolean =>
+  Array.isArray(value) ? value.length > 0 : value != null;
+
+/**
+ * A relation the transform could not resolve for the target locale comes back as
+ * an empty `set`. Anything else, including an explicit connect or disconnect, is
+ * left alone.
+ */
+const resolvedToNothing = (value: unknown): boolean =>
+  typeof value === 'object' &&
+  value !== null &&
+  'set' in value &&
+  Array.isArray((value as { set: unknown[] }).set) &&
+  (value as { set: unknown[] }).set.length === 0;
+
+/**
+ * True when `transformed` lost a relation that `source` had, anywhere inside the
+ * given component or dynamic zone value.
+ */
+const droppedARelation = (
+  schema: Schema.ContentType | Schema.Component,
+  source: any,
+  transformed: any
+): boolean => {
+  if (!schema?.attributes || !source || !transformed || typeof transformed !== 'object') {
+    return false;
+  }
+
+  return Object.entries(schema.attributes).some(([attributeName, attribute]) => {
+    const sourceValue = source[attributeName];
+    const transformedValue = transformed[attributeName];
+
+    if (attribute.type === 'relation') {
+      return hasTarget(sourceValue) && resolvedToNothing(transformedValue);
+    }
+
+    if (attribute.type === 'component') {
+      const componentSchema = strapi.getModel(attribute.component);
+
+      if (attribute.repeatable && Array.isArray(sourceValue) && Array.isArray(transformedValue)) {
+        return sourceValue.some((row, index) =>
+          droppedARelation(componentSchema, row, transformedValue[index])
+        );
+      }
+
+      return droppedARelation(componentSchema, sourceValue, transformedValue);
+    }
+
+    if (
+      attribute.type === 'dynamiczone' &&
+      Array.isArray(sourceValue) &&
+      Array.isArray(transformedValue)
+    ) {
+      return sourceValue.some((row, index) =>
+        row?.__component
+          ? droppedARelation(strapi.getModel(row.__component), row, transformedValue[index])
+          : false
+      );
+    }
+
+    return false;
+  });
+};
+
 /**
  * Update non localized fields of all the related localizations of an entry with the entry values
  */
@@ -106,10 +170,35 @@ const syncNonLocalizedAttributes = async (sourceEntry: any, model: Schema.Conten
       }
     );
 
+    // A shared field whose relation does not exist in this locale comes back with the
+    // relation emptied. Writing it would clear the field here and, because the field is
+    // shared, in every other locale on the next save. Leave those fields as they are.
+    const dataToWrite = Object.fromEntries(
+      Object.entries(transformedData as Record<string, any>).filter(([attributeName]) => {
+        const attribute = model.attributes[attributeName];
+
+        if (attribute?.type !== 'component' && attribute?.type !== 'dynamiczone') {
+          return true;
+        }
+
+        const dropped = droppedARelation(
+          model,
+          { [attributeName]: normalizedNonLocalizedAttributes[attributeName] },
+          { [attributeName]: (transformedData as Record<string, any>)[attributeName] }
+        );
+
+        if (dropped) {
+          strapi.log.warn(
+            `i18n: skipped syncing "${attributeName}" to locale "${entry.locale}" of ${uid} "${documentId}" because a relation it holds does not exist in that locale.`
+          );
+        }
+
+        return !dropped;
+      })
+    );
+
     // Update or create non localized components for the entry
-    const componentData = await strapi
-      .documents(uid)
-      .updateComponents(entry, transformedData as any);
+    const componentData = await strapi.documents(uid).updateComponents(entry, dataToWrite as any);
 
     // Update every other locale entry of this documentId in the same status
     await strapi.db.query(uid).update({


### PR DESCRIPTION
### What does it do?

In `syncNonLocalizedAttributes`, a component or dynamic zone is now skipped for a target locale when a relation it holds could not be resolved there, instead of being written with that relation emptied. Everything else still syncs, and the skip is logged.

The check compares the source data against what `transformData` returned. A relation that had a target in the source and comes back as `{ set: [] }` is treated as unresolved; an explicit connect or disconnect is left alone. It walks components, repeatable components and dynamic zones the same way `normalizeMediaIds` above it already does.

Dropping the attribute is enough because `updateComponents` skips any attribute that is not present in the data it is given, so the existing rows in that locale stay as they are.

### Why is it needed?

`transformData` is called with `allowMissingId: true`, so when the related document has no entry in the target locale `getRelationIds` returns `[]` and the relation is written as `{ set: [] }`. The component rows arrive in that locale without their relations.

Because the field is non-localized, that state spreads: the next save from that locale copies the relation-less rows back over every other locale, including the ones that still held the data. Scalars inside the component survive, so what an editor sees is all the rows present with nothing selected, with a 200 response and nothing in the logs.

The same failure for non-localized **media** was fixed in #26031, which added the `normalizeMediaIds` step in this function. Relations go through the same path and were still unguarded.

### How to test it?

Two unit tests in `packages/plugins/i18n/server/src/services/__tests__/localizations.test.ts`.

The first sets up a shared repeatable component holding a `oneToOne` relation, has `transformData` return that relation as `{ set: [] }` — what happens when the target does not exist in the other locale — and asserts `updateComponents` is not given the component at all. It fails on `develop`, where `updateComponents` receives `{ blocks: [{ mode: 'a', tag: { set: [] } }] }`.

The second is the control: same setup but the relation resolves, and the component is still passed through unchanged. It passes either way, so the first test is not just asserting the new behaviour back to itself.

End to end, the reproduction in #27467 is the way to check it: a tag that exists only in `en`, a shared component on the article holding it, then read and save the `fr` article and read `en` again.

I could not run the repo's eslint or `tsc` — installing the monorepo was not practical here — so I ran the tests through a standalone jest against the real sources and formatted both files with the repo's own prettier config.

### Related issue(s)/PR(s)

Fix #27467. Same shape as #26031, which did this for media.

AI disclosure: I used Claude to help write this, and I have gone through the diff and run the tests myself.
