### PR TITLE
fix(upload): filter the row replace picker by the asset's mime

### DIFF
--- a/packages/core/upload/admin/src/future/pages/Assets/components/AssetActionsMenu.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/AssetActionsMenu.tsx
@@ -209,6 +209,11 @@ export const AssetActionsMenu = ({ asset, dragData }: AssetActionsMenuProps) => 
         <input
           ref={fileInputRef}
           type="file"
+          // Replacing swaps the bytes of an existing asset, so the picker offers
+          // only its own type. Without this the picker accepted anything and a
+          // JPG could come back as PNG bytes still served under a `.jpg` url,
+          // since replace preserves hash and ext by design.
+          accept={asset.mime ?? ''}
           multiple={false}
           onChange={handleFileChange}
           aria-hidden

--- a/packages/core/upload/admin/src/future/pages/Assets/components/tests/AssetActionsMenu.test.tsx
+++ b/packages/core/upload/admin/src/future/pages/Assets/components/tests/AssetActionsMenu.test.tsx
@@ -225,6 +225,16 @@ describe('AssetActionsMenu', () => {
   });
 
   describe('Replace media', () => {
+    // Mirrors the drawer's own picker test: the two entry points call the same
+    // endpoint, and this one had drifted — its input carried no `accept`, so a
+    // JPG could be replaced with PNG bytes still served under a `.jpg` url.
+    it("offers only the asset's own type in the file picker", async () => {
+      setup();
+
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(document.querySelector('input[type="file"]')).toHaveAttribute('accept', 'image/png');
+    });
+
     it('warns before opening the file picker, and uploads the picked file against this asset', async () => {
       let uploadedId: string | null = null;
       let sentFileInfo: string | null = null;


### PR DESCRIPTION
### What does it do?

Adds the missing `accept` filter to the file input behind the row popover's **Replace media** action, in the new Media Library.

- `AssetActionsMenu.tsx` — `accept={asset.mime ?? ''}` on the hidden file input, matching the details drawer (`AssetDetailsDrawer.tsx`) and the legacy `ReplaceMediaButton.tsx`.
- `AssetActionsMenu.test.tsx` — asserts the input's `accept`, mirroring the drawer's own picker test.

The new Media Library has two replace entry points. Every other prop on the two inputs already matched; only `accept` had been dropped when the row-level flow was factored out.

### Why is it needed?

Replace swaps an asset's bytes but preserves its `hash` and `ext` by design. Without the filter the picker accepted any file, so replacing a JPG with a PNG left an asset whose `ext`/`url` contradicted its `mime` — PNG bytes served under a `.jpg` url.

Reproduced on `develop` (5.52.1), asset id 1311. `mime` correctly became `image/png` while `hash`, `ext` and `url` stayed `.jpg`; on disk `original_7e58827d1e.jpg` was `PNG image data, 640 x 480`.

The drawer path was already immune — it greys the PNG out. Only the row popover was affected.

### How to test it?

```bash
cd examples/getstarted && BETA_MEDIA_LIBRARY=true yarn develop
```

1. Upload a JPG to the Media Library.
2. From the row's **⋯ → Replace media**, confirm, and open the picker. A PNG is now greyed out; only JPEGs are selectable.
3. Compare with the details drawer's **Replace media** — same behaviour, as before.
4. Replace the JPG with another JPG and confirm replacement still works end to end (bytes swapped, name preserved).
5. `GET /api/upload/files` — `ext`, `url` and `mime` agree.

Automated:

```bash
yarn nx test:front @strapi/upload -- --testPathPattern 'AssetActionsMenu'   # 27 tests
```

The new test was checked against a deliberately broken version: removing `accept` fails it, and nothing else.

### Related issue(s)/PR(s)

fix CMS-1689

Sibling to #27501 (`fix CMS-1686`) — also the new-ML replace flow diverging from legacy, different file and different fix.
