### PR TITLE
fix(packages): namespace the source export condition as @strapi/source

### DIFF
--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -18,45 +18,45 @@
   ],
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "module": "./dist/index.mjs",
       "require": "./dist/index.js",
-      "source": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./after-env": {
+      "@strapi/source": "./src/after-env.ts",
       "types": "./dist/after-env.d.ts",
       "module": "./dist/after-env.mjs",
       "require": "./dist/after-env.js",
-      "source": "./src/after-env.ts",
       "default": "./dist/after-env.js"
     },
     "./environment": {
+      "@strapi/source": "./src/environment.ts",
       "types": "./dist/environment.d.ts",
       "module": "./dist/environment.mjs",
       "require": "./dist/environment.js",
-      "source": "./src/environment.ts",
       "default": "./dist/environment.js"
     },
     "./file-mock": {
+      "@strapi/source": "./src/file-mock.ts",
       "types": "./dist/file-mock.d.ts",
       "module": "./dist/file-mock.mjs",
       "require": "./dist/file-mock.js",
-      "source": "./src/file-mock.ts",
       "default": "./dist/file-mock.js"
     },
     "./global-setup": {
+      "@strapi/source": "./src/global-setup.ts",
       "types": "./dist/global-setup.d.ts",
       "module": "./dist/global-setup.mjs",
       "require": "./dist/global-setup.js",
-      "source": "./src/global-setup.ts",
       "default": "./dist/global-setup.js"
     },
     "./setup": {
+      "@strapi/source": "./src/setup.ts",
       "types": "./dist/setup.d.ts",
       "module": "./dist/setup.mjs",
       "require": "./dist/setup.js",
-      "source": "./src/setup.ts",
       "default": "./dist/setup.js"
     },
     "./package.json": "./package.json"

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -36,8 +36,8 @@
   "bin": "./bin/index.js",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -34,6 +34,16 @@
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "bin": "./bin/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "./dist",
     "./bin"

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -34,8 +34,18 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "bin": "./bin/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/",
     "bin/",

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -38,8 +38,8 @@
   "bin": "./bin/index.js",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -26,36 +26,36 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-admin/ee": {
+      "@strapi/source": "./admin/src/ee.ts",
       "types": "./dist/admin/src/ee.d.ts",
-      "source": "./admin/src/ee.ts",
       "import": "./dist/admin/ee.mjs",
       "require": "./dist/admin/ee.js",
       "default": "./dist/admin/ee.js"
     },
     "./strapi-admin/test": {
+      "@strapi/source": "./admin/tests/index.ts",
       "types": "./dist/admin/tests/index.d.ts",
-      "source": "./admin/tests/index.ts",
       "import": "./dist/admin/test.mjs",
       "require": "./dist/admin/test.js",
       "default": "./dist/admin/test.js"
     },
     "./_internal": {
+      "@strapi/source": "./_internal/index.ts",
       "types": "./dist/_internal/index.d.ts",
-      "source": "./_internal/index.ts",
       "import": "./dist/_internal.mjs",
       "require": "./dist/_internal.js",
       "default": "./dist/_internal.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.js",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -26,22 +26,22 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./_internal/shared": {
+      "@strapi/source": "./shared/index.ts",
       "types": "./dist/shared/index.d.ts",
-      "source": "./shared/index.ts",
       "import": "./dist/shared/index.mjs",
       "require": "./dist/shared/index.js",
       "default": "./dist/shared/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"
     },

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -26,15 +26,15 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -26,15 +26,15 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -30,8 +30,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -39,8 +39,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -37,6 +37,20 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ]
+  },
   "files": [
     "dist/"
   ],

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -28,6 +28,20 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ]
+  },
   "files": [
     "dist/"
   ],

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -30,8 +30,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -26,15 +26,15 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -30,8 +30,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -28,6 +28,20 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ]
+  },
   "files": [
     "dist/"
   ],

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -30,8 +30,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -26,15 +26,15 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -64,22 +64,22 @@
   ],
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./admin": {
+      "@strapi/source": "./src/admin.ts",
       "types": "./dist/admin.d.ts",
-      "source": "./src/admin.ts",
       "import": "./dist/admin.mjs",
       "require": "./dist/admin.js",
       "default": "./dist/admin.js"
     },
     "./admin/test": {
+      "@strapi/source": "./src/admin-test.ts",
       "types": "./dist/admin-test.d.ts",
-      "source": "./src/admin-test.ts",
       "import": "./dist/admin-test.mjs",
       "require": "./dist/admin-test.js",
       "default": "./dist/admin-test.js"

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -32,8 +32,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -39,6 +39,10 @@
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ],
     "./*": "./*"
   },
   "files": [

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -26,22 +26,22 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./_internal/shared": {
+      "@strapi/source": "./shared/index.ts",
       "types": "./dist/shared/index.d.ts",
-      "source": "./shared/index.ts",
       "import": "./dist/shared/index.mjs",
       "require": "./dist/shared/index.js",
       "default": "./dist/shared/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -32,6 +32,20 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": [
+      "./dist/*.js",
+      "./dist/*/index.js"
+    ]
+  },
   "files": [
     "dist/"
   ],

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -34,8 +34,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -32,6 +32,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -34,8 +34,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -26,8 +26,8 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -26,15 +26,15 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -26,15 +26,15 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -26,15 +26,15 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -26,15 +26,15 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -26,15 +26,15 @@
   ],
   "exports": {
     "./strapi-admin": {
+      "@strapi/source": "./admin/src/index.ts",
       "types": "./dist/admin/src/index.d.ts",
-      "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
+      "@strapi/source": "./server/src/index.ts",
       "types": "./dist/server/src/index.d.ts",
-      "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -26,13 +26,13 @@
   ],
   "exports": {
     "./strapi-admin": {
-      "source": "./admin/src/index.js",
+      "@strapi/source": "./admin/src/index.js",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
-      "source": "./server/src/index.js",
+      "@strapi/source": "./server/src/index.js",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",
       "default": "./dist/server/index.js"

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -31,8 +31,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -29,6 +29,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -33,6 +33,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -35,8 +35,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -48,11 +48,13 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./utils": {
+      "@strapi/source": "./src/utils/index.ts",
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.mjs",
       "require": "./dist/utils/index.js"

--- a/packages/providers/email-sendgrid/package.json
+++ b/packages/providers/email-sendgrid/package.json
@@ -33,6 +33,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/email-sendgrid/package.json
+++ b/packages/providers/email-sendgrid/package.json
@@ -35,8 +35,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -32,6 +32,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -34,8 +34,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -34,6 +34,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -36,8 +36,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/providers/upload-cloudinary/package.json
+++ b/packages/providers/upload-cloudinary/package.json
@@ -33,6 +33,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/upload-cloudinary/package.json
+++ b/packages/providers/upload-cloudinary/package.json
@@ -35,8 +35,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -32,6 +32,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -34,8 +34,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/utils/logger/package.json
+++ b/packages/utils/logger/package.json
@@ -28,6 +28,16 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/utils/logger/package.json
+++ b/packages/utils/logger/package.json
@@ -30,8 +30,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -32,6 +32,17 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./tsconfigs/*": "./tsconfigs/*",
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/",
     "tsconfigs/"

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -34,8 +34,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -34,8 +34,8 @@
   ],
   "exports": {
     ".": {
+      "@strapi/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
-      "source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"


### PR DESCRIPTION
> **Stacked on #27493.** Because GitHub requires the base branch to live in `strapi/strapi`, this PR targets `develop` and therefore shows #27493's commit too. Only the second commit — `fix(packages): namespace the source export condition as @strapi/source` — is new here. Merge #27493 first and this diff collapses to that one commit.

### What does it do?

Renames the `source` export condition to `@strapi/source` across the 36 published packages that declare one, and moves it ahead of `types` in each conditions object.

```diff
   "./strapi-admin": {
+    "@strapi/source": "./admin/src/index.ts",
     "types": "./dist/admin/src/index.d.ts",
-    "source": "./admin/src/index.ts",
     "import": "./dist/admin/index.mjs",
     "require": "./dist/admin/index.js",
     "default": "./dist/admin/index.js"
   },
```

Two related fixes ride along:

- **`@strapi/admin`'s `./strapi-server` source target was wrong** — it named `./server/src/index.js`, while the file on disk is `./server/src/index.ts`.
- **`@strapi/provider-email-nodemailer` had no source condition** — the only published package with an `exports` map that lacked one. It now declares it on `.` and `./utils`.

`oxlint-config` and `vitest-config` are untouched: both are private, have no build output, and their exports already point straight at the TypeScript sources. `create-strapi` is untouched for the same reason as in #27493 — a bin-only shim with no `exports` map at all.

### Why is it needed?

**The generic name is a hazard for consumers.** Every one of the 36 packages carrying the condition ships `"files": ["dist/"]`:

```
packages with a source condition:        36
packages whose `files` includes src/:     0
```

So in the published tarball `"source": "./src/index.ts"` names a path that does not exist. The condition is not merely unused downstream — it is actively wrong. A consumer whose bundler enables the generic `source` condition (`resolve.conditions: ['source']` is a common Vite setup, and several build tools accept it) gets a resolution failure from every Strapi package instead of falling through to `import`/`require`.

Namespacing it follows [Node's guidance for community conditions](https://nodejs.org/api/packages.html#community-conditions-definitions) and means no generic condition name matches any more. Inside the monorepo it still resolves through the workspace symlinks, so tooling that opts in explicitly keeps working.

**The ordering made it unreachable when it mattered.** Export targets are matched in key order, and TypeScript only falls through to a later condition when the matched target is missing from disk. With `types` listed first, the source entry was reachable only in a tree that had never been built:

```
# stale dist/index.d.ts present, condition listed after `types`
@strapi/utils → packages/core/utils/dist/index.d.ts

# same tree, condition listed first
@strapi/utils → packages/core/utils/src/index.ts
```

**What will use it (follow-up, not this PR).** Nothing in the tree enables the condition today — this PR is a manifest change only. The motivating consumer is a `customConditions: ["@strapi/source"]` typecheck configuration, which lets `tsc` resolve workspace dependencies to their TypeScript sources and so run without a prior `yarn build`.

That work is not ready. Pointing consumers at dependency sources means dependency files get checked under the *consumer's* `compilerOptions`, which surfaces ~2.5k errors today. Three things need fixing first, each worth doing on its own merits:

- **`declare const strapi: any` shims** in `@strapi/utils`, `@strapi/database` and `@strapi/permissions` (`src/global.d.ts` in each) switch off type checking for every `strapi.*` call in those packages — none of the three declares `@strapi/types` as a dependency. Swapping them for the real global exposes 7 genuine errors, e.g. `strapi.getModel(uid)` passing a `string` where `UID.Schema` is required, and `strapi.store.get()` results being treated as an array. `@strapi/database`'s `declare var strapi: any` is also outright incompatible with `@strapi/types`' `var strapi: Strapi`.
- **Server code reaching the admin React entry.** Three `import type` lines — `Permission`, `FieldContentSourceMap`, `SanitizedAdminUser` — pull all of `admin/admin/src` into server programs, because `@strapi/admin` exposes no server-safe path to its `shared/contracts` types. Separately, `@strapi/strapi` keeps its front-end entries (`src/admin.ts`, `src/admin-test.ts`) under a single Node `tsconfig`, with wildcard `declare module '@strapi/*/strapi-admin'` shims typing every plugin admin entry as `any`.
- **Per-package `custom.d.ts` ambients** (`Window.strapi`, the slate `CustomTypes` augmentation, asset module shims) live only in each package's own `include`, so they disappear the moment a consumer compiles that package's source.

The rename stands on its own regardless of whether that follow-up lands — the published condition is wrong as it is.

### How to test it?

The change is inert to every resolver the repo actually uses — nothing enables the condition: `@rollup/plugin-node-resolve`, Vite, and Jest (`customExportConditions: ['']` in `jest-preset.front.js`) all use condition sets that never contained `source`, and nothing under `scripts/` or `tests/` configures resolution conditions.

Node ignores the new name safely rather than rejecting the manifest:

```console
$ node -e 'require.resolve("@strapi/utils")'
MODULE_NOT_FOUND … Cannot find module '…/node_modules/@strapi/utils/dist/index.js'   # unbuilt tree; not a package-config error

$ node --conditions=@strapi/source -e 'console.log(require.resolve("@strapi/utils"))'
…/packages/core/utils/src/index.ts
```

And with the condition enabled, resolution reaches source even when a built `dist/` is present:

```console
$ tsc -p packages/core/database/tsconfig.json --noEmit --customConditions '@strapi/source' --traceResolution
Resolved under condition '@strapi/source'.
Module name '@strapi/utils' was successfully resolved to '…/packages/core/utils/src/index.ts'
```

`yarn version:check` and `yarn prettier:check` are clean.

### Related issue(s)/PR(s)

Stacked on #27493.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJkupUUvwwgQj7VEbMiYfL
