### PR TITLE
fix(packages): declare exports maps and fix deep subpath type resolution

### DIFF
--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -34,6 +34,16 @@
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "bin": "./bin/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "./dist",
     "./bin"

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -34,8 +34,18 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "bin": "./bin/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/",
     "bin/",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -37,6 +37,20 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ]
+  },
   "files": [
     "dist/"
   ],

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -28,6 +28,20 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ]
+  },
   "files": [
     "dist/"
   ],

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -28,6 +28,20 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ]
+  },
   "files": [
     "dist/"
   ],

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -39,6 +39,10 @@
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ],
     "./*": "./*"
   },
   "files": [

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -32,6 +32,20 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ]
+  },
   "files": [
     "dist/"
   ],

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -32,6 +32,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -29,6 +29,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -33,6 +33,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/email-sendgrid/package.json
+++ b/packages/providers/email-sendgrid/package.json
@@ -33,6 +33,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -32,6 +32,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -34,6 +34,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/upload-cloudinary/package.json
+++ b/packages/providers/upload-cloudinary/package.json
@@ -33,6 +33,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -32,6 +32,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/utils/logger/package.json
+++ b/packages/utils/logger/package.json
@@ -28,6 +28,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -32,6 +32,17 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./tsconfigs/*": "./tsconfigs/*",
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/",
     "tsconfigs/"


### PR DESCRIPTION
### What does it do?

Adds an `exports` map to the 16 public packages that had none, and fixes `@strapi/types` so the wildcard subpath entry it already carries actually resolves under exports-aware module resolution.

**Packages that gain a `.`-only map** (3 CLIs, 7 providers, `logger`, `typescript-utils`, `generators`) — none of them is deep-imported anywhere, so a single root entry is enough. `@strapi/typescript-utils` additionally declares `./tsconfigs/*`, since it ships `tsconfigs/{admin,server}.json` and TypeScript resolves `extends` through the exports map.

**Packages that also declare their `dist/` subpaths** — `utils`, `database`, `permissions`, `data-transfer`. These publish their API as namespace re-exports (`export * as errors from './errors'`), and `tsc`'s inference emit names the *declaring* module rather than the barrel. So consumers' published declarations contain specifiers like:

```ts
// packages/core/upload/dist/admin/src/hooks/useUpload.d.ts
error: import("@strapi/utils/dist/errors").ApplicationError<...> | ...
```

even though `useUpload.ts` never imports `@strapi/utils`. There are ~190 such specifiers across emitted declarations (`dist/errors` ×104, `dist/provider-factory` ×49, `dist/hooks` ×39, plus `database`, `permissions`, `data-transfer`). A `.`-only map would make every one of them unresolvable for downstream consumers.

The form matters. `"./*": "./*"` does **not** work — exports targets resolve literally, with no extension or directory-index search, so an extensionless target never matches `errors.d.ts`:

```
Export specifier './dist/errors' does not exist in package.json scope
  at '.../node_modules/@strapi/utils'.
```

Pointing at the `.js` sibling lets TypeScript strip the extension and pick up the neighbouring declaration, and lets Node require the real module:

```json
"./dist/*": ["./dist/*.js", "./dist/*/index.js"]
```

**`@strapi/types`** had exactly this problem. Its `"./*": "./*"` entry exists so consumers can reach the exported namespaces directly and augment them, but under exports-aware resolution every deep specifier it was meant to allow was rejected. It now declares `./dist/*` in the working form. The existing `"./*"` entry is kept, so nothing that resolves today stops resolving.

Also corrects `create-strapi-app`, whose `types` pointed at `./dist/src/index.d.ts` while `tsc` emits `./dist/index.d.ts`.

`create-strapi` is deliberately untouched — it is a bin-only shim with `"main": ""`, no build output, and nothing to export.

### Why is it needed?

Those 16 packages sat outside the conditional-exports contract the rest of the monorepo already follows, so ESM consumers received the CJS `main` unless a bundler happened to honour `module`. More pressingly, `@strapi/types`' wildcard was silently ineffective in every exports-aware mode — including two that Strapi already ships to users: `tsconfigs/admin.json` and the `vanilla-js` / `example-js` `jsconfig.json` templates both use `Bundler` / `nodenext` resolution.

### How to test it?

```bash
yarn build
```

Deep type specifiers resolve (fails on `develop` for `@strapi/types`, and would fail for the four core packages given a naive `.`-only map):

```bash
cat > /tmp/probe.ts <<'EOF'
export type A = import('@strapi/utils/dist/errors').ApplicationError;
export type B = typeof import('@strapi/permissions/dist/engine');
export type C = typeof import('@strapi/types/dist/core');
export type D = import('@strapi/types/dist/public/registries').ContentTypeSchemas;
EOF
yarn tsc --noEmit --moduleResolution bundler --module esnext --target es2022 /tmp/probe.ts
```

Add `--traceResolution` to confirm each specifier resolves through the exports map rather than falling back.

Both conditions resolve at runtime:

```bash
node -e "console.log(require.resolve('@strapi/logger'))"                       # dist/index.js
node --input-type=module -e "console.log(import.meta.resolve('@strapi/logger'))" # dist/index.mjs
```

Checks run: `yarn build`, `yarn test:ts`, `yarn lint`, `yarn test:unit`, `yarn test:front`, `yarn prettier:check`, `yarn version:check`. The only failure is `@strapi/upload:test:ts:front` (`uploadProgress.test.ts`, missing `completedAt`), which reproduces unchanged on a clean `develop` checkout and is unrelated to this PR.

### Related issue(s)/PR(s)

Known behaviour changes, called out for review:

- ESM consumers of the 16 packages now resolve to `dist/index.mjs` instead of falling back to the CJS `main`. That is the intent, but it changes default-vs-named export shape for `import x from '@strapi/logger'` in Node ESM.
- Node does not fall through array targets on a missing file (unlike TypeScript), so `require()` of a `dist/` **directory** subpath in the four core packages no longer resolves — 49 such directories. Type resolution for them is unaffected, and nothing in this repo requires them at runtime; these were never documented entry points.

Three pre-existing broken entrypoints turned up while auditing and are **not** fixed here — happy to split them into a follow-up:

- `@strapi/plugin-users-permissions` is the only public package with no `files` field, and `npm pack --dry-run` produces a tarball of 158 files with **zero** `dist/` entries while its `exports` map points exclusively at `./dist/...`.
- `@strapi/upload` exports `./_internal/shared` → `./dist/shared/index.*`; `shared/` has no `index.ts` and the plugin rollup config only builds `server/src` and `admin/src`, so no such file can exist.
- `@strapi/provider-email-nodemailer` exports `./utils` → `./dist/utils/index.{js,mjs}`; only declarations are emitted there, so the runtime conditions dangle.
