### PR TITLE
fix(core): cron job that fails after shutdown crashes the process

### DIFF
--- a/packages/core/core/src/providers/__tests__/cron.test.ts
+++ b/packages/core/core/src/providers/__tests__/cron.test.ts
@@ -1,0 +1,37 @@
+import cronProvider from '../cron';
+
+describe('cron provider', () => {
+  describe('init', () => {
+    it('registers the cron service with the strapi instance injected', () => {
+      const add = jest.fn();
+      const logError = jest.fn();
+      const strapi = { add, log: { error: logError } } as any;
+
+      cronProvider.init!(strapi);
+
+      expect(add).toHaveBeenCalledWith('cron', expect.any(Function));
+
+      // the registered factory must build the service from the instance, not from
+      // the ambient global, so that it survives `delete global.strapi` (#27469)
+      const factory = add.mock.calls[0][1];
+      const cron = factory();
+
+      cron.add({ myTask: { options: '* * * * * *', task: jest.fn() } });
+      cron.jobs[0].job.emit('error', new Error('job failed'));
+
+      expect(logError).toHaveBeenCalledWith('Cron job "myTask" failed', expect.any(Error));
+    });
+  });
+
+  describe('destroy', () => {
+    it('stops cron before Strapi tears down the rest of the instance', async () => {
+      const cron = { destroy: jest.fn() };
+      const strapi = { get: jest.fn(() => cron) } as any;
+
+      await cronProvider.destroy!(strapi);
+
+      expect(strapi.get).toHaveBeenCalledWith('cron');
+      expect(cron.destroy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/core/src/providers/cron.ts
+++ b/packages/core/core/src/providers/cron.ts
@@ -3,7 +3,7 @@ import createCronService from '../services/cron';
 
 export default defineProvider({
   init(strapi) {
-    strapi.add('cron', () => createCronService());
+    strapi.add('cron', () => createCronService(strapi));
   },
   async bootstrap(strapi) {
     if (strapi.config.get('server.cron.enabled', true)) {

--- a/packages/core/core/src/services/__tests__/cron.test.ts
+++ b/packages/core/core/src/services/__tests__/cron.test.ts
@@ -1,0 +1,101 @@
+import type { Core } from '@strapi/types';
+import createCronService from '../cron';
+
+/**
+ * These tests deliberately never assign `global.strapi`.
+ *
+ * The bug they guard against (#27469) is the cron service resolving the ambient
+ * global `strapi` at call time: once `Strapi.destroy()` has run `delete global.strapi`,
+ * a job that was still in flight rejects, `node-schedule` emits 'error', and the
+ * handler throws instead of logging. Leaving the global unset reproduces that
+ * exact condition.
+ */
+const createMockStrapi = () => {
+  const error = jest.fn();
+  const strapi = { log: { error } } as unknown as Core.Strapi;
+
+  return { strapi, error };
+};
+
+describe('Cron', () => {
+  it('logs a job failure through the injected strapi instance', () => {
+    const { strapi, error: logError } = createMockStrapi();
+    const cron = createCronService(strapi);
+
+    cron.add({ myTask: { options: '* * * * * *', task: jest.fn() } });
+
+    const error = new Error('job failed');
+    expect(() => cron.jobs[0].job.emit('error', error)).not.toThrow();
+
+    expect(logError).toHaveBeenCalledWith('Cron job "myTask" failed', error);
+  });
+
+  it('uses the rule as the job name when the task is declared as a function', () => {
+    const { strapi, error: logError } = createMockStrapi();
+    const cron = createCronService(strapi);
+
+    cron.add({ '* * * * * *': jest.fn() });
+
+    const error = new Error('job failed');
+    cron.jobs[0].job.emit('error', error);
+
+    expect(logError).toHaveBeenCalledWith('Cron job "* * * * * *" failed', error);
+  });
+
+  // Regression test for #27469
+  it('still logs, without throwing, when a job rejects after destroy()', () => {
+    const { strapi, error: logError } = createMockStrapi();
+    const cron = createCronService(strapi);
+
+    cron.add({ uploadWeekly: { options: '* * * * * *', task: jest.fn() } });
+    const { job } = cron.jobs[0];
+
+    cron.destroy();
+
+    // node-schedule cannot retract an invocation that is already running, so it
+    // emits 'error' from the rejected promise once teardown has completed.
+    const error = new Error('Cannot read db: connection destroyed');
+    expect(() => job.emit('error', error)).not.toThrow();
+
+    expect(logError).toHaveBeenCalledWith('Cron job "uploadWeekly" failed', error);
+  });
+
+  it('passes the injected strapi instance to the task', () => {
+    const { strapi } = createMockStrapi();
+    const task = jest.fn();
+    const cron = createCronService(strapi);
+
+    cron.add({ myTask: { options: '* * * * * *', task } });
+    cron.jobs[0].job.invoke();
+
+    expect(task).toHaveBeenCalled();
+    expect(task.mock.calls[0][0].strapi).toBe(strapi);
+  });
+
+  it('cancels every job on stop()', () => {
+    const { strapi } = createMockStrapi();
+    const cron = createCronService(strapi);
+
+    cron.add({ first: { options: '* * * * * *', task: jest.fn() } });
+    cron.add({ second: { options: '* * * * * *', task: jest.fn() } });
+
+    const cancels = cron.jobs.map(({ job }) => jest.spyOn(job, 'cancel'));
+
+    cron.stop();
+
+    expect(cancels).toHaveLength(2);
+    cancels.forEach((cancel) => expect(cancel).toHaveBeenCalled());
+  });
+
+  it('cancels every job on destroy()', () => {
+    const { strapi } = createMockStrapi();
+    const cron = createCronService(strapi);
+
+    cron.add({ myTask: { options: '* * * * * *', task: jest.fn() } });
+    const cancel = jest.spyOn(cron.jobs[0].job, 'cancel');
+
+    cron.destroy();
+
+    expect(cancel).toHaveBeenCalled();
+  });
+});

--- a/packages/core/core/src/services/cron.ts
+++ b/packages/core/core/src/services/cron.ts
@@ -31,7 +31,7 @@ interface Tasks {
   [key: string]: Task;
 }
 
-const createCronService = () => {
+const createCronService = (strapi: Core.Strapi) => {
   let jobsSpecs: JobSpec[] = [];
   let running = false;
 


### PR DESCRIPTION
cc @innerdvations — you're assigned on #27469. Findings and reasoning are written up in [this comment on the issue](https://github.com/strapi/strapi/issues/27469#issuecomment-5463412073); the short version is below. Two points at the bottom are yours to call, and I'm happy to revise either way.

Thanks to @macdevelop97 for the report — the analysis in it made this quick to pin down.

### What does it do?

Injects the `strapi` instance into the cron service instead of resolving the ambient global at call time:

```diff
- const createCronService = () => {
+ const createCronService = (strapi: Core.Strapi) => {
```

```diff
  init(strapi) {
-   strapi.add('cron', () => createCronService());
+   strapi.add('cron', () => createCronService(strapi));
  },
```

That one signature change shadows the global, so **both** existing references — `fn({ strapi }, ...args)` (`services/cron.ts:62`) and the job's `'error'` handler (`services/cron.ts:67`) — bind to the injected instance and stay valid after teardown. No other line of production code changes.

`createCronService` is internal (its only call site is `providers/cron.ts`; it isn't re-exported from the package), and `Modules.Cron.CronService` describes only the returned object, so there is no public API or type change.

Also adds regression tests for the cron service and the cron provider — neither had any unit tests.

### Why is it needed?

`Strapi.destroy()` ends with `delete global.strapi`. A cron job still in flight at that moment rejects afterwards, `node-schedule` emits `'error'`, and the handler dereferences the global that was just deleted — so the handler itself throws:

```
info: Shutting down Strapi
info: Strapi has been shut down
                                    ← ~10s gap
ReferenceError: strapi is not defined
    at Job.<anonymous> (@strapi/core/dist/services/cron.js:43:21)
    at Job.emit (node:events:519:28)
    at node-schedule/lib/Invocation.js:277:17
```

With `process.removeAllListeners()` already called, nothing contains it and the process exits non-zero — long after all the work succeeded. The underlying job failure is never reported either, because the handler throws before it can log.

**Stopping cron earlier is not the fix.** `Strapi.destroy()` already destroys cron through the providers loop (`providers/cron.ts` → `cron.destroy()` → `stop()` → `job.cancel()`), well before the global is deleted. I confirmed this at runtime, and confirmed that the crash still happens with `cron.destroy()` having already run: `job.cancel()` unschedules future invocations but cannot retract one already running, and `node-schedule@2.1.1` emits `'error'` from the rejected promise afterwards (`Invocation.js:275-280`).

This also brings the service in line with the repo guideline of injecting `strapi` rather than reaching for `global.strapi`.

### How to test it?

Unit tests:

```bash
yarn jest --config packages/core/core/jest.config.js --rootDir packages/core/core --testPathPattern "cron.test"
```

8 tests across the two new suites. Reverting just the two production lines makes 5 of them fail, so they do pin the bug rather than the implementation.

Note for anyone writing further tests here: `tests/setup/unit.setup.js` defines `global.strapi` as a non-configurable getter/setter, so `delete global.strapi` can't be used in a test. These tests instead simply never assign the global — it stays `undefined`, which reproduces the same failure and proves the service no longer touches it.

Manual reproduction of the original race, against a built `@strapi/core`, with a one-shot job whose task is still in flight when teardown runs:

*Before* — with `cron.destroy()` already called first:

```
[t=0ms]     cron started
[t=488ms]   job invoked (in flight)
[t=1264ms]  --- Strapi.destroy() ---
            ReferenceError: strapi is not defined  at .../dist/services/cron.js:43:21
EXIT CODE: 1
```

*After*:

```
[t=0ms]     cron started
[t=1245ms]  --- Strapi.destroy() ---
[strapi.log.error] Cron job "uploadWeekly" failed | Cannot read db: connection destroyed
[t=4038ms]  survived teardown
EXIT CODE: 0
```

The real failure is now logged instead of being masked by a `ReferenceError`, and the process survives.

As noted in the issue, `@strapi/upload`'s `registerCron()` makes this easy to hit rather than theoretical: on a fresh database it schedules `uploadWeekly` at `now + 15s`, so any suite running longer than ~15s has a doomed invocation in flight at teardown. That scheduling is left untouched here — it's the trigger, not the bug.

### Related issue(s)/PR(s)

Fix #27469

@innerdvations — two things I'd rather you decide than assume:

1. **Scope.** Deliberately left out, to keep the diff minimal; happy to open follow-ups, or fold any of them in here if you'd prefer:
   - `jobs: jobsSpecs` goes stale after `destroy()` rebinds the array (`services/cron.ts:105,108`)
   - `remove()` splices while `filter()` is iterating, so consecutive matching entries are skipped (`services/cron.ts:80-86`)
   - `Strapi.stop()` does not await `destroy()` (`Strapi.ts:410-419`)
2. **Approach.** The issue suggested the narrower `const { log } = strapi` capture. It's the same diff size, but it leaves `fnWithStrapi` on the global, so a late invocation would surface a bogus `ReferenceError: strapi is not defined` *as* the job failure instead of the real cause. I went with injection for that reason, and because it matches the "no `global.strapi`" guideline — but it's a one-line switch if you prefer the narrower version.
