### PR TITLE
fix(content-manager): relation picker loses locale in nested entries

### DIFF
--- a/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
@@ -106,7 +106,7 @@ const createAuditLogsLifecycleService = (strapi: Core.Strapi) => {
     return {
       action: name,
       date: new Date().toISOString(),
-      payload: { ...(getPayload(...args) || {}), origin },
+      payload: { ...getPayload(...args), origin },
       userId: user.id,
     };
   };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -1248,7 +1248,7 @@ const ListItem = React.memo(({ data, index, style }: ListItemProps) => {
   }, [dragPreviewRef]);
 
   const safeDocumentId = documentId ?? apiData?.documentId;
-  const safeLocale = locale ?? apiData?.locale ?? null;
+  const relationLocale = locale ?? apiData?.locale;
   const documentMeta = React.useMemo(
     () =>
       ({
@@ -1256,10 +1256,10 @@ const ListItem = React.memo(({ data, index, style }: ListItemProps) => {
         model: targetModel,
         collectionType: getCollectionType(href)!,
         params: {
-          locale: safeLocale,
+          locale: relationLocale ?? documentParams?.locale ?? null,
         },
       }) as DocumentMeta,
-    [safeDocumentId, href, safeLocale, targetModel]
+    [safeDocumentId, href, relationLocale, documentParams, targetModel]
   );
 
   return (

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/Relations.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/Relations.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
 } from '@tests/utils';
 import { http, HttpResponse } from 'msw';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 
 import { ComponentProvider } from '../../ComponentContext';
 import { RelationsInput, RelationsFieldProps } from '../Relations';
@@ -50,6 +50,76 @@ const render = (
   );
 
 describe('Relations', () => {
+  const renderRelationNavigation = (relation: {
+    documentId: string;
+    locale: string | null;
+    name: string;
+  }) => {
+    server.use(
+      http.get<{ model: string; id: string; fieldName: string }>(
+        '/content-manager/relations/:model/:id/:fieldName',
+        () =>
+          HttpResponse.json({
+            results: [
+              {
+                id: 1,
+                ...relation,
+                status: 'published',
+              },
+            ],
+            pagination: { page: 1, pageCount: 1, pageSize: 10, total: 1 },
+          })
+      )
+    );
+
+    const LocationProbe = () => {
+      const location = useLocation();
+
+      return <output data-testid="location">{`${location.pathname}${location.search}`}</output>;
+    };
+
+    return renderRTL(
+      <RelationsInput
+        attribute={{
+          type: 'relation',
+          relation: 'manyToMany',
+          target: 'api::category.category',
+          inversedBy: 'relation_locales',
+          // @ts-expect-error – this is what the API returns
+          targetModel: 'api::category.category',
+          relationType: 'manyToMany',
+        }}
+        label="relations"
+        mainField={{ name: 'name', type: 'string' }}
+        model="api::address.address"
+        name="relations"
+        type="relation"
+        isRelatedToCurrentDocument
+        onChange={jest.fn()}
+      />,
+      {
+        renderOptions: {
+          wrapper: ({ children }) => (
+            <Routes>
+              <Route
+                path="/content-manager/:collectionType/:slug/:id"
+                element={
+                  <>
+                    <LocationProbe />
+                    {children}
+                  </>
+                }
+              />
+            </Routes>
+          ),
+        },
+        initialEntries: [
+          '/content-manager/collection-types/api::address.address/12345?plugins[i18n][locale]=en',
+        ],
+      }
+    );
+  };
+
   /**
    * TODO: for some reason, we're not getting any data from MSW.
    */
@@ -200,6 +270,36 @@ describe('Relations', () => {
         id: '99',
       });
     });
+  });
+
+  it('preserves the active locale when opening a non-localized nested relation in full page', async () => {
+    const { user } = renderRelationNavigation({
+      documentId: 'non-localized-intermediate',
+      locale: null,
+      name: 'Non-localized intermediate',
+    });
+
+    await user.click(await screen.findByRole('button', { name: 'Non-localized intermediate' }));
+    await user.click(screen.getByRole('button', { name: 'Go to entry' }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/content-manager/collection-types/api::category.category/non-localized-intermediate?plugins[i18n][locale]=en'
+    );
+  });
+
+  it('uses the related record locale when opening a localized nested relation in full page', async () => {
+    const { user } = renderRelationNavigation({
+      documentId: 'localized-intermediate',
+      locale: 'fr',
+      name: 'Localized intermediate',
+    });
+
+    await user.click(await screen.findByRole('button', { name: 'Localized intermediate' }));
+    await user.click(screen.getByRole('button', { name: 'Go to entry' }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/content-manager/collection-types/api::category.category/localized-intermediate?plugins[i18n][locale]=fr'
+    );
   });
 
   describe.skip('Accessibility', () => {

--- a/packages/core/content-manager/server/src/services/permission-checker.ts
+++ b/packages/core/content-manager/server/src/services/permission-checker.ts
@@ -34,9 +34,7 @@ const createPermissionChecker =
       return entity ? permissionsManager.toSubject(entity, model) : model;
     };
 
-    // @ts-expect-error preserve the parameter order
-    // eslint-disable-next-line @typescript-eslint/default-param-last
-    const can = (action: string, entity?: Entity, field: string) => {
+    const can = (action: string, entity: Entity | undefined, field: string) => {
       const subject = toSubject(entity);
       const aliases = actionProvider.unstable_aliases(action, model) as string[];
 
@@ -48,9 +46,7 @@ const createPermissionChecker =
       );
     };
 
-    // @ts-expect-error preserve the parameter order
-    // eslint-disable-next-line @typescript-eslint/default-param-last
-    const cannot = (action: string, entity?: Entity, field: string) => {
+    const cannot = (action: string, entity: Entity | undefined, field: string) => {
       const subject = toSubject(entity);
       const aliases = actionProvider.unstable_aliases(action, model) as string[];
 

--- a/packages/plugins/users-permissions/server/src/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/src/controllers/auth.js
@@ -373,7 +373,10 @@ module.exports = ({ strapi }) => ({
       const cookieName = upSessions.cookie?.name || 'strapi_up_refresh';
       const isProduction = process.env.NODE_ENV === 'production';
 
-      const { maxAge, ...cookieOptions } = buildRefreshCookieOptions(upSessions, isProduction);
+      const { maxAge: _maxAge, ...cookieOptions } = buildRefreshCookieOptions(
+        upSessions,
+        isProduction
+      );
 
       ctx.cookies.set(cookieName, '', { ...cookieOptions, expires: new Date(0) });
     }


### PR DESCRIPTION
### What does it do?

Preserves the active i18n locale when an editor opens a non-localized intermediate relation in a full-page edit view. An explicit locale on the related record still takes precedence. Regression tests cover both paths.

### Why is it needed?

Nested relation navigation dropped the locale when the intermediate record was not localized. The next localized relation picker then lacked locale context and could show duplicate or cross-locale relation options instead of options scoped to the active translation.

### How to test it?

  1. Create a localized content type `Z`, a non-localized content type `Y`, and a localized content type `X`.
  2. Add a relation from `Z` to `Y` and a relation from `Y` to `X`. Create English and French entries for the localized types and link an English `Z` entry through `Y`.
  3. Open the English `Z` entry and confirm the URL contains `plugins[i18n][locale]=en`.
  4. Open the `Y` relation modal and select **Go to entry**.
  5. Confirm the `Y` edit-view URL still contains `plugins[i18n][locale]=en`.
  6. Open `Y`'s relation picker for `X` and confirm it is scoped to English entries rather than displaying duplicate/cross-locale variants.
  7. As a precedence check, open a related record that explicitly has locale `fr` from an English root and confirm its full-page URL uses `plugins[i18n][locale]=fr`.

### Related issue(s)/PR(s)

- Fixes [GitHub #21774](https://github.com/strapi/strapi/issues/21774)