### PR TITLE
fix(upload): repair the typecheck on develop after two merges collided

### DIFF
--- a/packages/core/upload/admin/src/future/store/tests/uploadProgress.test.ts
+++ b/packages/core/upload/admin/src/future/store/tests/uploadProgress.test.ts
@@ -326,7 +326,12 @@ describe('uploadProgress slice', () => {
       );
       const firstDone = uploadProgressReducer(
         uploading,
-        setFileComplete({ uploadId: opened.uploadId, index: 0, file: { id: 1 } as never })
+        setFileComplete({
+          uploadId: opened.uploadId,
+          index: 0,
+          file: { id: 1 } as never,
+          completedAt: 1000,
+        })
       );
 
       expect(firstDone.files[0].uploadedBytes).toBe(1000);
@@ -381,14 +386,24 @@ describe('uploadProgress slice', () => {
       );
       state = uploadProgressReducer(
         state,
-        setFileComplete({ uploadId: state.uploadId, index: 0, file: { id: 1 } as never })
+        setFileComplete({
+          uploadId: state.uploadId,
+          index: 0,
+          file: { id: 1 } as never,
+          completedAt: 1000,
+        })
       );
       expect(countBased(state)).toBe(33);
 
       // Second lands → 67%.
       state = uploadProgressReducer(
         state,
-        setFileComplete({ uploadId: state.uploadId, index: 1, file: { id: 2 } as never })
+        setFileComplete({
+          uploadId: state.uploadId,
+          index: 1,
+          file: { id: 2 } as never,
+          completedAt: 1000,
+        })
       );
       expect(countBased(state)).toBe(67);
     });


### PR DESCRIPTION
### What does it do?

Adds the required `completedAt` field to the three `setFileComplete` calls in `store/tests/uploadProgress.test.ts` that were missing it.

### Why is it needed?

`yarn nx test:ts:front @strapi/upload` currently fails on `develop` with three errors:

```
uploadProgress.test.ts(329,25): error TS2345: Property 'completedAt' is missing in type
'{ uploadId: number; index: number; file: never; }' but required in type
'{ index: number; file: File; uploadId: number; completedAt: number; }'
```

`completedAt` became required on the `setFileComplete` payload in #27456, where it decides when a completed upload stops being placed into the asset list. #27463 added these three call sites against the earlier signature. Both PRs passed CI in isolation — neither branch contained the other's change — so the typecheck only broke once the second one merged.

The type is left as-is rather than made optional. That field is what stops an uploaded asset being re-inserted after it has been deleted or moved; a dispatch site that omitted it would silently disable that and bring back the bug #27456 fixed. Required is correct — the tests were simply written against the older shape.

### How to test it?

```bash
yarn nx test:ts:front @strapi/upload   # green on this branch, three errors on develop
yarn nx test:front @strapi/upload      # 151 suites / 1292 tests
```

### Related issue(s)/PR(s)

N/A