### PR TITLE
chore(eslint-config): allow UPPER_CASE type names and drop naming-convention overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "@swc/core": "1.13.5",
     "@swc/helpers": "0.5.17",
     "@swc/jest": "0.2.39",
+    "@types/eslint": "8.56.12",
     "@types/fs-extra": "11.0.4",
     "@types/git-url-parse": "9.0.3",
     "@types/prompts": "2.4.9",

--- a/packages/core/admin/shared/.eslintrc.cjs
+++ b/packages/core/admin/shared/.eslintrc.cjs
@@ -17,7 +17,6 @@ const config = {
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/no-empty-interface': 'off',
-        '@typescript-eslint/naming-convention': 'off',
         'node/no-extraneous-import': 'off',
       },
     },

--- a/packages/core/content-manager/shared/.eslintrc.cjs
+++ b/packages/core/content-manager/shared/.eslintrc.cjs
@@ -17,7 +17,6 @@ const config = {
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/no-empty-interface': 'off',
-        '@typescript-eslint/naming-convention': 'off',
         'node/no-extraneous-import': 'off',
       },
     },

--- a/packages/core/content-releases/shared/.eslintrc.cjs
+++ b/packages/core/content-releases/shared/.eslintrc.cjs
@@ -17,7 +17,6 @@ const config = {
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/no-empty-interface': 'off',
-        '@typescript-eslint/naming-convention': 'off',
         'node/no-extraneous-import': 'off',
       },
     },

--- a/packages/core/database/src/entity-manager/morph-relations.ts
+++ b/packages/core/database/src/entity-manager/morph-relations.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */ // allow __type
 import { curry, groupBy, pipe, mapValues, map, isEmpty } from 'lodash/fp';
 import type { Knex } from 'knex';
 

--- a/packages/core/review-workflows/shared/.eslintrc.cjs
+++ b/packages/core/review-workflows/shared/.eslintrc.cjs
@@ -17,7 +17,6 @@ const config = {
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/no-empty-interface': 'off',
-        '@typescript-eslint/naming-convention': 'off',
         'node/no-extraneous-import': 'off',
       },
     },

--- a/packages/core/upload/shared/.eslintrc.cjs
+++ b/packages/core/upload/shared/.eslintrc.cjs
@@ -17,7 +17,6 @@ const config = {
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/no-empty-interface': 'off',
-        '@typescript-eslint/naming-convention': 'off',
         'node/no-extraneous-import': 'off',
         // Upload's folder contract keeps a mid-file `import type` to break a
         // type-only cycle with ./files.

--- a/packages/utils/eslint-config-custom/back/typescript.js
+++ b/packages/utils/eslint-config-custom/back/typescript.js
@@ -51,7 +51,7 @@ const config = {
       },
       {
         selector: 'typeLike',
-        format: ['PascalCase'],
+        format: ['PascalCase', 'UPPER_CASE'],
       },
     ],
     '@typescript-eslint/no-empty-interface': 'warn',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10987,6 +10987,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint@npm:8.56.12":
+  version: 8.56.12
+  resolution: "@types/eslint@npm:8.56.12"
+  dependencies:
+    "@types/estree": "npm:*"
+    "@types/json-schema": "npm:*"
+  checksum: 10c0/e4ca426abe9d55f82b69a3250bec78b6d340ad1e567f91c97ecc59d3b2d6a1d8494955ac62ad0ea14b97519db580611c02be8277cbea370bdfb0f96aa2910504
+  languageName: node
+  linkType: hard
+
 "@types/estree-jsx@npm:^1.0.0":
   version: 1.0.5
   resolution: "@types/estree-jsx@npm:1.0.5"
@@ -11226,7 +11236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -28162,6 +28172,7 @@ __metadata:
     "@swc/core": "npm:1.13.5"
     "@swc/helpers": "npm:0.5.17"
     "@swc/jest": "npm:0.2.39"
+    "@types/eslint": "npm:8.56.12"
     "@types/fs-extra": "npm:11.0.4"
     "@types/git-url-parse": "npm:9.0.3"
     "@types/prompts": "npm:2.4.9"


### PR DESCRIPTION
### What does it do?

Allows `UPPER_CASE` in the `typeLike` selector of the shared back-end `@typescript-eslint/naming-convention` rule (`packages/utils/eslint-config-custom/back/typescript.js`), then removes the per-package escape hatches that existed only because of that restriction:

- Removed `'@typescript-eslint/naming-convention': 'off'` from the `contracts/**` override in `shared/.eslintrc.cjs` of `admin`, `content-manager`, `content-releases`, `review-workflows` and `upload`.
- Removed the file-level `/* eslint-disable @typescript-eslint/naming-convention */ // allow __type` in `packages/core/database/src/entity-manager/morph-relations.ts`.
- Added `@types/eslint` as a root devDependency.

### Why is it needed?

The `typeLike` selector was restricted to `PascalCase`, but the contracts declare screaming-snake-case type aliases for field-name unions:

```ts
// packages/core/content-manager/shared/contracts/collection-types.ts
// packages/core/content-manager/shared/contracts/single-types.ts
type AT_FIELDS = 'updatedAt' | 'createdAt' | 'publishedAt';
type BY_FIELDS = 'createdBy' | 'updatedBy' | 'publishedBy';
```

Rather than turning the whole rule off for every `contracts/**` directory, the shared config now accepts `UPPER_CASE` for type-like names — so the rest of the rule (variables, parameters, functions) stays enforced in those files instead of being silently disabled. In `admin`, `content-releases`, `review-workflows` and `upload` the override turned out to be dead weight: those `contracts/**` trees have no `naming-convention` violations at all, so the `'off'` line is simply dropped.

The `morph-relations.ts` disable comment was also obsolete: `__type` is a variable/parameter, not a type, and the shared config already has explicit `filter: { regex: '^_', match: true }, format: null` entries for the `variable` and `parameter` selectors, so the binding lints clean without the override.

`@types/eslint` is needed so the `// @ts-check` annotated ESLint config files can resolve `/** @type {import('eslint').Linter.Config} */`.

### How to test it?

```bash
yarn install
yarn nx run-many --target=lint --nx-ignore-cycles --skip-nx-cache \
  --projects=@strapi/admin,@strapi/content-manager,@strapi/database,@strapi/content-releases,@strapi/review-workflows,@strapi/upload
```

All six packages lint clean with `--max-warnings=0`. `yarn version:check` also passes (all packages aligned at 5.52.2).

### Related issue(s)/PR(s)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124i6WyvxoMAbtxpmmuKWbB