### PR TITLE
chore(tsconfig): enable isolatedModules in base and client tsconfigs

### DIFF
--- a/packages/admin-test-utils/src/fixtures/collection-types/address.ts
+++ b/packages/admin-test-utils/src/fixtures/collection-types/address.ts
@@ -420,4 +420,4 @@ const address = {
 
 type Address = typeof address;
 
-export { address, Address };
+export { address, type Address };

--- a/packages/admin-test-utils/src/fixtures/meta-data/address.ts
+++ b/packages/admin-test-utils/src/fixtures/meta-data/address.ts
@@ -98,4 +98,4 @@ const address = {
 
 type Address = typeof address;
 
-export { address, Address };
+export { address, type Address };

--- a/packages/admin-test-utils/src/fixtures/permissions/admin-permissions.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/admin-permissions.ts
@@ -1907,4 +1907,4 @@ const app = {
 type Admin = typeof admin;
 type App = typeof app;
 
-export { admin, Admin, app, App };
+export { admin, type Admin, app, type App };

--- a/packages/admin-test-utils/src/fixtures/permissions/content-manager-permissions.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/content-manager-permissions.ts
@@ -60,4 +60,4 @@ const contentManager = [
 
 type ContentManager = typeof contentManager;
 
-export { contentManager, ContentManager };
+export { contentManager, type ContentManager };

--- a/packages/admin-test-utils/src/fixtures/permissions/content-type-builder-permissions.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/content-type-builder-permissions.ts
@@ -39,4 +39,4 @@ const contentTypeBuilder = [
 
 type ContentTypeBuilder = typeof contentTypeBuilder;
 
-export { contentTypeBuilder, ContentTypeBuilder };
+export { contentTypeBuilder, type ContentTypeBuilder };

--- a/packages/admin-test-utils/src/fixtures/permissions/documentation-permissions.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/documentation-permissions.ts
@@ -31,4 +31,4 @@ const documentation = [
 
 type Documentation = typeof documentation;
 
-export { documentation, Documentation };
+export { documentation, type Documentation };

--- a/packages/admin-test-utils/src/fixtures/permissions/index.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/index.ts
@@ -24,6 +24,6 @@ export {
   contentTypeBuilder,
   ContentTypeBuilder,
   allPermissions,
-  AdminPermissions,
+  type AdminPermissions,
   Documentation,
 };

--- a/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
@@ -5,7 +5,7 @@ import { useIntl } from 'react-intl';
 import { NavLink, useNavigate, Navigate, useLocation } from 'react-router-dom';
 import * as yup from 'yup';
 
-import { ResetPassword } from '../../../../../shared/contracts/authentication';
+import * as AuthenticationContracts from '../../../../../shared/contracts/authentication';
 import { Form } from '../../../components/Form';
 import { InputRenderer } from '../../../components/FormInputs/Renderer';
 import { Logo } from '../../../components/UnauthenticatedLogo';
@@ -111,7 +111,7 @@ const ResetPassword = () => {
 
   const [resetPassword, { error }] = useResetPasswordMutation();
 
-  const handleSubmit = async (body: ResetPassword.Request['body']) => {
+  const handleSubmit = async (body: AuthenticationContracts.ResetPassword.Request['body']) => {
     const res = await resetPassword(body);
 
     if ('data' in res) {

--- a/packages/core/admin/admin/src/types/permissions.ts
+++ b/packages/core/admin/admin/src/types/permissions.ts
@@ -33,4 +33,4 @@ interface PermissionMap {
     };
 }
 
-export { PermissionMap };
+export type { PermissionMap };

--- a/packages/core/admin/shared/contracts/audit-logs.ts
+++ b/packages/core/admin/shared/contracts/audit-logs.ts
@@ -75,4 +75,4 @@ namespace GetUsers {
       };
 }
 
-export { AuditLog, GetAll, Get, GetUsers };
+export type { AuditLog, GetAll, Get, GetUsers };

--- a/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
@@ -185,4 +185,4 @@ const extractAndDedupeFields = (permissions: Permission[] = []) => {
  */
 const removeNumericalStrings = (arr: string[]) => arr.filter((item) => isNaN(Number(item)));
 
-export { DocumentRBAC, useDocumentRBAC, DocumentRBACContextValue, DocumentRBACProps };
+export { DocumentRBAC, useDocumentRBAC, type DocumentRBACContextValue, type DocumentRBACProps };

--- a/packages/core/content-manager/admin/src/hooks/useDragAndDrop.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDragAndDrop.ts
@@ -261,8 +261,8 @@ const useDragAndDrop = <
 
 export {
   useDragAndDrop,
-  UseDragAndDropReturn,
-  UseDragAndDropOptions,
+  type UseDragAndDropReturn,
+  type UseDragAndDropOptions,
   DIRECTIONS,
   DROP_SENSITIVITY,
 };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
@@ -645,4 +645,4 @@ const BlocksContent = ({ placeholder, ariaLabelId }: BlocksContentProps) => {
   );
 };
 
-export { BlocksContent, BlocksContentProps };
+export { BlocksContent, type BlocksContentProps };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
@@ -116,4 +116,4 @@ const FormLayout = React.memo(({ layout, document, hasBackground = true }: FormL
 
 FormLayout.displayName = 'FormLayout';
 
-export { FormLayout, FormLayoutProps };
+export { FormLayout, type FormLayoutProps };

--- a/packages/core/core/src/utils/index.ts
+++ b/packages/core/core/src/utils/index.ts
@@ -3,7 +3,7 @@ export { isInitialized } from './is-initialized';
 export { getDirs } from '../configuration/get-dirs';
 export { ee } from './ee';
 export { createUpdateNotifier } from './update-notifier';
-export { createStrapiFetch, Fetch } from './fetch';
+export { createStrapiFetch, type Fetch } from './fetch';
 export { convertCustomFieldType } from './convert-custom-field-type';
 export { createStartupLogger } from './startup-logger';
 export { transformContentTypesToModels } from './transform-content-types-to-models';

--- a/packages/core/review-workflows/admin/src/routes/settings/hooks/useDragAndDrop.ts
+++ b/packages/core/review-workflows/admin/src/routes/settings/hooks/useDragAndDrop.ts
@@ -261,8 +261,8 @@ const useDragAndDrop = <
 
 export {
   useDragAndDrop,
-  UseDragAndDropReturn,
-  UseDragAndDropOptions,
+  type UseDragAndDropReturn,
+  type UseDragAndDropOptions,
   DIRECTIONS,
   DROP_SENSITIVITY,
 };

--- a/packages/plugins/i18n/admin/src/components/CreateLocale.tsx
+++ b/packages/plugins/i18n/admin/src/components/CreateLocale.tsx
@@ -30,7 +30,7 @@ import { Check, Plus } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import * as yup from 'yup';
 
-import { CreateLocale } from '../../../shared/contracts/locales';
+import { type CreateLocale } from '../../../shared/contracts/locales';
 import { useCreateLocaleMutation, useGetDefaultLocalesQuery } from '../services/locales';
 import { isBaseQueryError } from '../utils/baseQuery';
 import { getTranslation } from '../utils/getTranslation';

--- a/packages/plugins/i18n/server/src/services/content-types.ts
+++ b/packages/plugins/i18n/server/src/services/content-types.ts
@@ -207,4 +207,4 @@ const contentTypes = () => ({
 type ContentTypesService = typeof contentTypes;
 
 export default contentTypes;
-export { ContentTypesService };
+export { type ContentTypesService };

--- a/packages/utils/tsconfig/base.json
+++ b/packages/utils/tsconfig/base.json
@@ -15,6 +15,7 @@
     "noEmit": true,
     "types": [],
     "noUncheckedSideEffectImports": true,
-    "erasableSyntaxOnly": true
+    "erasableSyntaxOnly": true,
+    "isolatedModules": true
   }
 }

--- a/packages/utils/tsconfig/client.json
+++ b/packages/utils/tsconfig/client.json
@@ -19,6 +19,7 @@
     "jsx": "react-jsx",
     "types": [],
     "noUncheckedSideEffectImports": true,
-    "erasableSyntaxOnly": true
+    "erasableSyntaxOnly": true,
+    "isolatedModules": true
   }
 }


### PR DESCRIPTION
### What does it do?

Enables `isolatedModules` in the shared `tsconfig` package's `base.json` and `client.json` (extended repo-wide as `tsconfig/base.json` / `tsconfig/client.json`), and fixes the fallout across the packages that inherit them.

- `packages/utils/tsconfig/base.json` — add `"isolatedModules": true`
- `packages/utils/tsconfig/client.json` — add `"isolatedModules": true`
- Mark type-only re-exports and imports explicitly with the `type` modifier (`admin-test-utils` fixtures, `@strapi/admin` permissions/audit-log contracts, `@strapi/content-manager` `DocumentRBAC` / `useDragAndDrop` / `BlocksContent` / `FormLayout`, `@strapi/core` utils barrel, `@strapi/review-workflows` `useDragAndDrop`, `@strapi/plugin-i18n` `CreateLocale` and `content-types` service)
- `ResetPassword.tsx` — import the authentication contracts as a namespace (`import * as AuthenticationContracts`) instead of importing a namespace that only exists in the type space as a value

Every change is type-level only; there is no runtime behaviour change.

### Why is it needed?

Our build pipeline transpiles TypeScript file-by-file (swc/esbuild/vite), which means the emitter never sees the whole program and cannot tell whether an exported name is a type or a value. `isolatedModules` is the compiler flag that makes `tsc` type-check under exactly those constraints, so the ambiguities are reported as errors during type-checking rather than silently producing a wrong or broken emit.

It also pairs naturally with `erasableSyntaxOnly`, which is already enabled in both configs — both flags exist to keep the source compatible with single-file, type-stripping transpilers.

### How to test it?

```bash
yarn test:ts
yarn build
```

`yarn test:ts` passes locally across all 37 projects.

### Related issue(s)/PR(s)

None.