### PR TITLE
fix(security): prevent XSS via GuidedTour content rendering

### DIFF
--- a/packages/core/admin/admin/src/components/GuidedTour/Steps/Step.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Steps/Step.tsx
@@ -251,20 +251,20 @@ const createStepComponents = (tourName: ValidTourName): Step => ({
     const { formatMessage } = useIntl();
     let content = '';
     if (!('children' in props)) {
-      content = formatMessage({
-        id: props.id,
-        defaultMessage: props.defaultMessage,
-      });
+      // Use FormattedMessage for safe rendering (avoids dangerouslySetInnerHTML / XSS)
+      return (
+        <Box paddingBottom={5} paddingLeft={5} paddingRight={5} width="100%">
+          <ContentContainer>
+            <Typography tag="div" variant="omega">
+              <FormattedMessage id={props.id} defaultMessage={props.defaultMessage} values={props.values} />
+            </Typography>
+          </ContentContainer>
+        </Box>
+      );
     }
     return (
       <Box paddingBottom={5} paddingLeft={5} paddingRight={5} width="100%">
-        {'children' in props ? (
-          props.children
-        ) : (
-          <ContentContainer>
-            <Typography tag="div" variant="omega" dangerouslySetInnerHTML={{ __html: content }} />
-          </ContentContainer>
-        )}
+        {props.children}
       </Box>
     );
   },


### PR DESCRIPTION
## Summary
Fixes Cross-Site Scripting (XSS) via `dangerouslySetInnerHTML`.

**CVSS: 5.4 Medium** `CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:N` (CWE-79)

## Vulnerability
`packages/core/admin/admin/src/components/GuidedTour/Steps/Step.tsx:265`:
```tsx
<Typography dangerouslySetInnerHTML={{ __html: content }} />
```
where `content = formatMessage({id, defaultMessage})`. `formatMessage` returns HTML-escaped but translation files (`*.json`) are user-controlled (contributor, marketplace, or compromised i18n). An attacker who controls a translation string can inject:

```json
"tours.content": "Hello <img src=x onerror=alert(document.cookie)>"
```

Rendered unsanitized -> XSS in admin (victim must view Guided Tour, low privilege attacker can poison translations).

Semgrep `react-dangerouslysetinnerhtml`.

## Fix
Replace `dangerouslySetInnerHTML` with safe `FormattedMessage` rendering:

```tsx
<Typography><FormattedMessage id={props.id} defaultMessage={props.defaultMessage} values={props.values} /></Typography>
```

Preserves i18n `values` interpolation safely; no HTML bypass. For `children` case, render directly.

## Testing
- GuidedTour still renders translations
- `yarn test:front` passes

Target: `develop`