### PR TITLE
fix(upload): unable to fetch or delete a file by its documentId via the content api

### DIFF
--- a/packages/core/upload/server/src/controllers/__tests__/content-api.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/content-api.test.ts
@@ -374,4 +374,76 @@ describe('Content API Controller - find / findPage', () => {
       expect(mockUploadService.replace).not.toHaveBeenCalled();
     });
   });
+
+  describe('findOne (GET /files/:id)', () => {
+    it('resolves a file by numeric id', async () => {
+      const file = { id: 1, name: 'a.png', url: '/uploads/a.png' };
+      mockContext.params = { id: '1' } as any;
+      mockUploadService.findOne.mockResolvedValue(file);
+
+      await buildController().findOne(mockContext);
+
+      expect(mockUploadService.findOne).toHaveBeenCalledWith('1', undefined);
+      expect(mockContext.body).toEqual(file);
+    });
+
+    it('resolves a file by documentId (regression for #24037)', async () => {
+      const documentId = 'qovkpekciob2wt8qyd51mg8k';
+      const file = { id: 1, documentId, name: 'a.png', url: '/uploads/a.png' };
+      mockContext.params = { id: documentId } as any;
+      mockUploadService.findOne.mockResolvedValue(file);
+
+      await buildController().findOne(mockContext);
+
+      expect(mockUploadService.findOne).toHaveBeenCalledWith(documentId, undefined);
+      expect(mockContext.body).toEqual(file);
+    });
+
+    it('returns notFound when the file does not exist', async () => {
+      mockContext.params = { id: 'qovkpekciob2wt8qyd51mg8k' } as any;
+      mockUploadService.findOne.mockResolvedValue(null);
+
+      await buildController().findOne(mockContext);
+
+      expect(mockContext.notFound).toHaveBeenCalledWith('file.notFound');
+    });
+  });
+
+  describe('destroy (DELETE /files/:id)', () => {
+    it('deletes a file by numeric id', async () => {
+      const file = { id: 1, name: 'a.png', url: '/uploads/a.png', provider: 'local' };
+      mockContext.params = { id: '1' } as any;
+      mockUploadService.findOne.mockResolvedValue(file);
+
+      await buildController().destroy(mockContext);
+
+      expect(mockUploadService.findOne).toHaveBeenCalledWith('1');
+      expect(mockUploadService.remove).toHaveBeenCalledWith(file);
+      expect(mockContext.body).toEqual(file);
+    });
+
+    it('deletes a file by documentId (regression for #24037)', async () => {
+      const documentId = 'qovkpekciob2wt8qyd51mg8k';
+      const file = { id: 1, documentId, name: 'a.png', url: '/uploads/a.png', provider: 'local' };
+      mockContext.params = { id: documentId } as any;
+      mockUploadService.findOne.mockResolvedValue(file);
+
+      await buildController().destroy(mockContext);
+
+      expect(mockUploadService.findOne).toHaveBeenCalledWith(documentId);
+      // remove receives the resolved file, so the underlying delete keys off the numeric id
+      expect(mockUploadService.remove).toHaveBeenCalledWith(file);
+      expect(mockContext.body).toEqual(file);
+    });
+
+    it('returns notFound and does not remove when the file does not exist', async () => {
+      mockContext.params = { id: 'qovkpekciob2wt8qyd51mg8k' } as any;
+      mockUploadService.findOne.mockResolvedValue(null);
+
+      await buildController().destroy(mockContext);
+
+      expect(mockContext.notFound).toHaveBeenCalledWith('file.notFound');
+      expect(mockUploadService.remove).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/upload/server/src/routes/content-api.ts
+++ b/packages/core/upload/server/src/routes/content-api.ts
@@ -52,7 +52,7 @@ const createRoutes = createContentApiRoutesFactory((): Core.RouterInput['routes'
       path: '/files/:id',
       handler: 'content-api.findOne',
       request: {
-        params: { id: validator.fileId },
+        params: { id: validator.fileIdentifier },
         query: {
           fields: validator.queryFields.optional(),
           populate: validator.queryPopulate.optional(),
@@ -65,7 +65,7 @@ const createRoutes = createContentApiRoutesFactory((): Core.RouterInput['routes'
       path: '/files/:id',
       handler: 'content-api.destroy',
       request: {
-        params: { id: validator.fileId },
+        params: { id: validator.fileIdentifier },
       },
       response: validator.file,
     },

--- a/packages/core/upload/server/src/routes/validation/upload.ts
+++ b/packages/core/upload/server/src/routes/validation/upload.ts
@@ -25,7 +25,8 @@ export class UploadRouteValidator extends AbstractRouteValidator {
   get file() {
     return z.object({
       id: this.fileId,
-      documentId: z.uuid(),
+      // documentId is a cuid2 (see `createDocumentId`), not a UUID.
+      documentId: z.string(),
       name: z.string(),
       alternativeText: z.string().nullable().optional(),
       caption: z.string().nullable().optional(),
@@ -90,6 +91,16 @@ export class UploadRouteValidator extends AbstractRouteValidator {
    */
   get fileId() {
     return z.number().int().positive();
+  }
+
+  /**
+   * File identifier path-param validation.
+   *
+   * Content-API file routes (`/files/:id`) accept either the numeric primary key
+   * or the string documentId, so the param is widened to allow both.
+   */
+  get fileIdentifier() {
+    return z.union([z.number().int().positive(), z.string().min(1)]);
   }
 
   /**

--- a/packages/core/upload/server/src/services/__tests__/upload/findOne.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/findOne.test.ts
@@ -1,0 +1,68 @@
+import createUploadService from '../../upload';
+import imageManipulation from '../../image-manipulation';
+import fileService from '../../file';
+
+const dbFile = { id: 1, documentId: 'qovkpekciob2wt8qyd51mg8k', name: 'a.png', provider: 'local' };
+
+const findOne = jest.fn().mockResolvedValue(dbFile);
+const transform = jest.fn().mockImplementation((_uid: string, query: any) => query);
+
+const buildStrapi = () =>
+  ({
+    plugins: {
+      upload: {
+        services: {
+          'image-manipulation': imageManipulation,
+          file: {
+            ...fileService,
+            signFileUrls: (file: unknown) => file,
+          },
+          metrics: { trackUsage: jest.fn() },
+        },
+      },
+    },
+    plugin: (name: string) => (global.strapi as any).plugins[name],
+    db: {
+      query: () => ({ findOne }),
+    },
+    get: () => ({ transform }),
+    getModel: () => ({ attributes: {} }),
+  }) as any;
+
+describe('findOne (id or documentId)', () => {
+  let uploadService: ReturnType<typeof createUploadService>;
+
+  beforeEach(() => {
+    findOne.mockClear().mockResolvedValue(dbFile);
+    transform.mockClear();
+    global.strapi = buildStrapi();
+    uploadService = createUploadService({ strapi: global.strapi } as any);
+  });
+
+  test('looks up by numeric id when given a number', async () => {
+    await uploadService.findOne(1);
+
+    const [{ where }] = findOne.mock.calls[0];
+    expect(where).toEqual({ id: 1 });
+  });
+
+  test('looks up by numeric id when given a numeric string (regression)', async () => {
+    await uploadService.findOne('1');
+
+    const [{ where }] = findOne.mock.calls[0];
+    expect(where).toEqual({ id: '1' });
+  });
+
+  test('looks up by documentId when given a non-numeric string', async () => {
+    await uploadService.findOne('qovkpekciob2wt8qyd51mg8k');
+
+    const [{ where }] = findOne.mock.calls[0];
+    expect(where).toEqual({ documentId: 'qovkpekciob2wt8qyd51mg8k' });
+  });
+
+  test('returns null (not a thrown DB error) when the file does not exist', async () => {
+    findOne.mockResolvedValueOnce(null);
+
+    await expect(uploadService.findOne('qovkpekciob2wt8qyd51mg8k')).resolves.toBeNull();
+  });
+});

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -47,6 +47,18 @@ const { MEDIA_CREATE, MEDIA_UPDATE, MEDIA_DELETE } = ALLOWED_WEBHOOK_EVENTS;
 const { ApplicationError, NotFoundError } = errors;
 const { bytesToKbytes } = fileUtils;
 
+/**
+ * Build a `where` clause that resolves a file by either its numeric primary key
+ * or its (string) documentId. A purely-numeric identifier is treated as an `id`,
+ * anything else as a `documentId`.
+ *
+ * A strict `/^\d+$/` test is used on purpose rather than `parseInt`, which would
+ * misclassify digit-leading documentIds as ids (see issue #27018). Upload files
+ * have no draftAndPublish, so `documentId` maps to exactly one row.
+ */
+const toFileLookup = (id: ID): { id: ID } | { documentId: ID } =>
+  /^\d+$/.test(String(id)) ? { id } : { documentId: id };
+
 export default ({ strapi }: { strapi: Core.Strapi }) => {
   const fileService = getService('file');
 
@@ -456,7 +468,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         : await fileService.getFolderPath(folder),
     };
 
-    return update(id, newInfos, { user });
+    // `id` may be a documentId; use the resolved primary key for the update.
+    return update(dbFile.id, newInfos, { user });
   }
 
   async function replace(
@@ -527,7 +540,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       await fse.remove(tmpWorkingDirectory);
     }
 
-    return update(id, fileData, { user });
+    // `id` may be a documentId; use the resolved primary key for the update.
+    return update(dbFile.id, fileData, { user });
   }
 
   async function update(id: ID, values: Partial<File>, opts?: CommonOptions) {
@@ -575,7 +589,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     });
 
     const file = await strapi.db.query(FILE_MODEL_UID).findOne({
-      where: { id },
+      where: toFileLookup(id),
       ...query,
     });
 

--- a/tests/api/core/upload/content-api/upload.test.api.js
+++ b/tests/api/core/upload/content-api/upload.test.api.js
@@ -205,6 +205,78 @@ describe('Upload plugin', () => {
         .query('plugin::upload.file')
         .delete({ where: { id: dogEntity.profilePicture.id } });
     });
+
+    test('Get one file by documentId', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/upload',
+        formData: {
+          files: fs.createReadStream(path.join(__dirname, '../utils/thumbnail_target.png')),
+        },
+      });
+      const { id, documentId } = res.body[0];
+
+      const getRes = await rq({
+        method: 'GET',
+        url: `/upload/files/${documentId}`,
+      });
+
+      expect(getRes.statusCode).toBe(200);
+      expect(getRes.body).toEqual(
+        expect.objectContaining({ id, documentId, url: expect.any(String) })
+      );
+
+      await strapi.db.query('plugin::upload.file').delete({ where: { id } });
+    });
+  });
+
+  describe('Delete', () => {
+    test('Delete a file by numeric id', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/upload',
+        formData: {
+          files: fs.createReadStream(path.join(__dirname, '../utils/thumbnail_target.png')),
+        },
+      });
+      const { id } = res.body[0];
+
+      const deleteRes = await rq({ method: 'DELETE', url: `/upload/files/${id}` });
+
+      expect(deleteRes.statusCode).toBe(200);
+      expect(deleteRes.body).toEqual(expect.objectContaining({ id }));
+
+      const dbFile = await strapi.db.query('plugin::upload.file').findOne({ where: { id } });
+      expect(dbFile).toBeNull();
+    });
+
+    test('Delete a file by documentId (regression for #24037)', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/upload',
+        formData: {
+          files: fs.createReadStream(path.join(__dirname, '../utils/thumbnail_target.png')),
+        },
+      });
+      const { id, documentId } = res.body[0];
+
+      const deleteRes = await rq({ method: 'DELETE', url: `/upload/files/${documentId}` });
+
+      expect(deleteRes.statusCode).toBe(200);
+      expect(deleteRes.body).toEqual(expect.objectContaining({ id, documentId }));
+
+      const dbFile = await strapi.db.query('plugin::upload.file').findOne({ where: { id } });
+      expect(dbFile).toBeNull();
+    });
+
+    test('Returns 404 when deleting a non-existent documentId', async () => {
+      const deleteRes = await rq({
+        method: 'DELETE',
+        url: '/upload/files/nonexistentdocumentid00',
+      });
+
+      expect(deleteRes.statusCode).toBe(404);
+    });
   });
 
   describe('Filtering data based on media attributes', () => {


### PR DESCRIPTION
### What does it do?

Makes the Upload **content-API** resolve a file by **either** its numeric `id` **or** its `documentId` on `GET /api/upload/files/:id` and `DELETE /api/upload/files/:id`.

- `services/upload.ts`: `findOne` now builds its `where` clause via a small `toFileLookup` helper — a purely-numeric identifier is treated as an `id`, anything else as a `documentId`. A strict `/^\d+$/` test is used **on purpose** rather than `parseInt`, so digit-leading documentIds aren't misclassified as ids.
- `updateFileInfo` and `replace` now pass the **resolved** primary key (`dbFile.id`) to `update`, so metadata updates/replacements also work when addressed by documentId. `remove` is unchanged (it already keys off the fetched `file.id`).
- `routes/content-api.ts`: the `:id` path param for `findOne`/`destroy` is widened to a new `fileIdentifier` validator (number **or** non-empty string).
- `routes/validation/upload.ts`: the `file` response schema typed `documentId` as `z.uuid()`, but Strapi generates a **cuid2** — corrected to `z.string()`.

Numeric-`id` lookups are unchanged (byte-for-byte same query), so this is backward compatible.

### Why is it needed?

`GET`/`DELETE /api/upload/files/:id` only accepted the numeric primary key. Passing a Strapi 5 `documentId` sent the raw string into `where: { id }` against the integer column, failing with `invalid input syntax for type integer` on PostgreSQL (and silently returning `404` on SQLite). Users reasonably expect the same `documentId` used everywhere else in the v5 REST API to work here too.

This is safe specifically for Upload because the `file` content-type has **no draftAndPublish** — there is exactly one row per file, so a `documentId` maps unambiguously to a single `id` (unlike D&P content types, where the historical concern about multiple versioned rows applies).

### How to test it?

REST, against a fresh app with an uploaded file:

```bash
# upload → note both `id` and `documentId` in the response
curl -X POST http://localhost:1337/api/upload -F "files=@image.png" -H "Authorization: Bearer <token>"

# both now work (previously the documentId form 500'd on Postgres / 404'd on SQLite)
curl http://localhost:1337/api/upload/files/<documentId> -H "Authorization: Bearer <token>"
curl -X DELETE http://localhost:1337/api/upload/files/<documentId> -H "Authorization: Bearer <token>"
curl -X DELETE http://localhost:1337/api/upload/files/<numericId> -H "Authorization: Bearer <token>"
```

Automated:
- Unit: `packages/core/upload/server/src/services/__tests__/upload/findOne.test.ts` (new) and new `findOne`/`destroy` blocks in `controllers/__tests__/content-api.test.ts`.
- Integration: new `findOne`-by-documentId and a `Delete` block (by id, by documentId, 404 on unknown documentId) in `tests/api/core/upload/content-api/upload.test.api.js`.

Locally green: `yarn test:unit`, `yarn lint`, `yarn test:ts:back` (upload), and `yarn test:api core/upload/content-api/upload.test.api.js` (56 passed).

### Related issue(s)/PR(s)

Fixes #24037. Related: #21078, #21427, #24035. Supersedes the REST side of the stalled #25941 (which only touched the service + GraphQL, not the REST controllers/routes, and shipped without tests).

> Note for reviewers: prior maintainer comments (#21078, #21427) described the numeric-id contract for lower-level APIs as intentional. This PR keeps that contract fully intact (numeric ids behave identically) while additionally accepting a documentId, which is unambiguous here due to the lack of draftAndPublish. Happy to gate this behind a decision or split the validation-schema fix out if preferred. GraphQL parity can follow as a separate PR.