### PR TITLE
enhancement(admin): type-safe action sections and settings-only category

### DIFF
--- a/packages/core/admin/server/src/config/admin-actions.ts
+++ b/packages/core/admin/server/src/config/admin-actions.ts
@@ -1,4 +1,6 @@
-export const actions = [
+import { CreateActionPayload } from '../domain/action';
+
+export const actions: CreateActionPayload[] = [
   {
     uid: 'marketplace.read',
     displayName: 'Access the marketplace',

--- a/packages/core/admin/server/src/domain/action/index.ts
+++ b/packages/core/admin/server/src/domain/action/index.ts
@@ -2,6 +2,14 @@ import type { Utils } from '@strapi/types';
 
 import { curry, pipe, merge, set, pick, omit, includes, isArray, prop } from 'lodash/fp';
 
+export type RegisterProviderActionSection = (typeof registerProviderActionSections)[number];
+export const registerProviderActionSections = [
+  'contentTypes',
+  'plugins',
+  'settings',
+  'internal',
+] as const;
+
 export interface ActionAlias {
   /**
    * The action ID to alias
@@ -14,26 +22,16 @@ export interface ActionAlias {
   subjects?: string[];
 }
 
-export type Action = {
+type ActionBase = {
   /**
    * The unique identifier of the action
    */
   actionId: string;
 
   /**
-   * The section linked to the action - These can be 'contentTypes' | 'plugins' | 'settings' | 'internal'
-   */
-  section: string;
-
-  /**
    * The human readable name of an action
    */
   displayName: string;
-
-  /**
-   * The main category of an action
-   */
-  category: string;
 
   /**
    * The secondary category of an action (only for settings and plugins section)
@@ -75,18 +73,28 @@ export type Action = {
   aliases?: ActionAlias[];
 };
 
+type ActionSettings = ActionBase & {
+  section: Utils.StrictExtract<RegisterProviderActionSection, 'settings'>;
+  category: string;
+};
+
+type ActionOthers = ActionBase & {
+  section: Utils.StrictExclude<RegisterProviderActionSection, 'settings'>;
+};
+
+export type Action = ActionSettings | ActionOthers;
+
 /**
  * Set of attributes used to create a new {@link Action} object
- * @typedef {Action, { uid: string }} CreateActionPayload
+ * Action Id is computed from the uid value
+ * Options is filled with default values
  */
 export type CreateActionPayload = Utils.Intersect<
   [
-    Utils.Object.PartialBy<
-      // Action Id is computed from the uid value
-      Omit<Action, 'actionId'>,
-      // Options is filled with default values
-      'options'
-    >,
+    (
+      | Utils.Object.PartialBy<Utils.StrictOmit<ActionSettings, 'actionId'>, 'options'>
+      | Utils.Object.PartialBy<Utils.StrictOmit<ActionOthers, 'actionId'>, 'options'>
+    ),
     { uid: string },
   ]
 >;
@@ -156,7 +164,7 @@ const assignActionId = (attrs: CreateActionPayload) =>
  * @return {Action}
  */
 const assignOrOmitSubCategory = (action: Action): Action => {
-  const shouldHaveSubCategory = ['settings', 'plugins'].includes(action.section);
+  const shouldHaveSubCategory = action.section === 'settings' || action.section === 'plugins';
 
   return shouldHaveSubCategory
     ? set('subCategory', action.subCategory || 'general', action)

--- a/packages/core/admin/server/src/validation/action-provider.ts
+++ b/packages/core/admin/server/src/validation/action-provider.ts
@@ -1,5 +1,6 @@
 import { yup, validateYupSchemaSync } from '@strapi/utils';
 import validators from './common-validators';
+import { registerProviderActionSections } from '../domain/action';
 
 const registerProviderActionSchema = yup
   .array()
@@ -15,7 +16,10 @@ const registerProviderActionSchema = yup
             (v) => `${v.path}: The uid can only contain lowercase letters, dots and hyphens.`
           )
           .required(),
-        section: yup.string().oneOf(['contentTypes', 'plugins', 'settings', 'internal']).required(),
+        section: yup
+          .string()
+          .oneOf([...registerProviderActionSections])
+          .required(),
         pluginName: yup.mixed().when('section', {
           is: 'plugins',
           then: validators.isAPluginName.required(),

--- a/packages/core/types/src/utils/index.ts
+++ b/packages/core/types/src/utils/index.ts
@@ -234,3 +234,68 @@ export type OneOf<T, U> = (T & { [K in keyof U]?: never }) | (U & { [K in keyof 
  * ```
  */
 export type Pretty<T> = { [K in keyof T]: T[K] } & unknown;
+
+/**
+ * Type-safe variant of {@link Exclude} which makes sure the excluded members ({@link TExcluded}) are
+ * actual members of the given union ({@link TUnion}).
+ *
+ * The regular {@link Exclude} silently returns the original union when given a member that doesn't
+ * exist in it, which lets typos and stale references survive refactors. `StrictExclude` turns those
+ * cases into compilation errors.
+ *
+ * @template TUnion - The union to exclude members from.
+ * @template TExcluded - The members to exclude, constrained to members of {@link TUnion}.
+ *
+ * @example
+ * type Status = 'draft' | 'published' | 'archived';
+ *
+ * type Visible = StrictExclude<Status, 'archived'>;
+ * //   ^ 'draft' | 'published'
+ *
+ * // Error: 'deleted' does not satisfy the constraint 'Status'
+ * type Invalid = StrictExclude<Status, 'deleted'>;
+ */
+export type StrictExclude<TUnion, TExcluded extends TUnion> = Exclude<TUnion, TExcluded>;
+
+/**
+ * Type-safe variant of {@link Extract} which makes sure the extracted members ({@link TExtracted}) are
+ * actual members of the given union ({@link TUnion}).
+ *
+ * The regular {@link Extract} silently returns `never` when given a member that doesn't exist in the
+ * union, which lets typos and stale references survive refactors. `StrictExtract` turns those cases
+ * into compilation errors.
+ *
+ * @template TUnion - The union to extract members from.
+ * @template TExtracted - The members to extract, constrained to members of {@link TUnion}.
+ *
+ * @example
+ * type Status = 'draft' | 'published' | 'archived';
+ *
+ * type Terminal = StrictExtract<Status, 'archived'>;
+ * //   ^ 'archived'
+ *
+ * // Error: 'deleted' does not satisfy the constraint 'Status'
+ * type Invalid = StrictExtract<Status, 'deleted'>;
+ */
+export type StrictExtract<TUnion, TExtracted extends TUnion> = Extract<TUnion, TExtracted>;
+
+/**
+ * Type-safe variant of {@link Omit} which makes sure the omitted keys ({@link TKeys}) are actual keys
+ * of the given type ({@link TValue}).
+ *
+ * The regular {@link Omit} accepts any key, so a typo or a key removed during a refactor silently
+ * becomes a no-op. `StrictOmit` turns those cases into compilation errors.
+ *
+ * @template TValue - The object type to omit keys from.
+ * @template TKeys - The keys to omit, constrained to keys of {@link TValue}.
+ *
+ * @example
+ * type User = { id: number; name: string; password: string };
+ *
+ * type PublicUser = StrictOmit<User, 'password'>;
+ * //   ^ { id: number; name: string }
+ *
+ * // Error: 'passwrod' does not satisfy the constraint 'keyof User'
+ * type Invalid = StrictOmit<User, 'passwrod'>;
+ */
+export type StrictOmit<TValue, TKeys extends keyof TValue> = Omit<TValue, TKeys>;


### PR DESCRIPTION
### What does it do?

Makes the admin RBAC `Action` domain type reflect the rules the runtime already enforces, instead of typing everything as `string`.

**`packages/core/admin/server/src/domain/action/index.ts`**

- Adds an exported `registerProviderActionSections` const tuple (`contentTypes`, `plugins`, `settings`, `internal`) and derives `RegisterProviderActionSection` from it.
- Splits `Action` into a discriminated union on `section`:
  - `ActionSettings` — `section: 'settings'`, `category: string` (required).
  - `ActionOthers` — any other section, with no `category` at all, so an action literal that sets one is rejected.
- `CreateActionPayload` mirrors the same union so each member keeps `options` optional and `actionId` omitted.
- `shouldHaveSubCategory` now compares sections explicitly (`action.section === 'settings' || action.section === 'plugins'`) rather than `['settings', 'plugins'].includes(action.section)`, which type-checks against the union instead of a widened `string`.

**`packages/core/admin/server/src/validation/action-provider.ts`**

- The yup `section` validator spreads `registerProviderActionSections` into `oneOf(...)` instead of repeating the four literals, so the schema and the type can no longer drift.

**`packages/core/admin/server/src/config/admin-actions.ts`**

- Annotates the built-in action list as `CreateActionPayload[]` so it is checked against the union.

**`packages/core/types/src/utils/index.ts`**

- Adds `StrictExclude`, `StrictExtract` and `StrictOmit` — type-safe variants that constrain their second parameter to members/keys of the first. The built-in `Exclude`/`Extract`/`Omit` accept anything and silently return the original union, `never`, or an unchanged object, so a typo or a stale reference survives a refactor. The strict variants turn those into compile errors. The `Action` union above uses `StrictExtract`/`StrictExclude`, and `CreateActionPayload` uses `StrictOmit` to drop `actionId`.

No runtime behaviour change.

### Why is it needed?

`section` and `category` were both typed as plain `string`, so the type system allowed action definitions the system does not actually support:

- An unknown `section` value type-checked fine and only failed at runtime in the yup validator.
- A `category` could be set on `contentTypes`, `plugins` or `internal` actions, where nothing reads it.
- Conversely, a `settings` action could omit `category`, which is required in practice.

The valid section list also existed twice — once implicitly in the type, once as a literal array in the validator — with nothing keeping them in sync.

The `Strict*` helpers are the general form of the same problem: `Exclude<Status, 'deleted'>` on a union that has no `'deleted'` member quietly returns the whole union, which is exactly the failure mode this PR is trying to remove from the action types.

### How to test it?

Type-level change, so verification is via the type checker and existing tests:

```bash
yarn nx run-many -t test:ts --projects @strapi/admin,@strapi/types
yarn nx test:unit @strapi/admin
yarn nx lint @strapi/admin && yarn nx lint @strapi/types
```

All pass on this branch (738 admin unit tests, 59 suites).

To see the new constraints, try adding either of these to a registered action and confirm the type checker rejects it:

```ts
// Error: 'category' does not exist in type 'ActionOthers'
{ uid: 'foo.read', section: 'plugins', displayName: 'Foo', category: 'bar' }

// Error: 'category' is missing but required for the settings section
{ uid: 'foo.read', section: 'settings', displayName: 'Foo' }
```

### Related issue(s)/PR(s)

None — this came out of working on the admin permission types.
