### PR TITLE
chore(tsconfig): treat every non-declaration file as a module

### DIFF
--- a/packages/utils/tsconfig/base.json
+++ b/packages/utils/tsconfig/base.json
@@ -15,6 +15,7 @@
     "noEmit": true,
     "types": [],
     "noUncheckedSideEffectImports": true,
-    "erasableSyntaxOnly": true
+    "erasableSyntaxOnly": true,
+    "moduleDetection": "force"
   }
 }

--- a/packages/utils/tsconfig/client.json
+++ b/packages/utils/tsconfig/client.json
@@ -19,6 +19,7 @@
     "jsx": "react-jsx",
     "types": [],
     "noUncheckedSideEffectImports": true,
-    "erasableSyntaxOnly": true
+    "erasableSyntaxOnly": true,
+    "moduleDetection": "force"
   }
 }


### PR DESCRIPTION
### What does it do?

Sets `"moduleDetection": "force"` in the two shared tsconfig presets in `packages/utils/tsconfig`:

- `base.json` (server/Node packages)
- `client.json` (admin/browser packages)

With `force`, every non-declaration `.ts`/`.tsx`/`.js`/`.jsx` file is treated as a module, regardless of whether it happens to contain a top-level `import` or `export`.

### Why is it needed?

By default (`moduleDetection: "auto"`), a file with no top-level `import`/`export` is treated as a *global script*, not a module. That has two consequences:

- Its top-level identifiers land in the global scope, where they can silently collide with unrelated files in the same program.
- The file does not get module semantics — no per-file scope, no `import.meta`.

Because a file can flip between "script" and "module" purely as a side effect of adding or removing the last import, the resulting scoping rules are inconsistent and surprising. Forcing module detection removes that class of surprise and lines up with the bundler-oriented setup already in place in these presets (`"moduleResolution": "Bundler"`, `"erasableSyntaxOnly": true`, `"noUncheckedSideEffectImports": true`).

Declaration files (`.d.ts`) are explicitly not affected by `moduleDetection`, so existing global type augmentation keeps working unchanged.

### How to test it?

`yarn test:ts` passes across the monorepo with the change applied (37 projects, `test:ts`, `test:ts:front`, `test:ts:back`).

```bash
yarn install
yarn build
yarn test:ts
```

### Related issue(s)/PR(s)

None.
