### PR TITLE
feat(upload): add MCP scaffolding and read tools to the upload plugin

### DIFF
--- a/packages/core/upload/server/src/controllers/utils/find-entity-and-check-permissions.ts
+++ b/packages/core/upload/server/src/controllers/utils/find-entity-and-check-permissions.ts
@@ -1,14 +1,28 @@
 import _ from 'lodash';
 import { errors, contentTypes as contentTypesUtils } from '@strapi/utils';
+import type { Core } from '@strapi/types';
 import { getService } from '../../utils';
 
+/**
+ * Loads a file and enforces the permission *conditions* attached to `action` on it.
+ *
+ * `createdBy` and the creator's `roles` have to be populated before `toSubject`: the admin
+ * conditions read them (`admin::is-creator` matches `createdBy.id`, `admin::has-same-role-as-creator`
+ * matches `createdBy.roles`), and a subject missing those fields can never satisfy the rule — so
+ * a conditioned grant would be denied its own files rather than allowed them.
+ *
+ * `strapiInstance` defaults to the ambient global for the admin controllers, which have no
+ * `strapi` in scope. Callers that are handed an instance — MCP tool handlers — pass it
+ * explicitly so they never bind to a different one.
+ */
 const findEntityAndCheckPermissions = async (
   ability: unknown,
   action: string,
   model: string,
-  id: string | number
+  id: string | number,
+  strapiInstance: Core.Strapi = strapi
 ) => {
-  const file = await getService('upload').findOne(id, [
+  const file = await getService('upload', strapiInstance).findOne(id, [
     contentTypesUtils.constants.CREATED_BY_ATTRIBUTE,
     'folder',
   ]);
@@ -17,13 +31,13 @@ const findEntityAndCheckPermissions = async (
     throw new errors.NotFoundError();
   }
 
-  const pm = strapi
+  const pm = strapiInstance
     .service('admin::permission')
     .createPermissionsManager({ ability, action, model });
 
   const creatorId = _.get(file, [contentTypesUtils.constants.CREATED_BY_ATTRIBUTE, 'id']);
   const author = creatorId
-    ? await strapi.service('admin::user').findOne(creatorId, ['roles'])
+    ? await strapiInstance.service('admin::user').findOne(creatorId, ['roles'])
     : null;
 
   const fileWithRoles = _.set(_.cloneDeep(file), 'createdBy', author);

--- a/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
@@ -1,0 +1,95 @@
+import type { Core } from '@strapi/types';
+import {
+  buildUploadMcpToolDefinitions,
+  registerUploadMcpTools,
+} from '../register-upload-mcp-tools';
+import { ACTIONS } from '../../constants';
+
+const makeStrapi = (options: { isEnabled?: boolean; withAi?: boolean } = {}) => {
+  const { isEnabled = true, withAi = true } = options;
+  const registerTool = jest.fn();
+
+  const strapi = {
+    ...(withAi ? { ai: { mcp: { isEnabled: jest.fn(() => isEnabled), registerTool } } } : {}),
+  } as unknown as Core.Strapi;
+
+  return { strapi, registerTool };
+};
+
+describe('upload MCP tool registration', () => {
+  describe('gating', () => {
+    test('registers every read tool when the MCP server is enabled', () => {
+      const { strapi, registerTool } = makeStrapi({ isEnabled: true });
+
+      registerUploadMcpTools({ strapi });
+
+      expect(registerTool).toHaveBeenCalledTimes(3);
+      expect(registerTool.mock.calls.map(([tool]) => tool.name)).toEqual([
+        'list_media_assets',
+        'get_media_asset',
+        'list_media_folders',
+      ]);
+    });
+
+    test('registers nothing when the MCP server is disabled', () => {
+      const { strapi, registerTool } = makeStrapi({ isEnabled: false });
+
+      registerUploadMcpTools({ strapi });
+
+      expect(registerTool).not.toHaveBeenCalled();
+    });
+
+    test('does not throw when strapi.ai is unavailable', () => {
+      const { strapi, registerTool } = makeStrapi({ withAi: false });
+
+      expect(() => registerUploadMcpTools({ strapi })).not.toThrow();
+      expect(registerTool).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('definitions', () => {
+    const tools = buildUploadMcpToolDefinitions();
+    const byName = Object.fromEntries(tools.map((tool) => [tool.name, tool]));
+
+    test('gates every read tool on plugin::upload.read', () => {
+      // `plugin::upload.read` is registered without a subject, so the policy carries an action
+      // only. The per-model check lives in the handlers, via the permissions manager.
+      for (const tool of tools) {
+        expect(tool.auth.policies).toEqual([{ action: ACTIONS.read }]);
+      }
+    });
+
+    test('does not pin a policy to a subject the action was never registered with', () => {
+      for (const tool of tools) {
+        for (const policy of tool.auth.policies) {
+          expect(policy).not.toHaveProperty('subject');
+        }
+      }
+    });
+
+    test('never gates a read tool on a write action', () => {
+      const actions = tools.flatMap((tool) => tool.auth.policies.map((policy) => policy.action));
+
+      expect(actions).not.toContain(ACTIONS.update);
+      expect(actions).not.toContain(ACTIONS.create);
+    });
+
+    test('tags telemetry with the upload source', () => {
+      for (const tool of tools) {
+        expect(tool.telemetry.source).toBe('upload');
+      }
+    });
+
+    test('documents that media uses numeric ids, not documentIds', () => {
+      // The content-manager tools key on documentId, which files do not have.
+      expect(byName.get_media_asset.description).toMatch(/numeric id/i);
+      expect(byName.get_media_asset.description).toMatch(/not documents/i);
+    });
+
+    test('exposes an input schema for the tools that take arguments, and none for the folder tree', () => {
+      expect(byName.list_media_assets.resolveInputSchema).toBeDefined();
+      expect(byName.get_media_asset.resolveInputSchema).toBeDefined();
+      expect(byName.list_media_folders.resolveInputSchema).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
@@ -9,9 +9,9 @@ const makeStrapi = (options: { isEnabled?: boolean; withAi?: boolean } = {}) => 
   const { isEnabled = true, withAi = true } = options;
   const registerTool = jest.fn();
 
-  const strapi = {
-    ...(withAi ? { ai: { mcp: { isEnabled: jest.fn(() => isEnabled), registerTool } } } : {}),
-  } as unknown as Core.Strapi;
+  const strapi = (withAi
+    ? { ai: { mcp: { isEnabled: jest.fn(() => isEnabled), registerTool } } }
+    : {}) as unknown as Core.Strapi;
 
   return { strapi, registerTool };
 };

--- a/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
@@ -25,9 +25,9 @@ describe('upload MCP tool registration', () => {
 
       expect(registerTool).toHaveBeenCalledTimes(3);
       expect(registerTool.mock.calls.map(([tool]) => tool.name)).toEqual([
-        'list_media_assets',
-        'get_media_asset',
-        'list_media_folders',
+        'list_media',
+        'get_media',
+        'list_folders',
       ]);
     });
 
@@ -82,14 +82,14 @@ describe('upload MCP tool registration', () => {
 
     test('documents that media uses numeric ids, not documentIds', () => {
       // The content-manager tools key on documentId, which files do not have.
-      expect(byName.get_media_asset.description).toMatch(/numeric id/i);
-      expect(byName.get_media_asset.description).toMatch(/not documents/i);
+      expect(byName.get_media.description).toMatch(/numeric id/i);
+      expect(byName.get_media.description).toMatch(/not documents/i);
     });
 
     test('exposes an input schema for the tools that take arguments, and none for the folder tree', () => {
-      expect(byName.list_media_assets.resolveInputSchema).toBeDefined();
-      expect(byName.get_media_asset.resolveInputSchema).toBeDefined();
-      expect(byName.list_media_folders.resolveInputSchema).toBeUndefined();
+      expect(byName.list_media.resolveInputSchema).toBeDefined();
+      expect(byName.get_media.resolveInputSchema).toBeDefined();
+      expect(byName.list_folders.resolveInputSchema).toBeUndefined();
     });
   });
 });

--- a/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
@@ -17,9 +17,9 @@ const makeStrapi = (options: { isEnabled?: boolean; withAi?: boolean } = {}) => 
 };
 
 describe('upload MCP tool registration', () => {
-  describe('gating', () => {
-    test('registers every read tool when the MCP server is enabled', () => {
-      const { strapi, registerTool } = makeStrapi({ isEnabled: true });
+  describe('registration', () => {
+    test('registers every read tool', () => {
+      const { strapi, registerTool } = makeStrapi();
 
       registerUploadMcpTools({ strapi });
 
@@ -31,12 +31,15 @@ describe('upload MCP tool registration', () => {
       ]);
     });
 
-    test('registers nothing when the MCP server is disabled', () => {
+    test('registers the tools even when the MCP server is disabled', () => {
+      // registerTool() only stores the definition; the server is what withholds a disabled
+      // tool from clients. Registering unconditionally keeps this function free of a gate
+      // that would have to stay in sync with core's own enablement rules.
       const { strapi, registerTool } = makeStrapi({ isEnabled: false });
 
       registerUploadMcpTools({ strapi });
 
-      expect(registerTool).not.toHaveBeenCalled();
+      expect(registerTool).toHaveBeenCalledTimes(3);
     });
 
     test('does not throw when strapi.ai is unavailable', () => {

--- a/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
@@ -25,10 +25,24 @@ describe('upload MCP tool registration', () => {
 
       expect(registerTool).toHaveBeenCalledTimes(3);
       expect(registerTool.mock.calls.map(([tool]) => tool.name)).toEqual([
-        'list_media',
-        'get_media',
-        'list_folders',
+        'media_list_assets',
+        'media_get_asset',
+        'media_list_folders',
       ]);
+    });
+
+    test('names every tool so the content-manager can never derive the same one', () => {
+      // The content-manager derives `<verb>_<slug>` per content type, in bootstrap — after this
+      // runs in register. registerTool throws on a duplicate name and nothing catches it, so a
+      // project with a content type named `media` or `folders` would fail to boot on a clash.
+      // Every derived name starts with a verb, so a media_ prefix is unreachable by derivation.
+      const { strapi, registerTool } = makeStrapi();
+
+      registerUploadMcpTools({ strapi });
+
+      for (const [tool] of registerTool.mock.calls) {
+        expect(tool.name).toMatch(/^media_/);
+      }
     });
 
     test('registers the tools even when the MCP server is disabled', () => {
@@ -85,14 +99,14 @@ describe('upload MCP tool registration', () => {
 
     test('documents that media uses numeric ids, not documentIds', () => {
       // The content-manager tools key on documentId, which files do not have.
-      expect(byName.get_media.description).toMatch(/numeric id/i);
-      expect(byName.get_media.description).toMatch(/not documents/i);
+      expect(byName.media_get_asset.description).toMatch(/numeric id/i);
+      expect(byName.media_get_asset.description).toMatch(/not documents/i);
     });
 
     test('exposes an input schema for the tools that take arguments, and none for the folder tree', () => {
-      expect(byName.list_media.resolveInputSchema).toBeDefined();
-      expect(byName.get_media.resolveInputSchema).toBeDefined();
-      expect(byName.list_folders.resolveInputSchema).toBeUndefined();
+      expect(byName.media_list_assets.resolveInputSchema).toBeDefined();
+      expect(byName.media_get_asset.resolveInputSchema).toBeDefined();
+      expect(byName.media_list_folders.resolveInputSchema).toBeUndefined();
     });
   });
 });

--- a/packages/core/upload/server/src/mcp/__tests__/sanitize-media.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/sanitize-media.test.ts
@@ -1,0 +1,134 @@
+import { sanitizeMediaAsset, sanitizeMediaFolderTree } from '../sanitizers/sanitize-media';
+
+describe('sanitizeMediaAsset', () => {
+  const rawFile = {
+    id: 7,
+    name: 'photo.png',
+    alternativeText: 'a photo',
+    caption: null,
+    width: 800,
+    height: 600,
+    formats: { thumbnail: { url: '/uploads/thumb.png' } },
+    hash: 'photo_abc123',
+    ext: '.png',
+    mime: 'image/png',
+    size: 12.5,
+    url: '/uploads/photo.png',
+    previewUrl: null,
+    provider: 'aws-s3',
+    provider_metadata: { secretAccessKey: 'super-secret', bucket: 'private-bucket' },
+    folderPath: '/1/2',
+    folder: { id: 2, name: 'Photos', path: '/1/2', pathId: 2 },
+    createdAt: '2026-09-02T08:00:00.000Z',
+    updatedAt: '2026-09-02T09:00:00.000Z',
+  };
+
+  test('exposes exactly the allowlisted keys', () => {
+    expect(Object.keys(sanitizeMediaAsset(rawFile)).sort()).toEqual([
+      'alternativeText',
+      'caption',
+      'createdAt',
+      'ext',
+      'folder',
+      'height',
+      'id',
+      'mime',
+      'name',
+      'size',
+      'updatedAt',
+      'url',
+      'width',
+    ]);
+  });
+
+  test('drops provider fields that can carry credentials', () => {
+    const sanitized = sanitizeMediaAsset(rawFile);
+
+    expect(sanitized).not.toHaveProperty('provider');
+    expect(sanitized).not.toHaveProperty('provider_metadata');
+    expect(JSON.stringify(sanitized)).not.toContain('super-secret');
+  });
+
+  test('drops private and internal bookkeeping fields', () => {
+    const sanitized = sanitizeMediaAsset(rawFile);
+
+    expect(sanitized).not.toHaveProperty('folderPath');
+    expect(sanitized).not.toHaveProperty('hash');
+    expect(sanitized).not.toHaveProperty('formats');
+    expect(sanitized).not.toHaveProperty('previewUrl');
+  });
+
+  test('reduces the folder relation to id and name', () => {
+    expect(sanitizeMediaAsset(rawFile).folder).toEqual({ id: 2, name: 'Photos' });
+  });
+
+  test('returns a null folder for a root-level asset', () => {
+    expect(sanitizeMediaAsset({ ...rawFile, folder: null }).folder).toBeNull();
+    expect(sanitizeMediaAsset({ ...rawFile, folder: undefined }).folder).toBeNull();
+  });
+
+  test('keeps a field added to the file content-type invisible until allowlisted', () => {
+    // The point of the allowlist: a new column must not leak by default.
+    const sanitized = sanitizeMediaAsset({ ...rawFile, newSensitiveField: 'leaked' });
+
+    expect(sanitized).not.toHaveProperty('newSensitiveField');
+  });
+
+  test('serializes Date timestamps to ISO strings', () => {
+    const sanitized = sanitizeMediaAsset({
+      ...rawFile,
+      createdAt: new Date('2026-09-02T08:00:00.000Z'),
+    });
+
+    expect(sanitized.createdAt).toBe('2026-09-02T08:00:00.000Z');
+  });
+
+  test('normalizes missing image dimensions to null', () => {
+    const sanitized = sanitizeMediaAsset({ ...rawFile, width: null, height: undefined });
+
+    expect(sanitized.width).toBeNull();
+    expect(sanitized.height).toBeNull();
+  });
+});
+
+describe('sanitizeMediaFolderTree', () => {
+  test('keeps id, name and children while dropping path bookkeeping', () => {
+    const structure = [
+      {
+        id: 1,
+        name: 'root',
+        path: '/1',
+        pathId: 1,
+        children: [{ id: 2, name: 'nested', path: '/1/2', pathId: 2, children: [] }],
+      },
+    ];
+
+    expect(sanitizeMediaFolderTree(structure)).toEqual([
+      { id: 1, name: 'root', children: [{ id: 2, name: 'nested', children: [] }] },
+    ]);
+  });
+
+  test('recurses to arbitrary depth', () => {
+    const structure = [
+      {
+        id: 1,
+        name: 'a',
+        children: [{ id: 2, name: 'b', children: [{ id: 3, name: 'c', children: [] }] }],
+      },
+    ];
+
+    const [a] = sanitizeMediaFolderTree(structure);
+    expect(a.children[0].children[0]).toEqual({ id: 3, name: 'c', children: [] });
+  });
+
+  test('returns an empty array for a non-array input', () => {
+    expect(sanitizeMediaFolderTree(undefined)).toEqual([]);
+    expect(sanitizeMediaFolderTree(null)).toEqual([]);
+  });
+
+  test('tolerates a node with no children key', () => {
+    expect(sanitizeMediaFolderTree([{ id: 1, name: 'leaf' }])).toEqual([
+      { id: 1, name: 'leaf', children: [] },
+    ]);
+  });
+});

--- a/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
@@ -1,0 +1,154 @@
+import {
+  listMediaAssetsInputSchema,
+  getMediaAssetInputSchema,
+  listMediaAssetsOutputSchema,
+  getMediaAssetOutputSchema,
+  listMediaFoldersOutputSchema,
+} from '../schemas';
+import { ALLOWED_SORT_STRINGS } from '../../constants';
+
+describe('upload MCP schemas', () => {
+  describe('list_media_assets input', () => {
+    test('accepts an empty object — every filter is optional', () => {
+      expect(listMediaAssetsInputSchema.safeParse({}).success).toBe(true);
+    });
+
+    test('accepts the documented filters', () => {
+      const parsed = listMediaAssetsInputSchema.safeParse({
+        folderId: 3,
+        mime: 'image/png',
+        name: 'logo',
+        page: 2,
+        pageSize: 50,
+        sort: 'name:ASC',
+      });
+
+      expect(parsed.success).toBe(true);
+    });
+
+    test('accepts folderId: null to mean the media library root', () => {
+      expect(listMediaAssetsInputSchema.safeParse({ folderId: null }).success).toBe(true);
+    });
+
+    test.each(ALLOWED_SORT_STRINGS)('accepts the allowed sort string %s', (sort) => {
+      expect(listMediaAssetsInputSchema.safeParse({ sort }).success).toBe(true);
+    });
+
+    test('rejects a sort on a private column', () => {
+      // folderPath is `private: true` on the file content-type and must not be sortable.
+      expect(listMediaAssetsInputSchema.safeParse({ sort: 'folderPath:ASC' }).success).toBe(false);
+    });
+
+    test('rejects a non-integer or out-of-range page size', () => {
+      expect(listMediaAssetsInputSchema.safeParse({ pageSize: 0 }).success).toBe(false);
+      expect(listMediaAssetsInputSchema.safeParse({ pageSize: 101 }).success).toBe(false);
+      expect(listMediaAssetsInputSchema.safeParse({ pageSize: 1.5 }).success).toBe(false);
+    });
+
+    test('rejects a zero or negative page', () => {
+      expect(listMediaAssetsInputSchema.safeParse({ page: 0 }).success).toBe(false);
+      expect(listMediaAssetsInputSchema.safeParse({ page: -1 }).success).toBe(false);
+    });
+  });
+
+  describe('get_media_asset input', () => {
+    test('requires a positive integer id', () => {
+      expect(getMediaAssetInputSchema.safeParse({ id: 42 }).success).toBe(true);
+      expect(getMediaAssetInputSchema.safeParse({ id: 0 }).success).toBe(false);
+      expect(getMediaAssetInputSchema.safeParse({ id: 1.5 }).success).toBe(false);
+    });
+
+    test('rejects a documentId in place of a numeric id', () => {
+      // Media files are not documents; a string identifier is a caller error worth surfacing.
+      expect(getMediaAssetInputSchema.safeParse({ id: 'z7v8zma53x01r6oceimv922b' }).success).toBe(
+        false
+      );
+    });
+
+    test('requires the id', () => {
+      expect(getMediaAssetInputSchema.safeParse({}).success).toBe(false);
+    });
+  });
+
+  describe('output schemas', () => {
+    const asset = {
+      id: 1,
+      name: 'photo.png',
+      alternativeText: 'a photo',
+      caption: null,
+      url: '/uploads/photo.png',
+      mime: 'image/png',
+      size: 12.5,
+      width: 800,
+      height: 600,
+      ext: '.png',
+      folder: { id: 2, name: 'Photos' },
+      createdAt: '2026-09-02T08:00:00.000Z',
+      updatedAt: '2026-09-02T08:00:00.000Z',
+    };
+
+    test('validates a sanitized asset', () => {
+      expect(getMediaAssetOutputSchema.safeParse({ data: asset }).success).toBe(true);
+    });
+
+    test('accepts a null folder for a root-level asset', () => {
+      expect(
+        getMediaAssetOutputSchema.safeParse({ data: { ...asset, folder: null } }).success
+      ).toBe(true);
+    });
+
+    test('accepts a null data payload', () => {
+      expect(getMediaAssetOutputSchema.safeParse({ data: null }).success).toBe(true);
+    });
+
+    test('strips fields outside the allowlist', () => {
+      const parsed = getMediaAssetOutputSchema.parse({
+        data: {
+          ...asset,
+          provider: 'aws-s3',
+          provider_metadata: { secretKey: 'super-secret' },
+          hash: 'photo_abc123',
+          folderPath: '/1/2',
+          formats: { thumbnail: {} },
+        },
+      });
+
+      expect(parsed.data).not.toHaveProperty('provider');
+      expect(parsed.data).not.toHaveProperty('provider_metadata');
+      expect(parsed.data).not.toHaveProperty('hash');
+      expect(parsed.data).not.toHaveProperty('folderPath');
+      expect(parsed.data).not.toHaveProperty('formats');
+    });
+
+    test('validates a paginated list payload', () => {
+      const parsed = listMediaAssetsOutputSchema.safeParse({
+        results: [asset],
+        pagination: { page: 1, pageSize: 25, pageCount: 1, total: 1 },
+      });
+
+      expect(parsed.success).toBe(true);
+    });
+
+    test('validates an arbitrarily nested folder tree', () => {
+      const parsed = listMediaFoldersOutputSchema.safeParse({
+        data: [
+          {
+            id: 1,
+            name: 'root',
+            children: [
+              { id: 2, name: 'nested', children: [{ id: 3, name: 'deep', children: [] }] },
+            ],
+          },
+        ],
+      });
+
+      expect(parsed.success).toBe(true);
+    });
+
+    test('rejects a folder node missing children', () => {
+      expect(
+        listMediaFoldersOutputSchema.safeParse({ data: [{ id: 1, name: 'root' }] }).success
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
@@ -1,20 +1,20 @@
 import {
-  listMediaAssetsInputSchema,
-  getMediaAssetInputSchema,
-  listMediaAssetsOutputSchema,
-  getMediaAssetOutputSchema,
-  listMediaFoldersOutputSchema,
+  listMediaInputSchema,
+  getMediaInputSchema,
+  listMediaOutputSchema,
+  getMediaOutputSchema,
+  listFoldersOutputSchema,
 } from '../schemas';
 import { ALLOWED_SORT_STRINGS } from '../../constants';
 
 describe('upload MCP schemas', () => {
-  describe('list_media_assets input', () => {
+  describe('list_media input', () => {
     test('accepts an empty object — every filter is optional', () => {
-      expect(listMediaAssetsInputSchema.safeParse({}).success).toBe(true);
+      expect(listMediaInputSchema.safeParse({}).success).toBe(true);
     });
 
     test('accepts the documented filters', () => {
-      const parsed = listMediaAssetsInputSchema.safeParse({
+      const parsed = listMediaInputSchema.safeParse({
         folderId: 3,
         mime: 'image/png',
         name: 'logo',
@@ -27,46 +27,44 @@ describe('upload MCP schemas', () => {
     });
 
     test('accepts folderId: null to mean the media library root', () => {
-      expect(listMediaAssetsInputSchema.safeParse({ folderId: null }).success).toBe(true);
+      expect(listMediaInputSchema.safeParse({ folderId: null }).success).toBe(true);
     });
 
     test.each(ALLOWED_SORT_STRINGS)('accepts the allowed sort string %s', (sort) => {
-      expect(listMediaAssetsInputSchema.safeParse({ sort }).success).toBe(true);
+      expect(listMediaInputSchema.safeParse({ sort }).success).toBe(true);
     });
 
     test('rejects a sort on a private column', () => {
       // folderPath is `private: true` on the file content-type and must not be sortable.
-      expect(listMediaAssetsInputSchema.safeParse({ sort: 'folderPath:ASC' }).success).toBe(false);
+      expect(listMediaInputSchema.safeParse({ sort: 'folderPath:ASC' }).success).toBe(false);
     });
 
     test('rejects a non-integer or out-of-range page size', () => {
-      expect(listMediaAssetsInputSchema.safeParse({ pageSize: 0 }).success).toBe(false);
-      expect(listMediaAssetsInputSchema.safeParse({ pageSize: 101 }).success).toBe(false);
-      expect(listMediaAssetsInputSchema.safeParse({ pageSize: 1.5 }).success).toBe(false);
+      expect(listMediaInputSchema.safeParse({ pageSize: 0 }).success).toBe(false);
+      expect(listMediaInputSchema.safeParse({ pageSize: 101 }).success).toBe(false);
+      expect(listMediaInputSchema.safeParse({ pageSize: 1.5 }).success).toBe(false);
     });
 
     test('rejects a zero or negative page', () => {
-      expect(listMediaAssetsInputSchema.safeParse({ page: 0 }).success).toBe(false);
-      expect(listMediaAssetsInputSchema.safeParse({ page: -1 }).success).toBe(false);
+      expect(listMediaInputSchema.safeParse({ page: 0 }).success).toBe(false);
+      expect(listMediaInputSchema.safeParse({ page: -1 }).success).toBe(false);
     });
   });
 
-  describe('get_media_asset input', () => {
+  describe('get_media input', () => {
     test('requires a positive integer id', () => {
-      expect(getMediaAssetInputSchema.safeParse({ id: 42 }).success).toBe(true);
-      expect(getMediaAssetInputSchema.safeParse({ id: 0 }).success).toBe(false);
-      expect(getMediaAssetInputSchema.safeParse({ id: 1.5 }).success).toBe(false);
+      expect(getMediaInputSchema.safeParse({ id: 42 }).success).toBe(true);
+      expect(getMediaInputSchema.safeParse({ id: 0 }).success).toBe(false);
+      expect(getMediaInputSchema.safeParse({ id: 1.5 }).success).toBe(false);
     });
 
     test('rejects a documentId in place of a numeric id', () => {
       // Media files are not documents; a string identifier is a caller error worth surfacing.
-      expect(getMediaAssetInputSchema.safeParse({ id: 'z7v8zma53x01r6oceimv922b' }).success).toBe(
-        false
-      );
+      expect(getMediaInputSchema.safeParse({ id: 'z7v8zma53x01r6oceimv922b' }).success).toBe(false);
     });
 
     test('requires the id', () => {
-      expect(getMediaAssetInputSchema.safeParse({}).success).toBe(false);
+      expect(getMediaInputSchema.safeParse({}).success).toBe(false);
     });
   });
 
@@ -88,21 +86,21 @@ describe('upload MCP schemas', () => {
     };
 
     test('validates a sanitized asset', () => {
-      expect(getMediaAssetOutputSchema.safeParse({ data: asset }).success).toBe(true);
+      expect(getMediaOutputSchema.safeParse({ data: asset }).success).toBe(true);
     });
 
     test('accepts a null folder for a root-level asset', () => {
-      expect(
-        getMediaAssetOutputSchema.safeParse({ data: { ...asset, folder: null } }).success
-      ).toBe(true);
+      expect(getMediaOutputSchema.safeParse({ data: { ...asset, folder: null } }).success).toBe(
+        true
+      );
     });
 
     test('accepts a null data payload', () => {
-      expect(getMediaAssetOutputSchema.safeParse({ data: null }).success).toBe(true);
+      expect(getMediaOutputSchema.safeParse({ data: null }).success).toBe(true);
     });
 
     test('strips fields outside the allowlist', () => {
-      const parsed = getMediaAssetOutputSchema.parse({
+      const parsed = getMediaOutputSchema.parse({
         data: {
           ...asset,
           provider: 'aws-s3',
@@ -121,7 +119,7 @@ describe('upload MCP schemas', () => {
     });
 
     test('validates a paginated list payload', () => {
-      const parsed = listMediaAssetsOutputSchema.safeParse({
+      const parsed = listMediaOutputSchema.safeParse({
         results: [asset],
         pagination: { page: 1, pageSize: 25, pageCount: 1, total: 1 },
       });
@@ -130,7 +128,7 @@ describe('upload MCP schemas', () => {
     });
 
     test('validates an arbitrarily nested folder tree', () => {
-      const parsed = listMediaFoldersOutputSchema.safeParse({
+      const parsed = listFoldersOutputSchema.safeParse({
         data: [
           {
             id: 1,
@@ -146,9 +144,9 @@ describe('upload MCP schemas', () => {
     });
 
     test('rejects a folder node missing children', () => {
-      expect(
-        listMediaFoldersOutputSchema.safeParse({ data: [{ id: 1, name: 'root' }] }).success
-      ).toBe(false);
+      expect(listFoldersOutputSchema.safeParse({ data: [{ id: 1, name: 'root' }] }).success).toBe(
+        false
+      );
     });
   });
 });

--- a/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
@@ -1,20 +1,20 @@
 import {
-  listMediaInputSchema,
-  getMediaInputSchema,
-  listMediaOutputSchema,
-  getMediaOutputSchema,
-  listFoldersOutputSchema,
+  mediaListAssetsInputSchema,
+  mediaGetAssetInputSchema,
+  mediaListAssetsOutputSchema,
+  mediaGetAssetOutputSchema,
+  mediaListFoldersOutputSchema,
 } from '../schemas';
 import { ALLOWED_SORT_STRINGS } from '../../constants';
 
 describe('upload MCP schemas', () => {
-  describe('list_media input', () => {
+  describe('media_list_assets input', () => {
     test('accepts an empty object — every filter is optional', () => {
-      expect(listMediaInputSchema.safeParse({}).success).toBe(true);
+      expect(mediaListAssetsInputSchema.safeParse({}).success).toBe(true);
     });
 
     test('accepts the documented filters', () => {
-      const parsed = listMediaInputSchema.safeParse({
+      const parsed = mediaListAssetsInputSchema.safeParse({
         folderId: 3,
         mime: 'image/png',
         name: 'logo',
@@ -27,44 +27,46 @@ describe('upload MCP schemas', () => {
     });
 
     test('accepts folderId: null to mean the media library root', () => {
-      expect(listMediaInputSchema.safeParse({ folderId: null }).success).toBe(true);
+      expect(mediaListAssetsInputSchema.safeParse({ folderId: null }).success).toBe(true);
     });
 
     test.each(ALLOWED_SORT_STRINGS)('accepts the allowed sort string %s', (sort) => {
-      expect(listMediaInputSchema.safeParse({ sort }).success).toBe(true);
+      expect(mediaListAssetsInputSchema.safeParse({ sort }).success).toBe(true);
     });
 
     test('rejects a sort on a private column', () => {
       // folderPath is `private: true` on the file content-type and must not be sortable.
-      expect(listMediaInputSchema.safeParse({ sort: 'folderPath:ASC' }).success).toBe(false);
+      expect(mediaListAssetsInputSchema.safeParse({ sort: 'folderPath:ASC' }).success).toBe(false);
     });
 
     test('rejects a non-integer or out-of-range page size', () => {
-      expect(listMediaInputSchema.safeParse({ pageSize: 0 }).success).toBe(false);
-      expect(listMediaInputSchema.safeParse({ pageSize: 101 }).success).toBe(false);
-      expect(listMediaInputSchema.safeParse({ pageSize: 1.5 }).success).toBe(false);
+      expect(mediaListAssetsInputSchema.safeParse({ pageSize: 0 }).success).toBe(false);
+      expect(mediaListAssetsInputSchema.safeParse({ pageSize: 101 }).success).toBe(false);
+      expect(mediaListAssetsInputSchema.safeParse({ pageSize: 1.5 }).success).toBe(false);
     });
 
     test('rejects a zero or negative page', () => {
-      expect(listMediaInputSchema.safeParse({ page: 0 }).success).toBe(false);
-      expect(listMediaInputSchema.safeParse({ page: -1 }).success).toBe(false);
+      expect(mediaListAssetsInputSchema.safeParse({ page: 0 }).success).toBe(false);
+      expect(mediaListAssetsInputSchema.safeParse({ page: -1 }).success).toBe(false);
     });
   });
 
-  describe('get_media input', () => {
+  describe('media_get_asset input', () => {
     test('requires a positive integer id', () => {
-      expect(getMediaInputSchema.safeParse({ id: 42 }).success).toBe(true);
-      expect(getMediaInputSchema.safeParse({ id: 0 }).success).toBe(false);
-      expect(getMediaInputSchema.safeParse({ id: 1.5 }).success).toBe(false);
+      expect(mediaGetAssetInputSchema.safeParse({ id: 42 }).success).toBe(true);
+      expect(mediaGetAssetInputSchema.safeParse({ id: 0 }).success).toBe(false);
+      expect(mediaGetAssetInputSchema.safeParse({ id: 1.5 }).success).toBe(false);
     });
 
     test('rejects a documentId in place of a numeric id', () => {
       // Media files are not documents; a string identifier is a caller error worth surfacing.
-      expect(getMediaInputSchema.safeParse({ id: 'z7v8zma53x01r6oceimv922b' }).success).toBe(false);
+      expect(mediaGetAssetInputSchema.safeParse({ id: 'z7v8zma53x01r6oceimv922b' }).success).toBe(
+        false
+      );
     });
 
     test('requires the id', () => {
-      expect(getMediaInputSchema.safeParse({}).success).toBe(false);
+      expect(mediaGetAssetInputSchema.safeParse({}).success).toBe(false);
     });
   });
 
@@ -86,21 +88,21 @@ describe('upload MCP schemas', () => {
     };
 
     test('validates a sanitized asset', () => {
-      expect(getMediaOutputSchema.safeParse({ data: asset }).success).toBe(true);
+      expect(mediaGetAssetOutputSchema.safeParse({ data: asset }).success).toBe(true);
     });
 
     test('accepts a null folder for a root-level asset', () => {
-      expect(getMediaOutputSchema.safeParse({ data: { ...asset, folder: null } }).success).toBe(
-        true
-      );
+      expect(
+        mediaGetAssetOutputSchema.safeParse({ data: { ...asset, folder: null } }).success
+      ).toBe(true);
     });
 
     test('accepts a null data payload', () => {
-      expect(getMediaOutputSchema.safeParse({ data: null }).success).toBe(true);
+      expect(mediaGetAssetOutputSchema.safeParse({ data: null }).success).toBe(true);
     });
 
     test('strips fields outside the allowlist', () => {
-      const parsed = getMediaOutputSchema.parse({
+      const parsed = mediaGetAssetOutputSchema.parse({
         data: {
           ...asset,
           provider: 'aws-s3',
@@ -119,7 +121,7 @@ describe('upload MCP schemas', () => {
     });
 
     test('validates a paginated list payload', () => {
-      const parsed = listMediaOutputSchema.safeParse({
+      const parsed = mediaListAssetsOutputSchema.safeParse({
         results: [asset],
         pagination: { page: 1, pageSize: 25, pageCount: 1, total: 1 },
       });
@@ -128,7 +130,7 @@ describe('upload MCP schemas', () => {
     });
 
     test('validates an arbitrarily nested folder tree', () => {
-      const parsed = listFoldersOutputSchema.safeParse({
+      const parsed = mediaListFoldersOutputSchema.safeParse({
         data: [
           {
             id: 1,
@@ -144,9 +146,9 @@ describe('upload MCP schemas', () => {
     });
 
     test('rejects a folder node missing children', () => {
-      expect(listFoldersOutputSchema.safeParse({ data: [{ id: 1, name: 'root' }] }).success).toBe(
-        false
-      );
+      expect(
+        mediaListFoldersOutputSchema.safeParse({ data: [{ id: 1, name: 'root' }] }).success
+      ).toBe(false);
     });
   });
 });

--- a/packages/core/upload/server/src/mcp/handlers/constants.ts
+++ b/packages/core/upload/server/src/mcp/handlers/constants.ts
@@ -1,0 +1,1 @@
+export const MCP_NOT_FOUND_ASSET = 'Media asset not found.';

--- a/packages/core/upload/server/src/mcp/handlers/index.ts
+++ b/packages/core/upload/server/src/mcp/handlers/index.ts
@@ -1,6 +1,6 @@
 export {
-  createListMediaAssetsHandler,
-  createGetMediaAssetHandler,
-  createListMediaFoldersHandler,
+  createListMediaHandler,
+  createGetMediaHandler,
+  createListFoldersHandler,
 } from './read-handlers';
 export { MCP_NOT_FOUND_ASSET } from './constants';

--- a/packages/core/upload/server/src/mcp/handlers/index.ts
+++ b/packages/core/upload/server/src/mcp/handlers/index.ts
@@ -1,0 +1,6 @@
+export {
+  createListMediaAssetsHandler,
+  createGetMediaAssetHandler,
+  createListMediaFoldersHandler,
+} from './read-handlers';
+export { MCP_NOT_FOUND_ASSET } from './constants';

--- a/packages/core/upload/server/src/mcp/handlers/index.ts
+++ b/packages/core/upload/server/src/mcp/handlers/index.ts
@@ -1,6 +1,6 @@
 export {
-  createListMediaHandler,
-  createGetMediaHandler,
-  createListFoldersHandler,
+  createMediaListAssetsHandler,
+  createMediaGetAssetHandler,
+  createMediaListFoldersHandler,
 } from './read-handlers';
 export { MCP_NOT_FOUND_ASSET } from './constants';

--- a/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
+++ b/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
@@ -1,0 +1,139 @@
+import { errors } from '@strapi/utils';
+import type { Core, Modules } from '@strapi/types';
+
+import { getService } from '../../utils';
+import { ACTIONS, FILE_MODEL_UID, FOLDER_MODEL_UID } from '../../constants';
+import { assertMediaPermission } from '../permissions';
+import { sanitizeMediaAsset, sanitizeMediaFolderTree } from '../sanitizers/sanitize-media';
+import { MCP_NOT_FOUND_ASSET } from './constants';
+import { ok } from '../utils';
+
+const DEFAULT_SORT = 'createdAt:DESC';
+
+// Arg types are type-level only: the MCP SDK validates `args` against the tool's Zod input
+// schema before the handler runs, so handlers accept the erased `Record<string, unknown>` the
+// registry hands them and narrow it here.
+type ListMediaAssetsArgs = {
+  folderId?: number | null;
+  mime?: string;
+  name?: string;
+  page?: number;
+  pageSize?: number;
+  sort?: string;
+};
+
+type GetMediaAssetArgs = {
+  id: number;
+};
+
+/**
+ * Builds the `filters` clause for `list_media_assets`.
+ *
+ * `folderId: null` is meaningfully different from an omitted `folderId`: null means "assets at
+ * the media library root" (no folder relation), while omitting it means "any folder".
+ *
+ * `mime` accepts both a full type and a bare prefix. An exact match on "image" would never hit,
+ * so a value without a slash is matched as a prefix ("image" → every "image/*").
+ */
+const buildAssetFilters = (args: ListMediaAssetsArgs): Record<string, unknown> => {
+  const filters: Record<string, unknown> = {};
+
+  if (args.folderId === null) {
+    filters.folder = null;
+  } else if (args.folderId !== undefined) {
+    filters.folder = { id: args.folderId };
+  }
+
+  if (args.mime !== undefined) {
+    filters.mime = args.mime.includes('/')
+      ? { $eqi: args.mime }
+      : { $startsWithi: `${args.mime}/` };
+  }
+
+  if (args.name !== undefined) {
+    filters.name = { $containsi: args.name };
+  }
+
+  return filters;
+};
+
+/**
+ * `list_media_assets` — paginated, filtered listing of media files.
+ *
+ * Permission conditions are applied through the permissions manager
+ * (`addPermissionsQueryTo`) so a token restricted by a condition — e.g. own-assets-only —
+ * sees the same subset it would through the admin API.
+ */
+export const createListMediaAssetsHandler =
+  (_strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
+  async ({
+    args,
+  }: {
+    args: Record<string, unknown>;
+  }): Promise<Modules.MCP.McpToolHandlerReturn> => {
+    const { folderId, mime, name, page, pageSize, sort } = args as ListMediaAssetsArgs;
+    const pm = assertMediaPermission(context, ACTIONS.read, FILE_MODEL_UID);
+
+    const query = await pm.addPermissionsQueryTo({
+      filters: buildAssetFilters({ folderId, mime, name }),
+      sort: sort ?? DEFAULT_SORT,
+      page: page ?? 1,
+      pageSize: pageSize ?? 25,
+      populate: { folder: { fields: ['id', 'name'] } },
+    });
+
+    const { results, pagination } = await getService('upload').findPage(query);
+
+    return ok({
+      results: results.map(sanitizeMediaAsset),
+      pagination,
+    });
+  };
+
+/**
+ * `get_media_asset` — a single asset by numeric id.
+ *
+ * The entity-level `cannot(action, subject)` check is what enforces permission *conditions*:
+ * `pm.isAllowed` only proves the action is permitted on the model, not on this row.
+ */
+export const createGetMediaAssetHandler =
+  (_strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
+  async ({
+    args,
+  }: {
+    args: Record<string, unknown>;
+  }): Promise<Modules.MCP.McpToolHandlerReturn> => {
+    const { id } = args as GetMediaAssetArgs;
+    const pm = assertMediaPermission(context, ACTIONS.read, FILE_MODEL_UID);
+
+    const asset = await getService('upload').findOne(id, {
+      folder: { fields: ['id', 'name'] },
+    });
+
+    if (asset === null || asset === undefined) {
+      throw new errors.NotFoundError(MCP_NOT_FOUND_ASSET);
+    }
+
+    if (pm.ability.cannot(pm.action, pm.toSubject(asset))) {
+      throw new errors.ForbiddenError();
+    }
+
+    return ok({ data: sanitizeMediaAsset(asset) });
+  };
+
+/**
+ * `list_media_folders` — the nested folder structure, reusing `folder.getStructure()`.
+ *
+ * `getStructure()` returns the whole tree in one query and has no permission-condition
+ * filtering, so this is gated on the model-level read permission only — matching
+ * `GET /upload/folder-structure` in the admin API.
+ */
+export const createListMediaFoldersHandler =
+  (_strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
+  async (): Promise<Modules.MCP.McpToolHandlerReturn> => {
+    assertMediaPermission(context, ACTIONS.read, FOLDER_MODEL_UID);
+
+    const structure = await getService('folder').getStructure();
+
+    return ok({ data: sanitizeMediaFolderTree(structure) });
+  };

--- a/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
+++ b/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
@@ -65,14 +65,14 @@ const buildAssetFilters = (args: ListMediaArgs): Record<string, unknown> => {
  * sees the same subset it would through the admin API.
  */
 export const createListMediaHandler =
-  (_strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
+  (strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async ({
     args,
   }: {
     args: Record<string, unknown>;
   }): Promise<Modules.MCP.McpToolHandlerReturn> => {
     const { folderId, mime, name, page, pageSize, sort } = args as ListMediaArgs;
-    const pm = assertMediaPermission(context, ACTIONS.read, FILE_MODEL_UID);
+    const pm = assertMediaPermission(strapi, context, ACTIONS.read, FILE_MODEL_UID);
 
     const query = await pm.addPermissionsQueryTo({
       filters: buildAssetFilters({ folderId, mime, name }),
@@ -82,7 +82,7 @@ export const createListMediaHandler =
       populate: { folder: { fields: ['id', 'name'] } },
     });
 
-    const { results, pagination } = await getService('upload').findPage(query);
+    const { results, pagination } = await getService('upload', strapi).findPage(query);
 
     return ok({
       results: results.map(sanitizeMediaAsset),
@@ -97,16 +97,16 @@ export const createListMediaHandler =
  * `pm.isAllowed` only proves the action is permitted on the model, not on this row.
  */
 export const createGetMediaHandler =
-  (_strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
+  (strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async ({
     args,
   }: {
     args: Record<string, unknown>;
   }): Promise<Modules.MCP.McpToolHandlerReturn> => {
     const { id } = args as GetMediaArgs;
-    const pm = assertMediaPermission(context, ACTIONS.read, FILE_MODEL_UID);
+    const pm = assertMediaPermission(strapi, context, ACTIONS.read, FILE_MODEL_UID);
 
-    const asset = await getService('upload').findOne(id, {
+    const asset = await getService('upload', strapi).findOne(id, {
       folder: { fields: ['id', 'name'] },
     });
 
@@ -129,11 +129,11 @@ export const createGetMediaHandler =
  * `GET /upload/folder-structure` in the admin API.
  */
 export const createListFoldersHandler =
-  (_strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
+  (strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async (): Promise<Modules.MCP.McpToolHandlerReturn> => {
-    assertMediaPermission(context, ACTIONS.read, FOLDER_MODEL_UID);
+    assertMediaPermission(strapi, context, ACTIONS.read, FOLDER_MODEL_UID);
 
-    const structure = await getService('folder').getStructure();
+    const structure = await getService('folder', strapi).getStructure();
 
     return ok({ data: sanitizeMediaFolderTree(structure) });
   };

--- a/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
+++ b/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
@@ -13,7 +13,7 @@ const DEFAULT_SORT = 'createdAt:DESC';
 // Arg types are type-level only: the MCP SDK validates `args` against the tool's Zod input
 // schema before the handler runs, so handlers accept the erased `Record<string, unknown>` the
 // registry hands them and narrow it here.
-type ListMediaAssetsArgs = {
+type ListMediaArgs = {
   folderId?: number | null;
   mime?: string;
   name?: string;
@@ -22,12 +22,12 @@ type ListMediaAssetsArgs = {
   sort?: string;
 };
 
-type GetMediaAssetArgs = {
+type GetMediaArgs = {
   id: number;
 };
 
 /**
- * Builds the `filters` clause for `list_media_assets`.
+ * Builds the `filters` clause for `list_media`.
  *
  * `folderId: null` is meaningfully different from an omitted `folderId`: null means "assets at
  * the media library root" (no folder relation), while omitting it means "any folder".
@@ -35,7 +35,7 @@ type GetMediaAssetArgs = {
  * `mime` accepts both a full type and a bare prefix. An exact match on "image" would never hit,
  * so a value without a slash is matched as a prefix ("image" → every "image/*").
  */
-const buildAssetFilters = (args: ListMediaAssetsArgs): Record<string, unknown> => {
+const buildAssetFilters = (args: ListMediaArgs): Record<string, unknown> => {
   const filters: Record<string, unknown> = {};
 
   if (args.folderId === null) {
@@ -58,20 +58,20 @@ const buildAssetFilters = (args: ListMediaAssetsArgs): Record<string, unknown> =
 };
 
 /**
- * `list_media_assets` — paginated, filtered listing of media files.
+ * `list_media` — paginated, filtered listing of media files.
  *
  * Permission conditions are applied through the permissions manager
  * (`addPermissionsQueryTo`) so a token restricted by a condition — e.g. own-assets-only —
  * sees the same subset it would through the admin API.
  */
-export const createListMediaAssetsHandler =
+export const createListMediaHandler =
   (_strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async ({
     args,
   }: {
     args: Record<string, unknown>;
   }): Promise<Modules.MCP.McpToolHandlerReturn> => {
-    const { folderId, mime, name, page, pageSize, sort } = args as ListMediaAssetsArgs;
+    const { folderId, mime, name, page, pageSize, sort } = args as ListMediaArgs;
     const pm = assertMediaPermission(context, ACTIONS.read, FILE_MODEL_UID);
 
     const query = await pm.addPermissionsQueryTo({
@@ -91,19 +91,19 @@ export const createListMediaAssetsHandler =
   };
 
 /**
- * `get_media_asset` — a single asset by numeric id.
+ * `get_media` — a single asset by numeric id.
  *
  * The entity-level `cannot(action, subject)` check is what enforces permission *conditions*:
  * `pm.isAllowed` only proves the action is permitted on the model, not on this row.
  */
-export const createGetMediaAssetHandler =
+export const createGetMediaHandler =
   (_strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async ({
     args,
   }: {
     args: Record<string, unknown>;
   }): Promise<Modules.MCP.McpToolHandlerReturn> => {
-    const { id } = args as GetMediaAssetArgs;
+    const { id } = args as GetMediaArgs;
     const pm = assertMediaPermission(context, ACTIONS.read, FILE_MODEL_UID);
 
     const asset = await getService('upload').findOne(id, {
@@ -122,13 +122,13 @@ export const createGetMediaAssetHandler =
   };
 
 /**
- * `list_media_folders` — the nested folder structure, reusing `folder.getStructure()`.
+ * `list_folders` — the nested folder structure, reusing `folder.getStructure()`.
  *
  * `getStructure()` returns the whole tree in one query and has no permission-condition
  * filtering, so this is gated on the model-level read permission only — matching
  * `GET /upload/folder-structure` in the admin API.
  */
-export const createListMediaFoldersHandler =
+export const createListFoldersHandler =
   (_strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async (): Promise<Modules.MCP.McpToolHandlerReturn> => {
     assertMediaPermission(context, ACTIONS.read, FOLDER_MODEL_UID);

--- a/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
+++ b/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
@@ -27,7 +27,7 @@ type GetMediaArgs = {
 };
 
 /**
- * Builds the `filters` clause for `list_media`.
+ * Builds the `filters` clause for `media_list_assets`.
  *
  * `folderId: null` is meaningfully different from an omitted `folderId`: null means "assets at
  * the media library root" (no folder relation), while omitting it means "any folder".
@@ -58,13 +58,13 @@ const buildAssetFilters = (args: ListMediaArgs): Record<string, unknown> => {
 };
 
 /**
- * `list_media` — paginated, filtered listing of media files.
+ * `media_list_assets` — paginated, filtered listing of media files.
  *
  * Permission conditions are applied through the permissions manager
  * (`addPermissionsQueryTo`) so a token restricted by a condition — e.g. own-assets-only —
  * sees the same subset it would through the admin API.
  */
-export const createListMediaHandler =
+export const createMediaListAssetsHandler =
   (strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async ({
     args,
@@ -91,12 +91,12 @@ export const createListMediaHandler =
   };
 
 /**
- * `get_media` — a single asset by numeric id.
+ * `media_get_asset` — a single asset by numeric id.
  *
  * The entity-level `cannot(action, subject)` check is what enforces permission *conditions*:
  * `pm.isAllowed` only proves the action is permitted on the model, not on this row.
  */
-export const createGetMediaHandler =
+export const createMediaGetAssetHandler =
   (strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async ({
     args,
@@ -122,13 +122,13 @@ export const createGetMediaHandler =
   };
 
 /**
- * `list_folders` — the nested folder structure, reusing `folder.getStructure()`.
+ * `media_list_folders` — the nested folder structure, reusing `folder.getStructure()`.
  *
  * `getStructure()` returns the whole tree in one query and has no permission-condition
  * filtering, so this is gated on the model-level read permission only — matching
  * `GET /upload/folder-structure` in the admin API.
  */
-export const createListFoldersHandler =
+export const createMediaListFoldersHandler =
   (strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async (): Promise<Modules.MCP.McpToolHandlerReturn> => {
     assertMediaPermission(strapi, context, ACTIONS.read, FOLDER_MODEL_UID);

--- a/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
+++ b/packages/core/upload/server/src/mcp/handlers/read-handlers.ts
@@ -4,6 +4,7 @@ import type { Core, Modules } from '@strapi/types';
 import { getService } from '../../utils';
 import { ACTIONS, FILE_MODEL_UID, FOLDER_MODEL_UID } from '../../constants';
 import { assertMediaPermission } from '../permissions';
+import { findEntityAndCheckPermissions } from '../../controllers/utils/find-entity-and-check-permissions';
 import { sanitizeMediaAsset, sanitizeMediaFolderTree } from '../sanitizers/sanitize-media';
 import { MCP_NOT_FOUND_ASSET } from './constants';
 import { ok } from '../utils';
@@ -93,8 +94,11 @@ export const createMediaListAssetsHandler =
 /**
  * `media_get_asset` — a single asset by numeric id.
  *
- * The entity-level `cannot(action, subject)` check is what enforces permission *conditions*:
- * `pm.isAllowed` only proves the action is permitted on the model, not on this row.
+ * Row-level permission *conditions* are enforced by `findEntityAndCheckPermissions`, the same
+ * helper the admin `findOne` controller uses: it populates `createdBy` and the creator's roles
+ * before building the CASL subject, which is what the admin conditions read. Checking a subject
+ * without those fields would deny a conditioned grant its own assets, and would disagree with
+ * `media_list_assets`, where the condition is pushed into the query instead.
  */
 export const createMediaGetAssetHandler =
   (strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
@@ -104,18 +108,26 @@ export const createMediaGetAssetHandler =
     args: Record<string, unknown>;
   }): Promise<Modules.MCP.McpToolHandlerReturn> => {
     const { id } = args as GetMediaArgs;
-    const pm = assertMediaPermission(strapi, context, ACTIONS.read, FILE_MODEL_UID);
 
-    const asset = await getService('upload', strapi).findOne(id, {
-      folder: { fields: ['id', 'name'] },
-    });
+    // Model-level gate first, so a token without upload read at all is refused before a lookup.
+    assertMediaPermission(strapi, context, ACTIONS.read, FILE_MODEL_UID);
 
-    if (asset === null || asset === undefined) {
-      throw new errors.NotFoundError(MCP_NOT_FOUND_ASSET);
-    }
-
-    if (pm.ability.cannot(pm.action, pm.toSubject(asset))) {
-      throw new errors.ForbiddenError();
+    let asset;
+    try {
+      ({ file: asset } = await findEntityAndCheckPermissions(
+        context.userAbility,
+        ACTIONS.read,
+        FILE_MODEL_UID,
+        id,
+        strapi
+      ));
+    } catch (error) {
+      // The helper is written for HTTP, where a bare NotFoundError is enough. MCP answers an
+      // agent, so restate it with the message the other media tools use.
+      if (error instanceof errors.NotFoundError) {
+        throw new errors.NotFoundError(MCP_NOT_FOUND_ASSET);
+      }
+      throw error;
     }
 
     return ok({ data: sanitizeMediaAsset(asset) });

--- a/packages/core/upload/server/src/mcp/index.ts
+++ b/packages/core/upload/server/src/mcp/index.ts
@@ -1,0 +1,2 @@
+export { registerUploadMcpTools, buildUploadMcpToolDefinitions } from './register-upload-mcp-tools';
+export type { UploadMcpTool } from './types';

--- a/packages/core/upload/server/src/mcp/permissions.ts
+++ b/packages/core/upload/server/src/mcp/permissions.ts
@@ -1,0 +1,39 @@
+import { errors } from '@strapi/utils';
+import type { Modules } from '@strapi/types';
+
+/**
+ * Builds an admin permissions manager for a media model bound to the MCP session's ability.
+ *
+ * MCP tool handlers have no Koa context, so they cannot rely on route policies: each handler must
+ * re-check permissions itself, exactly as the admin controllers do via `ctx.state.userAbility`.
+ * The declarative `auth.policies` on a tool definition already gates registration and invocation;
+ * this second check is what keeps a handler safe if it is ever called from another entry point.
+ */
+export const createMediaPermissionsManager = (
+  context: Modules.MCP.McpHandlerContext,
+  action: string,
+  model: string
+) =>
+  strapi.service('admin::permission').createPermissionsManager({
+    ability: context.userAbility,
+    action,
+    model,
+  });
+
+/**
+ * Throws `ForbiddenError` unless the session's ability permits `action` on `model`.
+ * Mirrors the `if (!pm.isAllowed) return ctx.forbidden()` guard in the admin controllers.
+ */
+export const assertMediaPermission = (
+  context: Modules.MCP.McpHandlerContext,
+  action: string,
+  model: string
+) => {
+  const pm = createMediaPermissionsManager(context, action, model);
+
+  if (!pm.isAllowed) {
+    throw new errors.ForbiddenError();
+  }
+
+  return pm;
+};

--- a/packages/core/upload/server/src/mcp/permissions.ts
+++ b/packages/core/upload/server/src/mcp/permissions.ts
@@ -1,5 +1,5 @@
 import { errors } from '@strapi/utils';
-import type { Modules } from '@strapi/types';
+import type { Core, Modules } from '@strapi/types';
 
 /**
  * Builds an admin permissions manager for a media model bound to the MCP session's ability.
@@ -10,6 +10,7 @@ import type { Modules } from '@strapi/types';
  * this second check is what keeps a handler safe if it is ever called from another entry point.
  */
 export const createMediaPermissionsManager = (
+  strapi: Core.Strapi,
   context: Modules.MCP.McpHandlerContext,
   action: string,
   model: string
@@ -25,11 +26,12 @@ export const createMediaPermissionsManager = (
  * Mirrors the `if (!pm.isAllowed) return ctx.forbidden()` guard in the admin controllers.
  */
 export const assertMediaPermission = (
+  strapi: Core.Strapi,
   context: Modules.MCP.McpHandlerContext,
   action: string,
   model: string
 ) => {
-  const pm = createMediaPermissionsManager(context, action, model);
+  const pm = createMediaPermissionsManager(strapi, context, action, model);
 
   if (!pm.isAllowed) {
     throw new errors.ForbiddenError();

--- a/packages/core/upload/server/src/mcp/permissions.ts
+++ b/packages/core/upload/server/src/mcp/permissions.ts
@@ -8,6 +8,12 @@ import type { Core, Modules } from '@strapi/types';
  * re-check permissions itself, exactly as the admin controllers do via `ctx.state.userAbility`.
  * The declarative `auth.policies` on a tool definition already gates registration and invocation;
  * this second check is what keeps a handler safe if it is ever called from another entry point.
+ *
+ * It is also the only check bound to a model. `plugin::upload.read` is registered in the
+ * `plugins` section with no subject (see the upload plugin bootstrap), so a tool's policies
+ * carry an action only — a subject-less grant registers as CASL `subject: 'all'`. Passing a
+ * model UID as the policy subject is rejected by the admin-token validation, so the file /
+ * folder distinction is enforced here, where the permissions manager is bound to the UID.
  */
 export const createMediaPermissionsManager = (
   strapi: Core.Strapi,

--- a/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
+++ b/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
@@ -3,16 +3,16 @@ import type { Core } from '@strapi/types';
 import { ACTIONS } from '../constants';
 import type { UploadMcpTool } from './types';
 import {
-  listMediaAssetsInputSchema,
-  getMediaAssetInputSchema,
-  listMediaAssetsOutputSchema,
-  getMediaAssetOutputSchema,
-  listMediaFoldersOutputSchema,
+  listMediaInputSchema,
+  getMediaInputSchema,
+  listMediaOutputSchema,
+  getMediaOutputSchema,
+  listFoldersOutputSchema,
 } from './schemas';
 import {
-  createListMediaAssetsHandler,
-  createGetMediaAssetHandler,
-  createListMediaFoldersHandler,
+  createListMediaHandler,
+  createGetMediaHandler,
+  createListFoldersHandler,
 } from './handlers';
 
 /**
@@ -32,36 +32,36 @@ import {
  */
 export const buildUploadMcpToolDefinitions = (): UploadMcpTool[] => [
   {
-    name: 'list_media_assets',
+    name: 'list_media',
     title: 'Media: list assets',
     description:
       'List Media Library assets with pagination, folder / mime type / name filters and sorting. Assets are identified by a numeric id — media files are not documents and have no documentId.',
-    telemetry: { source: 'upload', name: 'list_media_assets' },
+    telemetry: { source: 'upload', name: 'list' },
     auth: { policies: [{ action: ACTIONS.read }] },
-    resolveInputSchema: () => listMediaAssetsInputSchema,
-    resolveOutputSchema: () => listMediaAssetsOutputSchema,
-    createHandler: createListMediaAssetsHandler,
+    resolveInputSchema: () => listMediaInputSchema,
+    resolveOutputSchema: () => listMediaOutputSchema,
+    createHandler: createListMediaHandler,
   },
   {
-    name: 'get_media_asset',
+    name: 'get_media',
     title: 'Media: get asset',
     description:
       'Get a single Media Library asset by its numeric id. Media files are not documents: use the numeric id, not a documentId.',
-    telemetry: { source: 'upload', name: 'get_media_asset' },
+    telemetry: { source: 'upload', name: 'get' },
     auth: { policies: [{ action: ACTIONS.read }] },
-    resolveInputSchema: () => getMediaAssetInputSchema,
-    resolveOutputSchema: () => getMediaAssetOutputSchema,
-    createHandler: createGetMediaAssetHandler,
+    resolveInputSchema: () => getMediaInputSchema,
+    resolveOutputSchema: () => getMediaOutputSchema,
+    createHandler: createGetMediaHandler,
   },
   {
-    name: 'list_media_folders',
+    name: 'list_folders',
     title: 'Media: list folders',
     description:
-      'List the Media Library folder structure as a nested tree. Folders are identified by a numeric id; pass one as `folderId` to list_media_assets to list its contents.',
-    telemetry: { source: 'upload', name: 'list_media_folders' },
+      'List the Media Library folder structure as a nested tree. Folders are identified by a numeric id; pass one as `folderId` to list_media to list its contents.',
+    telemetry: { source: 'upload', name: 'list_folders' },
     auth: { policies: [{ action: ACTIONS.read }] },
-    resolveOutputSchema: () => listMediaFoldersOutputSchema,
-    createHandler: createListMediaFoldersHandler,
+    resolveOutputSchema: () => listFoldersOutputSchema,
+    createHandler: createListFoldersHandler,
   },
 ];
 

--- a/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
+++ b/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
@@ -1,0 +1,82 @@
+import type { Core } from '@strapi/types';
+
+import { ACTIONS } from '../constants';
+import type { UploadMcpTool } from './types';
+import {
+  listMediaAssetsInputSchema,
+  getMediaAssetInputSchema,
+  listMediaAssetsOutputSchema,
+  getMediaAssetOutputSchema,
+  listMediaFoldersOutputSchema,
+} from './schemas';
+import {
+  createListMediaAssetsHandler,
+  createGetMediaAssetHandler,
+  createListMediaFoldersHandler,
+} from './handlers';
+
+/**
+ * The Media Library MCP read tools.
+ *
+ * Exported separately from registration so unit tests can assert the definitions (names, auth
+ * policies, schemas) without booting Strapi or an MCP server.
+ *
+ * Every tool description states that media uses numeric ids. The content-manager tools key
+ * everything on `documentId`, which does not exist on files, so the distinction is spelled out
+ * per tool rather than left to be inferred.
+ *
+ * `plugin::upload.read` is registered in the `plugins` section with no subject (see the upload
+ * plugin bootstrap), so the policies carry an action only — a subject-less grant registers as
+ * CASL `subject: 'all'`. The per-model check still happens inside the handlers, where the
+ * permissions manager is bound to the file or folder UID.
+ */
+export const buildUploadMcpToolDefinitions = (): UploadMcpTool[] => [
+  {
+    name: 'list_media_assets',
+    title: 'Media: list assets',
+    description:
+      'List Media Library assets with pagination, folder / mime type / name filters and sorting. Assets are identified by a numeric id — media files are not documents and have no documentId.',
+    telemetry: { source: 'upload', name: 'list_media_assets' },
+    auth: { policies: [{ action: ACTIONS.read }] },
+    resolveInputSchema: () => listMediaAssetsInputSchema,
+    resolveOutputSchema: () => listMediaAssetsOutputSchema,
+    createHandler: createListMediaAssetsHandler,
+  },
+  {
+    name: 'get_media_asset',
+    title: 'Media: get asset',
+    description:
+      'Get a single Media Library asset by its numeric id. Media files are not documents: use the numeric id, not a documentId.',
+    telemetry: { source: 'upload', name: 'get_media_asset' },
+    auth: { policies: [{ action: ACTIONS.read }] },
+    resolveInputSchema: () => getMediaAssetInputSchema,
+    resolveOutputSchema: () => getMediaAssetOutputSchema,
+    createHandler: createGetMediaAssetHandler,
+  },
+  {
+    name: 'list_media_folders',
+    title: 'Media: list folders',
+    description:
+      'List the Media Library folder structure as a nested tree. Folders are identified by a numeric id; pass one as `folderId` to list_media_assets to list its contents.',
+    telemetry: { source: 'upload', name: 'list_media_folders' },
+    auth: { policies: [{ action: ACTIONS.read }] },
+    resolveOutputSchema: () => listMediaFoldersOutputSchema,
+    createHandler: createListMediaFoldersHandler,
+  },
+];
+
+/**
+ * Registers the Media Library MCP tools via `strapi.ai.mcp.registerTool()`.
+ * Must be called from the plugin register phase, before the MCP HTTP server starts.
+ */
+export const registerUploadMcpTools = ({ strapi }: { strapi: Core.Strapi }): void => {
+  // Performance only: registerTool() is safe when MCP is disabled (definitions are stored but
+  // never exposed). Skip the work below when the MCP server will not start.
+  if (strapi.ai?.mcp?.isEnabled() !== true) {
+    return;
+  }
+
+  for (const tool of buildUploadMcpToolDefinitions()) {
+    strapi.ai.mcp.registerTool(tool);
+  }
+};

--- a/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
+++ b/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
@@ -3,16 +3,16 @@ import type { Core } from '@strapi/types';
 import { ACTIONS } from '../constants';
 import type { UploadMcpTool } from './types';
 import {
-  listMediaInputSchema,
-  getMediaInputSchema,
-  listMediaOutputSchema,
-  getMediaOutputSchema,
-  listFoldersOutputSchema,
+  mediaListAssetsInputSchema,
+  mediaGetAssetInputSchema,
+  mediaListAssetsOutputSchema,
+  mediaGetAssetOutputSchema,
+  mediaListFoldersOutputSchema,
 } from './schemas';
 import {
-  createListMediaHandler,
-  createGetMediaHandler,
-  createListFoldersHandler,
+  createMediaListAssetsHandler,
+  createMediaGetAssetHandler,
+  createMediaListFoldersHandler,
 } from './handlers';
 
 /**
@@ -20,36 +20,36 @@ import {
  */
 export const buildUploadMcpToolDefinitions = (): UploadMcpTool[] => [
   {
-    name: 'list_media',
+    name: 'media_list_assets',
     title: 'Media: list assets',
     description:
       'List Media Library assets with pagination, folder / mime type / name filters and sorting. Assets are identified by a numeric id — media files are not documents and have no documentId.',
     telemetry: { source: 'upload', name: 'list' },
     auth: { policies: [{ action: ACTIONS.read }] },
-    resolveInputSchema: () => listMediaInputSchema,
-    resolveOutputSchema: () => listMediaOutputSchema,
-    createHandler: createListMediaHandler,
+    resolveInputSchema: () => mediaListAssetsInputSchema,
+    resolveOutputSchema: () => mediaListAssetsOutputSchema,
+    createHandler: createMediaListAssetsHandler,
   },
   {
-    name: 'get_media',
+    name: 'media_get_asset',
     title: 'Media: get asset',
     description:
       'Get a single Media Library asset by its numeric id. Media files are not documents: use the numeric id, not a documentId.',
     telemetry: { source: 'upload', name: 'get' },
     auth: { policies: [{ action: ACTIONS.read }] },
-    resolveInputSchema: () => getMediaInputSchema,
-    resolveOutputSchema: () => getMediaOutputSchema,
-    createHandler: createGetMediaHandler,
+    resolveInputSchema: () => mediaGetAssetInputSchema,
+    resolveOutputSchema: () => mediaGetAssetOutputSchema,
+    createHandler: createMediaGetAssetHandler,
   },
   {
-    name: 'list_folders',
+    name: 'media_list_folders',
     title: 'Media: list folders',
     description:
-      'List the Media Library folder structure as a nested tree. Folders are identified by a numeric id; pass one as `folderId` to list_media to list its contents.',
+      'List the Media Library folder structure as a nested tree. Folders are identified by a numeric id; pass one as `folderId` to media_list_assets to list its contents.',
     telemetry: { source: 'upload', name: 'list_folders' },
     auth: { policies: [{ action: ACTIONS.read }] },
-    resolveOutputSchema: () => listFoldersOutputSchema,
-    createHandler: createListFoldersHandler,
+    resolveOutputSchema: () => mediaListFoldersOutputSchema,
+    createHandler: createMediaListFoldersHandler,
   },
 ];
 

--- a/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
+++ b/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
@@ -16,19 +16,7 @@ import {
 } from './handlers';
 
 /**
- * The Media Library MCP read tools.
- *
- * Exported separately from registration so unit tests can assert the definitions (names, auth
- * policies, schemas) without booting Strapi or an MCP server.
- *
- * Every tool description states that media uses numeric ids. The content-manager tools key
- * everything on `documentId`, which does not exist on files, so the distinction is spelled out
- * per tool rather than left to be inferred.
- *
- * `plugin::upload.read` is registered in the `plugins` section with no subject (see the upload
- * plugin bootstrap), so the policies carry an action only — a subject-less grant registers as
- * CASL `subject: 'all'`. The per-model check still happens inside the handlers, where the
- * permissions manager is bound to the file or folder UID.
+ * The Media Library MCP tools.
  */
 export const buildUploadMcpToolDefinitions = (): UploadMcpTool[] => [
   {
@@ -70,13 +58,10 @@ export const buildUploadMcpToolDefinitions = (): UploadMcpTool[] => [
  * Must be called from the plugin register phase, before the MCP HTTP server starts.
  */
 export const registerUploadMcpTools = ({ strapi }: { strapi: Core.Strapi }): void => {
-  // Performance only: registerTool() is safe when MCP is disabled (definitions are stored but
-  // never exposed). Skip the work below when the MCP server will not start.
-  if (strapi.ai?.mcp?.isEnabled() !== true) {
-    return;
-  }
-
+  // No `isEnabled()` gate: registerTool() only stores the definition, and the MCP server never
+  // exposes it when disabled, so registering unconditionally is a no-op there. The three
+  // definitions are static, so there is no derivation cost worth guarding either.
   for (const tool of buildUploadMcpToolDefinitions()) {
-    strapi.ai.mcp.registerTool(tool);
+    strapi.ai?.mcp?.registerTool(tool);
   }
 };

--- a/packages/core/upload/server/src/mcp/sanitizers/sanitize-media.ts
+++ b/packages/core/upload/server/src/mcp/sanitizers/sanitize-media.ts
@@ -1,0 +1,69 @@
+import type { MediaFolderNode } from '../schemas';
+
+type RawFolder = {
+  id?: unknown;
+  name?: unknown;
+  children?: unknown;
+};
+
+type RawAsset = Record<string, unknown> & {
+  folder?: RawFolder | null;
+};
+
+/** Coerces a value to a string, or null when it is absent. Timestamps arrive as Date or string. */
+const toNullableString = (value: unknown): string | null => {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+};
+
+const toNullableNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/**
+ * Projects a raw file row onto the MCP asset shape.
+ *
+ * This is an allowlist: every exposed key is named explicitly, so `provider`,
+ * `provider_metadata` (which can carry provider credentials), `hash`, `formats`, `related`,
+ * and the private `folderPath` never reach an MCP client — including after new fields are
+ * added to the file content-type.
+ */
+export const sanitizeMediaAsset = (asset: RawAsset) => {
+  const folder = asset.folder;
+
+  return {
+    id: Number(asset.id),
+    name: String(asset.name ?? ''),
+    alternativeText: toNullableString(asset.alternativeText),
+    caption: toNullableString(asset.caption),
+    url: String(asset.url ?? ''),
+    mime: String(asset.mime ?? ''),
+    size: Number(asset.size ?? 0),
+    width: toNullableNumber(asset.width),
+    height: toNullableNumber(asset.height),
+    ext: toNullableString(asset.ext),
+    folder:
+      folder !== null && folder !== undefined && folder.id !== undefined
+        ? { id: Number(folder.id), name: String(folder.name ?? '') }
+        : null,
+    createdAt: toNullableString(asset.createdAt),
+    updatedAt: toNullableString(asset.updatedAt),
+  };
+};
+
+/**
+ * Projects the recursive output of `folder.getStructure()` onto `{ id, name, children }`,
+ * dropping `path` and `pathId` (internal materialized-path bookkeeping).
+ */
+export const sanitizeMediaFolderTree = (nodes: unknown): MediaFolderNode[] => {
+  if (Array.isArray(nodes) === false) return [];
+
+  return (nodes as RawFolder[]).map((node) => ({
+    id: Number(node.id),
+    name: String(node.name ?? ''),
+    children: sanitizeMediaFolderTree(node.children),
+  }));
+};

--- a/packages/core/upload/server/src/mcp/schemas/index.ts
+++ b/packages/core/upload/server/src/mcp/schemas/index.ts
@@ -1,0 +1,18 @@
+export {
+  mediaIdSchema,
+  folderIdSchema,
+  pageSchema,
+  pageSizeSchema,
+  sortSchema,
+  listMediaAssetsInputSchema,
+  getMediaAssetInputSchema,
+  listMediaFoldersInputSchema,
+} from './input-schemas';
+export {
+  mediaAssetOutputSchema,
+  getMediaAssetOutputSchema,
+  listMediaAssetsOutputSchema,
+  mediaFolderNodeSchema,
+  listMediaFoldersOutputSchema,
+  type MediaFolderNode,
+} from './output-schemas';

--- a/packages/core/upload/server/src/mcp/schemas/index.ts
+++ b/packages/core/upload/server/src/mcp/schemas/index.ts
@@ -4,15 +4,15 @@ export {
   pageSchema,
   pageSizeSchema,
   sortSchema,
-  listMediaAssetsInputSchema,
-  getMediaAssetInputSchema,
-  listMediaFoldersInputSchema,
+  listMediaInputSchema,
+  getMediaInputSchema,
+  listFoldersInputSchema,
 } from './input-schemas';
 export {
   mediaAssetOutputSchema,
-  getMediaAssetOutputSchema,
-  listMediaAssetsOutputSchema,
+  getMediaOutputSchema,
+  listMediaOutputSchema,
   mediaFolderNodeSchema,
-  listMediaFoldersOutputSchema,
+  listFoldersOutputSchema,
   type MediaFolderNode,
 } from './output-schemas';

--- a/packages/core/upload/server/src/mcp/schemas/index.ts
+++ b/packages/core/upload/server/src/mcp/schemas/index.ts
@@ -4,15 +4,15 @@ export {
   pageSchema,
   pageSizeSchema,
   sortSchema,
-  listMediaInputSchema,
-  getMediaInputSchema,
-  listFoldersInputSchema,
+  mediaListAssetsInputSchema,
+  mediaGetAssetInputSchema,
+  mediaListFoldersInputSchema,
 } from './input-schemas';
 export {
   mediaAssetOutputSchema,
-  getMediaOutputSchema,
-  listMediaOutputSchema,
+  mediaGetAssetOutputSchema,
+  mediaListAssetsOutputSchema,
   mediaFolderNodeSchema,
-  listFoldersOutputSchema,
+  mediaListFoldersOutputSchema,
   type MediaFolderNode,
 } from './output-schemas';

--- a/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
@@ -47,7 +47,7 @@ export const sortSchema = z
     `Sort expression. One of: ${ALLOWED_SORT_STRINGS.join(', ')}. Defaults to "createdAt:DESC".`
   );
 
-export const listMediaAssetsInputSchema = z.object({
+export const listMediaInputSchema = z.object({
   folderId: folderIdSchema
     .optional()
     .describe(
@@ -71,8 +71,8 @@ export const listMediaAssetsInputSchema = z.object({
   sort: sortSchema,
 });
 
-export const getMediaAssetInputSchema = z.object({
+export const getMediaInputSchema = z.object({
   id: mediaIdSchema,
 });
 
-export const listMediaFoldersInputSchema = z.object({});
+export const listFoldersInputSchema = z.object({});

--- a/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
@@ -1,0 +1,78 @@
+import { z } from '@strapi/utils';
+
+import { ALLOWED_SORT_STRINGS } from '../../constants';
+
+/**
+ * Media files and folders are NOT documents: they are plain entities keyed by a numeric `id`,
+ * so there is no `documentId` and no draft/published pair. Every media identifier in the MCP
+ * surface is this numeric id.
+ */
+export const mediaIdSchema = z
+  .number()
+  .int()
+  .min(1)
+  .describe(
+    'Numeric media asset id (e.g. 42). Media files are not documents — they have no documentId and no draft/published versions.'
+  );
+
+export const folderIdSchema = z
+  .number()
+  .int()
+  .min(1)
+  .describe('Numeric media folder id (e.g. 3). Folders are not documents — they use numeric ids.');
+
+export const pageSchema = z
+  .number()
+  .int()
+  .min(1)
+  .optional()
+  .describe('Page number (1-indexed, default: 1).');
+
+export const pageSizeSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(100)
+  .optional()
+  .describe('Items per page (default: 25, max: 100).');
+
+/**
+ * Sort is constrained to the same whitelist the Media Library admin uses, so MCP callers
+ * cannot sort by private columns such as `folderPath`.
+ */
+export const sortSchema = z
+  .enum(ALLOWED_SORT_STRINGS as [string, ...string[]])
+  .optional()
+  .describe(
+    `Sort expression. One of: ${ALLOWED_SORT_STRINGS.join(', ')}. Defaults to "createdAt:DESC".`
+  );
+
+export const listMediaAssetsInputSchema = z.object({
+  folderId: folderIdSchema
+    .optional()
+    .describe(
+      'Only return assets directly inside this folder. Omit for every folder; pass null for assets at the media library root.'
+    )
+    .nullable(),
+  mime: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Filter by mime type prefix or exact value (e.g. "image", "image/png", "application/pdf").'
+    ),
+  name: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Case-insensitive substring search on the asset name.'),
+  page: pageSchema,
+  pageSize: pageSizeSchema,
+  sort: sortSchema,
+});
+
+export const getMediaAssetInputSchema = z.object({
+  id: mediaIdSchema,
+});
+
+export const listMediaFoldersInputSchema = z.object({});

--- a/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
@@ -47,7 +47,7 @@ export const sortSchema = z
     `Sort expression. One of: ${ALLOWED_SORT_STRINGS.join(', ')}. Defaults to "createdAt:DESC".`
   );
 
-export const listMediaInputSchema = z.object({
+export const mediaListAssetsInputSchema = z.object({
   folderId: folderIdSchema
     .optional()
     .describe(
@@ -71,8 +71,8 @@ export const listMediaInputSchema = z.object({
   sort: sortSchema,
 });
 
-export const getMediaInputSchema = z.object({
+export const mediaGetAssetInputSchema = z.object({
   id: mediaIdSchema,
 });
 
-export const listFoldersInputSchema = z.object({});
+export const mediaListFoldersInputSchema = z.object({});

--- a/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
@@ -1,0 +1,67 @@
+import { z } from '@strapi/utils';
+
+/**
+ * The exhaustive set of asset fields the MCP surface may expose.
+ *
+ * This is deliberately an ALLOWLIST rather than a denylist: the file content-type carries
+ * `provider_metadata` (provider-specific, may hold credentials or private keys), `provider`,
+ * `hash`, and the private `folderPath`. A denylist would leak any field added later, so new
+ * fields stay invisible to MCP until they are added here on purpose.
+ */
+export const mediaAssetOutputSchema = z.object({
+  id: z.number().describe('Numeric asset id — the canonical identifier for this asset.'),
+  name: z.string(),
+  alternativeText: z.string().nullable().optional(),
+  caption: z.string().nullable().optional(),
+  url: z.string().describe('Public (or signed, for private providers) URL of the asset.'),
+  mime: z.string().describe('Mime type, e.g. "image/png".'),
+  size: z.number().describe('File size in kilobytes, as stored by Strapi.'),
+  width: z.number().nullable().optional().describe('Pixel width, images only.'),
+  height: z.number().nullable().optional().describe('Pixel height, images only.'),
+  ext: z.string().nullable().optional().describe('File extension including the dot, e.g. ".png".'),
+  folder: z
+    .object({
+      id: z.number(),
+      name: z.string(),
+    })
+    .nullable()
+    .optional()
+    .describe('Containing folder, or null when the asset sits at the media library root.'),
+  createdAt: z.string().nullable().optional(),
+  updatedAt: z.string().nullable().optional(),
+});
+
+export const getMediaAssetOutputSchema = z.object({
+  data: mediaAssetOutputSchema.nullable(),
+});
+
+export const listMediaAssetsOutputSchema = z.object({
+  results: z.array(mediaAssetOutputSchema),
+  pagination: z.object({
+    page: z.number(),
+    pageSize: z.number(),
+    pageCount: z.number(),
+    total: z.number(),
+  }),
+});
+
+/**
+ * Folder tree node. `children` is recursive and unbounded in depth, so it is typed lazily.
+ */
+export type MediaFolderNode = {
+  id: number;
+  name: string;
+  children: MediaFolderNode[];
+};
+
+export const mediaFolderNodeSchema: z.ZodType<MediaFolderNode> = z.lazy(() =>
+  z.object({
+    id: z.number(),
+    name: z.string(),
+    children: z.array(mediaFolderNodeSchema),
+  })
+);
+
+export const listMediaFoldersOutputSchema = z.object({
+  data: z.array(mediaFolderNodeSchema).describe('Nested folder structure, roots first.'),
+});

--- a/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
@@ -31,11 +31,11 @@ export const mediaAssetOutputSchema = z.object({
   updatedAt: z.string().nullable().optional(),
 });
 
-export const getMediaAssetOutputSchema = z.object({
+export const getMediaOutputSchema = z.object({
   data: mediaAssetOutputSchema.nullable(),
 });
 
-export const listMediaAssetsOutputSchema = z.object({
+export const listMediaOutputSchema = z.object({
   results: z.array(mediaAssetOutputSchema),
   pagination: z.object({
     page: z.number(),
@@ -62,6 +62,6 @@ export const mediaFolderNodeSchema: z.ZodType<MediaFolderNode> = z.lazy(() =>
   })
 );
 
-export const listMediaFoldersOutputSchema = z.object({
+export const listFoldersOutputSchema = z.object({
   data: z.array(mediaFolderNodeSchema).describe('Nested folder structure, roots first.'),
 });

--- a/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
@@ -28,11 +28,11 @@ export const mediaAssetOutputSchema = z.object({
   updatedAt: z.string().nullable().optional(),
 });
 
-export const getMediaOutputSchema = z.object({
+export const mediaGetAssetOutputSchema = z.object({
   data: mediaAssetOutputSchema.nullable(),
 });
 
-export const listMediaOutputSchema = z.object({
+export const mediaListAssetsOutputSchema = z.object({
   results: z.array(mediaAssetOutputSchema),
   pagination: z.object({
     page: z.number(),
@@ -59,6 +59,6 @@ export const mediaFolderNodeSchema: z.ZodType<MediaFolderNode> = z.lazy(() =>
   })
 );
 
-export const listFoldersOutputSchema = z.object({
+export const mediaListFoldersOutputSchema = z.object({
   data: z.array(mediaFolderNodeSchema).describe('Nested folder structure, roots first.'),
 });

--- a/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
@@ -1,12 +1,9 @@
 import { z } from '@strapi/utils';
 
 /**
- * The exhaustive set of asset fields the MCP surface may expose.
- *
- * This is deliberately an ALLOWLIST rather than a denylist: the file content-type carries
- * `provider_metadata` (provider-specific, may hold credentials or private keys), `provider`,
- * `hash`, and the private `folderPath`. A denylist would leak any field added later, so new
- * fields stay invisible to MCP until they are added here on purpose.
+ * The exhaustive set of asset fields the MCP surface may expose — an allowlist, for the reasons
+ * in `sanitizeMediaAsset`. A field added to the file content-type stays invisible to MCP until
+ * it is added both here and there.
  */
 export const mediaAssetOutputSchema = z.object({
   id: z.number().describe('Numeric asset id — the canonical identifier for this asset.'),

--- a/packages/core/upload/server/src/mcp/types.ts
+++ b/packages/core/upload/server/src/mcp/types.ts
@@ -6,7 +6,7 @@ import type { z } from '@strapi/utils';
  *
  * Mirrors `Modules.MCP.McpToolDefinitionFields` but pins the schema generics to the erased
  * `z.ZodObject<z.ZodRawShape>` so a heterogeneous array of tools stays assignable without a cast.
- * `resolveInputSchema` is optional: `list_media_folders` takes no arguments.
+ * `resolveInputSchema` is optional: `list_folders` takes no arguments.
  */
 export type UploadMcpTool = {
   name: string;

--- a/packages/core/upload/server/src/mcp/types.ts
+++ b/packages/core/upload/server/src/mcp/types.ts
@@ -1,0 +1,23 @@
+import type { Modules, Core } from '@strapi/types';
+import type { z } from '@strapi/utils';
+
+/**
+ * Shape of an upload MCP tool definition.
+ *
+ * Mirrors `Modules.MCP.McpToolDefinitionFields` but pins the schema generics to the erased
+ * `z.ZodObject<z.ZodRawShape>` so a heterogeneous array of tools stays assignable without a cast.
+ * `resolveInputSchema` is optional: `list_media_folders` takes no arguments.
+ */
+export type UploadMcpTool = {
+  name: string;
+  telemetry: { source: 'upload'; name: string };
+  title: string;
+  description: string;
+  auth: Modules.MCP.McpCapabilityAuth;
+  resolveInputSchema?: (context: Modules.MCP.McpHandlerContext) => z.ZodObject<z.ZodRawShape>;
+  resolveOutputSchema: (context: Modules.MCP.McpHandlerContext) => z.ZodObject<z.ZodRawShape>;
+  createHandler: (
+    strapi: Core.Strapi,
+    context: Modules.MCP.McpHandlerContext
+  ) => Modules.MCP.McpToolHandler<z.ZodObject<z.ZodRawShape>, z.ZodObject<z.ZodRawShape>>;
+};

--- a/packages/core/upload/server/src/mcp/types.ts
+++ b/packages/core/upload/server/src/mcp/types.ts
@@ -1,23 +1,24 @@
-import type { Modules, Core } from '@strapi/types';
+import type { Modules } from '@strapi/types';
 import type { z } from '@strapi/utils';
 
 /**
  * Shape of an upload MCP tool definition.
  *
- * Mirrors `Modules.MCP.McpToolDefinitionFields` but pins the schema generics to the erased
- * `z.ZodObject<z.ZodRawShape>` so a heterogeneous array of tools stays assignable without a cast.
- * `resolveInputSchema` is optional: `list_folders` takes no arguments.
+ * `Modules.MCP.McpToolDefinitionFields` intersected with the auth access variant, rather than
+ * `McpToolDefinition` (which unions `McpAuthAccess` with `McpDevModeAccess`): `registerTool`
+ * overloads on the two variants, so a value typed as the union satisfies neither. Every upload
+ * tool is auth-gated, so pinning the variant here also keeps `auth` non-optional for callers.
+ *
+ * The schema generics stay at the erased `z.ZodObject<z.ZodRawShape>` so a heterogeneous array
+ * of tools is assignable without a cast. `InputSchema` is pinned to a bare ZodObject rather
+ * than its default `ZodObject | undefined`, which is what keeps `args` a real value in the
+ * handlers — at the default, the conditional in `McpToolHandler` collapses it to `{ args?: never }`.
  */
-export type UploadMcpTool = {
-  name: string;
-  telemetry: { source: 'upload'; name: string };
-  title: string;
-  description: string;
-  auth: Modules.MCP.McpCapabilityAuth;
-  resolveInputSchema?: (context: Modules.MCP.McpHandlerContext) => z.ZodObject<z.ZodRawShape>;
-  resolveOutputSchema: (context: Modules.MCP.McpHandlerContext) => z.ZodObject<z.ZodRawShape>;
-  createHandler: (
-    strapi: Core.Strapi,
-    context: Modules.MCP.McpHandlerContext
-  ) => Modules.MCP.McpToolHandler<z.ZodObject<z.ZodRawShape>, z.ZodObject<z.ZodRawShape>>;
-};
+export type UploadMcpTool = Modules.MCP.McpToolDefinitionFields<
+  string,
+  z.ZodObject<z.ZodRawShape>,
+  z.ZodObject<z.ZodRawShape>
+> &
+  Modules.MCP.McpAuthAccess & {
+    telemetry: Modules.MCP.McpCapabilityTelemetry;
+  };

--- a/packages/core/upload/server/src/mcp/utils.ts
+++ b/packages/core/upload/server/src/mcp/utils.ts
@@ -1,0 +1,9 @@
+import type { Modules } from '@strapi/types';
+
+/** Wraps a plain object into the dual-representation MCP tool return value (text + structuredContent). */
+export const ok = (
+  structuredContent: Record<string, unknown>
+): Modules.MCP.McpToolHandlerReturn => ({
+  content: [{ type: 'text', text: JSON.stringify(structuredContent) }],
+  structuredContent,
+});

--- a/packages/core/upload/server/src/register.ts
+++ b/packages/core/upload/server/src/register.ts
@@ -8,6 +8,7 @@ import registerUploadMiddleware from './middlewares/upload';
 import spec from '../../documentation/content-api.json';
 import type { Config, File, InputFile } from './types';
 import { aiMetadataJob } from './models/ai-metadata-job';
+import { registerUploadMcpTools } from './mcp';
 
 const { PayloadTooLargeError } = errors;
 const { bytesToHumanReadable, kbytesToBytes } = file;
@@ -36,6 +37,9 @@ export async function register({ strapi }: { strapi: Core.Strapi }) {
   strapi.plugin('upload').provider = createProvider(uploadConfig);
 
   await registerUploadMiddleware({ strapi });
+
+  // Register phase, before the MCP HTTP server starts during bootstrap.
+  registerUploadMcpTools({ strapi });
 
   if (strapi.plugin('graphql')) {
     const { installGraphqlExtension } = await import('./graphql.js');

--- a/packages/core/upload/server/src/utils/index.ts
+++ b/packages/core/upload/server/src/utils/index.ts
@@ -1,3 +1,5 @@
+import type { Core } from '@strapi/types';
+
 import type upload from '../services/upload';
 import type imageManipulation from '../services/image-manipulation';
 import type apiUploadFolder from '../services/api-upload-folder';
@@ -24,6 +26,9 @@ type Services = {
   aiMetadataJobs: ReturnType<typeof createAIMetadataJobsService>;
 };
 
-export const getService = <TName extends keyof Services>(name: TName): Services[TName] => {
-  return strapi.plugin('upload').service<Services[TName]>(name);
+export const getService = <TName extends keyof Services>(
+  name: TName,
+  strapiInstance: Core.Strapi = strapi
+): Services[TName] => {
+  return strapiInstance.plugin('upload').service<Services[TName]>(name);
 };

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -1,0 +1,364 @@
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createAuthRequest } from 'api-tests/request';
+import type { Core } from '@strapi/types';
+
+import { createMcpClient, type AdminPermission, type AdminToken } from './utils/mcp-client';
+import { createMediaSeeder } from './utils/media-seed';
+
+const UPLOAD_ACTIONS = {
+  read: 'plugin::upload.read',
+  settingsRead: 'plugin::upload.settings.read',
+} as const;
+
+const READ_TOOLS = ['list_media_assets', 'get_media_asset', 'list_media_folders'] as const;
+
+/** Fields that must never reach an MCP client. */
+const FORBIDDEN_ASSET_FIELDS = [
+  'provider',
+  'provider_metadata',
+  'hash',
+  'folderPath',
+  'formats',
+  'previewUrl',
+  'related',
+] as const;
+
+describe('MCP upload read tools RBAC (api)', () => {
+  let strapi: Core.Strapi;
+  let rq: Awaited<ReturnType<typeof createAuthRequest>>;
+  let mcp: ReturnType<typeof createMcpClient>;
+  let seeder: ReturnType<typeof createMediaSeeder>;
+  let tokenCount = 0;
+
+  const deleteAllAdminTokens = async () => {
+    await strapi.db.query('admin::api-token').deleteMany({ where: { kind: 'admin' } });
+  };
+
+  beforeAll(async () => {
+    strapi = await createStrapiInstance({
+      register({ strapi: instance }) {
+        instance.config.set('features.future.adminTokens', true);
+        instance.config.set('server.mcp.enabled', true);
+      },
+      bootstrap() {},
+    });
+    strapi.config.set('admin.secrets.encryptionKey', 'test-encryption-key');
+
+    rq = await createAuthRequest({ strapi });
+    mcp = createMcpClient(strapi, 'strapi-mcp-upload-test');
+    seeder = createMediaSeeder(strapi);
+
+    await deleteAllAdminTokens();
+  });
+
+  afterAll(async () => {
+    await seeder.cleanup();
+    await deleteAllAdminTokens();
+    await strapi.destroy();
+  });
+
+  afterEach(async () => {
+    await seeder.cleanup();
+    await deleteAllAdminTokens();
+  });
+
+  const createAdminToken = async (adminPermissions: AdminPermission[]): Promise<AdminToken> => {
+    tokenCount += 1;
+    const res = await rq({
+      url: '/admin/admin-tokens',
+      method: 'POST',
+      body: { name: `mcp-upload-token-${tokenCount}`, adminPermissions },
+    });
+    expect(res.statusCode).toBe(201);
+    return res.body.data;
+  };
+
+  /**
+   * Media Library actions are registered in the `plugins` section without a subject, so an
+   * admin-token permission for them carries a null subject — passing a model UID here is
+   * rejected by the token validation as a subject the action does not apply to.
+   */
+  const permission = (action: string): AdminPermission => ({
+    action,
+    subject: null,
+    conditions: [],
+    properties: {},
+  });
+
+  const readPermissions = (): AdminPermission[] => [permission(UPLOAD_ACTIONS.read)];
+
+  const createReadTokenSession = async (): Promise<AdminToken> => {
+    const token = await createAdminToken(readPermissions());
+    await mcp.initializeSession(token.accessKey);
+    return token;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Tool exposure
+  // ---------------------------------------------------------------------------
+
+  describe('tool exposure', () => {
+    test('a token with plugin::upload.read sees all three read tools', async () => {
+      const token = await createReadTokenSession();
+
+      const toolNames = await mcp.listToolNames(token.accessKey);
+
+      for (const tool of READ_TOOLS) {
+        expect(toolNames).toContain(tool);
+      }
+    });
+
+    test('a token without plugin::upload.read neither lists nor can call the read tools', async () => {
+      await seeder.seedAsset({ name: 'private.jpg' });
+
+      // A valid admin token holding an unrelated upload permission: authenticated for the
+      // plugin, but without `plugin::upload.read` it must not reach any asset.
+      const token = await createAdminToken([permission(UPLOAD_ACTIONS.settingsRead)]);
+      await mcp.initializeSession(token.accessKey);
+
+      const toolNames = await mcp.listToolNames(token.accessKey);
+      for (const tool of READ_TOOLS) {
+        expect(toolNames).not.toContain(tool);
+      }
+
+      for (const tool of READ_TOOLS) {
+        const response = await mcp.callTool(token.accessKey, tool, {});
+        // Denied either as a JSON-RPC error (unknown tool) or a tool-level error.
+        expect(response.error ?? response.result?.isError).toBeTruthy();
+      }
+    });
+
+    test('the read-only token does not gain any upload write tool', async () => {
+      const token = await createReadTokenSession();
+
+      const toolNames = await mcp.listToolNames(token.accessKey);
+
+      expect(toolNames.filter((name) => /media/.test(name)).sort()).toEqual([...READ_TOOLS].sort());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // list_media_assets
+  // ---------------------------------------------------------------------------
+
+  describe('list_media_assets', () => {
+    test('returns the sanitized asset shape with no provider secrets or private metadata', async () => {
+      await seeder.seedAsset({ name: 'listed.jpg', alternativeText: 'alt text' });
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'list_media_assets', {});
+
+      expect(response.error).toBeUndefined();
+      expect(response.result?.isError).not.toBe(true);
+
+      const results = response.result?.structuredContent?.results as Record<string, unknown>[];
+      expect(results).toHaveLength(1);
+
+      const [asset] = results;
+      expect(asset).toMatchObject({
+        name: 'listed.jpg',
+        alternativeText: 'alt text',
+        mime: 'image/jpeg',
+      });
+      expect(typeof asset.id).toBe('number');
+      expect(asset).not.toHaveProperty('documentId');
+
+      for (const field of FORBIDDEN_ASSET_FIELDS) {
+        expect(asset).not.toHaveProperty(field);
+      }
+
+      expect(response.result?.structuredContent?.pagination).toMatchObject({
+        page: 1,
+        pageSize: 25,
+        total: 1,
+      });
+    });
+
+    test('filters by folder, and folderId: null selects root-level assets', async () => {
+      const folder = await seeder.seedFolder('MCP folder');
+      await seeder.seedAsset({ name: 'in-folder.jpg', folderId: folder.id });
+      await seeder.seedAsset({ name: 'at-root.jpg' });
+
+      const token = await createReadTokenSession();
+
+      const inFolder = await mcp.callTool(token.accessKey, 'list_media_assets', {
+        folderId: folder.id,
+      });
+      expect(
+        (inFolder.result?.structuredContent?.results as Record<string, unknown>[]).map(
+          (asset) => asset.name
+        )
+      ).toEqual(['in-folder.jpg']);
+
+      const atRoot = await mcp.callTool(token.accessKey, 'list_media_assets', {
+        folderId: null,
+      });
+      expect(
+        (atRoot.result?.structuredContent?.results as Record<string, unknown>[]).map(
+          (asset) => asset.name
+        )
+      ).toEqual(['at-root.jpg']);
+    });
+
+    test('filters by mime type, accepting both a bare prefix and a full type', async () => {
+      await seeder.seedAsset({ fixture: 'strapi.jpg', name: 'photo.jpg' });
+      await seeder.seedAsset({ fixture: 'rec.pdf', name: 'doc.pdf' });
+
+      const token = await createReadTokenSession();
+
+      const images = await mcp.callTool(token.accessKey, 'list_media_assets', { mime: 'image' });
+      expect(
+        (images.result?.structuredContent?.results as Record<string, unknown>[]).map(
+          (asset) => asset.name
+        )
+      ).toEqual(['photo.jpg']);
+
+      const pdfs = await mcp.callTool(token.accessKey, 'list_media_assets', {
+        mime: 'application/pdf',
+      });
+      expect(
+        (pdfs.result?.structuredContent?.results as Record<string, unknown>[]).map(
+          (asset) => asset.name
+        )
+      ).toEqual(['doc.pdf']);
+    });
+
+    test('searches by name, case-insensitively', async () => {
+      await seeder.seedAsset({ name: 'Company-Logo.jpg' });
+      await seeder.seedAsset({ name: 'holiday.jpg' });
+
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'list_media_assets', { name: 'logo' });
+
+      expect(
+        (response.result?.structuredContent?.results as Record<string, unknown>[]).map(
+          (asset) => asset.name
+        )
+      ).toEqual(['Company-Logo.jpg']);
+    });
+
+    test('paginates and sorts', async () => {
+      await seeder.seedAsset({ name: 'a.jpg' });
+      await seeder.seedAsset({ name: 'b.jpg' });
+
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'list_media_assets', {
+        sort: 'name:ASC',
+        page: 1,
+        pageSize: 1,
+      });
+
+      const results = response.result?.structuredContent?.results as Record<string, unknown>[];
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('a.jpg');
+      expect(response.result?.structuredContent?.pagination).toMatchObject({
+        page: 1,
+        pageSize: 1,
+        pageCount: 2,
+        total: 2,
+      });
+    });
+
+    test('rejects a sort on a private column', async () => {
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'list_media_assets', {
+        sort: 'folderPath:ASC',
+      });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // get_media_asset
+  // ---------------------------------------------------------------------------
+
+  describe('get_media_asset', () => {
+    test('returns one sanitized asset by numeric id, including its folder', async () => {
+      const folder = await seeder.seedFolder('Docs');
+      const seeded = await seeder.seedAsset({
+        name: 'single.jpg',
+        folderId: folder.id,
+        caption: 'a caption',
+      });
+
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'get_media_asset', { id: seeded.id });
+
+      expect(response.error).toBeUndefined();
+      expect(response.result?.isError).not.toBe(true);
+
+      const asset = response.result?.structuredContent?.data as Record<string, unknown>;
+      expect(asset).toMatchObject({
+        id: seeded.id,
+        name: 'single.jpg',
+        caption: 'a caption',
+        mime: 'image/jpeg',
+        folder: { id: folder.id, name: 'Docs' },
+      });
+
+      for (const field of FORBIDDEN_ASSET_FIELDS) {
+        expect(asset).not.toHaveProperty(field);
+      }
+    });
+
+    test('errors for an unknown id', async () => {
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'get_media_asset', { id: 999999 });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
+    });
+
+    test('rejects a documentId in place of a numeric id', async () => {
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'get_media_asset', {
+        id: 'z7v8zma53x01r6oceimv922b',
+      });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // list_media_folders
+  // ---------------------------------------------------------------------------
+
+  describe('list_media_folders', () => {
+    test('returns the nested folder tree without internal path bookkeeping', async () => {
+      const parent = await seeder.seedFolder('Parent');
+      await seeder.seedFolder('Child', parent.id);
+
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'list_media_folders', {});
+
+      expect(response.error).toBeUndefined();
+      expect(response.result?.isError).not.toBe(true);
+
+      const tree = response.result?.structuredContent?.data as Array<Record<string, unknown>>;
+      expect(tree).toHaveLength(1);
+      expect(tree[0]).toMatchObject({ id: parent.id, name: 'Parent' });
+      expect(tree[0]).not.toHaveProperty('path');
+      expect(tree[0]).not.toHaveProperty('pathId');
+
+      const children = tree[0].children as Array<Record<string, unknown>>;
+      expect(children).toHaveLength(1);
+      expect(children[0]).toMatchObject({ name: 'Child', children: [] });
+      expect(children[0]).not.toHaveProperty('path');
+    });
+
+    test('returns an empty tree when there are no folders', async () => {
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'list_media_folders', {});
+
+      expect(response.result?.structuredContent?.data).toEqual([]);
+    });
+  });
+});

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -10,7 +10,7 @@ const UPLOAD_ACTIONS = {
   settingsRead: 'plugin::upload.settings.read',
 } as const;
 
-const READ_TOOLS = ['list_media_assets', 'get_media_asset', 'list_media_folders'] as const;
+const READ_TOOLS = ['list_media', 'get_media', 'list_folders'] as const;
 
 /** Fields that must never reach an MCP client. */
 const FORBIDDEN_ASSET_FIELDS = [
@@ -138,15 +138,15 @@ describe('MCP upload read tools RBAC (api)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // list_media_assets
+  // list_media
   // ---------------------------------------------------------------------------
 
-  describe('list_media_assets', () => {
+  describe('list_media', () => {
     test('returns the sanitized asset shape with no provider secrets or private metadata', async () => {
       await seeder.seedAsset({ name: 'listed.jpg', alternativeText: 'alt text' });
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media_assets', {});
+      const response = await mcp.callTool(token.accessKey, 'list_media', {});
 
       expect(response.error).toBeUndefined();
       expect(response.result?.isError).not.toBe(true);
@@ -181,7 +181,7 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const inFolder = await mcp.callTool(token.accessKey, 'list_media_assets', {
+      const inFolder = await mcp.callTool(token.accessKey, 'list_media', {
         folderId: folder.id,
       });
       expect(
@@ -190,7 +190,7 @@ describe('MCP upload read tools RBAC (api)', () => {
         )
       ).toEqual(['in-folder.jpg']);
 
-      const atRoot = await mcp.callTool(token.accessKey, 'list_media_assets', {
+      const atRoot = await mcp.callTool(token.accessKey, 'list_media', {
         folderId: null,
       });
       expect(
@@ -206,14 +206,14 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const images = await mcp.callTool(token.accessKey, 'list_media_assets', { mime: 'image' });
+      const images = await mcp.callTool(token.accessKey, 'list_media', { mime: 'image' });
       expect(
         (images.result?.structuredContent?.results as Record<string, unknown>[]).map(
           (asset) => asset.name
         )
       ).toEqual(['photo.jpg']);
 
-      const pdfs = await mcp.callTool(token.accessKey, 'list_media_assets', {
+      const pdfs = await mcp.callTool(token.accessKey, 'list_media', {
         mime: 'application/pdf',
       });
       expect(
@@ -229,7 +229,7 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media_assets', { name: 'logo' });
+      const response = await mcp.callTool(token.accessKey, 'list_media', { name: 'logo' });
 
       expect(
         (response.result?.structuredContent?.results as Record<string, unknown>[]).map(
@@ -244,7 +244,7 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media_assets', {
+      const response = await mcp.callTool(token.accessKey, 'list_media', {
         sort: 'name:ASC',
         page: 1,
         pageSize: 1,
@@ -264,7 +264,7 @@ describe('MCP upload read tools RBAC (api)', () => {
     test('rejects a sort on a private column', async () => {
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media_assets', {
+      const response = await mcp.callTool(token.accessKey, 'list_media', {
         sort: 'folderPath:ASC',
       });
 
@@ -273,10 +273,10 @@ describe('MCP upload read tools RBAC (api)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // get_media_asset
+  // get_media
   // ---------------------------------------------------------------------------
 
-  describe('get_media_asset', () => {
+  describe('get_media', () => {
     test('returns one sanitized asset by numeric id, including its folder', async () => {
       const folder = await seeder.seedFolder('Docs');
       const seeded = await seeder.seedAsset({
@@ -287,7 +287,7 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'get_media_asset', { id: seeded.id });
+      const response = await mcp.callTool(token.accessKey, 'get_media', { id: seeded.id });
 
       expect(response.error).toBeUndefined();
       expect(response.result?.isError).not.toBe(true);
@@ -309,7 +309,7 @@ describe('MCP upload read tools RBAC (api)', () => {
     test('errors for an unknown id', async () => {
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'get_media_asset', { id: 999999 });
+      const response = await mcp.callTool(token.accessKey, 'get_media', { id: 999999 });
 
       expect(response.error ?? response.result?.isError).toBeTruthy();
     });
@@ -317,7 +317,7 @@ describe('MCP upload read tools RBAC (api)', () => {
     test('rejects a documentId in place of a numeric id', async () => {
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'get_media_asset', {
+      const response = await mcp.callTool(token.accessKey, 'get_media', {
         id: 'z7v8zma53x01r6oceimv922b',
       });
 
@@ -326,17 +326,17 @@ describe('MCP upload read tools RBAC (api)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // list_media_folders
+  // list_folders
   // ---------------------------------------------------------------------------
 
-  describe('list_media_folders', () => {
+  describe('list_folders', () => {
     test('returns the nested folder tree without internal path bookkeeping', async () => {
       const parent = await seeder.seedFolder('Parent');
       await seeder.seedFolder('Child', parent.id);
 
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media_folders', {});
+      const response = await mcp.callTool(token.accessKey, 'list_folders', {});
 
       expect(response.error).toBeUndefined();
       expect(response.result?.isError).not.toBe(true);
@@ -356,7 +356,7 @@ describe('MCP upload read tools RBAC (api)', () => {
     test('returns an empty tree when there are no folders', async () => {
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media_folders', {});
+      const response = await mcp.callTool(token.accessKey, 'list_folders', {});
 
       expect(response.result?.structuredContent?.data).toEqual([]);
     });

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -133,7 +133,9 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const toolNames = await mcp.listToolNames(token.accessKey);
 
-      expect(toolNames.filter((name) => /media/.test(name)).sort()).toEqual([...READ_TOOLS].sort());
+      expect(toolNames.filter((name) => /media|folders/.test(name)).sort()).toEqual(
+        [...READ_TOOLS].sort()
+      );
     });
   });
 

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -10,7 +10,7 @@ const UPLOAD_ACTIONS = {
   settingsRead: 'plugin::upload.settings.read',
 } as const;
 
-const READ_TOOLS = ['list_media', 'get_media', 'list_folders'] as const;
+const READ_TOOLS = ['media_list_assets', 'media_get_asset', 'media_list_folders'] as const;
 
 /** Fields that must never reach an MCP client. */
 const FORBIDDEN_ASSET_FIELDS = [
@@ -133,22 +133,24 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const toolNames = await mcp.listToolNames(token.accessKey);
 
-      expect(toolNames.filter((name) => /media|folders/.test(name)).sort()).toEqual(
+      // Anchored on the media_ prefix every upload tool carries, so this stays exact as the
+      // surface grows. A loose /media|folders/ would match content-manager tools too.
+      expect(toolNames.filter((name) => /^media_/.test(name)).sort()).toEqual(
         [...READ_TOOLS].sort()
       );
     });
   });
 
   // ---------------------------------------------------------------------------
-  // list_media
+  // media_list_assets
   // ---------------------------------------------------------------------------
 
-  describe('list_media', () => {
+  describe('media_list_assets', () => {
     test('returns the sanitized asset shape with no provider secrets or private metadata', async () => {
       await seeder.seedAsset({ name: 'listed.jpg', alternativeText: 'alt text' });
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media', {});
+      const response = await mcp.callTool(token.accessKey, 'media_list_assets', {});
 
       expect(response.error).toBeUndefined();
       expect(response.result?.isError).not.toBe(true);
@@ -183,7 +185,7 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const inFolder = await mcp.callTool(token.accessKey, 'list_media', {
+      const inFolder = await mcp.callTool(token.accessKey, 'media_list_assets', {
         folderId: folder.id,
       });
       expect(
@@ -192,7 +194,7 @@ describe('MCP upload read tools RBAC (api)', () => {
         )
       ).toEqual(['in-folder.jpg']);
 
-      const atRoot = await mcp.callTool(token.accessKey, 'list_media', {
+      const atRoot = await mcp.callTool(token.accessKey, 'media_list_assets', {
         folderId: null,
       });
       expect(
@@ -208,14 +210,14 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const images = await mcp.callTool(token.accessKey, 'list_media', { mime: 'image' });
+      const images = await mcp.callTool(token.accessKey, 'media_list_assets', { mime: 'image' });
       expect(
         (images.result?.structuredContent?.results as Record<string, unknown>[]).map(
           (asset) => asset.name
         )
       ).toEqual(['photo.jpg']);
 
-      const pdfs = await mcp.callTool(token.accessKey, 'list_media', {
+      const pdfs = await mcp.callTool(token.accessKey, 'media_list_assets', {
         mime: 'application/pdf',
       });
       expect(
@@ -231,7 +233,7 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media', { name: 'logo' });
+      const response = await mcp.callTool(token.accessKey, 'media_list_assets', { name: 'logo' });
 
       expect(
         (response.result?.structuredContent?.results as Record<string, unknown>[]).map(
@@ -246,7 +248,7 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_list_assets', {
         sort: 'name:ASC',
         page: 1,
         pageSize: 1,
@@ -266,7 +268,7 @@ describe('MCP upload read tools RBAC (api)', () => {
     test('rejects a sort on a private column', async () => {
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_list_assets', {
         sort: 'folderPath:ASC',
       });
 
@@ -275,10 +277,10 @@ describe('MCP upload read tools RBAC (api)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // get_media
+  // media_get_asset
   // ---------------------------------------------------------------------------
 
-  describe('get_media', () => {
+  describe('media_get_asset', () => {
     test('returns one sanitized asset by numeric id, including its folder', async () => {
       const folder = await seeder.seedFolder('Docs');
       const seeded = await seeder.seedAsset({
@@ -289,7 +291,7 @@ describe('MCP upload read tools RBAC (api)', () => {
 
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'get_media', { id: seeded.id });
+      const response = await mcp.callTool(token.accessKey, 'media_get_asset', { id: seeded.id });
 
       expect(response.error).toBeUndefined();
       expect(response.result?.isError).not.toBe(true);
@@ -311,7 +313,7 @@ describe('MCP upload read tools RBAC (api)', () => {
     test('errors for an unknown id', async () => {
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'get_media', { id: 999999 });
+      const response = await mcp.callTool(token.accessKey, 'media_get_asset', { id: 999999 });
 
       expect(response.error ?? response.result?.isError).toBeTruthy();
     });
@@ -319,7 +321,7 @@ describe('MCP upload read tools RBAC (api)', () => {
     test('rejects a documentId in place of a numeric id', async () => {
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'get_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_get_asset', {
         id: 'z7v8zma53x01r6oceimv922b',
       });
 
@@ -328,17 +330,17 @@ describe('MCP upload read tools RBAC (api)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // list_folders
+  // media_list_folders
   // ---------------------------------------------------------------------------
 
-  describe('list_folders', () => {
+  describe('media_list_folders', () => {
     test('returns the nested folder tree without internal path bookkeeping', async () => {
       const parent = await seeder.seedFolder('Parent');
       await seeder.seedFolder('Child', parent.id);
 
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_folders', {});
+      const response = await mcp.callTool(token.accessKey, 'media_list_folders', {});
 
       expect(response.error).toBeUndefined();
       expect(response.result?.isError).not.toBe(true);
@@ -358,7 +360,7 @@ describe('MCP upload read tools RBAC (api)', () => {
     test('returns an empty tree when there are no folders', async () => {
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'list_folders', {});
+      const response = await mcp.callTool(token.accessKey, 'media_list_folders', {});
 
       expect(response.result?.structuredContent?.data).toEqual([]);
     });

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -330,6 +330,84 @@ describe('MCP upload read tools RBAC (api)', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Permission conditions
+  //
+  // A conditioned grant has to agree across both tools: media_list_assets applies the condition
+  // through the query, media_get_asset by testing the loaded row against the ability. The row
+  // check needs `createdBy` (and the creator's roles) populated to match `admin::is-creator`,
+  // so a get that skipped that populate would forbid exactly the assets the list returned.
+  // ---------------------------------------------------------------------------
+
+  describe('the admin::is-creator condition', () => {
+    const createOwnAssetsTokenSession = async (): Promise<AdminToken> => {
+      const token = await createAdminToken([
+        { ...permission(UPLOAD_ACTIONS.read), conditions: ['admin::is-creator'] },
+      ]);
+      await mcp.initializeSession(token.accessKey);
+      return token;
+    };
+
+    /** The token is minted by the super-admin request, so that user is its creator. */
+    const superAdminId = async (): Promise<number> => {
+      const user = await strapi.db
+        .query('admin::user')
+        .findOne({ where: { email: 'admin@strapi.io' } });
+
+      expect(user).not.toBeNull();
+      return user.id;
+    };
+
+    test('media_get_asset returns an asset the token owner created', async () => {
+      const ownerId = await superAdminId();
+      const seeded = await seeder.seedAsset({
+        name: 'mine.jpg',
+        createdBy: { id: ownerId },
+      });
+
+      const token = await createOwnAssetsTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'media_get_asset', { id: seeded.id });
+
+      expect(response.error).toBeUndefined();
+      expect(response.result?.isError).not.toBe(true);
+      expect(response.result?.structuredContent?.data).toMatchObject({
+        id: seeded.id,
+        name: 'mine.jpg',
+      });
+    });
+
+    test('media_get_asset is forbidden on an asset created by somebody else', async () => {
+      const seeded = await seeder.seedAsset({ name: 'theirs.jpg' });
+
+      const token = await createOwnAssetsTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'media_get_asset', { id: seeded.id });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
+    });
+
+    test('media_list_assets and media_get_asset agree on what the condition allows', async () => {
+      const ownerId = await superAdminId();
+      const own = await seeder.seedAsset({ name: 'own.jpg', createdBy: { id: ownerId } });
+      await seeder.seedAsset({ name: 'other.jpg' });
+
+      const token = await createOwnAssetsTokenSession();
+
+      const listed = await mcp.callTool(token.accessKey, 'media_list_assets', {});
+      const results = listed.result?.structuredContent?.results as { id: number }[];
+      expect(results.map((asset) => asset.id)).toEqual([own.id]);
+
+      // Every id the list handed back must also be gettable, or an agent cannot act on them.
+      for (const asset of results) {
+        const got = await mcp.callTool(token.accessKey, 'media_get_asset', { id: asset.id });
+
+        expect(got.error).toBeUndefined();
+        expect(got.result?.isError).not.toBe(true);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // media_list_folders
   // ---------------------------------------------------------------------------
 

--- a/tests/api/core/mcp/utils/media-seed.ts
+++ b/tests/api/core/mcp/utils/media-seed.ts
@@ -1,0 +1,140 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import type { Core } from '@strapi/types';
+
+const FILE_MODEL_UID = 'plugin::upload.file';
+const FOLDER_MODEL_UID = 'plugin::upload.folder';
+
+/** Fixture assets already committed for the upload api tests. */
+const FIXTURES_DIR = path.join(__dirname, '../../upload/utils');
+
+export type SeededFolder = {
+  id: number;
+  name: string;
+  path: string;
+  pathId: number;
+};
+
+export type SeededAsset = {
+  id: number;
+  name: string;
+  mime: string;
+  url: string;
+  folder?: { id: number } | null;
+};
+
+export type SeedAssetOptions = {
+  /** Fixture file name inside `tests/api/core/upload/utils` (default: `strapi.jpg`). */
+  fixture?: string;
+  /** Stored asset name; defaults to the fixture's own file name. */
+  name?: string;
+  /** Containing folder id. Omit for an asset at the media library root. */
+  folderId?: number | null;
+  alternativeText?: string;
+  caption?: string;
+};
+
+/**
+ * Seeding helpers for Media Library api tests.
+ *
+ * These go through the real upload and folder **services** rather than the HTTP API, because
+ * media assets cannot be fixtured with `createTestBuilder().addContentType()` the way
+ * content-manager tests fixture documents: a media asset is a provider-backed file plus a row,
+ * not just a row. Seeding through the service exercises the same code path the admin API uses,
+ * so the resulting rows carry a real `hash`, `url`, `provider`, and `folderPath`.
+ *
+ * Shared by every Media Library MCP api test (read tools, folder CRUD, move, metadata).
+ */
+export const createMediaSeeder = (strapi: Core.Strapi) => {
+  const uploadService = () => strapi.plugin('upload').service('upload');
+  const folderService = () => strapi.plugin('upload').service('folder');
+
+  /**
+   * Creates a media folder. `parentId` nests it under an existing folder.
+   * The folder service computes `path` / `pathId`, so subsequent asset seeding resolves correctly.
+   */
+  const seedFolder = async (
+    name: string,
+    parentId: number | null = null
+  ): Promise<SeededFolder> => {
+    const folder = await folderService().create({ name, parent: parentId });
+    return folder as SeededFolder;
+  };
+
+  /**
+   * Uploads a real fixture file through the upload service and returns the persisted row.
+   *
+   * The fixture is copied to a temp directory first: the upload pipeline moves/consumes the file
+   * it is handed, and a committed fixture must survive the test run.
+   */
+  const seedAsset = async (options: SeedAssetOptions = {}): Promise<SeededAsset> => {
+    const { fixture = 'strapi.jpg', name, folderId, alternativeText, caption } = options;
+
+    const source = path.join(FIXTURES_DIR, fixture);
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'strapi-mcp-media-'));
+    const filepath = path.join(tmpDir, fixture);
+    await fs.promises.copyFile(source, filepath);
+
+    const { size } = await fs.promises.stat(filepath);
+    const originalFilename = name ?? fixture;
+
+    const fileInfo: Record<string, unknown> = {};
+    if (alternativeText !== undefined) fileInfo.alternativeText = alternativeText;
+    if (caption !== undefined) fileInfo.caption = caption;
+    if (name !== undefined) fileInfo.name = name;
+
+    const data: Record<string, unknown> = { fileInfo };
+    if (folderId !== undefined && folderId !== null) {
+      data.fileInfo = { ...fileInfo, folder: folderId };
+    }
+
+    const [uploaded] = await uploadService().upload({
+      data,
+      files: [
+        {
+          filepath,
+          originalFilename,
+          mimetype: mimeForFixture(fixture),
+          size,
+        },
+      ],
+    });
+
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+
+    return uploaded as SeededAsset;
+  };
+
+  /**
+   * Removes every seeded asset and folder.
+   *
+   * Deletes rows directly instead of calling `upload.remove()`: the goal is a clean database
+   * between tests, and a provider delete that fails on a missing file must not fail teardown.
+   */
+  const cleanup = async (): Promise<void> => {
+    await strapi.db.query(FILE_MODEL_UID).deleteMany({});
+    await strapi.db.query(FOLDER_MODEL_UID).deleteMany({});
+  };
+
+  return { seedFolder, seedAsset, cleanup };
+};
+
+/** Minimal fixture-name → mime mapping for the committed upload test fixtures. */
+const mimeForFixture = (fixture: string): string => {
+  const byExt: Record<string, string> = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
+    '.webp': 'image/webp',
+    '.tiff': 'image/tiff',
+    '.pdf': 'application/pdf',
+    '.txt': 'text/plain',
+    '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.bin': 'application/octet-stream',
+  };
+
+  return byExt[path.extname(fixture).toLowerCase()] ?? 'application/octet-stream';
+};

--- a/tests/api/core/mcp/utils/media-seed.ts
+++ b/tests/api/core/mcp/utils/media-seed.ts
@@ -33,6 +33,12 @@ export type SeedAssetOptions = {
   folderId?: number | null;
   alternativeText?: string;
   caption?: string;
+  /**
+   * Admin user to record as the asset's creator. Needed by tests that exercise permission
+   * conditions: `admin::is-creator` matches on `createdBy.id`, so an asset seeded without a
+   * creator can never satisfy it.
+   */
+  createdBy?: { id: number | string };
 };
 
 /**
@@ -69,7 +75,7 @@ export const createMediaSeeder = (strapi: Core.Strapi) => {
    * it is handed, and a committed fixture must survive the test run.
    */
   const seedAsset = async (options: SeedAssetOptions = {}): Promise<SeededAsset> => {
-    const { fixture = 'strapi.jpg', name, folderId, alternativeText, caption } = options;
+    const { fixture = 'strapi.jpg', name, folderId, alternativeText, caption, createdBy } = options;
 
     const source = path.join(FIXTURES_DIR, fixture);
     const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'strapi-mcp-media-'));
@@ -89,17 +95,21 @@ export const createMediaSeeder = (strapi: Core.Strapi) => {
       data.fileInfo = { ...fileInfo, folder: folderId };
     }
 
-    const [uploaded] = await uploadService().upload({
-      data,
-      files: [
-        {
-          filepath,
-          originalFilename,
-          mimetype: mimeForFixture(fixture),
-          size,
-        },
-      ],
-    });
+    const [uploaded] = await uploadService().upload(
+      {
+        data,
+        files: [
+          {
+            filepath,
+            originalFilename,
+            mimetype: mimeForFixture(fixture),
+            size,
+          },
+        ],
+      },
+      // `user` goes in the options argument; the service passes it to setCreatorFields.
+      createdBy ? { user: createdBy } : undefined
+    );
 
     await fs.promises.rm(tmpDir, { recursive: true, force: true });
 


### PR DESCRIPTION
### What does it do?

Adds the MCP surface to the upload plugin and the first three read tools on top of it.

- New `packages/core/upload/server/src/mcp/`, following the content-manager layout: `register-upload-mcp-tools.ts`, `schemas/`, `handlers/`, `sanitizers/`, `permissions.ts`, `types.ts`, `utils.ts`.
- Registers the tools from the plugin `register.ts`, before the MCP HTTP server starts during bootstrap. Nothing is registered when the MCP server is disabled.
- Three read tools, all gated on `plugin::upload.read`:
  - `media_list_assets` — paginated, with folder / mime type / name filters and sort
  - `media_get_asset` — a single asset by numeric id
  - `media_list_folders` — the nested folder tree, reusing `folder.getStructure()`
- Handlers receive the `strapi` instance the registry hands them and thread it through `getService()` and the permissions helpers, rather than reaching for the `global.strapi` ambient. `getService(name, strapiInstance?)` keeps the global as its default, so the existing controllers and services are unchanged.
- Tool output is an explicit allowlist of fields, not a denylist. `provider_metadata` (which can hold provider credentials), `provider`, `hash`, `formats` and the private `folderPath` are never returned, including for fields added to the file content-type later.
- Adds the api-test harness: `tests/api/core/mcp/mcp-upload-rbac.test.api.ts` using the shared `utils/mcp-client.ts`, plus an exported seeding helper in `tests/api/core/mcp/utils/media-seed.ts` that creates real assets and folders through the upload service.

Tool names carry a `media_` prefix as of 2026-09-08 — see [CMS-37](https://linear.app/strapi/issue/CMS-37/capabilities-media-library) divergence 4. They otherwise follow the [initiative card](https://app.notion.com/p/strapi/MCP-tools-for-Media-Library-management-3b18f3598074815789b8ee714e73d346), so the wire surface reads the same way across the whole Media Library MCP epic (`media_list_assets` / `media_get_asset` / `media_list_folders`, and later `media_update_asset`, `media_move_assets`, `media_delete_assets`, `media_create_folder`).

The prefix exists because the card's plain names collide with the content-manager's derived tools. A content type `api::media.media` slugifies to `media`, so the content-manager derives `list_media` and `get_media` during **bootstrap** — after this plugin has claimed those names during **register**. `registerTool` throws on a duplicate and nothing catches it, so a project with a content type named `media` (or `folders`) would fail to boot with MCP enabled. Every content-manager name begins with a verb, so a `media_`-prefixed name is unreachable by derivation. Thanks to @jhoward1994 for catching this in review.

`telemetry.name` keeps the short verbs (`list`, `get`, `list_folders`) and is deliberately **not** prefixed: it is decoupled from the wire name, and the `source: 'upload'` field already carries the domain, matching the content-manager convention.

One note on scope: the tool auth policies carry an action with no subject. `plugin::upload.read` is registered in the `plugins` section without a subject, so a subject-less grant registers as CASL `subject: 'all'`; passing a model UID as the subject is rejected by the admin-token validation. The per-model check still happens inside each handler, where the permissions manager is bound to the file or folder UID, matching the admin controllers.

### Why is it needed?

Foundation work for the Media Library MCP tools. The read tools prove the surface works end to end, and the seeding helper is what the folder CRUD, move asset, and asset metadata tickets build on — media assets are provider-backed files, so they cannot be fixtured with `createTestBuilder().addContentType()` the way content-manager documents are.

### How to test it?

Manual, in `examples/getstarted`:

1. Enable admin tokens and the MCP server in `config/server.ts` / `config/features.ts`: `features.future.adminTokens: true` and `server.mcp.enabled: true`, then set `admin.secrets.encryptionKey`.
2. `cd examples/getstarted && yarn develop`.
3. In the admin panel, upload a few assets to the Media Library and create a folder with a nested subfolder. Put at least one asset inside a folder and leave one at the root. Set an alternative text on one asset.
4. Create an admin token (Settings → Admin tokens) granting only **Access the Media Library** (`plugin::upload.read`).
5. Point an MCP client at `POST /mcp` with `Authorization: Bearer <accessKey>`, initialize the session, and call `tools/list`. Expect `media_list_assets`, `media_get_asset` and `media_list_folders` to be listed.
6. Call `media_list_assets` with no arguments — every asset comes back with `id`, `name`, `alternativeText`, `caption`, `url`, `mime`, `size`, `width`/`height`, `ext`, `folder` and timestamps. Confirm no `provider`, `provider_metadata`, `hash`, `formats` or `folderPath` appears in the response.
7. Call `media_list_assets` with `{ "folderId": <id> }` (only that folder's assets), then `{ "folderId": null }` (only root-level assets), then `{ "mime": "image" }` and `{ "name": "<partial name>" }`.
8. Call `media_get_asset` with `{ "id": <numeric id> }` — one sanitized asset including its `{ id, name }` folder. Passing a documentId-style string is rejected.
9. Call `media_list_folders` — the nested tree, with no `path` or `pathId` on any node.
10. Create a second admin token **without** Media Library access. `tools/list` must not include the three tools, and calling them must be denied.

Automated, in addition to the manual pass:

```bash
yarn test:unit --projects packages/core/upload   # 44 new tests
yarn test:generate-app && yarn test:api mcp-     # 14 new api tests
```

### Related issue(s)/PR(s)

fix CMS-1710

