### PR TITLE
fix(admin): stop the roles list crashing without the create permission

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -112,6 +112,8 @@ const ListPage = () => {
     navigate(`duplicate/${role.id}`);
   };
 
+  const handleClickEdit = (role: AdminRole) => () => navigate(role.id.toString());
+
   const rowCount = roles.length + 1;
   const colCount = 6;
 
@@ -240,7 +242,7 @@ const ListPage = () => {
                         } satisfies RoleRowProps['icons'][number]),
                       canUpdate &&
                         ({
-                          onClick: () => navigate(role.id.toString()),
+                          onClick: handleClickEdit(role),
                           label: formatMessage({ id: 'app.utils.edit', defaultMessage: 'Edit' }),
                           children: <Pencil />,
                         } satisfies RoleRowProps['icons'][number]),
@@ -253,7 +255,7 @@ const ListPage = () => {
                     ].filter(Boolean) as RoleRowProps['icons']
                   }
                   rowIndex={index + 2}
-                  canUpdate={canUpdate}
+                  onRowClick={canUpdate ? handleClickEdit(role) : undefined}
                 />
               ))}
             </Tbody>

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -223,7 +223,7 @@ const ListPage = () => {
             <Tbody>
               {roles?.map((role, index) => (
                 <RoleRow
-                  cursor="pointer"
+                  cursor={canUpdate ? 'pointer' : undefined}
                   key={role.id}
                   id={role.id}
                   name={role.name}

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/RoleRow.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/RoleRow.tsx
@@ -6,7 +6,7 @@ import type { AdminRole } from '../../../../../hooks/useAdminRoles';
 interface RoleRowProps extends Pick<AdminRole, 'id' | 'name' | 'description' | 'usersCount'> {
   icons: Array<Required<Pick<IconButtonProps, 'children' | 'label' | 'onClick'>>>;
   rowIndex: number;
-  canUpdate?: boolean;
+  onRowClick?: IconButtonProps['onClick'];
   cursor?: string;
 }
 
@@ -17,11 +17,10 @@ const RoleRow = ({
   usersCount,
   icons,
   rowIndex,
-  canUpdate,
+  onRowClick,
   cursor,
 }: RoleRowProps) => {
   const { formatMessage } = useIntl();
-  const [, editObject] = icons;
 
   const usersCountText = formatMessage(
     {
@@ -37,7 +36,7 @@ const RoleRow = ({
       aria-rowindex={rowIndex}
       key={id}
       // @ts-expect-error – the prop uses `HTMLButtonElement` but we just specify `HTMLElement`
-      onClick={canUpdate ? editObject.onClick : undefined}
+      onClick={onRowClick}
     >
       <Td maxWidth={`13rem`}>
         <Typography ellipsis textColor="neutral800">

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/tests/ListPage.test.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/tests/ListPage.test.tsx
@@ -2,6 +2,27 @@ import { render } from '@tests/utils';
 
 import { ListPage } from '../ListPage';
 
+const mockNavigate = jest.fn();
+
+let mockAllowedActions = {
+  canCreate: true,
+  canDelete: true,
+  canRead: true,
+  canUpdate: true,
+};
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../../../hooks/useRBAC', () => ({
+  useRBAC: jest.fn(() => ({
+    isLoading: false,
+    allowedActions: mockAllowedActions,
+  })),
+}));
+
 jest.mock('../../../../../hooks/useAdminRoles', () => ({
   useAdminRoles: jest.fn(() => ({
     roles: [
@@ -20,9 +41,35 @@ jest.mock('../../../../../hooks/useAdminRoles', () => ({
 }));
 
 describe('<ListPage />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockAllowedActions = {
+      canCreate: true,
+      canDelete: true,
+      canRead: true,
+      canUpdate: true,
+    };
+  });
+
   it('should show a list of roles', async () => {
     const { findByText } = render(<ListPage />);
 
     expect(await findByText('Super Admin')).toBeInTheDocument();
+  });
+
+  it('should go to the edit page when a row is clicked and the user can update but not create', async () => {
+    mockAllowedActions = {
+      canCreate: false,
+      canDelete: false,
+      canRead: true,
+      canUpdate: true,
+    };
+
+    const { findByText, user } = render(<ListPage />);
+
+    await user.click(await findByText('Super Admin'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('1');
   });
 });

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/tests/ListPage.test.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/tests/ListPage.test.tsx
@@ -1,27 +1,16 @@
 import { render } from '@tests/utils';
 
+import { useRBAC } from '../../../../../hooks/useRBAC';
 import { ListPage } from '../ListPage';
 
 const mockNavigate = jest.fn();
-
-let mockAllowedActions = {
-  canCreate: true,
-  canDelete: true,
-  canRead: true,
-  canUpdate: true,
-};
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock('../../../../../hooks/useRBAC', () => ({
-  useRBAC: jest.fn(() => ({
-    isLoading: false,
-    allowedActions: mockAllowedActions,
-  })),
-}));
+jest.mock('../../../../../hooks/useRBAC');
 
 jest.mock('../../../../../hooks/useAdminRoles', () => ({
   useAdminRoles: jest.fn(() => ({
@@ -40,16 +29,17 @@ jest.mock('../../../../../hooks/useAdminRoles', () => ({
   })),
 }));
 
+const setupPermissions = (canCreate: boolean, canUpdate: boolean) => {
+  // @ts-expect-error – mocking
+  useRBAC.mockImplementation(() => ({
+    isLoading: false,
+    allowedActions: { canRead: true, canCreate, canUpdate, canDelete: false },
+  }));
+};
+
 describe('<ListPage />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    mockAllowedActions = {
-      canCreate: true,
-      canDelete: true,
-      canRead: true,
-      canUpdate: true,
-    };
   });
 
   it('should show a list of roles', async () => {
@@ -58,18 +48,23 @@ describe('<ListPage />', () => {
     expect(await findByText('Super Admin')).toBeInTheDocument();
   });
 
-  it('should go to the edit page when a row is clicked and the user can update but not create', async () => {
-    mockAllowedActions = {
-      canCreate: false,
-      canDelete: false,
-      canRead: true,
-      canUpdate: true,
-    };
+  it('should go to the edit page when a row is clicked without the create permission', async () => {
+    setupPermissions(false, true);
 
     const { findByText, user } = render(<ListPage />);
 
     await user.click(await findByText('Super Admin'));
 
     expect(mockNavigate).toHaveBeenCalledWith('1');
+  });
+
+  it('should not go to the edit page when a row is clicked without the update permission', async () => {
+    setupPermissions(false, false);
+
+    const { findByText, user } = render(<ListPage />);
+
+    await user.click(await findByText('Super Admin'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### What does it do?

`RoleRow` picked the row's click handler out of the `icons` array by position (`const [, editObject] = icons`), assuming the Edit action was always the second entry. `ListPage` builds that array from three permission-gated entries and then drops the falsy ones with `.filter(Boolean)`, so the position is not stable.

The edit handler is now passed to `RoleRow` as its own `onRowClick` prop, and the `canUpdate` prop it replaces is gone. The pointer cursor follows the same condition, so a row without a handler no longer looks clickable.

### Why is it needed?

When an admin can update roles but not create them, the Duplicate entry is filtered out and Edit moves to index `0`. `canUpdate` is still true, so the row reads `icons[1].onClick` on either the Delete entry or on nothing at all. Settings > Roles then fails to render with `TypeError: Cannot read properties of undefined (reading 'onClick')`, and with delete permission it silently wires the row to the delete handler instead.

#16276 fixed one symptom of this in 4.9.2 without removing the index assumption, which is why it came back for a different permission combination.

### How to test it?

```bash
cd examples/getstarted && yarn develop
```

1. Create a role with `read` and `update` on Settings > Users & Roles, leaving `create` and `delete` unchecked.
2. Assign it to a test admin user and log in as that user.
3. Open Settings > Roles. The list renders, and only the Edit icon is shown.
4. Click a row and confirm it opens that role's edit page.
5. Drop `update` as well and confirm the rows no longer show a pointer cursor and do nothing when clicked.
6. Re-check `create` and confirm Duplicate is back and both the row click and the Edit icon still open the edit page.

### Related issue(s)/PR(s)

Fixes #27536
