### PR TITLE
fix(upload): contain fast provider rejections in upload batches

### DIFF
--- a/packages/core/upload/server/src/services/__tests__/upload/unhandled-provider-rejection.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/unhandled-provider-rejection.test.ts
@@ -1,0 +1,152 @@
+// The `unhandledRejection` process event cannot be used here — jest's runner
+// intercepts it, so a genuinely unhandled rejection never reaches a listener
+// registered inside a test. The containment is asserted directly instead.
+import path from 'path';
+import fs from 'fs';
+import fse from 'fs-extra';
+import _ from 'lodash';
+
+import createUploadService from '../../upload';
+import imageManipulation from '../../image-manipulation';
+
+const defaultConfig = {
+  'plugin::upload': {
+    provider: 'local',
+    breakpoints: {
+      large: 1000,
+      medium: 750,
+    },
+  },
+};
+
+const providerService = {
+  upload: jest.fn(),
+  replace: jest.fn(),
+};
+
+const providerInstance = {
+  delete: jest.fn().mockResolvedValue(undefined),
+};
+
+global.strapi = {
+  config: {
+    get: (key: any, defaultValue?: any) => _.get(defaultConfig, key, defaultValue),
+  },
+  plugins: {
+    upload: {
+      provider: providerInstance,
+      services: {
+        provider: providerService,
+        upload: {
+          getSettings: () => ({ responsiveDimensions: true }),
+        },
+        'image-manipulation': imageManipulation,
+      },
+    },
+  },
+} as any;
+
+// `replaceImage` reads the configured provider off the injected instance, not the global.
+const uploadService = createUploadService({ strapi: global.strapi } as any);
+
+const imageFilePath = path.join(__dirname, './image.png');
+const tmpWorkingDirectory = path.join(__dirname, './tmp-unhandled');
+
+const getFileData = () => ({
+  alternativeText: 'image.png',
+  caption: 'image.png',
+  ext: '.png',
+  folder: undefined,
+  folderPath: '/',
+  filepath: imageFilePath,
+  getStream: () => fs.createReadStream(imageFilePath),
+  hash: 'image_d9b4f84424',
+  height: 1000,
+  size: 4,
+  width: 1500,
+  tmpWorkingDirectory,
+  name: 'image.png',
+});
+
+const settle = (operation: Promise<unknown>) =>
+  operation.then(
+    () => null,
+    (error) => error
+  );
+
+describe('queueConcurrentOperation', () => {
+  test('attaches a rejection handler in the same turn as the push', () => {
+    const queue: Promise<unknown>[] = [];
+    const operation = Promise.reject(new Error('InvalidAccessKeyId'));
+    const catchSpy = jest.spyOn(operation, 'catch');
+
+    uploadService._queueConcurrentOperation(queue, operation);
+
+    // Synchronous — before the caller moves on to `await`ing image work.
+    expect(catchSpy).toHaveBeenCalledTimes(1);
+
+    return expect(Promise.all(queue)).rejects.toThrow('InvalidAccessKeyId');
+  });
+
+  test('queues the operation itself so the batch still fails', async () => {
+    const queue: Promise<unknown>[] = [];
+    const providerError = new Error('InvalidAccessKeyId');
+    const operation = Promise.reject(providerError);
+
+    uploadService._queueConcurrentOperation(queue, operation);
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toBe(operation);
+    await expect(Promise.all(queue)).rejects.toBe(providerError);
+  });
+
+  test('accepts a provider that returns a plain value instead of a promise', async () => {
+    const queue: Promise<unknown>[] = [];
+
+    expect(() =>
+      uploadService._queueConcurrentOperation(queue, undefined as unknown as Promise<void>)
+    ).not.toThrow();
+
+    await expect(Promise.all(queue)).resolves.toEqual([undefined]);
+  });
+});
+
+describe('Provider rejections during concurrent uploads', () => {
+  beforeAll(async () => {
+    await fse.mkdir(tmpWorkingDirectory);
+  });
+
+  afterAll(async () => {
+    await fse.remove(tmpWorkingDirectory);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    providerInstance.delete.mockResolvedValue(undefined);
+  });
+
+  test('still surfaces an immediate upload rejection to the caller', async () => {
+    const providerError = new Error('InvalidAccessKeyId: synthetic provider rejection');
+    // Containing the rejection must not swallow it.
+    providerService.upload.mockRejectedValueOnce(providerError).mockResolvedValue(undefined);
+
+    await expect(settle(uploadService._uploadImage(getFileData()))).resolves.toBe(providerError);
+  });
+
+  test('still surfaces an immediate replace rejection to the caller', async () => {
+    const providerError = new Error('InvalidAccessKeyId: synthetic provider rejection');
+    providerService.replace.mockRejectedValueOnce(providerError).mockResolvedValue(undefined);
+    providerService.upload.mockResolvedValue(undefined);
+
+    const oldFile = {
+      hash: 'image_d9b4f84424',
+      ext: '.png',
+      provider: 'local',
+      formats: {},
+    };
+
+    await expect(
+      settle(uploadService._replaceImage(getFileData() as any, oldFile as any))
+    ).resolves.toBe(providerError);
+  });
+});

--- a/packages/core/upload/server/src/services/__tests__/upload/unhandled-provider-rejection.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/unhandled-provider-rejection.test.ts
@@ -125,17 +125,25 @@ describe('Provider rejections during concurrent uploads', () => {
     providerInstance.delete.mockResolvedValue(undefined);
   });
 
-  test('still surfaces an immediate upload rejection to the caller', async () => {
+  test('handles an immediate upload rejection in the same turn, without swallowing it', async () => {
     const providerError = new Error('InvalidAccessKeyId: synthetic provider rejection');
-    // Containing the rejection must not swallow it.
-    providerService.upload.mockRejectedValueOnce(providerError).mockResolvedValue(undefined);
+    const rejection = Promise.reject(providerError);
+    const catchSpy = jest.spyOn(rejection, 'catch');
+    providerService.upload.mockReturnValueOnce(rejection).mockResolvedValue(undefined);
 
     await expect(settle(uploadService._uploadImage(getFileData()))).resolves.toBe(providerError);
+
+    // The property the fix adds: a handler on the pushed promise before the
+    // caller awaits the image work. Asserting only that the error arrives passes
+    // without the fix, because `Promise.all` always surfaced it.
+    expect(catchSpy).toHaveBeenCalled();
   });
 
-  test('still surfaces an immediate replace rejection to the caller', async () => {
+  test('handles an immediate replace rejection in the same turn, without swallowing it', async () => {
     const providerError = new Error('InvalidAccessKeyId: synthetic provider rejection');
-    providerService.replace.mockRejectedValueOnce(providerError).mockResolvedValue(undefined);
+    const rejection = Promise.reject(providerError);
+    const catchSpy = jest.spyOn(rejection, 'catch');
+    providerService.replace.mockReturnValueOnce(rejection).mockResolvedValue(undefined);
     providerService.upload.mockResolvedValue(undefined);
 
     const oldFile = {
@@ -148,5 +156,7 @@ describe('Provider rejections during concurrent uploads', () => {
     await expect(
       settle(uploadService._replaceImage(getFileData() as any, oldFile as any))
     ).resolves.toBe(providerError);
+
+    expect(catchSpy).toHaveBeenCalled();
   });
 });

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -47,6 +47,18 @@ const { MEDIA_CREATE, MEDIA_UPDATE, MEDIA_DELETE } = ALLOWED_WEBHOOK_EVENTS;
 const { ApplicationError, NotFoundError } = errors;
 const { bytesToKbytes } = fileUtils;
 
+/**
+ * Queue a provider operation for a later `Promise.all`, with a rejection handler
+ * attached in the same turn so a fast failure is never an unhandled rejection.
+ *
+ * `Promise.resolve` first — a provider may hand back a plain value, which
+ * `Promise.all` accepts but `.catch` would throw on.
+ */
+const queueConcurrentOperation = <T>(queue: Promise<T>[], operation: Promise<T>) => {
+  Promise.resolve(operation).catch(() => undefined);
+  queue.push(operation);
+};
+
 export default ({ strapi }: { strapi: Core.Strapi }) => {
   const fileService = getService('file');
 
@@ -315,13 +327,13 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     const uploadPromises: Promise<void>[] = [];
 
     // Upload image
-    uploadPromises.push(getService('provider').upload(fileData));
+    queueConcurrentOperation(uploadPromises, getService('provider').upload(fileData));
 
     // Generate & Upload thumbnail and responsive formats
     if (await isResizableImage(fileData)) {
       const thumbnailFile = await generateThumbnail(fileData);
       if (thumbnailFile) {
-        uploadPromises.push(uploadThumbnail(thumbnailFile));
+        queueConcurrentOperation(uploadPromises, uploadThumbnail(thumbnailFile));
       }
 
       const formats = await generateResponsiveFormats(fileData);
@@ -329,7 +341,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         for (const format of formats) {
           // eslint-disable-next-line no-continue
           if (!format) continue;
-          uploadPromises.push(uploadResponsiveFormat(format));
+          queueConcurrentOperation(uploadPromises, uploadResponsiveFormat(format));
         }
       }
     }
@@ -367,7 +379,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     const promises: Promise<unknown>[] = [];
 
     // Replace the main file
-    promises.push(getService('provider').replace(fileData, oldFile));
+    queueConcurrentOperation(promises, getService('provider').replace(fileData, oldFile));
 
     const newFormatKeys = new Set<string>();
 
@@ -375,7 +387,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       const thumbnailFile = await generateThumbnail(fileData);
       if (thumbnailFile) {
         newFormatKeys.add('thumbnail');
-        promises.push(replaceFormat('thumbnail', thumbnailFile));
+        queueConcurrentOperation(promises, replaceFormat('thumbnail', thumbnailFile));
       }
 
       const formats = await generateResponsiveFormats(fileData);
@@ -384,7 +396,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
           // eslint-disable-next-line no-continue
           if (!format) continue;
           newFormatKeys.add(format.key);
-          promises.push(replaceFormat(format.key, format.file));
+          queueConcurrentOperation(promises, replaceFormat(format.key, format.file));
         }
       }
     }
@@ -397,7 +409,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       for (const oldKey of Object.keys(oldFile.formats)) {
         if (!newFormatKeys.has(oldKey)) {
           const oldFormat = oldFile.formats[oldKey] as File;
-          promises.push(strapi.plugin('upload').provider.delete(oldFormat));
+          queueConcurrentOperation(promises, strapi.plugin('upload').provider.delete(oldFormat));
         }
       }
     }
@@ -774,5 +786,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
      * @internal
      */
     _uploadImage: uploadImage,
+    _replaceImage: replaceImage,
+    _queueConcurrentOperation: queueConcurrentOperation,
   };
 };


### PR DESCRIPTION
### What does it do?

- Adds a `queueConcurrentOperation(queue, operation)` helper in the upload service: it attaches a no-op rejection handler in the same turn as the push, and queues the original promise so the closing `Promise.all` still fails.
- Uses it at every push site in `uploadImage` (main file, thumbnail, responsive formats) and `replaceImage` (main replace, replaced formats, deletion of formats the new image no longer has).
- Exposes `_replaceImage` and `_queueConcurrentOperation` in the existing testing-only block of the service.
- Adds `unhandled-provider-rejection.test.ts` covering the helper's contract and the two service paths.

`remove()` and the non-image branch of `replace()` build and `await` their `Promise.all` in a single expression, so there is no window to close there — they are untouched.

### Why is it needed?

Both batches start every provider write up front, then `await` image manipulation before reaching `Promise.all`:

- `uploadImage` pushes the main upload, then awaits `isResizableImage`, `generateThumbnail` and `generateResponsiveFormats`.
- `replaceImage` has the same shape around `provider.replace`.

A provider that rejects quickly — an S3 `403 InvalidAccessKeyId`, say — therefore rejects during those awaits, while no handler is attached yet. Node's default `--unhandled-rejections=throw` turns that into an uncaught exception and the process exits, so the upload request never gets to return a 5xx.

Two details worth flagging for review:

- The helper goes through `Promise.resolve(operation)` because a provider may hand back a plain value rather than a promise (`Promise.all` accepts it, `.catch` would throw on it). The existing `uploadImage` test does exactly that.
- The `unhandledRejection` process event is **not** usable to test this: jest's runner intercepts it, so a listener registered inside a test never fires, and a test asserting "no unhandled rejection" passes whether or not the bug is fixed. The tests assert the containment property directly instead — the handler is attached synchronously with the push, the queued promise is still the original, and the batch still rejects with the provider's error. Verified to fail with the fix reverted.

### How to test it?

Automated:

```bash
cd packages/core/upload && yarn jest server/src
```

Manually, with a provider that rejects fast:

1. Configure `@strapi/provider-upload-aws-s3` with credentials the endpoint rejects (any bad access key).
2. Upload a resizable image so the thumbnail/responsive path runs.
3. Before: the Strapi process exits on the unhandled rejection. After: the request fails with a 5xx and the server stays up.

### Related issue(s)/PR(s)

- fix CMS-1626
- Closes #27374
