### PR TITLE
fix(upload): bound the focal point fields to the crop area

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
@@ -457,10 +457,15 @@ export const AssetCropEditor = ({
   };
 
   /**
-   * Forces the focal fields to redisplay the state on blur.
+   * Forces a focal field to redisplay the state on blur.
+   *
+   * One key per axis: a shared key remounted both fields, so tabbing out of X
+   * destroyed Y before it could take focus and it was unreachable by keyboard.
    */
-  const [focalFieldKey, setFocalFieldKey] = React.useState(0);
-  const syncFocalFields = () => setFocalFieldKey((key) => key + 1);
+  const [focalXKey, setFocalXKey] = React.useState(0);
+  const [focalYKey, setFocalYKey] = React.useState(0);
+  const syncFocalX = () => setFocalXKey((key) => key + 1);
+  const syncFocalY = () => setFocalYKey((key) => key + 1);
 
   const cropPercents =
     naturalSize.width && naturalSize.height
@@ -685,14 +690,14 @@ export const AssetCropEditor = ({
                         id: getTranslationKey('asset-details.crop.focal-x'),
                         defaultMessage: 'Focal point X (px)',
                       })}
-                      key={`focal-x-${focalFieldKey}`}
+                      key={`focal-x-${focalXKey}`}
                       value={focalPxX}
                       min={0}
                       max={width || undefined}
                       onValueChange={(next) => {
                         if (next !== undefined) setFocalPx('x', next);
                       }}
-                      onBlur={syncFocalFields}
+                      onBlur={syncFocalX}
                     />
                   </FieldRow>
                   <FieldRow name="focal-y" gap={2}>
@@ -707,14 +712,14 @@ export const AssetCropEditor = ({
                         id: getTranslationKey('asset-details.crop.focal-y'),
                         defaultMessage: 'Focal point Y (px)',
                       })}
-                      key={`focal-y-${focalFieldKey}`}
+                      key={`focal-y-${focalYKey}`}
                       value={focalPxY}
                       min={0}
                       max={height || undefined}
                       onValueChange={(next) => {
                         if (next !== undefined) setFocalPx('y', next);
                       }}
-                      onBlur={syncFocalFields}
+                      onBlur={syncFocalY}
                     />
                   </FieldRow>
                 </Flex>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/AssetCropEditor.tsx
@@ -456,6 +456,12 @@ export const AssetCropEditor = ({
     setFocal((prev) => ({ ...prev, [axis]: Math.round(pct) }));
   };
 
+  /**
+   * Forces the focal fields to redisplay the state on blur.
+   */
+  const [focalFieldKey, setFocalFieldKey] = React.useState(0);
+  const syncFocalFields = () => setFocalFieldKey((key) => key + 1);
+
   const cropPercents =
     naturalSize.width && naturalSize.height
       ? {
@@ -679,10 +685,14 @@ export const AssetCropEditor = ({
                         id: getTranslationKey('asset-details.crop.focal-x'),
                         defaultMessage: 'Focal point X (px)',
                       })}
+                      key={`focal-x-${focalFieldKey}`}
                       value={focalPxX}
+                      min={0}
+                      max={width || undefined}
                       onValueChange={(next) => {
                         if (next !== undefined) setFocalPx('x', next);
                       }}
+                      onBlur={syncFocalFields}
                     />
                   </FieldRow>
                   <FieldRow name="focal-y" gap={2}>
@@ -697,10 +707,14 @@ export const AssetCropEditor = ({
                         id: getTranslationKey('asset-details.crop.focal-y'),
                         defaultMessage: 'Focal point Y (px)',
                       })}
+                      key={`focal-y-${focalFieldKey}`}
                       value={focalPxY}
+                      min={0}
+                      max={height || undefined}
                       onValueChange={(next) => {
                         if (next !== undefined) setFocalPx('y', next);
                       }}
+                      onBlur={syncFocalFields}
                     />
                   </FieldRow>
                 </Flex>

--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetDetails/tests/AssetCropEditor.test.tsx
@@ -138,6 +138,82 @@ describe('AssetCropEditor focus on open', () => {
   });
 });
 
+describe('AssetCropEditor focal point bounds', () => {
+  it('bounds the focal inputs to the crop, so an out-of-range value cannot be typed', async () => {
+    await renderEditor();
+
+    // The fields display pixels of the current crop area while the stored value
+    // is a percentage, so an unbounded field silently relocated the focal point
+    // to an edge: 320 on a 600px-tall crop clamped to y: 100 with no feedback.
+    // The numeric panel is hidden below the tablet breakpoint and jsdom matches
+    // no media query, so these are out of the accessibility tree — queried by
+    // label rather than by role.
+    const focalY = screen.getByLabelText('Focal point Y (px)');
+    const focalX = screen.getByLabelText('Focal point X (px)');
+
+    expect(focalY).toHaveAttribute('max', String(NATURAL.height));
+    expect(focalY).toHaveAttribute('min', '0');
+    expect(focalX).toHaveAttribute('max', String(NATURAL.width));
+    expect(focalX).toHaveAttribute('min', '0');
+  });
+});
+
+describe('AssetCropEditor focal point bounds', () => {
+  it('advertises the crop as the focal inputs range', async () => {
+    await renderEditor();
+
+    // The numeric panel is hidden below the tablet breakpoint and jsdom matches
+    // no media query, so these are out of the accessibility tree — queried by
+    // label rather than by role.
+    const focalY = screen.getByLabelText('Focal point Y (px)');
+    const focalX = screen.getByLabelText('Focal point X (px)');
+
+    // Bounds are the crop's dimensions, not the file's — the displayed pixels
+    // are relative to the crop area.
+    expect(focalX).toHaveAttribute('min', '0');
+    expect(focalX).toHaveAttribute('max', String(NATURAL.width));
+    expect(focalY).toHaveAttribute('min', '0');
+    expect(focalY).toHaveAttribute('max', String(NATURAL.height));
+  });
+
+  it('corrects an out-of-range entry to the edge it was clamped to', async () => {
+    const { focalHandle } = await renderEditor();
+
+    fireEvent.change(screen.getByLabelText('Focal point Y (px)'), {
+      target: { value: '9999' },
+    });
+    fireEvent.blur(screen.getByLabelText('Focal point Y (px)'));
+
+    // The stored focal point is a percentage and was already clamped to the
+    // bottom edge; before this fix the field kept showing the typed number
+    // (reformatted to "9,999"), so the user never saw that it had not been
+    // honoured. Re-queried because the field remounts to drop its edit string.
+    expect(screen.getByLabelText('Focal point Y (px)')).toHaveValue('600');
+    expect(focalHandle).toHaveStyle({ top: '100%' });
+  });
+
+  it('leaves an in-range entry alone', async () => {
+    const { focalHandle } = await renderEditor();
+
+    fireEvent.change(screen.getByLabelText('Focal point Y (px)'), {
+      target: { value: '150' },
+    });
+    fireEvent.blur(screen.getByLabelText('Focal point Y (px)'));
+
+    // 150 of 600 is 25%, which round-trips back to the same pixel.
+    expect(screen.getByLabelText('Focal point Y (px)')).toHaveValue('150');
+    expect(focalHandle).toHaveStyle({ top: '25%' });
+  });
+
+  it('moves the bound with the crop rather than the original file', async () => {
+    await renderEditor();
+
+    fireEvent.change(screen.getByLabelText('Height (px)'), { target: { value: '150' } });
+
+    expect(screen.getByLabelText('Focal point Y (px)')).toHaveAttribute('max', '150');
+  });
+});
+
 describe('AssetCropEditor pointer drags', () => {
   it('follows the pointer for the whole focal-point drag', async () => {
     const { focalHandle } = await renderEditor();

--- a/packages/core/upload/server/src/controllers/validation/__tests__/upload-focal-point.test.ts
+++ b/packages/core/upload/server/src/controllers/validation/__tests__/upload-focal-point.test.ts
@@ -1,0 +1,40 @@
+import { validateUploadBody as validateAdminUploadBody } from '../admin/upload';
+import { validateUploadBody as validateContentApiUploadBody } from '../content-api/upload';
+
+/**
+ * The focal point is stored as a percentage of the image, so 0–100 is the whole
+ * valid range. The admin panel clamps to it before submitting, which means these
+ * bounds are the only thing standing between a hand-rolled request and an
+ * out-of-range value reaching the database.
+ */
+describe.each([
+  ['admin', validateAdminUploadBody],
+  ['content-api', validateContentApiUploadBody],
+])('%s upload validation — focal point bounds', (_name, validateUploadBody) => {
+  const withFocalPoint = (focalPoint: unknown) => ({ fileInfo: { focalPoint } });
+
+  it('accepts both ends of the range', async () => {
+    await expect(validateUploadBody(withFocalPoint({ x: 0, y: 0 }))).resolves.toBeTruthy();
+    await expect(validateUploadBody(withFocalPoint({ x: 100, y: 100 }))).resolves.toBeTruthy();
+  });
+
+  it('rejects a value past the far edge', async () => {
+    await expect(validateUploadBody(withFocalPoint({ x: 50, y: 101 }))).rejects.toThrow();
+    await expect(validateUploadBody(withFocalPoint({ x: 101, y: 50 }))).rejects.toThrow();
+  });
+
+  it('rejects a negative value', async () => {
+    await expect(validateUploadBody(withFocalPoint({ x: -1, y: 50 }))).rejects.toThrow();
+    await expect(validateUploadBody(withFocalPoint({ x: 50, y: -1 }))).rejects.toThrow();
+  });
+
+  it('requires both axes once a focal point is given', async () => {
+    await expect(validateUploadBody(withFocalPoint({ x: 50 }))).rejects.toThrow();
+    await expect(validateUploadBody(withFocalPoint({ y: 50 }))).rejects.toThrow();
+  });
+
+  it('accepts no focal point at all', async () => {
+    await expect(validateUploadBody(withFocalPoint(null))).resolves.toBeTruthy();
+    await expect(validateUploadBody({ fileInfo: {} })).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
### What does it do?

Stops the Crop & Focus focal point fields showing a value that was never saved.

- **The fields now redisplay the stored value on blur.** Typing `9999` into the focal Y of a 600px-tall crop now corrects the field to `600` when you leave it, matching the focal point that was actually stored.
- **`min`/`max` added, bounded to the crop** — `max={width}` / `max={height}`, not the original file's dimensions, since the displayed pixels are relative to the current crop area. The bound moves with the crop rectangle.

**The `min`/`max` attributes are not what fixes this.** I added them first and then checked the behaviour: the design system's `NumberInput` renders as `type="text"`, so the browser applies no range constraint. With the attributes in place, typing `9999` still left `9999` on screen and `validity.rangeOverflow` was `false`. Blur did not help either — the field reformatted to `"9,999"` and kept it, because it caches its own edit string and stops following `value` once typed into, even though the prop had legitimately changed from `300` to `600`.

What fixes it is remounting the two fields on blur (a `key` bumped from `onBlur`), which discards that cached string and forces a redisplay of the real state. The attributes stay because they communicate the range to assistive tech and native form validation, but they carry none of the behaviour.

Blur rather than per keystroke, deliberately: typing `9999` on a 600px crop passes the bound at `999`, so clamping while typing would remount mid-entry and take the focus with it.

**Beyond the ticket:** the ticket flagged two test gaps and this closes both. The second is server-side — `focalPoint`'s `min(0).max(100)` in the admin *and* content-api schemas had no test at all, so `packages/core/upload/server/.../validation/__tests__/upload-focal-point.test.ts` is new. No server behaviour changed.

### Why is it needed?

The focal point X/Y fields accepted any number with no bound tied to the image. On a 200×150 crop, typing `320` into Y was accepted with no error, and the saved focal point came back as `{"x":38,"y":100}` — clamped to the bottom edge, nowhere near where the number pointed. `9999` was accepted too and rendered as `9,999`.

The clamp itself is correct and is what keeps the stored data valid — server validation constrains x and y to 0–100 and the client clamps to the same range before submitting, so nothing invalid is persisted. The defect was purely feedback: the field kept showing a number it had no intention of honouring, so a typo silently relocated the focal point with no indication.

Two things made it worse than a plain missing `max`: the inputs are in pixels while the stored value is a percentage, and the pixel range is the crop area rather than the natural image, so any bound has to track the crop.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

1. Open any image's details drawer, click **Crop**.
2. Set width `200`, height `150`, click **Apply**. The image is now 200×150.
3. Open **Crop** again. The focal point fields show X and Y in pixels.
4. Type `320` into focal **Y**, then click elsewhere to blur the field. It should correct itself to `150` — the bottom edge, which is what gets stored.
5. Type an in-range value such as `75` and blur. It should stay `75`, and the focal handle should move to the matching position on the image.
6. Change the crop height while the panel is open, then check the focal Y field's `max` has followed it (inspect the element) rather than staying on the original file's height.
7. Click **Apply** and inspect the `focal_point` column of the `files` table — the stored percentage should match the position shown, with no gap between them.

Automated:

```bash
yarn nx test:front @strapi/upload     # 151 suites / 1297 tests
yarn nx test:unit @strapi/upload      # 26 suites / 277 tests
```

4 new front tests (bounds advertised, out-of-range corrected on blur, in-range left alone, bound follows the crop) and 10 new server tests run against both schemas (both ends of the range, past the far edge, negative, both axes required, no focal point at all).

Each was checked against a deliberately broken version: removing the blur resync (the original bug), a key that never changes, bounding to the file instead of the crop, dropping `min`/`max` (3 failures), and dropping the server's `max(100)`. All fail.

### Not addressed here

The ticket floats showing **percent instead of pixels**, which would remove the unit mismatch at its root — percent is what is stored, what the clamp applies to, and what stays meaningful across crops. That is a UX change and needs design input, so it is deliberately left out.

Rounding drift is handled by holding the typed value until blur, which is one of the options the ticket offered.

### Related issue(s)/PR(s)

fix CMS-1624

🚀