### PR TITLE
chore: declare module system explicitly across the monorepo

### DIFF
--- a/.github/actions/check-pr-status/jsconfig.json
+++ b/.github/actions/check-pr-status/jsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6"
+    "module": "node20",
+    "lib": ["ES2023"],
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/.github/actions/check-pr-status/jsconfig.json
+++ b/.github/actions/check-pr-status/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "node20",
+    "target": "es2023",
     "lib": ["ES2023"],
     "types": ["node"]
   },

--- a/.github/actions/check-pr-status/package.json
+++ b/.github/actions/check-pr-status/package.json
@@ -1,6 +1,7 @@
 {
   "name": "check-pr-status",
   "version": "5.52.2",
+  "type": "commonjs",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/.github/actions/community-pr-triage/package.json
+++ b/.github/actions/community-pr-triage/package.json
@@ -1,6 +1,7 @@
 {
   "name": "community-pr-triage",
   "version": "5.43.0",
+  "type": "commonjs",
   "private": true,
   "main": "dist/index.cjs",
   "scripts": {

--- a/.github/actions/community-pr-triage/tsconfig.json
+++ b/.github/actions/community-pr-triage/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "node20",
+    "lib": ["ES2023"],
+    "types": [],
     "strict": true,
     "esModuleInterop": true,
     "outDir": "dist",

--- a/.github/actions/community-pr-triage/tsconfig.json
+++ b/.github/actions/community-pr-triage/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "node20",
+    "target": "es2023",
     "lib": ["ES2023"],
     "types": [],
     "strict": true,

--- a/.github/scripts/community-pr-lifecycle.ts
+++ b/.github/scripts/community-pr-lifecycle.ts
@@ -1,8 +1,8 @@
-import type { getOctokit } from '@actions/github';
-import type { Context } from '@actions/github/lib/context';
+import type { context, getOctokit } from '@actions/github';
 import type * as Core from '@actions/core';
 
 type Octokit = ReturnType<typeof getOctokit>;
+type Context = typeof context;
 
 interface ScriptArgs {
   github: Octokit;

--- a/.github/scripts/tsconfig.json
+++ b/.github/scripts/tsconfig.json
@@ -1,12 +1,15 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "CommonJS",
-    "lib": ["ES2020"],
+    "module": "node20",
+    "lib": ["ES2023"],
+    "types": [],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   },
-  "include": ["*.ts"]
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/.github/scripts/tsconfig.json
+++ b/.github/scripts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "node20",
+    "target": "es2023",
     "lib": ["ES2023"],
     "types": [],
     "strict": true,

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "docs",
   "version": "0.0.0",
+  "type": "commonjs",
   "private": true,
   "scripts": {
     "build": "docusaurus build",

--- a/examples/complex/package.json
+++ b/examples/complex/package.json
@@ -1,6 +1,7 @@
 {
   "name": "complex",
   "version": "0.0.0",
+  "type": "commonjs",
   "private": true,
   "description": "Migration test fixture: Strapi app with rich schemas, seeds, and validators for v4→v5 integration tests (see tests/migration/)",
   "scripts": {

--- a/examples/empty/package.json
+++ b/examples/empty/package.json
@@ -1,6 +1,7 @@
 {
   "name": "empty",
   "version": "0.0.0",
+  "type": "commonjs",
   "private": true,
   "description": "A Strapi application",
   "scripts": {

--- a/examples/getstarted/package.json
+++ b/examples/getstarted/package.json
@@ -1,6 +1,7 @@
 {
   "name": "getstarted",
   "version": "0.0.0",
+  "type": "commonjs",
   "private": true,
   "description": "A Strapi application.",
   "license": "SEE LICENSE IN LICENSE",

--- a/examples/getstarted/src/plugins/local-plugin/package.json
+++ b/examples/getstarted/src/plugins/local-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "strapi-plugin-local-plugin",
   "version": "0.0.0",
+  "type": "commonjs",
   "private": true,
   "description": "This is the description of my plugin.",
   "strapi": {

--- a/examples/kitchensink-ts/package.json
+++ b/examples/kitchensink-ts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "kitchensink-ts",
   "version": "0.0.0",
+  "type": "commonjs",
   "private": true,
   "description": "A Strapi application",
   "license": "MIT",

--- a/examples/kitchensink/package.json
+++ b/examples/kitchensink/package.json
@@ -1,6 +1,7 @@
 {
   "name": "kitchensink",
   "version": "0.0.0",
+  "type": "commonjs",
   "private": true,
   "description": "A Strapi application.",
   "license": "SEE LICENSE IN LICENSE",

--- a/examples/plugins/todo-example/package.json
+++ b/examples/plugins/todo-example/package.json
@@ -1,6 +1,7 @@
 {
   "name": "strapi-plugin-todo-example",
   "version": "0.0.0",
+  "type": "commonjs",
   "description": "Keep track of your content management with todo lists",
   "license": "SEE LICENSE IN LICENSE",
   "exports": {

--- a/examples/plugins/workspace-plugin/package.json
+++ b/examples/plugins/workspace-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "strapi-plugin-workspace-plugin",
   "version": "0.0.0",
+  "type": "commonjs",
   "private": true,
   "description": "This is the description of my plugin.",
   "exports": {

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "rootDir": ".",
-    "module": "commonjs",
-    "target": "es6"
+    "module": "node20",
+    "lib": ["ES2023"],
+    "types": ["node"]
   },
   "exclude": [
     "**/node_modules/*",

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "module": "node20",
+    "target": "es2023",
     "lib": ["ES2023"],
     "types": ["node"]
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "strapi",
+  "type": "commonjs",
   "private": true,
   "bugs": {
     "url": "https://github.com/strapi/strapi/issues"

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/admin-test-utils",
   "version": "5.52.2",
+  "type": "commonjs",
   "private": true,
   "description": "Test utilities for the Strapi administration panel",
   "license": "MIT",

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/cloud-cli",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Commands to interact with the Strapi Cloud",
   "keywords": [
     "strapi",

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "create-strapi-app",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Generate a new Strapi application.",
   "keywords": [
     "create-strapi-app",

--- a/packages/cli/create-strapi-app/templates/example-js/package.json
+++ b/packages/cli/create-strapi-app/templates/example-js/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "commonjs",
   "scripts": {
     "build": "strapi build",
     "deploy": "strapi deploy",

--- a/packages/cli/create-strapi-app/templates/example/package.json
+++ b/packages/cli/create-strapi-app/templates/example/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "commonjs",
   "scripts": {
     "build": "strapi build",
     "deploy": "strapi deploy",

--- a/packages/cli/create-strapi-app/templates/vanilla-js/package.json
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "commonjs",
   "scripts": {
     "build": "strapi build",
     "deploy": "strapi deploy",

--- a/packages/cli/create-strapi-app/templates/vanilla/package.json
+++ b/packages/cli/create-strapi-app/templates/vanilla/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "commonjs",
   "scripts": {
     "build": "strapi build",
     "deploy": "strapi deploy",

--- a/packages/cli/create-strapi/jsconfig.json
+++ b/packages/cli/create-strapi/jsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6"
+    "module": "node20",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/cli/create-strapi/package.json
+++ b/packages/cli/create-strapi/package.json
@@ -1,6 +1,7 @@
 {
   "name": "create-strapi",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Generate a new Strapi application.",
   "keywords": [
     "create-strapi",

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/admin",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Strapi Admin",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/content-manager",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "A powerful UI to easily manage your data.",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/content-releases",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Strapi plugin for organizing and releasing content",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/content-type-builder",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Create and manage content types",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/core",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Core of Strapi",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/data-transfer",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Data transfer capabilities for Strapi",
   "keywords": [
     "strapi",

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/database",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Strapi's database layer",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/email",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Easily configure your Strapi application to send emails.",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/openapi",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "A tool set to help generate and validate API documentation for Strapi projects",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/permissions",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Strapi's permission layer.",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/review-workflows",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Review workflows for your content",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/strapi",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "An open source headless CMS solution to create and manage your own API. It provides a powerful dashboard and features to make your life easier. Databases supported: MySQL, MariaDB, PostgreSQL, SQLite",
   "keywords": [
     "strapi",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/types",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Shared typescript types for Strapi internal use",
   "keywords": [
     "strapi"

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/upload",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Makes it easy to upload images and files to your Strapi Application.",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/utils",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Shared utilities for the Strapi packages",
   "keywords": [
     "strapi",

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/generators",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Interactive API generator.",
   "keywords": [
     "strapi",

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/plugin-cloud",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Instructions to deploy your local project to Strapi Cloud",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/plugin-color-picker",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Strapi maintained Custom Fields",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/plugin-documentation",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Create an OpenAPI Document and visualize your API with SWAGGER UI.",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/plugin-graphql",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Adds GraphQL endpoint with default API methods.",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/i18n",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Create read and update content in different languages, both from the Admin Panel and from the API",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/plugin-sentry",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Send Strapi error events to Sentry",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/plugins/users-permissions/admin/jsconfig.json
+++ b/packages/plugins/users-permissions/admin/jsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig/client.json"
+}

--- a/packages/plugins/users-permissions/jsconfig.json
+++ b/packages/plugins/users-permissions/jsconfig.json
@@ -1,7 +1,0 @@
-{
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6"
-  },
-  "exclude": ["node_modules", "dist"]
-}

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/plugin-users-permissions",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Protect your API with a full-authentication process based on JWT",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/plugins/users-permissions/server/jsconfig.json
+++ b/packages/plugins/users-permissions/server/jsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig/base.json"
+}

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/provider-email-amazon-ses",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Amazon SES provider for strapi email",
   "keywords": [
     "email",

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/provider-email-mailgun",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Mailgun provider for strapi email plugin",
   "keywords": [
     "email",

--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/provider-email-nodemailer",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Nodemailer provider for Strapi",
   "keywords": [
     "strapi",

--- a/packages/providers/email-sendgrid/package.json
+++ b/packages/providers/email-sendgrid/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/provider-email-sendgrid",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Sendgrid provider for strapi email",
   "keywords": [
     "email",

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/provider-email-sendmail",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Sendmail provider for strapi email",
   "keywords": [
     "email",

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/provider-upload-aws-s3",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "AWS S3 provider for strapi upload",
   "keywords": [
     "upload",

--- a/packages/providers/upload-cloudinary/package.json
+++ b/packages/providers/upload-cloudinary/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/provider-upload-cloudinary",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Cloudinary provider for strapi upload",
   "keywords": [
     "upload",

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/provider-upload-local",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Local provider for strapi upload",
   "keywords": [
     "upload",

--- a/packages/utils/api-tests/jsconfig.json
+++ b/packages/utils/api-tests/jsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6"
+    "module": "node20",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/utils/api-tests/package.json
+++ b/packages/utils/api-tests/package.json
@@ -1,6 +1,7 @@
 {
   "name": "api-tests",
   "version": "5.52.2",
+  "type": "commonjs",
   "private": true,
   "dependencies": {
     "dotenv": "16.6.1",

--- a/packages/utils/eslint-config-custom/jsconfig.json
+++ b/packages/utils/eslint-config-custom/jsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6"
+    "module": "node20",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/utils/eslint-config-custom/package.json
+++ b/packages/utils/eslint-config-custom/package.json
@@ -1,6 +1,7 @@
 {
   "name": "eslint-config-custom",
   "version": "5.52.2",
+  "type": "commonjs",
   "private": true,
   "main": "index.js"
 }

--- a/packages/utils/logger/package.json
+++ b/packages/utils/logger/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/logger",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Strapi's logger",
   "homepage": "https://strapi.io",
   "bugs": {

--- a/packages/utils/tsconfig/package.json
+++ b/packages/utils/tsconfig/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tsconfig",
   "version": "5.52.2",
+  "type": "commonjs",
   "private": true,
   "devDependencies": {
     "@tsconfig/node20": "20.1.6"

--- a/packages/utils/typescript/jsconfig.json
+++ b/packages/utils/typescript/jsconfig.json
@@ -1,7 +1,0 @@
-{
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6"
-  },
-  "exclude": ["node_modules", "dist"]
-}

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/typescript-utils",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "Typescript support for Strapi",
   "keywords": [
     "strapi",

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/upgrade",
   "version": "5.52.2",
+  "type": "commonjs",
   "description": "CLI to upgrade Strapi applications effortless",
   "keywords": [
     "strapi",

--- a/packages/utils/vitest-config/package.json
+++ b/packages/utils/vitest-config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vitest-config",
   "version": "5.52.2",
+  "type": "commonjs",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "exports": {

--- a/scripts/front/package.json
+++ b/scripts/front/package.json
@@ -1,6 +1,7 @@
 {
   "name": "scripts-front",
   "version": "5.52.2",
+  "type": "commonjs",
   "private": true,
   "scripts": {
     "test:front": "jest --config jest.config.front.js",

--- a/scripts/jsconfig.json
+++ b/scripts/jsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6"
+    "module": "node20",
+    "lib": ["ES2023"],
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/scripts/jsconfig.json
+++ b/scripts/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "node20",
+    "target": "es2023",
     "lib": ["ES2023"],
     "types": ["node"]
   },

--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -1,5 +1,6 @@
 {
   "name": "website",
+  "type": "commonjs",
   "private": true,
   "scripts": {
     "develop": "strapi develop",

--- a/tests/app-template/package.json
+++ b/tests/app-template/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@strapi/e2e-test-app",
   "version": "0.1.0",
+  "type": "commonjs",
   "private": true,
   "description": "E2E template application",
   "license": "MIT",

--- a/tests/jsconfig.json
+++ b/tests/jsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6"
+    "module": "node20",
+    "lib": ["ES2023", "DOM"],
+    "types": ["node", "jest"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/tests/jsconfig.json
+++ b/tests/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "node20",
+    "target": "es2023",
     "lib": ["ES2023", "DOM"],
     "types": ["node", "jest"]
   },


### PR DESCRIPTION
### What does it do?

Normalizes how the module system is declared across the monorepo, in two parts.

**1. Explicit `"type"` in every `package.json`**

Adds `"type": "commonjs"` to the 61 `package.json` files that omitted the field. This is
already Node's default when the field is absent, so the change is a runtime no-op — it makes
the current behaviour explicit rather than inherited. The two packages that genuinely ship ESM
(`.github/scripts`, `packages/utils/oxlint-config`) already declare `"type": "module"` and are
left untouched.

**2. `module: node20` in the TypeScript/JS configs**

Replaces the legacy `"module": "commonjs"` + `"target": "es6"` pairing with `"module": "node20"`,
and states `"target"`, `"lib"` and `"types"` explicitly on each config:

```
jsconfig.json
scripts/jsconfig.json
tests/jsconfig.json
packages/cli/create-strapi/jsconfig.json
packages/utils/api-tests/jsconfig.json
packages/utils/eslint-config-custom/jsconfig.json
.github/scripts/tsconfig.json
.github/actions/check-pr-status/jsconfig.json
.github/actions/community-pr-triage/tsconfig.json
```

All three settings are written out rather than inherited, because they move on different
schedules. `"module": "node20"` already implies `"target": "es2023"`, so naming the target
changes nothing today — but `"module"` only needs revising when the import system itself gains
something new, whereas `"target"` and `"lib"` are what we bump when raising the supported Node
version. Stating them keeps a future Node upgrade an edit to those two fields, instead of a
change in meaning inherited from `"module"`.

`"lib"` is explicit for a second reason: its default follows `"target"` and resolves to the full
library set, which includes DOM. Every Node-only project here lists `["ES2023"]` alone. Only
`tests/jsconfig.json` adds `"DOM"`, for the Playwright sources under `tests/e2e` and `tests/utils`
that execute in browser context and rely on `window`, `document`, `localStorage`, `SVGElement`
and `DataTransfer`. That project goes from 648 to 481 reported type errors; the remainder are
pre-existing and unrelated to module resolution.

Three smaller changes come along with this:

- `packages/plugins/users-permissions/jsconfig.json` is replaced by one config per entry point —
  `admin/jsconfig.json` extending `tsconfig/client.json`, `server/jsconfig.json` extending
  `tsconfig/base.json`. The plugin's two halves have different `lib` and module-resolution needs,
  so a single config at the package root could only ever suit one of them. This matches how
  `review-workflows` already splits its tsconfig files.
- `.github/scripts/tsconfig.json` gains `allowImportingTsExtensions`, needed because four files
  there import `./issue-template-check.ts` with the explicit extension so that Node's
  `--experimental-strip-types` can resolve them on disk. That option requires one of `noEmit`,
  `emitDeclarationOnly` or `rewriteRelativeImportExtensions`; `noEmit` is the right pick here
  because the `dist` output is produced by `tsup` from the workflow, not by `tsc`, so this config
  only ever type checks.
- `packages/utils/typescript/jsconfig.json` is deleted — nothing in the repository references it.

### Why is it needed?

Under `module: node20`, TypeScript detects each file's module format from the nearest
`package.json#type` rather than from a compiler flag. Making that field explicit means the
compiler's inference is driven by a value we state deliberately, and it gives us a single
switch for the eventual ESM migration: when the ecosystem and our own consumers are ready,
flipping `"type": "commonjs"` to `"type": "module"` changes the format everywhere it matters,
instead of requiring a sweep of compiler options.

This does not commit us to ESM now. Strapi already publishes both formats — 23 packages emit
`dist/index.js` and `dist/index.mjs` side by side — so this PR only records which of the two is
the default today.

### How to test it?

The `"type"` additions are semantically inert, so the check is that nothing changes:

```bash
yarn build
yarn test:unit
yarn test:ts
yarn prettier:check
yarn version:check
```

Spot-check that a built package is unchanged in shape — `dist/index.js` should still be
CommonJS, with `dist/index.mjs` and `dist/index.d.ts` beside it:

```bash
yarn nx build @strapi/utils
head -1 packages/core/utils/dist/index.js     # 'use strict';
ls packages/core/utils/dist/index.js packages/core/utils/dist/index.mjs packages/core/utils/dist/index.d.ts
```

The `.github/scripts` suite should stay green at 22 passing:

```bash
cd .github/scripts && node --experimental-strip-types --test issue-template-check.test.ts
```

### Related issue(s)/PR(s)

None yet — opening as a draft to agree on direction before the follow-up work below.

---

Known gaps deliberately left out of this PR, to be handled separately:

- **Dual-package types hazard.** All 8 packages with a `"."` object export declare `types` as a
  single top-level condition, so `import` and `require` resolve to the same CJS-flavoured
  `.d.ts`; no `.d.mts` is emitted anywhere in `dist`. Under `node20` resolution an ESM consumer
  therefore gets CommonJS-shaped types, which surfaces as default-export mismatches. The fix is
  condition-nested types, and it depends on the bundler being able to emit `.d.mts`:

  ```json
  "import":  { "types": "./dist/index.d.mts", "default": "./dist/index.mjs" },
  "require": { "types": "./dist/index.d.ts",  "default": "./dist/index.js"  }
  ```

- **Inconsistent `exports` coverage.** 20 of 43 named workspaces have no `exports` map at all and
  still rely on bare `main`/`module`/`types` — 17 of those 20 are published packages, including
  `@strapi/database`, `@strapi/utils`, `@strapi/permissions` and `@strapi/data-transfer`. Node
  falls back to `main` for these, so they work, but they are outside the conditional-exports
  contract that the migration depends on.

- **`@strapi/types` must keep its `"./*": "./*"` entry.** Noting this as a constraint rather than
  a gap: the wildcard is deliberate. It is what lets consumers augment the exported namespaces —
  the generated content-type and component registries do exactly this, reopening
  `declare module '@strapi/types' { export namespace Public { ... } }` — and reach the namespace
  types directly. Any tightening of `exports` in this package has to preserve that, since under
  `node20` resolution an augmentation is only valid for a specifier that resolves through the
  `exports` map.

- **Source imports are extensionless.** The bundler rewrites relative specifiers to explicit
  `.mjs` in its output, so runtime is unaffected. But `module: node20` implies node16-style
  resolution for `tsc` itself, so the day `"type"` flips to `"module"` the compiler will flag
  those extensionless relative imports (`TS2835` — 471 in `packages/core/core/src` alone) even
  though the build still succeeds. Either add explicit extensions ahead of time, or set
  `moduleResolution: bundler` on the config used to typecheck source.
