### PR TITLE
feat: add HTML editor and locale Google translation Plugin

### DIFF
--- a/examples/getstarted/config/plugins.js
+++ b/examples/getstarted/config/plugins.js
@@ -30,6 +30,14 @@ module.exports = () => ({
       testConf: 3,
     },
   },
+  'google-translate': {
+    enabled: true,
+    resolve: './src/plugins/google-translate',
+  },
+  'html-editor': {
+    enabled: true,
+    resolve: './src/plugins/html-editor',
+  },
   // NOTE: set enabled:true to test with a pre-built plugin. Make sure to run yarn build in the plugin folder first
   todo: {
     enabled: false,

--- a/examples/getstarted/src/plugins/google-translate/admin/src/components/TranslateActions.jsx
+++ b/examples/getstarted/src/plugins/google-translate/admin/src/components/TranslateActions.jsx
@@ -1,0 +1,207 @@
+import * as React from 'react';
+import {
+  Button,
+  Dialog,
+  Field,
+  Flex,
+  SingleSelect,
+  SingleSelectOption,
+  Typography,
+} from '@strapi/design-system';
+import { useFetchClient, useNotification, useQueryParams } from '@strapi/strapi/admin';
+
+const TranslateIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    aria-hidden
+  >
+    <text x="0.5" y="11.5" fontSize="9" fill="currentColor" fontFamily="system-ui, sans-serif">
+      文
+    </text>
+    <text x="8" y="13" fontSize="10" fill="currentColor" fontFamily="system-ui, sans-serif">
+      A
+    </text>
+  </svg>
+);
+
+const useGoogleTranslate = () => {
+  const { get, post } = useFetchClient();
+  const [configured, setConfigured] = React.useState(false);
+  const [locales, setLocales] = React.useState([]);
+
+  React.useEffect(() => {
+    Promise.all([get('/google-translate/settings'), get('/google-translate/locales')])
+      .then(([settingsRes, localesRes]) => {
+        setConfigured(Boolean(settingsRes.data?.configured));
+        setLocales(localesRes.data || []);
+      })
+      .catch(() => {
+        setConfigured(false);
+      });
+  }, [get]);
+
+  return { configured, locales, post };
+};
+
+const TranslateDialogContent = ({
+  locales,
+  sourceLocale,
+  setSourceLocale,
+  currentLocale,
+  configured,
+  loading,
+  onClose,
+  onConfirm,
+}) => {
+  const sourceOptions = locales.filter((locale) => locale.code !== currentLocale);
+
+  return (
+    <>
+      <Dialog.Body>
+        <Flex direction="column" gap={3} width="100%">
+          {!configured ? (
+            <Typography textAlign="center">
+              Add Google credentials first: Settings → Google Translate.
+            </Typography>
+          ) : (
+            <>
+              <Typography textAlign="center">
+                Your current locale will be filled with a Google translation from the language you
+                select.
+              </Typography>
+              <Field.Root width="100%">
+                <Field.Label>Translate from</Field.Label>
+                <SingleSelect
+                  value={sourceLocale}
+                  placeholder="Select one locale..."
+                  onChange={(value) => setSourceLocale(value)}
+                >
+                  {sourceOptions.map((locale) => (
+                    <SingleSelectOption key={locale.code} value={locale.code}>
+                      {locale.name}
+                    </SingleSelectOption>
+                  ))}
+                </SingleSelect>
+              </Field.Root>
+            </>
+          )}
+        </Flex>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Flex gap={2} width="100%">
+          <Button flex="auto" variant="tertiary" onClick={onClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            flex="auto"
+            onClick={onConfirm}
+            loading={loading}
+            disabled={!configured || !sourceLocale}
+          >
+            Translate
+          </Button>
+        </Flex>
+      </Dialog.Footer>
+    </>
+  );
+};
+
+/**
+ * Header icon next to the locale picker (same pattern as "Fill from another locale").
+ */
+const GoogleTranslateHeaderAction = ({ documentId, model, document }) => {
+  const { toggleNotification } = useNotification();
+  const [{ query }] = useQueryParams();
+  const { configured, locales, post } = useGoogleTranslate();
+  const [sourceLocale, setSourceLocale] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+
+  const currentLocale = query?.plugins?.i18n?.locale || query?.locale || document?.locale;
+
+  React.useEffect(() => {
+    const fallback =
+      locales.find((locale) => locale.code !== currentLocale && locale.isDefault)?.code ||
+      locales.find((locale) => locale.code !== currentLocale)?.code ||
+      '';
+    setSourceLocale((current) => {
+      if (current && current !== currentLocale) {
+        return current;
+      }
+      return fallback;
+    });
+  }, [locales, currentLocale]);
+
+  if (!documentId) {
+    return null;
+  }
+
+  const runTranslate = (onClose) => async () => {
+    if (!configured) {
+      toggleNotification({
+        type: 'danger',
+        message: 'Add Google credentials in Settings → Google Translate first.',
+      });
+      return;
+    }
+
+    if (!sourceLocale || !currentLocale) {
+      toggleNotification({
+        type: 'danger',
+        message: 'Choose a source language and open a locale in the editor.',
+      });
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await post('/google-translate/translate', {
+        uid: model,
+        documentId,
+        sourceLocale,
+        targetLocale: currentLocale,
+      });
+      toggleNotification({
+        type: 'success',
+        message: `Translated from ${sourceLocale} to ${currentLocale}`,
+      });
+      onClose();
+      window.location.reload();
+    } catch (error) {
+      toggleNotification({
+        type: 'danger',
+        message: error?.response?.data?.error?.message || error.message || 'Translation failed',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    type: 'icon',
+    icon: <TranslateIcon />,
+    disabled: locales.length < 2,
+    label: 'Translate from another locale',
+    dialog: {
+      type: 'dialog',
+      title: 'Translate from another locale',
+      content: ({ onClose }) => (
+        <TranslateDialogContent
+          locales={locales}
+          sourceLocale={sourceLocale}
+          setSourceLocale={setSourceLocale}
+          currentLocale={currentLocale}
+          configured={configured}
+          loading={loading}
+          onClose={onClose}
+          onConfirm={runTranslate(onClose)}
+        />
+      ),
+    },
+  };
+};
+
+export { GoogleTranslateHeaderAction };

--- a/examples/getstarted/src/plugins/google-translate/admin/src/index.js
+++ b/examples/getstarted/src/plugins/google-translate/admin/src/index.js
@@ -1,0 +1,58 @@
+import { prefixPluginTranslations } from './utils/prefixPluginTranslations';
+import pluginId from './pluginId';
+import { GoogleTranslateHeaderAction } from './components/TranslateActions';
+
+export default {
+  register(app) {
+    app.createSettingSection(
+      {
+        id: pluginId,
+        intlLabel: {
+          id: `${pluginId}.plugin.name`,
+          defaultMessage: 'Google Translate',
+        },
+      },
+      [
+        {
+          intlLabel: {
+            id: `${pluginId}.settings.title`,
+            defaultMessage: 'Credentials',
+          },
+          id: 'credentials',
+          to: `${pluginId}/credentials`,
+          Component: () => import('./pages/SettingsPage'),
+          permissions: [],
+        },
+      ]
+    );
+
+    app.registerPlugin({
+      id: pluginId,
+      name: pluginId,
+    });
+  },
+
+  bootstrap(app) {
+    const contentManager = app.getPlugin('content-manager');
+    const apis = contentManager?.apis;
+
+    if (apis?.addDocumentHeaderAction) {
+      apis.addDocumentHeaderAction((actions) => [...actions, GoogleTranslateHeaderAction]);
+    }
+  },
+
+  async registerTrads({ locales }) {
+    const importedTrads = await Promise.all(
+      locales.map((locale) => {
+        return import(`./translations/${locale}.json`)
+          .then(({ default: data }) => ({
+            data: prefixPluginTranslations(data, pluginId),
+            locale,
+          }))
+          .catch(() => ({ data: {}, locale }));
+      })
+    );
+
+    return Promise.resolve(importedTrads);
+  },
+};

--- a/examples/getstarted/src/plugins/google-translate/admin/src/pages/SettingsPage.jsx
+++ b/examples/getstarted/src/plugins/google-translate/admin/src/pages/SettingsPage.jsx
@@ -1,0 +1,187 @@
+import * as React from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Flex,
+  Field,
+  Textarea,
+  TextInput,
+  Typography,
+} from '@strapi/design-system';
+import { Check, Trash } from '@strapi/icons';
+import { Layouts, Page, useFetchClient, useNotification } from '@strapi/strapi/admin';
+import { useIntl } from 'react-intl';
+
+import getTrad from '../utils/getTrad';
+
+const SettingsPage = () => {
+  const { formatMessage } = useIntl();
+  const { toggleNotification } = useNotification();
+  const { get, put, post } = useFetchClient();
+
+  const [status, setStatus] = React.useState(null);
+  const [credentialsJson, setCredentialsJson] = React.useState('');
+  const [apiKey, setApiKey] = React.useState('');
+  const [saving, setSaving] = React.useState(false);
+  const [testing, setTesting] = React.useState(false);
+
+  const loadSettings = React.useCallback(async () => {
+    const { data } = await get('/google-translate/settings');
+    setStatus(data);
+  }, [get]);
+
+  React.useEffect(() => {
+    loadSettings().catch(() => {
+      setStatus({ configured: false });
+    });
+  }, [loadSettings]);
+
+  const save = async ({ clear = false } = {}) => {
+    setSaving(true);
+    try {
+      const { data } = await put('/google-translate/settings', {
+        credentialsJson: clear ? '' : credentialsJson,
+        apiKey: clear ? '' : apiKey,
+      });
+      setStatus(data);
+      setCredentialsJson('');
+      setApiKey('');
+      toggleNotification({
+        type: 'success',
+        message: clear ? 'Credentials removed' : 'Google credentials saved',
+      });
+    } catch (error) {
+      toggleNotification({
+        type: 'danger',
+        message: error?.response?.data?.error?.message || error.message || 'Could not save credentials',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const test = async () => {
+    setTesting(true);
+    try {
+      const { data } = await post('/google-translate/settings/test');
+      toggleNotification({
+        type: 'success',
+        message: `Google Translate works. Sample: ${data.sample}`,
+      });
+    } catch (error) {
+      toggleNotification({
+        type: 'danger',
+        message: error?.response?.data?.error?.message || error.message || 'Translation test failed',
+      });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <Page.Main>
+      <Layouts.Header
+        title={formatMessage({
+          id: getTrad('settings.title'),
+          defaultMessage: 'Google Translate',
+        })}
+        subtitle={formatMessage({
+          id: getTrad('settings.subtitle'),
+          defaultMessage:
+            'Paste your Google credentials here. They are stored in Strapi and never read from .env.',
+        })}
+        primaryAction={
+          <Button startIcon={<Check />} loading={saving} onClick={() => save()}>
+            {formatMessage({ id: getTrad('settings.save'), defaultMessage: 'Save credentials' })}
+          </Button>
+        }
+      />
+      <Layouts.Content>
+        <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
+          <Flex direction="column" alignItems="stretch" gap={4}>
+            {status?.configured ? (
+              <Alert closeLabel="Close" variant="success">
+                {formatMessage({
+                  id: getTrad('settings.configured'),
+                  defaultMessage: 'Credentials are saved',
+                })}
+                {status.kind === 'serviceAccount' && status.clientEmail
+                  ? ` (${status.clientEmail})`
+                  : status.kind === 'apiKey'
+                    ? ' (API key)'
+                    : ''}
+              </Alert>
+            ) : (
+              <Alert closeLabel="Close" variant="default">
+                {formatMessage({
+                  id: getTrad('settings.notConfigured'),
+                  defaultMessage: 'No credentials saved yet',
+                })}
+              </Alert>
+            )}
+
+            <Field.Root
+              name="credentialsJson"
+              hint="Download a JSON key for a service account that can use Cloud Translation API."
+            >
+              <Field.Label>
+                {formatMessage({
+                  id: getTrad('settings.json.label'),
+                  defaultMessage: 'Service account JSON',
+                })}
+              </Field.Label>
+              <Textarea
+                value={credentialsJson}
+                onChange={(event) => setCredentialsJson(event.target.value)}
+                placeholder={formatMessage({
+                  id: getTrad('settings.json.placeholder'),
+                  defaultMessage: 'Paste the full JSON key file from Google Cloud',
+                })}
+              />
+            </Field.Root>
+
+            <Field.Root name="apiKey">
+              <Field.Label>
+                {formatMessage({
+                  id: getTrad('settings.apiKey.label'),
+                  defaultMessage: 'Or API key',
+                })}
+              </Field.Label>
+              <TextInput
+                type="password"
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                placeholder={formatMessage({
+                  id: getTrad('settings.apiKey.placeholder'),
+                  defaultMessage: 'Optional if you use a simple API key instead of a service account',
+                })}
+              />
+            </Field.Root>
+
+            <Typography variant="pi" textColor="neutral600">
+              Paste either the service account JSON or an API key, then save. The private key is not shown
+              again after saving.
+            </Typography>
+
+            <Flex gap={2}>
+              <Button variant="secondary" loading={testing} disabled={!status?.configured} onClick={test}>
+                {formatMessage({ id: getTrad('settings.test'), defaultMessage: 'Test translation' })}
+              </Button>
+              <Button
+                variant="danger-light"
+                startIcon={<Trash />}
+                disabled={!status?.configured || saving}
+                onClick={() => save({ clear: true })}
+              >
+                {formatMessage({ id: getTrad('settings.clear'), defaultMessage: 'Remove credentials' })}
+              </Button>
+            </Flex>
+          </Flex>
+        </Box>
+      </Layouts.Content>
+    </Page.Main>
+  );
+};
+
+export default SettingsPage;

--- a/examples/getstarted/src/plugins/google-translate/admin/src/pluginId.js
+++ b/examples/getstarted/src/plugins/google-translate/admin/src/pluginId.js
@@ -1,0 +1,3 @@
+const pluginId = 'google-translate';
+
+export default pluginId;

--- a/examples/getstarted/src/plugins/google-translate/admin/src/translations/en.json
+++ b/examples/getstarted/src/plugins/google-translate/admin/src/translations/en.json
@@ -1,0 +1,19 @@
+{
+  "plugin.name": "Google Translate",
+  "settings.title": "Google Translate",
+  "settings.subtitle": "Paste your Google credentials here. They are stored in Strapi and never read from .env.",
+  "settings.json.label": "Service account JSON",
+  "settings.json.placeholder": "Paste the full JSON key file from Google Cloud",
+  "settings.apiKey.label": "Or API key",
+  "settings.apiKey.placeholder": "Optional if you use a simple API key instead of a service account",
+  "settings.save": "Save credentials",
+  "settings.test": "Test translation",
+  "settings.clear": "Remove credentials",
+  "settings.configured": "Credentials are saved",
+  "settings.notConfigured": "No credentials saved yet",
+  "panel.title": "Google Translate",
+  "panel.source": "Translate from",
+  "panel.action": "Translate this locale",
+  "panel.missingCredentials": "Add Google credentials in Settings first",
+  "panel.needLocales": "Add at least two locales in Settings → Internationalization"
+}

--- a/examples/getstarted/src/plugins/google-translate/admin/src/utils/getTrad.js
+++ b/examples/getstarted/src/plugins/google-translate/admin/src/utils/getTrad.js
@@ -1,0 +1,5 @@
+import pluginId from '../pluginId';
+
+const getTrad = (id) => `${pluginId}.${id}`;
+
+export default getTrad;

--- a/examples/getstarted/src/plugins/google-translate/admin/src/utils/prefixPluginTranslations.js
+++ b/examples/getstarted/src/plugins/google-translate/admin/src/utils/prefixPluginTranslations.js
@@ -1,0 +1,12 @@
+const prefixPluginTranslations = (trad, pluginId) => {
+  if (!pluginId) {
+    throw new TypeError("pluginId can't be empty");
+  }
+
+  return Object.keys(trad).reduce((acc, current) => {
+    acc[`${pluginId}.${current}`] = trad[current];
+    return acc;
+  }, {});
+};
+
+export { prefixPluginTranslations };

--- a/examples/getstarted/src/plugins/google-translate/package.json
+++ b/examples/getstarted/src/plugins/google-translate/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "strapi-plugin-google-translate",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Translate Strapi content with Google Cloud Translation. Credentials are saved from the admin Settings page.",
+  "strapi": {
+    "name": "google-translate",
+    "displayName": "Google Translate",
+    "description": "Translate content with Google Cloud Translation. Add credentials in Settings.",
+    "kind": "plugin"
+  }
+}

--- a/examples/getstarted/src/plugins/google-translate/server/bootstrap.js
+++ b/examples/getstarted/src/plugins/google-translate/server/bootstrap.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = () => {};

--- a/examples/getstarted/src/plugins/google-translate/server/config/index.js
+++ b/examples/getstarted/src/plugins/google-translate/server/config/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  default: {},
+  validator() {},
+};

--- a/examples/getstarted/src/plugins/google-translate/server/controllers/index.js
+++ b/examples/getstarted/src/plugins/google-translate/server/controllers/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const settings = require('./settings');
+const translate = require('./translate');
+
+module.exports = {
+  settings,
+  translate,
+};

--- a/examples/getstarted/src/plugins/google-translate/server/controllers/settings.js
+++ b/examples/getstarted/src/plugins/google-translate/server/controllers/settings.js
@@ -1,0 +1,32 @@
+'use strict';
+
+module.exports = {
+  async getSettings(ctx) {
+    ctx.body = await strapi.plugin('google-translate').service('credentials').getPublic();
+  },
+
+  async updateSettings(ctx) {
+    try {
+      ctx.body = await strapi
+        .plugin('google-translate')
+        .service('credentials')
+        .save(ctx.request.body || {});
+    } catch (error) {
+      ctx.throw(400, error.message);
+    }
+  },
+
+  async testSettings(ctx) {
+    try {
+      const translated = await strapi.plugin('google-translate').service('google').translateTexts({
+        texts: 'Hello',
+        sourceLocale: 'en',
+        targetLocale: 'es',
+        format: 'text',
+      });
+      ctx.body = { ok: true, sample: translated };
+    } catch (error) {
+      ctx.throw(400, error.message);
+    }
+  },
+};

--- a/examples/getstarted/src/plugins/google-translate/server/controllers/translate.js
+++ b/examples/getstarted/src/plugins/google-translate/server/controllers/translate.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = {
+  async locales(ctx) {
+    const localesService = strapi.plugin('i18n').service('locales');
+    const locales = await localesService.setIsDefault(await localesService.find());
+    ctx.body = (locales || []).map((locale) => ({
+      code: locale.code,
+      name: locale.name,
+      isDefault: Boolean(locale.isDefault),
+    }));
+  },
+
+  async translate(ctx) {
+    const { uid, documentId, sourceLocale, targetLocale } = ctx.request.body || {};
+
+    try {
+      const entry = await strapi
+        .plugin('google-translate')
+        .service('translate-entry')
+        .translateEntry({ uid, documentId, sourceLocale, targetLocale });
+
+      ctx.body = { ok: true, documentId: entry?.documentId, locale: targetLocale };
+    } catch (error) {
+      ctx.throw(400, error.message);
+    }
+  },
+};

--- a/examples/getstarted/src/plugins/google-translate/server/register.js
+++ b/examples/getstarted/src/plugins/google-translate/server/register.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = () => {};

--- a/examples/getstarted/src/plugins/google-translate/server/routes/admin.js
+++ b/examples/getstarted/src/plugins/google-translate/server/routes/admin.js
@@ -1,0 +1,37 @@
+'use strict';
+
+module.exports = {
+  type: 'admin',
+  routes: [
+    {
+      method: 'GET',
+      path: '/settings',
+      handler: 'settings.getSettings',
+      config: { policies: [] },
+    },
+    {
+      method: 'PUT',
+      path: '/settings',
+      handler: 'settings.updateSettings',
+      config: { policies: [] },
+    },
+    {
+      method: 'POST',
+      path: '/settings/test',
+      handler: 'settings.testSettings',
+      config: { policies: [] },
+    },
+    {
+      method: 'GET',
+      path: '/locales',
+      handler: 'translate.locales',
+      config: { policies: [] },
+    },
+    {
+      method: 'POST',
+      path: '/translate',
+      handler: 'translate.translate',
+      config: { policies: [] },
+    },
+  ],
+};

--- a/examples/getstarted/src/plugins/google-translate/server/routes/index.js
+++ b/examples/getstarted/src/plugins/google-translate/server/routes/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  admin: require('./admin'),
+};

--- a/examples/getstarted/src/plugins/google-translate/server/services/credentials.js
+++ b/examples/getstarted/src/plugins/google-translate/server/services/credentials.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const STORE_KEY = 'credentials';
+
+const sanitize = (credentials) => {
+  if (!credentials) {
+    return { configured: false };
+  }
+
+  if (credentials.kind === 'apiKey') {
+    return { configured: true, kind: 'apiKey' };
+  }
+
+  return {
+    configured: true,
+    kind: 'serviceAccount',
+    projectId: credentials.projectId || null,
+    clientEmail: credentials.clientEmail || null,
+  };
+};
+
+module.exports = ({ strapi }) => {
+  const store = () => strapi.store({ type: 'plugin', name: 'google-translate' });
+
+  return {
+    async get() {
+      const value = await store().get({ key: STORE_KEY });
+      return value || null;
+    },
+
+    async getPublic() {
+      return sanitize(await this.get());
+    },
+
+    async save({ credentialsJson, apiKey } = {}) {
+      const jsonInput = typeof credentialsJson === 'string' ? credentialsJson.trim() : '';
+      const keyInput = typeof apiKey === 'string' ? apiKey.trim() : '';
+
+      if (!jsonInput && !keyInput) {
+        await store().set({ key: STORE_KEY, value: null });
+        return sanitize(null);
+      }
+
+      if (jsonInput) {
+        let parsed;
+        try {
+          parsed = JSON.parse(jsonInput);
+        } catch {
+          throw new Error('Service account JSON is not valid JSON');
+        }
+
+        if (parsed.type !== 'service_account' || !parsed.private_key || !parsed.client_email) {
+          throw new Error(
+            'JSON must be a Google service account key (type, client_email, private_key)'
+          );
+        }
+
+        const credentials = {
+          kind: 'serviceAccount',
+          projectId: parsed.project_id || null,
+          clientEmail: parsed.client_email,
+          json: parsed,
+        };
+
+        await store().set({ key: STORE_KEY, value: credentials });
+        return sanitize(credentials);
+      }
+
+      const credentials = {
+        kind: 'apiKey',
+        apiKey: keyInput,
+      };
+
+      await store().set({ key: STORE_KEY, value: credentials });
+      return sanitize(credentials);
+    },
+  };
+};

--- a/examples/getstarted/src/plugins/google-translate/server/services/google.js
+++ b/examples/getstarted/src/plugins/google-translate/server/services/google.js
@@ -1,0 +1,198 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const TRANSLATE_URL = 'https://translation.googleapis.com/language/translate/v2';
+const TRANSLATE_SCOPE = 'https://www.googleapis.com/auth/cloud-translation';
+
+const LOCALE_ALIASES = {
+  'zh-hans': 'zh-CN',
+  'zh-hant': 'zh-TW',
+  zh: 'zh-CN',
+  'en-gb': 'en',
+  'en-us': 'en',
+};
+
+const REGIONAL_GOOGLE_LOCALES = new Set(['zh-CN', 'zh-TW', 'pt-BR', 'pt-PT']);
+
+const tokenCache = {
+  token: null,
+  expiresAt: 0,
+  email: null,
+};
+
+const toBase64Url = (input) =>
+  Buffer.from(input)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+
+const toGoogleLocale = (locale) => {
+  if (!locale) {
+    return locale;
+  }
+
+  const lower = String(locale).toLowerCase();
+  if (LOCALE_ALIASES[lower]) {
+    return LOCALE_ALIASES[lower];
+  }
+
+  const parts = String(locale).split('-');
+  if (parts.length >= 2) {
+    const regional = `${parts[0].toLowerCase()}-${parts[1].toUpperCase()}`;
+    if (REGIONAL_GOOGLE_LOCALES.has(regional)) {
+      return regional;
+    }
+    return parts[0].toLowerCase();
+  }
+
+  return lower;
+};
+
+const createServiceAccountJwt = (credentialsJson) => {
+  const now = Math.floor(Date.now() / 1000);
+  const header = toBase64Url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = toBase64Url(
+    JSON.stringify({
+      iss: credentialsJson.client_email,
+      scope: TRANSLATE_SCOPE,
+      aud: TOKEN_URL,
+      iat: now,
+      exp: now + 3600,
+    })
+  );
+  const unsigned = `${header}.${payload}`;
+  const signer = crypto.createSign('RSA-SHA256');
+  signer.update(unsigned);
+  const signature = toBase64Url(signer.sign(credentialsJson.private_key));
+  return `${unsigned}.${signature}`;
+};
+
+const getAccessToken = async (credentialsJson) => {
+  const now = Date.now();
+  if (
+    tokenCache.token &&
+    tokenCache.email === credentialsJson.client_email &&
+    tokenCache.expiresAt > now + 60_000
+  ) {
+    return tokenCache.token;
+  }
+
+  const assertion = createServiceAccountJwt(credentialsJson);
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }),
+  });
+
+  const payload = await response.json();
+  if (!response.ok || !payload.access_token) {
+    throw new Error(payload.error_description || payload.error || 'Failed to get Google access token');
+  }
+
+  tokenCache.token = payload.access_token;
+  tokenCache.email = credentialsJson.client_email;
+  tokenCache.expiresAt = now + (payload.expires_in || 3600) * 1000;
+  return payload.access_token;
+};
+
+const parseGoogleError = async (response) => {
+  try {
+    const payload = await response.json();
+    return payload?.error?.message || payload?.error_description || JSON.stringify(payload);
+  } catch {
+    return response.statusText;
+  }
+};
+
+const translateWithApiKey = async ({ apiKey, texts, source, target, format }) => {
+  const url = `${TRANSLATE_URL}?key=${encodeURIComponent(apiKey)}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: texts, source, target, format }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google Translate API failed (${response.status}): ${await parseGoogleError(response)}`);
+  }
+
+  const payload = await response.json();
+  return payload.data.translations.map((item) => item.translatedText);
+};
+
+const translateWithAccessToken = async ({ accessToken, texts, source, target, format }) => {
+  const response = await fetch(TRANSLATE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ q: texts, source, target, format }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google Translate API failed (${response.status}): ${await parseGoogleError(response)}`);
+  }
+
+  const payload = await response.json();
+  return payload.data.translations.map((item) => item.translatedText);
+};
+
+const chunk = (items, size) => {
+  const groups = [];
+  for (let i = 0; i < items.length; i += size) {
+    groups.push(items.slice(i, i + size));
+  }
+  return groups;
+};
+
+module.exports = ({ strapi }) => ({
+  toGoogleLocale,
+
+  async translateTexts({ texts, sourceLocale, targetLocale, format = 'text' }) {
+    const credentials = await strapi.plugin('google-translate').service('credentials').get();
+
+    if (!credentials) {
+      throw new Error('Google Translate credentials are not configured. Add them in Settings.');
+    }
+
+    const source = toGoogleLocale(sourceLocale);
+    const target = toGoogleLocale(targetLocale);
+    const googleFormat = format === 'html' ? 'html' : 'text';
+    const input = Array.isArray(texts) ? texts : [texts];
+    const results = [];
+
+    for (const group of chunk(input, 128)) {
+      if (credentials.kind === 'apiKey') {
+        results.push(
+          ...(await translateWithApiKey({
+            apiKey: credentials.apiKey,
+            texts: group,
+            source,
+            target,
+            format: googleFormat,
+          }))
+        );
+      } else {
+        const accessToken = await getAccessToken(credentials.json);
+        results.push(
+          ...(await translateWithAccessToken({
+            accessToken,
+            texts: group,
+            source,
+            target,
+            format: googleFormat,
+          }))
+        );
+      }
+    }
+
+    return Array.isArray(texts) ? results : results[0];
+  },
+});

--- a/examples/getstarted/src/plugins/google-translate/server/services/index.js
+++ b/examples/getstarted/src/plugins/google-translate/server/services/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const credentials = require('./credentials');
+const google = require('./google');
+const translateEntry = require('./translate-entry');
+
+module.exports = {
+  credentials,
+  google,
+  'translate-entry': translateEntry,
+};

--- a/examples/getstarted/src/plugins/google-translate/server/services/translate-entry.js
+++ b/examples/getstarted/src/plugins/google-translate/server/services/translate-entry.js
@@ -1,0 +1,192 @@
+'use strict';
+
+const TRANSLATABLE_TYPES = new Set(['string', 'text', 'richtext', 'email']);
+
+const SYSTEM_KEYS = new Set([
+  'id',
+  'documentId',
+  'createdAt',
+  'updatedAt',
+  'publishedAt',
+  'createdBy',
+  'updatedBy',
+  'locale',
+  'localizations',
+]);
+
+const isLocalizedAttribute = (attribute) => {
+  if (!attribute) {
+    return false;
+  }
+  return attribute.pluginOptions?.i18n?.localized !== false;
+};
+
+const walkBlocks = (nodes, items) => {
+  if (!Array.isArray(nodes)) {
+    return;
+  }
+
+  nodes.forEach((node) => {
+    if (node && typeof node.text === 'string' && node.text.trim()) {
+      items.push({
+        value: node.text,
+        format: 'text',
+        apply(translated) {
+          node.text = translated;
+        },
+      });
+    }
+    if (node?.children) {
+      walkBlocks(node.children, items);
+    }
+  });
+};
+
+const collectFromData = (data, attributes, components, items) => {
+  if (!data || !attributes) {
+    return;
+  }
+
+  Object.entries(attributes).forEach(([name, attribute]) => {
+    const value = data[name];
+    if (value == null || !isLocalizedAttribute(attribute)) {
+      return;
+    }
+
+    if (TRANSLATABLE_TYPES.has(attribute.type)) {
+      if (typeof value === 'string' && value.trim()) {
+        items.push({
+          value,
+          format: attribute.type === 'richtext' ? 'html' : 'text',
+          apply(translated) {
+            data[name] = translated;
+          },
+        });
+      }
+      return;
+    }
+
+    if (attribute.type === 'customField' && typeof value === 'string' && value.trim()) {
+      const customField = String(attribute.customField || '');
+      const isHtml = customField.includes('html-editor') || customField.endsWith('.html');
+      items.push({
+        value,
+        format: isHtml ? 'html' : 'text',
+        apply(translated) {
+          data[name] = translated;
+        },
+      });
+      return;
+    }
+
+    if (attribute.type === 'blocks' && Array.isArray(value)) {
+      walkBlocks(value, items);
+      return;
+    }
+
+    if (attribute.type === 'component') {
+      const componentSchema = components[attribute.component];
+      if (!componentSchema) {
+        return;
+      }
+      if (attribute.repeatable && Array.isArray(value)) {
+        value.forEach((entry) => collectFromData(entry, componentSchema.attributes, components, items));
+      } else if (value && typeof value === 'object') {
+        collectFromData(value, componentSchema.attributes, components, items);
+      }
+      return;
+    }
+
+    if (attribute.type === 'dynamiczone' && Array.isArray(value)) {
+      value.forEach((entry) => {
+        const componentSchema = components[entry?.__component];
+        if (componentSchema) {
+          collectFromData(entry, componentSchema.attributes, components, items);
+        }
+      });
+    }
+  });
+};
+
+const toPayload = (data, attributes) => {
+  const payload = {};
+
+  Object.keys(attributes).forEach((name) => {
+    const attribute = attributes[name];
+    if (SYSTEM_KEYS.has(name) || !isLocalizedAttribute(attribute)) {
+      return;
+    }
+    if (['relation', 'media', 'uid', 'password'].includes(attribute.type)) {
+      return;
+    }
+    if (data[name] !== undefined) {
+      payload[name] = data[name];
+    }
+  });
+
+  return payload;
+};
+
+module.exports = ({ strapi }) => ({
+  async translateEntry({ uid, documentId, sourceLocale, targetLocale }) {
+    if (!uid || !documentId || !sourceLocale || !targetLocale) {
+      throw new Error('uid, documentId, sourceLocale and targetLocale are required');
+    }
+
+    if (sourceLocale === targetLocale) {
+      throw new Error('Source and target locale must be different');
+    }
+
+    const contentType = strapi.contentTypes[uid];
+    if (!contentType) {
+      throw new Error(`Unknown content type: ${uid}`);
+    }
+
+    if (!contentType.pluginOptions?.i18n?.localized) {
+      throw new Error('This content type is not localized');
+    }
+
+    const source = await strapi.documents(uid).findOne({
+      documentId,
+      locale: sourceLocale,
+    });
+
+    if (!source) {
+      throw new Error(`No content found for locale ${sourceLocale}`);
+    }
+
+    const data = JSON.parse(JSON.stringify(source));
+    const items = [];
+    collectFromData(data, contentType.attributes, strapi.components, items);
+
+    if (!items.length) {
+      throw new Error('No translatable text fields were found on this entry');
+    }
+
+    const google = strapi.plugin('google-translate').service('google');
+    const groups = {
+      text: items.filter((item) => item.format === 'text'),
+      html: items.filter((item) => item.format === 'html'),
+    };
+
+    for (const format of Object.keys(groups)) {
+      const group = groups[format];
+      if (!group.length) {
+        continue;
+      }
+      const translated = await google.translateTexts({
+        texts: group.map((item) => item.value),
+        sourceLocale,
+        targetLocale,
+        format,
+      });
+      group.forEach((item, index) => item.apply(translated[index]));
+    }
+
+    return strapi.documents(uid).update({
+      documentId,
+      locale: targetLocale,
+      data: toPayload(data, contentType.attributes),
+    });
+  },
+});

--- a/examples/getstarted/src/plugins/google-translate/strapi-admin.js
+++ b/examples/getstarted/src/plugins/google-translate/strapi-admin.js
@@ -1,0 +1,3 @@
+import admin from './admin/src';
+
+export default admin;

--- a/examples/getstarted/src/plugins/google-translate/strapi-server.js
+++ b/examples/getstarted/src/plugins/google-translate/strapi-server.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const config = require('./server/config');
+const controllers = require('./server/controllers');
+const register = require('./server/register');
+const bootstrap = require('./server/bootstrap');
+const routes = require('./server/routes');
+const services = require('./server/services');
+
+module.exports = () => ({
+  register,
+  bootstrap,
+  config,
+  controllers,
+  routes,
+  services,
+});

--- a/examples/getstarted/src/plugins/html-editor/admin/src/components/HtmlEditorIcon.jsx
+++ b/examples/getstarted/src/plugins/html-editor/admin/src/components/HtmlEditorIcon.jsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+export const HtmlEditorIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none">
+    <rect x="4" y="6" width="24" height="20" rx="3" stroke="currentColor" strokeWidth="2" />
+    <path d="M8 12h16M8 16h12M8 20h8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);

--- a/examples/getstarted/src/plugins/html-editor/admin/src/components/HtmlEditorInput.jsx
+++ b/examples/getstarted/src/plugins/html-editor/admin/src/components/HtmlEditorInput.jsx
@@ -1,0 +1,450 @@
+import * as React from 'react';
+import { Box, Field, Flex, Popover, SingleSelect, SingleSelectOption } from '@strapi/design-system';
+import { useField } from '@strapi/strapi/admin';
+import { styled } from 'styled-components';
+
+const PRESET_COLORS = [
+  '#000000',
+  '#4A4A4A',
+  '#8B72F5',
+  '#E11D48',
+  '#2563EB',
+  '#16A34A',
+  '#CA8A04',
+  '#EA580C',
+  '#FFFFFF',
+];
+
+const Shell = styled.div`
+  border: 1px solid ${({ theme, $error }) => ($error ? theme.colors.danger600 : theme.colors.neutral200)};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  background: ${({ theme }) => theme.colors.neutral0};
+  overflow: hidden;
+`;
+
+const Toolbar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 10px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.neutral200};
+  background: ${({ theme }) => theme.colors.neutral100};
+`;
+
+const ToolBtn = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 6px;
+  background: ${({ $active }) => ($active ? '#e8e8e8' : 'transparent')};
+  color: ${({ theme }) => theme.colors.neutral800};
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+
+  &:hover:not(:disabled) {
+    background: ${({ theme }) => theme.colors.neutral200};
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+`;
+
+const Divider = styled.span`
+  width: 1px;
+  height: 20px;
+  margin: 0 4px;
+  background: ${({ theme }) => theme.colors.neutral300};
+`;
+
+const ColorMark = styled.span`
+  display: inline-block;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1;
+  border-bottom: 3px solid ${({ $color }) => $color || '#8B72F5'};
+  padding-bottom: 1px;
+`;
+
+const ColorSwatch = styled.button`
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  border: 1px solid ${({ theme }) => theme.colors.neutral300};
+  background: ${({ $color }) => $color};
+  cursor: pointer;
+  padding: 0;
+`;
+
+const EditorSurface = styled.div`
+  min-height: 280px;
+  max-height: 560px;
+  overflow: auto;
+  padding: 16px 18px;
+  outline: none;
+  color: ${({ theme }) => theme.colors.neutral800};
+  font-size: 14px;
+  line-height: 1.6;
+  cursor: text;
+
+  &:empty:before {
+    content: attr(data-placeholder);
+    color: ${({ theme }) => theme.colors.neutral500};
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-weight: 700;
+    margin: 0.8em 0 0.4em;
+    line-height: 1.3;
+  }
+
+  h1 {
+    font-size: 1.75em;
+  }
+
+  h2 {
+    font-size: 1.35em;
+  }
+
+  h3 {
+    font-size: 1.15em;
+  }
+
+  p {
+    margin: 0 0 0.75em;
+  }
+
+  img,
+  video,
+  iframe {
+    max-width: 100%;
+    height: auto;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.75em 0;
+  }
+
+  td,
+  th {
+    border: 1px solid ${({ theme }) => theme.colors.neutral300};
+    padding: 8px;
+    min-width: 48px;
+  }
+
+  a {
+    color: ${({ theme }) => theme.colors.primary600};
+  }
+
+  ul,
+  ol {
+    padding-left: 1.4em;
+    margin: 0 0 0.75em;
+  }
+
+  [style*='text-align: center'] {
+    text-align: center;
+  }
+`;
+
+const SourceArea = styled.textarea`
+  display: block;
+  width: 100%;
+  min-height: 280px;
+  max-height: 560px;
+  padding: 16px 18px;
+  border: 0;
+  resize: vertical;
+  outline: none;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  background: ${({ theme }) => theme.colors.neutral0};
+  color: ${({ theme }) => theme.colors.neutral800};
+`;
+
+const toYoutubeEmbed = (url) => {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.includes('youtu.be')) {
+      return `https://www.youtube.com/embed/${parsed.pathname.replace('/', '')}`;
+    }
+    if (parsed.hostname.includes('youtube.com')) {
+      const id = parsed.searchParams.get('v');
+      if (id) {
+        return `https://www.youtube.com/embed/${id}`;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+};
+
+export const HtmlEditorInput = React.forwardRef((props, forwardedRef) => {
+  const { hint, disabled, labelAction, label, name, placeholder, required } = props;
+  const field = useField(name);
+  const editorRef = React.useRef(null);
+  const lastHtml = React.useRef(field.value || '');
+  const [sourceMode, setSourceMode] = React.useState(false);
+  const [color, setColor] = React.useState('#8B72F5');
+  const [block, setBlock] = React.useState('p');
+
+  React.useEffect(() => {
+    if (sourceMode || !editorRef.current) {
+      return;
+    }
+    const next = field.value || '';
+    if (next !== editorRef.current.innerHTML && next !== lastHtml.current) {
+      editorRef.current.innerHTML = next;
+      lastHtml.current = next;
+    }
+  }, [field.value, sourceMode]);
+
+  const emitChange = React.useCallback(() => {
+    if (!editorRef.current) {
+      return;
+    }
+    const html = editorRef.current.innerHTML;
+    lastHtml.current = html;
+    field.onChange(name, html);
+  }, [field, name]);
+
+  const run = (command, value) => {
+    if (disabled || sourceMode) {
+      return;
+    }
+    editorRef.current?.focus();
+    document.execCommand('styleWithCSS', false, true);
+    document.execCommand(command, false, value);
+    emitChange();
+  };
+
+  const applyColor = (nextColor) => {
+    setColor(nextColor);
+    run('foreColor', nextColor);
+  };
+
+  const applyBlock = (tag) => {
+    setBlock(tag);
+    run('formatBlock', `<${tag}>`);
+  };
+
+  const insertHtml = (html) => {
+    run('insertHTML', html);
+  };
+
+  const isSafeUrl = (url) => /^(https?:|\/)/i.test(url);
+
+  const handleLink = () => {
+    const href = window.prompt('Link URL', 'https://');
+    if (!href || !isSafeUrl(href)) {
+      return;
+    }
+    run('createLink', href);
+  };
+
+  const handleImage = () => {
+    const src = window.prompt('Image URL', 'https://');
+    if (!src || !isSafeUrl(src)) {
+      return;
+    }
+    const alt = (window.prompt('Image alt text', '') || '').replace(/"/g, '&quot;');
+    insertHtml(`<img src="${src.replace(/"/g, '&quot;')}" alt="${alt}" />`);
+  };
+
+  const handleVideo = () => {
+    const url = window.prompt('Video URL (YouTube or direct file)', 'https://');
+    if (!url || !isSafeUrl(url)) {
+      return;
+    }
+    const embed = toYoutubeEmbed(url);
+    if (embed) {
+      insertHtml(
+        `<iframe src="${embed}" width="560" height="315" title="Video" frameborder="0" allowfullscreen></iframe>`
+      );
+      return;
+    }
+    insertHtml(
+      `<video src="${url.replace(/"/g, '&quot;')}" controls style="max-width:100%"></video>`
+    );
+  };
+
+  const handleTable = () => {
+    insertHtml(
+      '<table><thead><tr><th>Heading</th><th>Heading</th></tr></thead><tbody><tr><td>Cell</td><td>Cell</td></tr><tr><td>Cell</td><td>Cell</td></tr></tbody></table><p></p>'
+    );
+  };
+
+  return (
+    <Field.Root name={name} id={name} error={field.error} hint={hint} required={required}>
+      <Flex direction="column" alignItems="stretch" gap={1}>
+        <Field.Label action={labelAction}>{label}</Field.Label>
+        <Shell $error={Boolean(field.error)}>
+          <Toolbar>
+            <SingleSelect
+              size="S"
+              disabled={disabled || sourceMode}
+              value={block}
+              onChange={applyBlock}
+              aria-label="Block format"
+            >
+              <SingleSelectOption value="p">Paragraph</SingleSelectOption>
+              <SingleSelectOption value="h1">Heading 1</SingleSelectOption>
+              <SingleSelectOption value="h2">Heading 2</SingleSelectOption>
+              <SingleSelectOption value="h3">Heading 3</SingleSelectOption>
+              <SingleSelectOption value="h4">Heading 4</SingleSelectOption>
+              <SingleSelectOption value="blockquote">Quote</SingleSelectOption>
+            </SingleSelect>
+            <Divider />
+            <ToolBtn type="button" disabled={disabled || sourceMode} onClick={() => run('bold')} title="Bold">
+              B
+            </ToolBtn>
+            <ToolBtn type="button" disabled={disabled || sourceMode} onClick={() => run('italic')} title="Italic">
+              <em>I</em>
+            </ToolBtn>
+            <ToolBtn
+              type="button"
+              disabled={disabled || sourceMode}
+              onClick={() => run('underline')}
+              title="Underline"
+            >
+              <u>U</u>
+            </ToolBtn>
+            <Popover.Root>
+              <Popover.Trigger>
+                <ToolBtn type="button" disabled={disabled || sourceMode} title="Text color">
+                  <ColorMark $color={color}>A</ColorMark>
+                </ToolBtn>
+              </Popover.Trigger>
+              <Popover.Content sideOffset={6}>
+                <Box padding={3}>
+                  <Flex gap={2} wrap="wrap" style={{ width: 160 }}>
+                    {PRESET_COLORS.map((preset) => (
+                      <ColorSwatch
+                        key={preset}
+                        type="button"
+                        $color={preset}
+                        title={preset}
+                        onClick={() => applyColor(preset)}
+                      />
+                    ))}
+                  </Flex>
+                  <Box paddingTop={3}>
+                    <input
+                      type="color"
+                      value={color}
+                      aria-label="Custom text color"
+                      onChange={(event) => applyColor(event.target.value)}
+                      style={{ width: '100%', height: 32, border: 0, background: 'transparent', cursor: 'pointer' }}
+                    />
+                  </Box>
+                </Box>
+              </Popover.Content>
+            </Popover.Root>
+            <Divider />
+            <ToolBtn
+              type="button"
+              disabled={disabled || sourceMode}
+              onClick={() => run('justifyLeft')}
+              title="Align left"
+            >
+              ≡
+            </ToolBtn>
+            <ToolBtn
+              type="button"
+              disabled={disabled || sourceMode}
+              onClick={() => run('justifyCenter')}
+              title="Align center"
+            >
+              ≣
+            </ToolBtn>
+            <ToolBtn
+              type="button"
+              disabled={disabled || sourceMode}
+              onClick={() => run('justifyRight')}
+              title="Align right"
+            >
+              ≡
+            </ToolBtn>
+            <Divider />
+            <ToolBtn type="button" disabled={disabled || sourceMode} onClick={handleLink} title="Insert link">
+              🔗
+            </ToolBtn>
+            <ToolBtn type="button" disabled={disabled || sourceMode} onClick={handleImage} title="Insert image">
+              🖼
+            </ToolBtn>
+            <ToolBtn type="button" disabled={disabled || sourceMode} onClick={handleVideo} title="Insert video">
+              ▶
+            </ToolBtn>
+            <ToolBtn type="button" disabled={disabled || sourceMode} onClick={handleTable} title="Insert table">
+              ⊞
+            </ToolBtn>
+            <div style={{ marginLeft: 'auto' }}>
+              <ToolBtn
+                type="button"
+                $active={sourceMode}
+                disabled={disabled}
+                onClick={() => {
+                  if (!sourceMode && editorRef.current) {
+                    lastHtml.current = editorRef.current.innerHTML;
+                    field.onChange(name, editorRef.current.innerHTML);
+                  }
+                  setSourceMode((current) => !current);
+                }}
+                title="HTML source"
+              >
+                {'</>'}
+              </ToolBtn>
+            </div>
+          </Toolbar>
+          {sourceMode ? (
+            <SourceArea
+              ref={forwardedRef}
+              disabled={disabled}
+              value={field.value || ''}
+              placeholder={placeholder || '<p>Write HTML…</p>'}
+              onChange={(event) => field.onChange(name, event.target.value)}
+            />
+          ) : (
+            <EditorSurface
+              ref={(node) => {
+                editorRef.current = node;
+                if (typeof forwardedRef === 'function') {
+                  forwardedRef(node);
+                } else if (forwardedRef) {
+                  forwardedRef.current = node;
+                }
+                if (node && !node.innerHTML && field.value) {
+                  node.innerHTML = field.value;
+                }
+              }}
+              contentEditable={!disabled}
+              suppressContentEditableWarning
+              data-placeholder={placeholder || 'Write your article…'}
+              onInput={emitChange}
+              onBlur={emitChange}
+            />
+          )}
+        </Shell>
+        <Field.Hint />
+        <Field.Error />
+      </Flex>
+    </Field.Root>
+  );
+});
+
+HtmlEditorInput.displayName = 'HtmlEditorInput';

--- a/examples/getstarted/src/plugins/html-editor/admin/src/index.js
+++ b/examples/getstarted/src/plugins/html-editor/admin/src/index.js
@@ -1,0 +1,51 @@
+import { prefixPluginTranslations } from './utils/prefixPluginTranslations';
+import pluginId from './pluginId';
+import { HtmlEditorIcon } from './components/HtmlEditorIcon';
+import getTrad from './utils/getTrad';
+
+export default {
+  register(app) {
+    app.customFields.register({
+      name: 'html',
+      pluginId,
+      type: 'richtext',
+      icon: HtmlEditorIcon,
+      intlLabel: {
+        id: getTrad('html-editor.label'),
+        defaultMessage: 'HTML editor',
+      },
+      intlDescription: {
+        id: getTrad('html-editor.description'),
+        defaultMessage: 'Rich text with colors, media, tables, and HTML source',
+      },
+      components: {
+        Input: async () =>
+          import('./components/HtmlEditorInput').then((module) => ({
+            default: module.HtmlEditorInput,
+          })),
+      },
+    });
+
+    app.registerPlugin({
+      id: pluginId,
+      name: pluginId,
+    });
+  },
+
+  bootstrap() {},
+
+  async registerTrads({ locales }) {
+    const importedTrads = await Promise.all(
+      locales.map((locale) => {
+        return import(`./translations/${locale}.json`)
+          .then(({ default: data }) => ({
+            data: prefixPluginTranslations(data, pluginId),
+            locale,
+          }))
+          .catch(() => ({ data: {}, locale }));
+      })
+    );
+
+    return Promise.resolve(importedTrads);
+  },
+};

--- a/examples/getstarted/src/plugins/html-editor/admin/src/pluginId.js
+++ b/examples/getstarted/src/plugins/html-editor/admin/src/pluginId.js
@@ -1,0 +1,3 @@
+const pluginId = 'html-editor';
+
+export default pluginId;

--- a/examples/getstarted/src/plugins/html-editor/admin/src/translations/en.json
+++ b/examples/getstarted/src/plugins/html-editor/admin/src/translations/en.json
@@ -1,0 +1,4 @@
+{
+  "html-editor.label": "HTML editor",
+  "html-editor.description": "Rich text with colors, media, tables, and HTML source"
+}

--- a/examples/getstarted/src/plugins/html-editor/admin/src/utils/getTrad.js
+++ b/examples/getstarted/src/plugins/html-editor/admin/src/utils/getTrad.js
@@ -1,0 +1,5 @@
+import pluginId from '../pluginId';
+
+const getTrad = (id) => `${pluginId}.${id}`;
+
+export default getTrad;

--- a/examples/getstarted/src/plugins/html-editor/admin/src/utils/prefixPluginTranslations.js
+++ b/examples/getstarted/src/plugins/html-editor/admin/src/utils/prefixPluginTranslations.js
@@ -1,0 +1,12 @@
+const prefixPluginTranslations = (trad, pluginId) => {
+  if (!pluginId) {
+    throw new TypeError("pluginId can't be empty");
+  }
+
+  return Object.keys(trad).reduce((acc, current) => {
+    acc[`${pluginId}.${current}`] = trad[current];
+    return acc;
+  }, {});
+};
+
+export { prefixPluginTranslations };

--- a/examples/getstarted/src/plugins/html-editor/package.json
+++ b/examples/getstarted/src/plugins/html-editor/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "strapi-plugin-html-editor",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Rich HTML editor with text color, alignment, media, tables, and source view.",
+  "strapi": {
+    "name": "html-editor",
+    "displayName": "HTML Editor",
+    "description": "Rich HTML editor with text color. Stores HTML that the API returns as-is.",
+    "kind": "plugin"
+  }
+}

--- a/examples/getstarted/src/plugins/html-editor/server/bootstrap.js
+++ b/examples/getstarted/src/plugins/html-editor/server/bootstrap.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = () => {};

--- a/examples/getstarted/src/plugins/html-editor/server/config/index.js
+++ b/examples/getstarted/src/plugins/html-editor/server/config/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  default: {},
+  validator() {},
+};

--- a/examples/getstarted/src/plugins/html-editor/server/controllers/index.js
+++ b/examples/getstarted/src/plugins/html-editor/server/controllers/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/examples/getstarted/src/plugins/html-editor/server/register.js
+++ b/examples/getstarted/src/plugins/html-editor/server/register.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = ({ strapi }) => {
+  strapi.customFields.register({
+    name: 'html',
+    plugin: 'html-editor',
+    type: 'richtext',
+    inputSize: {
+      default: 12,
+      isResizable: false,
+    },
+  });
+};

--- a/examples/getstarted/src/plugins/html-editor/server/routes/index.js
+++ b/examples/getstarted/src/plugins/html-editor/server/routes/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  admin: {
+    type: 'admin',
+    routes: [],
+  },
+};

--- a/examples/getstarted/src/plugins/html-editor/server/services/index.js
+++ b/examples/getstarted/src/plugins/html-editor/server/services/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/examples/getstarted/src/plugins/html-editor/strapi-admin.js
+++ b/examples/getstarted/src/plugins/html-editor/strapi-admin.js
@@ -1,0 +1,3 @@
+import admin from './admin/src';
+
+export default admin;

--- a/examples/getstarted/src/plugins/html-editor/strapi-server.js
+++ b/examples/getstarted/src/plugins/html-editor/strapi-server.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const config = require('./server/config');
+const controllers = require('./server/controllers');
+const register = require('./server/register');
+const bootstrap = require('./server/bootstrap');
+const routes = require('./server/routes');
+const services = require('./server/services');
+
+module.exports = () => ({
+  register,
+  bootstrap,
+  config,
+  controllers,
+  routes,
+  services,
+});


### PR DESCRIPTION
### What does it do?

Adds two example plugins in `examples/getstarted`:

- **HTML editor**: a rich HTML custom field (text color, alignment, media, tables, source view) that stores formatted content as HTML and returns it from the API as-is.
- **Google Translate**: a Content Manager header action to fill the current locale from another locale, with credentials configured in Settings.

### Why is it needed?

Editors often need HTML output (including text color) and a way to translate an entry from another locale without leaving the edit view.

### How to test it?

1. From the repo root: `yarn install` then `yarn setup`.
2. `cd examples/getstarted` and `yarn develop`.
3. In the admin panel, add an HTML editor custom field to a content type and confirm the API returns HTML.
4. Open Settings → Google Translate, add credentials, then use **Translate from another locale** on a localized entry.

### Related issue(s)/PR(s)

None yet. Happy to split these into standalone Marketplace plugins if that is a better fit than shipping them in getstarted.
