### PR TITLE
fix: ai endpoints requested when the ai feature is unavailable

### DIFF
--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AIUsage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AIUsage.tsx
@@ -2,6 +2,7 @@ import { Flex, Typography, Grid, ProgressBar } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
 
+import { useAIAvailability } from '../../../../../hooks/useAIAvailability';
 import { useGetAiUsageQuery } from '../../../../../services/ai';
 
 const StyledProgressBar = styled(ProgressBar)`
@@ -20,9 +21,15 @@ const StyledGridItem = styled(Grid.Item)`
 
 export const AIUsage = () => {
   const { formatMessage } = useIntl();
+  const isAIAvailable = useAIAvailability();
   const { data, isLoading, error } = useGetAiUsageQuery(undefined, {
     refetchOnMountOrArgChange: true,
+    skip: !isAIAvailable,
   });
+
+  if (!isAIAvailable) {
+    return null;
+  }
 
   if (isLoading) {
     return null;

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/tests/AIUsage.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/tests/AIUsage.test.tsx
@@ -1,0 +1,46 @@
+import { render, server, waitFor } from '@tests/utils';
+import { http, HttpResponse } from 'msw';
+
+import { useAIAvailability } from '../../../../../../hooks/useAIAvailability';
+import { AIUsage } from '../AIUsage';
+
+jest.mock('../../../../../../hooks/useAIAvailability');
+
+describe('<AIUsage />', () => {
+  const getAiUsage = jest.fn(() =>
+    HttpResponse.json({
+      data: {
+        cmsAiCreditsUsed: 10,
+        subscription: {
+          cmsAiEnabled: true,
+          cmsAiCreditsBase: 100,
+          cmsAiCreditsMaxUsage: 100,
+        },
+      },
+    })
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAiUsage.mockClear();
+    server.use(http.get('/admin/ai-usage', getAiUsage));
+  });
+
+  test('does not request AI usage when AI is not available', async () => {
+    jest.mocked(useAIAvailability).mockReturnValue(false);
+
+    const { queryByText } = render(<AIUsage />);
+
+    await waitFor(() => expect(queryByText('AI Usage')).not.toBeInTheDocument());
+
+    expect(getAiUsage).not.toHaveBeenCalled();
+  });
+
+  test('requests AI usage when AI is available', async () => {
+    jest.mocked(useAIAvailability).mockReturnValue(true);
+
+    render(<AIUsage />);
+
+    await waitFor(() => expect(getAiUsage).toHaveBeenCalled());
+  });
+});

--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentActions.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentActions.test.ts
@@ -5,13 +5,18 @@ import { http, HttpResponse } from 'msw';
 import { mockData } from '../../../tests/mockData';
 import { useDocumentActions } from '../useDocumentActions';
 
+const mockUseAIAvailability = jest.fn(() => false);
+
 jest.mock('@strapi/admin/strapi-admin/ee', () => ({
   ...jest.requireActual('@strapi/admin/strapi-admin/ee'),
-  useGetAiFeatureConfigQuery: () => ({ data: undefined }),
-  useAIAvailability: () => false,
+  useAIAvailability: () => mockUseAIAvailability(),
 }));
 
 describe('useDocumentActions', () => {
+  beforeEach(() => {
+    mockUseAIAvailability.mockReturnValue(false);
+  });
+
   it('should return an object with the correct methods', async () => {
     const { result } = renderHook(() => useDocumentActions());
 
@@ -719,6 +724,34 @@ describe('useDocumentActions', () => {
       });
 
       await screen.findByText("Couldn't unpublish entries.");
+    });
+  });
+
+  describe('AI feature config', () => {
+    const getAiFeatureConfig = jest.fn(() =>
+      HttpResponse.json({ data: { isAiI18nConfigured: true } })
+    );
+
+    beforeEach(() => {
+      getAiFeatureConfig.mockClear();
+      mockUseAIAvailability.mockReturnValue(false);
+      server.use(http.get('/admin/ai-feature-config', getAiFeatureConfig));
+    });
+
+    it('should not request the AI feature config when AI is not available', async () => {
+      const { result } = renderHook(() => useDocumentActions());
+
+      await waitFor(() => expect(result.current.update).toEqual(expect.any(Function)));
+
+      expect(getAiFeatureConfig).not.toHaveBeenCalled();
+    });
+
+    it('should request the AI feature config when AI is available', async () => {
+      mockUseAIAvailability.mockReturnValue(true);
+
+      renderHook(() => useDocumentActions());
+
+      await waitFor(() => expect(getAiFeatureConfig).toHaveBeenCalled());
     });
   });
 });

--- a/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
@@ -202,8 +202,10 @@ const useDocumentActions: UseDocumentActions = () => {
   const { trackUsage } = useTracking();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
   const navigate = useNavigate();
-  const { data: aiFeatureConfig } = useGetAiFeatureConfigQuery();
   const isAiAvailable = useAIAvailability();
+  const { data: aiFeatureConfig } = useGetAiFeatureConfigQuery(undefined, {
+    skip: !isAiAvailable,
+  });
   const isAiI18nConfigured = Boolean(aiFeatureConfig?.isAiI18nConfigured);
 
   // Get metadata from context providers for tracking purposes

--- a/packages/core/content-type-builder/admin/src/components/AIChat/hooks/tests/useAIFetch.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/hooks/tests/useAIFetch.test.ts
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react';
+
+import { useFetchGenerateTitle } from '../useAIFetch';
+
+const mockUseAIAvailability = jest.fn();
+const mockUseGetAiUsageQuery = jest.fn((_arg: unknown, _options: unknown) => ({
+  refetch: jest.fn(),
+}));
+
+jest.mock('@strapi/admin/strapi-admin/ee', () => ({
+  useAIAvailability: () => mockUseAIAvailability(),
+  useGetAiUsageQuery: (arg: unknown, options: unknown) => mockUseGetAiUsageQuery(arg, options),
+}));
+
+jest.mock('@strapi/admin/strapi-admin', () => ({
+  useAppInfo: () => undefined,
+}));
+
+describe('useAIFetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips the AI usage query when AI is not available', () => {
+    mockUseAIAvailability.mockReturnValue(false);
+
+    renderHook(() => useFetchGenerateTitle());
+
+    expect(mockUseGetAiUsageQuery).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ skip: true })
+    );
+  });
+
+  it('runs the AI usage query when AI is available', () => {
+    mockUseAIAvailability.mockReturnValue(true);
+
+    renderHook(() => useFetchGenerateTitle());
+
+    expect(mockUseGetAiUsageQuery).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ skip: false })
+    );
+  });
+});

--- a/packages/core/content-type-builder/admin/src/components/AIChat/hooks/tests/usePrefetchAIToken.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/hooks/tests/usePrefetchAIToken.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react';
+
+import { prefetchAIToken } from '../../lib/aiClient';
+import { usePrefetchAIToken } from '../usePrefetchAIToken';
+
+const mockUseAIAvailability = jest.fn();
+
+jest.mock('@strapi/admin/strapi-admin/ee', () => ({
+  useAIAvailability: () => mockUseAIAvailability(),
+}));
+
+jest.mock('../../lib/aiClient', () => ({
+  prefetchAIToken: jest.fn(),
+}));
+
+describe('usePrefetchAIToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not request an AI token when AI is not available', () => {
+    mockUseAIAvailability.mockReturnValue(false);
+
+    renderHook(() => usePrefetchAIToken());
+
+    expect(prefetchAIToken).not.toHaveBeenCalled();
+  });
+
+  it('requests an AI token when AI is available', () => {
+    mockUseAIAvailability.mockReturnValue(true);
+
+    renderHook(() => usePrefetchAIToken());
+
+    expect(prefetchAIToken).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/content-type-builder/admin/src/components/AIChat/hooks/useAIFetch.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/hooks/useAIFetch.ts
@@ -8,7 +8,7 @@ import { useState } from 'react';
 
 import { UIMessage, useChat } from '@ai-sdk/react';
 import { useAppInfo } from '@strapi/admin/strapi-admin';
-import { useGetAiUsageQuery } from '@strapi/admin/strapi-admin/ee';
+import { useAIAvailability, useGetAiUsageQuery } from '@strapi/admin/strapi-admin/ee';
 import { DefaultChatTransport } from 'ai';
 
 import { fetchAI, makeChatFetch, safeParseJson } from '../lib/aiClient';
@@ -149,7 +149,11 @@ export const createAIFetchHook = <T extends keyof AIEndpoints>(endpoint: T) => {
     const strapiVersion = useAppInfo('useAIFetch', (state) => state.strapiVersion);
     const projectId = useAppInfo('useAIFetch', (state) => state.projectId);
     const userId = useAppInfo('useAIFetch-user', (state) => state.userId);
-    const aiUsage = useGetAiUsageQuery(undefined, { refetchOnMountOrArgChange: true });
+    const isAiAvailable = useAIAvailability();
+    const aiUsage = useGetAiUsageQuery(undefined, {
+      refetchOnMountOrArgChange: true,
+      skip: !isAiAvailable,
+    });
 
     const [isPending, setIsPending] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -180,7 +184,9 @@ export const createAIFetchHook = <T extends keyof AIEndpoints>(endpoint: T) => {
           ctx: { strapiVersion, projectId, userId },
         });
         // refetch ai usage data on every successful request
-        aiUsage.refetch();
+        if (isAiAvailable) {
+          aiUsage.refetch();
+        }
 
         const body = await safeParseJson(response);
 

--- a/packages/core/content-type-builder/admin/src/components/AIChat/hooks/usePrefetchAIToken.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/hooks/usePrefetchAIToken.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+import { useAIAvailability } from '@strapi/admin/strapi-admin/ee';
+
+import { prefetchAIToken } from '../lib/aiClient';
+
+export const usePrefetchAIToken = () => {
+  const isAIAvailable = useAIAvailability();
+
+  useEffect(() => {
+    if (!isAIAvailable) {
+      return;
+    }
+
+    prefetchAIToken();
+  }, [isAIAvailable]);
+};

--- a/packages/core/content-type-builder/admin/src/pages/App/index.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/App/index.tsx
@@ -9,7 +9,7 @@ import { useIntl } from 'react-intl';
 import { Route, Routes } from 'react-router-dom';
 
 import { Chat } from '../../components/AIChat/Chat';
-import { prefetchAIToken } from '../../components/AIChat/lib/aiClient';
+import { usePrefetchAIToken } from '../../components/AIChat/hooks/usePrefetchAIToken';
 import { ChatProvider } from '../../components/AIChat/providers/ChatProvider';
 import { AutoReloadOverlayBlockerProvider } from '../../components/AutoReloadOverlayBlocker';
 import { ContentTypeBuilderNav } from '../../components/ContentTypeBuilderNav/ContentTypeBuilderNav';
@@ -36,10 +36,7 @@ const App = () => {
   const state = useGuidedTour('ContentTypeBuilderApp', (s) => s.state);
   const dispatch = useGuidedTour('ContentTypeBuilderApp', (s) => s.dispatch);
 
-  // Prefetch AI token on initial load
-  useEffect(() => {
-    prefetchAIToken();
-  }, []);
+  usePrefetchAIToken();
 
   // Set tour type based on AI availability when the app loads
   useEffect(() => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Gates the four client call sites that request `/admin/ai-*` on `useAIAvailability()`. `useDocumentActions`, `createAIFetchHook` and the EE `AIUsage` widget now pass `skip`; the Content-Type Builder's token prefetch moves out of `App` into a new `usePrefetchAIToken` hook that no-ops when AI is unavailable.

### Why is it needed?

The three AI routes are registered unconditionally and their controllers return `ctx.notFound()` when `strapi.ai.admin.isEnabled()` is false, so every admin load produced three 404s on distinct `/admin/*` paths. That signature matches `crowdsecurity/http-admin-interface-probing` and equivalent ModSecurity CRS and Cloudflare rules, so the panel got its own editors banned at the edge. `useAIUsageWarning` already gated its query on `useAIAvailability`; the other four call sites did not.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made. 

### Related issue(s)/PR(s)
Fixes #27522