### PR TITLE
fix(content-manager): relation fields display document ids when main fields are empty

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -63,6 +63,10 @@ const LinkEllipsis = styled(Link)`
 
 const CustomRelationInput = (props: RelationsFieldProps) => {
   const { formatMessage } = useIntl();
+  const emptyLabel = formatMessage({
+    id: 'content-manager.containers.untitled',
+    defaultMessage: 'Untitled',
+  });
   const field = useField<
     { results: RelationResult[]; meta: { missingCount: number } } | RelationResult[]
   >(props.name);
@@ -126,7 +130,7 @@ const CustomRelationInput = (props: RelationsFieldProps) => {
             // @ts-expect-error - targetModel does exist on the attribute. But it's not typed.
             const { targetModel } = props.attribute;
             const href = `../${COLLECTION_TYPES}/${targetModel}/${relationData.documentId}`;
-            const label = getRelationLabel(relationData, props.mainField);
+            const label = getRelationLabel(relationData, props.mainField, emptyLabel);
             const isAdminUserRelation = targetModel === 'admin::user';
 
             return (

--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -64,7 +64,7 @@ const LinkEllipsis = styled(Link)`
 const CustomRelationInput = (props: RelationsFieldProps) => {
   const { formatMessage } = useIntl();
   const emptyLabel = formatMessage({
-    id: 'content-manager.containers.untitled',
+    id: 'content-manager.containers.empty-label',
     defaultMessage: 'Untitled',
   });
   const field = useField<

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -172,7 +172,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
 
     const { formatMessage } = useIntl();
     const emptyLabel = formatMessage({
-      id: 'content-manager.containers.untitled',
+      id: 'content-manager.containers.empty-label',
       defaultMessage: 'Untitled',
     });
 
@@ -711,7 +711,7 @@ const RelationModalWithContext = ({
   const [textValue, setTextValue] = React.useState<string | undefined>('');
   const { formatMessage } = useIntl();
   const emptyLabel = formatMessage({
-    id: 'content-manager.containers.untitled',
+    id: 'content-manager.containers.empty-label',
     defaultMessage: 'Untitled',
   });
   const canCreate = useDocumentRBAC('RelationModalWrapper', (state) => state.canCreate);
@@ -1211,7 +1211,7 @@ const ListItem = React.memo(({ data, index, style }: ListItemProps) => {
 
   const { formatMessage } = useIntl();
   const emptyLabel = formatMessage({
-    id: 'content-manager.containers.untitled',
+    id: 'content-manager.containers.empty-label',
     defaultMessage: 'Untitled',
   });
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -171,6 +171,10 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
     const documentId = currentDocument.document?.documentId;
 
     const { formatMessage } = useIntl();
+    const emptyLabel = formatMessage({
+      id: 'content-manager.containers.untitled',
+      defaultMessage: 'Untitled',
+    });
 
     const isMorph = props.attribute.relation.toLowerCase().includes('morph');
     const isDisabled = isMorph || disabled;
@@ -274,6 +278,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
         field: field.value,
         href: `../${COLLECTION_TYPES}/${targetModel}`,
         mainField: props.mainField,
+        emptyLabel,
       };
 
       /**
@@ -290,9 +295,17 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
       const connectItems = (field.value?.connect ?? []).map((rel: Relation) => {
         const urlLocaleParam = rel.locale ? `?plugins[i18n][locale]=${rel.locale}` : '';
         if (rel.href) return rel;
+
+        const mainFieldValue = props.mainField
+          ? (rel as RelationResult)[props.mainField.name]
+          : undefined;
+        const hasEmptyMainField = mainFieldValue === '' || mainFieldValue === null;
+
         return {
           ...rel,
-          label: rel.label ?? getRelationLabel(rel, props.mainField),
+          label: hasEmptyMainField
+            ? getRelationLabel(rel, props.mainField, emptyLabel)
+            : (rel.label ?? getRelationLabel(rel, props.mainField, emptyLabel)),
           href: `../${COLLECTION_TYPES}/${targetModel}/${rel.documentId}${urlLocaleParam}`,
         };
       });
@@ -306,7 +319,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
         if (a.__temp_key__ > b.__temp_key__) return 1;
         return 0;
       });
-    }, [serverData, field.value, targetModel, props.mainField]);
+    }, [serverData, field.value, targetModel, props.mainField, emptyLabel]);
 
     const handleDisconnect = useHandleDisconnect(props.name, 'RelationsField');
 
@@ -328,7 +341,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
           __temp_key__: generateNKeysBetween(lastItemInList?.__temp_key__ ?? null, null, 1)[0],
           // Fallback to `id` if there is no `mainField` value, which will overwrite the above `id` property with the exact same data.
           [props.mainField?.name ?? 'documentId']: relation[props.mainField?.name ?? 'documentId'],
-          label: getRelationLabel(relation, props.mainField),
+          label: getRelationLabel(relation, props.mainField, emptyLabel),
           href: `../${COLLECTION_TYPES}/${targetModel}/${relation.documentId}?${relation.locale ? `plugins[i18n][locale]=${relation.locale}` : ''}`,
         };
 
@@ -343,6 +356,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
         }
       },
       [
+        emptyLabel,
         field,
         handleDisconnect,
         onChangeRelationField,
@@ -423,6 +437,7 @@ const StyledFlex = styled<FlexComponent>(Flex)`
 interface TransformationContext extends Pick<RelationsFieldProps, 'mainField'> {
   field?: RelationsFormValue;
   href: string;
+  emptyLabel: string;
 }
 
 /**
@@ -456,14 +471,14 @@ const removeDisconnected =
  * a better UI where we can link to the relation and display a human-readable label.
  */
 const addLabelAndHref =
-  ({ mainField, href }: TransformationContext) =>
+  ({ mainField, href, emptyLabel }: TransformationContext) =>
   (relations: RelationResult[]): Relation[] =>
     relations.map((relation) => {
       return {
         ...relation,
         // Fallback to `id` if there is no `mainField` value, which will overwrite the above `documentId` property with the exact same data.
         [mainField?.name ?? 'documentId']: relation[mainField?.name ?? 'documentId'],
-        label: getRelationLabel(relation, mainField),
+        label: getRelationLabel(relation, mainField, emptyLabel),
         href: `${href}/${relation.documentId}?${relation.locale ? `plugins[i18n][locale]=${relation.locale}` : ''}`,
       };
     });
@@ -695,6 +710,10 @@ const RelationModalWithContext = ({
 }: RelationModalWithContextProps) => {
   const [textValue, setTextValue] = React.useState<string | undefined>('');
   const { formatMessage } = useIntl();
+  const emptyLabel = formatMessage({
+    id: 'content-manager.containers.untitled',
+    defaultMessage: 'Untitled',
+  });
   const canCreate = useDocumentRBAC('RelationModalWrapper', (state) => state.canCreate);
   const fieldRef = useFocusInputField<HTMLInputElement>(name);
   const componentUID = useComponent('RelationsField', (state) => state.uid);
@@ -784,7 +803,7 @@ const RelationModalWithContext = ({
           {...props}
         >
           {options?.map((opt) => {
-            const textValue = getRelationLabel(opt, mainField);
+            const textValue = getRelationLabel(opt, mainField, emptyLabel);
 
             return (
               <ComboboxOption key={opt.id} value={opt.id.toString()} textValue={textValue}>
@@ -1191,6 +1210,10 @@ const ListItem = React.memo(({ data, index, style }: ListItemProps) => {
   const isDesktop = useIsDesktop();
 
   const { formatMessage } = useIntl();
+  const emptyLabel = formatMessage({
+    id: 'content-manager.containers.untitled',
+    defaultMessage: 'Untitled',
+  });
 
   const {
     href,
@@ -1218,7 +1241,8 @@ const ListItem = React.memo(({ data, index, style }: ListItemProps) => {
     },
     { skip: !isTemporary }
   );
-  const label = isTemporary && document ? getRelationLabel(document, mainField) : originalLabel;
+  const label =
+    isTemporary && document ? getRelationLabel(document, mainField, emptyLabel) : originalLabel;
   const status = isTemporary && document ? document?.status : originalStatus;
 
   const [{ handlerId, isDragging, handleKeyDown }, relationRef, dropRef, dragRef, dragPreviewRef] =

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/Relations.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/Relations.test.tsx
@@ -1,3 +1,4 @@
+import { Form } from '@strapi/admin/strapi-admin';
 import {
   RenderOptions,
   fireEvent,
@@ -15,8 +16,12 @@ import { RelationsInput, RelationsFieldProps } from '../Relations';
 const render = (
   {
     initialEntries,
+    initialValues,
     ...props
-  }: Partial<RelationsFieldProps> & Pick<RenderOptions, 'initialEntries'> = { initialEntries: [] }
+  }: Partial<RelationsFieldProps> &
+    Pick<RenderOptions, 'initialEntries'> & { initialValues?: Record<string, unknown> } = {
+    initialEntries: [],
+  }
 ) =>
   renderRTL(
     <RelationsInput
@@ -39,7 +44,18 @@ const render = (
       renderOptions: {
         wrapper: ({ children }) => (
           <Routes>
-            <Route path="/content-manager/:collectionType/:slug/:id" element={children} />
+            <Route
+              path="/content-manager/:collectionType/:slug/:id"
+              element={
+                initialValues ? (
+                  <Form method="POST" onSubmit={jest.fn()} initialValues={initialValues}>
+                    {children}
+                  </Form>
+                ) : (
+                  children
+                )
+              }
+            />
           </Routes>
         ),
       },
@@ -89,6 +105,38 @@ describe('Relations', () => {
     expect(screen.getByRole('button', { name: 'Relation entity 1' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Relation entity 2' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Relation entity 3' })).toBeInTheDocument();
+  });
+
+  it('renders localized fallback labels for fill-from-locale connect items', async () => {
+    render({
+      initialValues: {
+        relations: {
+          connect: [
+            {
+              id: 101,
+              documentId: 'internal-empty-key',
+              locale: 'fr',
+              name: '',
+              label: '',
+              __temp_key__: 'a0',
+            },
+            {
+              id: 102,
+              documentId: 'internal-null-key',
+              locale: 'fr',
+              name: null,
+              label: 'internal-null-key',
+              __temp_key__: 'a1',
+            },
+          ],
+          disconnect: [],
+        },
+      },
+    });
+
+    expect(await screen.findAllByRole('button', { name: 'Untitled' })).toHaveLength(2);
+    expect(screen.queryByText('internal-empty-key')).not.toBeInTheDocument();
+    expect(screen.queryByText('internal-null-key')).not.toBeInTheDocument();
   });
 
   it('should be disabled when the prop is passed', async () => {

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
@@ -18,9 +18,15 @@ import type { CellContentProps } from './CellContent';
 interface RelationSingleProps extends Pick<CellContentProps, 'mainField' | 'content'> {}
 
 const RelationSingle = ({ mainField, content }: RelationSingleProps) => {
+  const { formatMessage } = useIntl();
+  const emptyLabel = formatMessage({
+    id: 'content-manager.containers.untitled',
+    defaultMessage: 'Untitled',
+  });
+
   return (
     <Typography maxWidth="50rem" textColor="neutral800" ellipsis>
-      {getRelationLabel(content, mainField)}
+      {getRelationLabel(content, mainField, emptyLabel)}
     </Typography>
   );
 };
@@ -35,6 +41,10 @@ interface RelationMultipleProps
 const RelationMultiple = ({ mainField, content, rowId, name }: RelationMultipleProps) => {
   const { model } = useDoc();
   const { formatMessage } = useIntl();
+  const emptyLabel = formatMessage({
+    id: 'content-manager.containers.untitled',
+    defaultMessage: 'Untitled',
+  });
   const { notifyStatus } = useNotifyAT();
   const [isOpen, setIsOpen] = React.useState(false);
   const [{ query }] = useQueryParams<{ plugins?: { i18n?: { locale?: string } } }>();
@@ -99,7 +109,7 @@ const RelationMultiple = ({ mainField, content, rowId, name }: RelationMultipleP
             {data.results.map((entry) => (
               <Menu.Item key={entry.documentId}>
                 <Typography maxWidth="50rem" ellipsis>
-                  {getRelationLabel(entry, mainField)}
+                  {getRelationLabel(entry, mainField, emptyLabel)}
                 </Typography>
               </Menu.Item>
             ))}

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
@@ -20,7 +20,7 @@ interface RelationSingleProps extends Pick<CellContentProps, 'mainField' | 'cont
 const RelationSingle = ({ mainField, content }: RelationSingleProps) => {
   const { formatMessage } = useIntl();
   const emptyLabel = formatMessage({
-    id: 'content-manager.containers.untitled',
+    id: 'content-manager.containers.empty-label',
     defaultMessage: 'Untitled',
   });
 
@@ -42,7 +42,7 @@ const RelationMultiple = ({ mainField, content, rowId, name }: RelationMultipleP
   const { model } = useDoc();
   const { formatMessage } = useIntl();
   const emptyLabel = formatMessage({
-    id: 'content-manager.containers.untitled',
+    id: 'content-manager.containers.empty-label',
     defaultMessage: 'Untitled',
   });
   const { notifyStatus } = useNotifyAT();

--- a/packages/core/content-manager/admin/src/translations/cs.json
+++ b/packages/core/content-manager/admin/src/translations/cs.json
@@ -180,6 +180,7 @@
   "containers.SettingsPage.pluginHeaderDescription": "Nakonfigurujte nastavení pro všechny své Collection Types a skupiny",
   "containers.SettingsView.list.subtitle": "Nakonfigurujte rozložení a zobrazení svých Collection Types a skupin",
   "containers.SettingsView.list.title": "Zobrazit nastavení",
+  "containers.empty-label": "Bez názvu",
   "containers.untitled": "Bez názvu",
   "dnd.cancel-item": "{item}, puštěno. Změna pořadí zrušena.",
   "dnd.drop-item": "{item}, puštěno. Konečná pozice v seznamu: {position}.",

--- a/packages/core/content-manager/admin/src/translations/de.json
+++ b/packages/core/content-manager/admin/src/translations/de.json
@@ -156,6 +156,7 @@
   "containers.SettingsPage.pluginHeaderDescription": "Einstellungen für alle Sammlungen und Gruppen konfigurieren",
   "containers.SettingsView.list.subtitle": "Layout und Darstellung für alle Sammlungen und Gruppen konfigurieren",
   "containers.SettingsView.list.title": "Darstellungsoptionen",
+  "containers.empty-label": "Unbenannt",
   "containers.untitled": "Unbenannt",
   "dnd.cancel-item": "{item}, fallen gelassen. Neuordnung abgebrochen.",
   "dnd.drop-item": "{item}, fallen gelassen. Endposition in der Liste: {position}.",

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -173,6 +173,7 @@
   "containers.SettingsPage.pluginHeaderDescription": "Configure the settings for all your Collection Types and Groups",
   "containers.SettingsView.list.subtitle": "Configure the layout and display of your Collection Types and Groups",
   "containers.SettingsView.list.title": "Display configurations",
+  "containers.empty-label": "Untitled",
   "containers.untitled": "Untitled",
   "dnd.cancel-item": "{item}, dropped. Re-order cancelled.",
   "dnd.drop-item": "{item}, dropped. Final position in list: {position}.",

--- a/packages/core/content-manager/admin/src/translations/fr.json
+++ b/packages/core/content-manager/admin/src/translations/fr.json
@@ -259,6 +259,7 @@
   "containers.edit-settings.modal-form.placeholder": "Placeholder",
   "containers.edit-settings.modal-form.mainField": "Titre de l'entrée",
   "containers.edit-settings.modal-form.editable": "Champ modifiable",
+  "containers.empty-label": "Sans titre",
   "containers.untitled": "Sans titre",
   "dnd.cancel-item": "{item}, , abandonné. Annulation de la réorganisation.",
   "dnd.drop-item": "{item}, abandonné. Position finale dans la liste : {position}",

--- a/packages/core/content-manager/admin/src/translations/ja.json
+++ b/packages/core/content-manager/admin/src/translations/ja.json
@@ -191,6 +191,7 @@
   "containers.SettingsView.list.subtitle": "コレクションタイプとグループのレイアウトと表示を設定",
   "containers.SettingsView.list.title": "表示設定",
   "containers.SettingViewModel.pluginHeader.title": "コンテンツ管理 - {name}",
+  "containers.empty-label": "無題",
   "containers.untitled": "無題",
   "dnd.cancel-item": "{item}をドロップしました。並べ替えがキャンセルされました。",
   "dnd.drop-item": "{item}をドロップしました。リスト内の最終位置: {position}。",

--- a/packages/core/content-manager/admin/src/translations/ko.json
+++ b/packages/core/content-manager/admin/src/translations/ko.json
@@ -263,6 +263,7 @@
   "containers.SettingPage.editSettings.relationOpenMode.newTab": "새 탭에서 열기",
   "containers.SettingPage.editSettings.relationOpenMode.page": "페이지로 이동",
   "containers.SettingPage.relations": "관련 필드",
+  "containers.empty-label": "제목 없음",
   "containers.untitled": "제목 없음",
   "dnd.cancel-item": "{item}, 놓았습니다. 순서 변경이 취소되었습니다.",
   "dnd.drop-item": "{item}, 놓았습니다. 목록에서의 최종 위치: {position}.",

--- a/packages/core/content-manager/admin/src/translations/nl.json
+++ b/packages/core/content-manager/admin/src/translations/nl.json
@@ -195,6 +195,7 @@
   "containers.list.selectedEntriesModal.title": "Items publiceren",
   "containers.list.table-headers.publishedAt": "Status",
   "containers.list.table.row-actions": "Rijacties",
+  "containers.empty-label": "Naamloos",
   "containers.untitled": "Naamloos",
   "dnd.cancel-item": "{item}, losgelaten. Herschikking geannuleerd.",
   "dnd.drop-item": "{item}, losgelaten. Uiteindelijke positie in lijst: {position}.",

--- a/packages/core/content-manager/admin/src/translations/pl.json
+++ b/packages/core/content-manager/admin/src/translations/pl.json
@@ -171,6 +171,7 @@
   "containers.SettingsPage.pluginHeaderDescription": "Skonfiguruj domyślne opcje wszystkich twoich modeli",
   "containers.SettingsView.list.subtitle": "Skonfiguruj układ i wyświetlanie modeli i grup",
   "containers.SettingsView.list.title": "Wyświetl ustawienia",
+  "containers.empty-label": "Bez tytułu",
   "containers.untitled": "Bez tytułu",
   "dnd.cancel-item": "{item}, upuszczony. Anulowano zmianę kolejności.",
   "dnd.drop-item": "{item}, upuszczony. Finalna pozycja na liście: {position}.",

--- a/packages/core/content-manager/admin/src/translations/sk.json
+++ b/packages/core/content-manager/admin/src/translations/sk.json
@@ -189,6 +189,7 @@
   "containers.SettingsPage.pluginHeaderDescription": "Konfigurovať nastavenia pre všetky Vaše kolekcie a skupiny",
   "containers.SettingsView.list.subtitle": "Konfigurovať rozloženie a zobrazenie stránky Vaších kolekcií a skupín",
   "containers.SettingsView.list.title": "Zobraziť nastavenia",
+  "containers.empty-label": "Bez názvu",
   "containers.untitled": "Bez názvu",
   "dnd.cancel-item": "{item}, pustené. Zmena poradia zrušená.",
   "dnd.drop-item": "{item}, pustené. Konečná pozícia v zozname: {position}.",

--- a/packages/core/content-manager/admin/src/utils/relations.ts
+++ b/packages/core/content-manager/admin/src/utils/relations.ts
@@ -5,12 +5,23 @@ import type { RelationResult } from '../../../shared/contracts/relations';
  * @internal
  * @description Get the label of a relation, the contract has [key: string]: unknown,
  * so we need to check if the mainFieldKey is defined and if the relation has a value
- * under that property. If it does, we then verify it's type of string and return it.
+ * under that property. If it does, we then verify its type and return it.
  *
- * We fallback to the documentId.
+ * An empty string or null uses a neutral label instead of exposing the documentId. Other missing
+ * or unsupported values fallback to the documentId.
  */
-const getRelationLabel = (relation: RelationResult, mainField?: MainField): string => {
-  const label = mainField && relation[mainField.name] ? relation[mainField.name] : null;
+const getRelationLabel = (
+  relation: RelationResult,
+  mainField?: MainField,
+  emptyLabel = 'Untitled'
+): string => {
+  const mainFieldValue = mainField ? relation[mainField.name] : undefined;
+
+  if (mainFieldValue === '' || mainFieldValue === null) {
+    return emptyLabel;
+  }
+
+  const label = mainFieldValue || null;
 
   if (typeof label === 'string') {
     return label;

--- a/packages/core/content-manager/admin/src/utils/tests/relations.test.ts
+++ b/packages/core/content-manager/admin/src/utils/tests/relations.test.ts
@@ -32,6 +32,44 @@ describe('getRelationLabel', () => {
     ).toBe('doc-1');
   });
 
+  it('returns Untitled when a localized relation has an empty text main field', () => {
+    expect(
+      getRelationLabel(
+        { documentId: 'internal-document-key', id: 1, locale: 'fr', title: '' },
+        mainField('title', 'string')
+      )
+    ).toBe('Untitled');
+  });
+
+  it('uses the provided empty label when the text main field is empty', () => {
+    expect(
+      getRelationLabel(
+        { documentId: 'internal-document-key', id: 1, title: '' },
+        mainField('title', 'string'),
+        'Sans titre'
+      )
+    ).toBe('Sans titre');
+  });
+
+  it('returns Untitled when the configured main field is null', () => {
+    expect(
+      getRelationLabel(
+        { documentId: 'internal-document-key', id: 1, title: null },
+        mainField('title', 'string')
+      )
+    ).toBe('Untitled');
+  });
+
+  it('uses the provided empty label when the configured main field is null', () => {
+    expect(
+      getRelationLabel(
+        { documentId: 'internal-document-key', id: 1, title: null },
+        mainField('title', 'string'),
+        'Sans titre'
+      )
+    ).toBe('Sans titre');
+  });
+
   it('falls back to documentId when mainField is not provided', () => {
     expect(getRelationLabel({ documentId: 'doc-1', id: 1, pub_number: 42 })).toBe('doc-1');
   });

--- a/packages/plugins/i18n/server/src/services/__tests__/fill-from-locale.test.ts
+++ b/packages/plugins/i18n/server/src/services/__tests__/fill-from-locale.test.ts
@@ -848,7 +848,7 @@ describe('transformDocument — relation handling', () => {
       expect((result.category as any).connect[0].label).toBe('Technology');
     });
 
-    test('falls back to documentId as label when mainField is not a string', async () => {
+    test('uses an untranslated empty marker when mainField is null', async () => {
       const { service, mockStrapi, dbFindMany } = makeService();
 
       (mockStrapi.getModel as jest.Mock).mockImplementation((uid: string) => {
@@ -860,7 +860,6 @@ describe('transformDocument — relation handling', () => {
         mockStrapi.plugins.i18n.services['content-types'].isLocalizedContentType as jest.Mock
       ).mockReturnValue(false);
 
-      // name is null — should fall back to documentId
       dbFindMany.mockResolvedValue([{ documentId: 'cat-1', id: 10, name: null }]);
 
       const result = await service.transformDocument(
@@ -870,7 +869,8 @@ describe('transformDocument — relation handling', () => {
         makeUserAbility()
       );
 
-      expect((result.category as any).connect[0].label).toBe('cat-1');
+      expect((result.category as any).connect[0].label).toBe('');
+      expect((result.category as any).connect[0].label).not.toBe('cat-1');
     });
   });
 });

--- a/packages/plugins/i18n/server/src/services/fill-from-locale.ts
+++ b/packages/plugins/i18n/server/src/services/fill-from-locale.ts
@@ -20,12 +20,12 @@ const getMainField = async (targetUid: UID.Schema): Promise<string> => {
 };
 
 /**
- * Returns the display label for a relation.
- * Matches the logic of the getRelationLabel function in the content-manager plugin.
+ * Returns the display label for a relation in form state.
+ * Empty configured values stay untranslated so the admin can provide its localized fallback.
  */
 const getRelationLabel = (relation: Record<string, unknown>, mainField: string): string => {
   const label = relation[mainField];
-  if (typeof label === 'string') return label;
+  if (label === null || typeof label === 'string') return label ?? '';
   return String(relation.documentId ?? '');
 };
 


### PR DESCRIPTION
### What does it do?

Prevents relation labels from exposing internal document IDs when the configured relation main field is explicitly empty. Content Manager now displays the existing localized `Untitled` fallback for empty-string and `null` values in relation pickers, connected relation items, list cells, and history rendering. The i18n fill-from-locale service leaves explicit empty labels untranslated so Content Manager can apply that localized fallback, while legitimate labels and the existing missing-property compatibility fallback remain unchanged.

### Why is it needed?

Localized relation entries can have an empty configured main field. Those entries were displayed using their internal `documentId`, leaking an implementation identifier into user-facing Content Manager relation fields instead of showing a neutral label.

### How to test it?

  1. Start a Strapi development app with Content Manager and i18n enabled.
  2. Create an i18n-enabled collection type whose configured main field is a text field such as `name`.
  3. Create entries in at least two locales, leaving `name` empty on one localized entry.
  4. Create a non-localized collection type with a relation to the localized type, then open an entry's relation picker.
  5. Confirm the empty-main-field relation candidate and connected relation item display the localized `Untitled` label and do not display the entry's internal `documentId`.
  6. Use fill-from-locale on content containing a relation to an entry whose configured main field is empty or `null`; confirm the resulting relation item displays localized `Untitled`, not an empty accessible label or internal identifier.
  7. Confirm a relation with a non-empty main field still displays that value, and a payload where the configured property is genuinely missing retains the existing fallback behavior.
  8. Where available, inspect the relation in Content Manager list and history views and confirm the same localized neutral label is used.

### Related issue(s)/PR(s)

Fixes #21168