### PR TITLE
fix(upload): keep a replaced file in its folder

### DIFF
--- a/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
@@ -135,6 +135,68 @@ describe('Upload service - replace()', () => {
     expect(providerMethods.delete).not.toHaveBeenCalled();
   });
 
+  test('keeps the file in its folder', async () => {
+    currentDbFile = {
+      id: 4,
+      hash: 'in_folder_abc',
+      ext: '.txt',
+      provider: PROVIDER,
+      formats: null,
+      folderPath: '/7',
+    };
+
+    await uploadService.replace(4, {
+      data: { fileInfo: {} as any },
+      file: inputFile() as any,
+    });
+
+    // Left to `formatFileInfo` this became '/', contradicting the surviving
+    // relation — and `folder.deleteByIds` selects by folderPath, so deleting the
+    // folder left the file behind, invisible and never freed from storage.
+    expect(dbUpdate.mock.calls[0][0].data).toMatchObject({ folderPath: '/7' });
+  });
+
+  test('moves the file when a folder is sent explicitly', async () => {
+    currentDbFile = {
+      id: 5,
+      hash: 'moving_def',
+      ext: '.txt',
+      provider: PROVIDER,
+      formats: null,
+      folderPath: '/7',
+    };
+
+    fileServiceMock.getFolderPath.mockImplementationOnce(async () => '/9');
+
+    // Replace-and-move in one request is a supported call, so an explicit folder
+    // still wins over the file's current location.
+    await uploadService.replace(5, {
+      data: { fileInfo: { folder: 9 } as any },
+      file: inputFile() as any,
+    });
+
+    expect(dbUpdate.mock.calls[0][0].data).toMatchObject({ folder: 9, folderPath: '/9' });
+  });
+
+  test('sends the file to the root when the folder is explicitly cleared', async () => {
+    currentDbFile = {
+      id: 6,
+      hash: 'to_root_ghi',
+      ext: '.txt',
+      provider: PROVIDER,
+      formats: null,
+      folderPath: '/7',
+    };
+
+    // `null` is a deliberate move to the root, unlike an absent folder.
+    await uploadService.replace(6, {
+      data: { fileInfo: { folder: null } as any },
+      file: inputFile() as any,
+    });
+
+    expect(dbUpdate.mock.calls[0][0].data).toMatchObject({ folder: null, folderPath: '/' });
+  });
+
   test('checks the file size before writing anything to the provider', async () => {
     currentDbFile = {
       id: 3,

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -507,6 +507,13 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         ext: dbFile.ext,
       });
 
+      // A plain replace sends no folder, so `formatFileInfo` resolved folderPath to
+      // '/' while the relation survived — and folder deletion selects by folderPath,
+      // which orphaned the file. An explicitly sent folder still moves it.
+      if (fileInfo?.folder === undefined) {
+        _.assign(fileData, { folderPath: dbFile.folderPath });
+      }
+
       // clear old formats — replaceImage / replace will set new ones
       _.set(fileData, 'formats', {});
 

--- a/tests/api/core/upload/admin/folder-file.test.api.js
+++ b/tests/api/core/upload/admin/folder-file.test.api.js
@@ -187,6 +187,33 @@ describe('Bulk actions for folders & files', () => {
       expect(existingfilesIds).toEqual(expect.not.arrayContaining([file.id]));
     });
 
+    test('Deletes a replaced file along with its folder', async () => {
+      const folder = await createFolder('folder-with-replaced-file', null);
+      const file = await createAFile(folder.id);
+
+      await rq({
+        method: 'POST',
+        url: `/upload?id=${file.id}`,
+        formData: {
+          files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+        },
+      });
+
+      await rq({
+        method: 'POST',
+        url: '/upload/actions/bulk-delete',
+        body: { folderIds: [folder.id] },
+      });
+
+      // Deletion selects the folder's files by folderPath. Replacing used to
+      // reset that to '/', so the file survived its folder — invisible in the
+      // Media Library and never freed from storage.
+      const resFiles = await rq({ method: 'GET', url: '/upload/files' });
+      const remainingIds = resFiles.body.results.map((f) => f.id);
+
+      expect(remainingIds).not.toContain(file.id);
+    });
+
     test('Can delete only folders', async () => {
       const folder = await createFolder('a random folder', null);
 

--- a/tests/api/core/upload/admin/folder-file.test.api.js
+++ b/tests/api/core/upload/admin/folder-file.test.api.js
@@ -191,13 +191,18 @@ describe('Bulk actions for folders & files', () => {
       const folder = await createFolder('folder-with-replaced-file', null);
       const file = await createAFile(folder.id);
 
-      await rq({
+      const resReplace = await rq({
         method: 'POST',
         url: `/upload?id=${file.id}`,
         formData: {
           files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
         },
       });
+
+      // Asserted directly: a failed replace would leave the file at `folder.path`, so the
+      // deletion below would still remove it and this test would pass without the fix.
+      expect(resReplace.statusCode).toBe(200);
+      expect(resReplace.body.folderPath).toBe(folder.path);
 
       await rq({
         method: 'POST',


### PR DESCRIPTION
### What does it do?

Keeps a replaced file in the folder it was already in.

- `upload.ts` — `replace()` now preserves `folderPath` from the existing record, next to the `hash`/`ext` preservation that already keeps the URL stable:

  ```ts
  if (fileInfo?.folder === undefined) {
    _.assign(fileData, { folderPath: dbFile.folderPath });
  }
  ```

Two deliberate details:

- **`folderPath` only, not `folder`.** `findOne(id)` is called with `populate = {}`, so `dbFile.folder` is undefined and assigning it would write nothing. The relation already survived, because `undefined` is dropped from the update payload — `folderPath` was the only field actually being corrupted.
- **`=== undefined`, not falsy.** `fileInfo.folder = null` is a deliberate move to the root and still has to be honoured, so a falsy check would have broken it. Replace-and-move in one request keeps working.

### Why is it needed?

`formatFileInfo` derives both fields from `fileInfo`:

```ts
folder:     fileInfo.folder                                    // undefined on a plain replace
folderPath: await fileService.getFolderPath(fileInfo.folder)   // -> '/'
```

A plain replace sends no folder, so `folder` was dropped from the update and the relation survived — but `'/'` is a real value, so `folderPath` was written. The row ended up internally inconsistent, and that inconsistency has consequences:

- **Deleting the folder orphaned the asset.** `folder.deleteByIds` selects the files to remove by `folderPath`, not by folder id. A replaced file no longer matched, so the folder was deleted and the file survived pointing at a folder that no longer exists — invisible in the Media Library, and its bytes never freed from storage.
- **Moving the folder left it behind**, since descendants are rewritten by `folderPath` too.

Server-side, so it affects the legacy Media Library, the new one and the content API equally — all three reach the same `replace()`.

### How to test it?

```bash
cd examples/getstarted && yarn develop
```

1. Create a folder and upload a file into it.
2. Replace that file — row popover → **Replace media**, or the details drawer.
3. Inspect the `files` row: `folder` still points at the folder, and `folder_path` now stays at the folder's path instead of becoming `/`.
4. Delete the folder. The file is deleted with it, rather than surviving invisibly.
5. Replace-and-move still works: `POST /upload?id=N` with `fileInfo: { folder: <other> }` moves the file, and `fileInfo: { folder: null }` sends it to the root.

### Related issue(s)/PR(s)

fix CMS-1709

Found while investigating #27501 (`CMS-1686`, replace changing the filename), which turned out to be client-side; this one is genuinely server-side.

🚀