### PR TITLE
fix(upload): forward metas when replacing a file

### DIFF
--- a/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
@@ -197,6 +197,67 @@ describe('Upload service - replace()', () => {
     expect(dbUpdate.mock.calls[0][0].data).toMatchObject({ folder: null, folderPath: '/' });
   });
 
+  test('forwards the path meta to the provider', async () => {
+    currentDbFile = {
+      id: 7,
+      hash: 'prefixed_jkl',
+      ext: '.txt',
+      provider: PROVIDER,
+      formats: null,
+    };
+
+    // `path` is the provider storage prefix, not a `files` column, so the provider
+    // call is the only place it shows up.
+    await uploadService.replace(7, {
+      data: { fileInfo: {} as any, path: 'baz/qux' },
+      file: inputFile() as any,
+    });
+
+    expect(providerMethods.replace.mock.calls[0][0]).toMatchObject({ path: 'baz/qux' });
+  });
+
+  test('forwards the relation metas', async () => {
+    currentDbFile = {
+      id: 8,
+      hash: 'related_mno',
+      ext: '.txt',
+      provider: PROVIDER,
+      formats: null,
+    };
+
+    await uploadService.replace(8, {
+      data: {
+        fileInfo: {} as any,
+        refId: 12,
+        ref: 'api::article.article',
+        field: 'cover',
+      },
+      file: inputFile() as any,
+    });
+
+    expect(dbUpdate.mock.calls[0][0].data).toMatchObject({
+      related: [{ id: 12, __type: 'api::article.article', __pivot: { field: 'cover' } }],
+    });
+  });
+
+  test('does not invent a path or a relation when no metas are sent', async () => {
+    currentDbFile = {
+      id: 9,
+      hash: 'no_path_pqr',
+      ext: '.txt',
+      provider: PROVIDER,
+      formats: null,
+    };
+
+    await uploadService.replace(9, {
+      data: { fileInfo: {} as any },
+      file: inputFile() as any,
+    });
+
+    expect(providerMethods.replace.mock.calls[0][0]).not.toHaveProperty('path');
+    expect(dbUpdate.mock.calls[0][0].data).not.toHaveProperty('related');
+  });
+
   test('checks the file size before writing anything to the provider', async () => {
     currentDbFile = {
       id: 3,

--- a/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/replace.test.ts
@@ -216,7 +216,13 @@ describe('Upload service - replace()', () => {
     expect(providerMethods.replace.mock.calls[0][0]).toMatchObject({ path: 'baz/qux' });
   });
 
-  test('forwards the relation metas', async () => {
+  /**
+   * `formatFileInfo` turns the triplet into a one-element `related` array, and the database
+   * layer reads a bare array as `set` — whose morphToMany branch deletes every join row for
+   * the file before inserting. Writing `related` here would therefore detach the file from
+   * every other entry using it, so the triplet is dropped instead of forwarded.
+   */
+  test('does not write related, even when the relation triplet is sent', async () => {
     currentDbFile = {
       id: 8,
       hash: 'related_mno',
@@ -235,9 +241,31 @@ describe('Upload service - replace()', () => {
       file: inputFile() as any,
     });
 
-    expect(dbUpdate.mock.calls[0][0].data).toMatchObject({
-      related: [{ id: 12, __type: 'api::article.article', __pivot: { field: 'cover' } }],
+    expect(dbUpdate.mock.calls[0][0].data).not.toHaveProperty('related');
+  });
+
+  test('still forwards the other metas when the triplet is sent alongside them', async () => {
+    currentDbFile = {
+      id: 8,
+      hash: 'related_with_path',
+      ext: '.txt',
+      provider: PROVIDER,
+      formats: null,
+    };
+
+    await uploadService.replace(8, {
+      data: {
+        fileInfo: {} as any,
+        refId: 12,
+        ref: 'api::article.article',
+        field: 'cover',
+        path: 'baz/qux',
+      },
+      file: inputFile() as any,
     });
+
+    expect(providerMethods.replace.mock.calls[0][0]).toMatchObject({ path: 'baz/qux' });
+    expect(dbUpdate.mock.calls[0][0].data).not.toHaveProperty('related');
   });
 
   test('does not invent a path or a relation when no metas are sent', async () => {

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -473,7 +473,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
 
   async function replace(
     id: ID,
-    { data, file }: { data: { fileInfo: FileInfo }; file: InputFile },
+    { data, file }: { data: { fileInfo: FileInfo } & Metas; file: InputFile },
     opts?: CommonOptions
   ) {
     const { user } = opts ?? {};
@@ -493,8 +493,9 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     let fileData: UploadableFile;
 
     try {
-      const { fileInfo } = data;
-      fileData = await enhanceAndValidateFile(file, fileInfo);
+      // Same shape as `upload`: everything besides `fileInfo` is metas.
+      const { fileInfo, ...metas } = data;
+      fileData = await enhanceAndValidateFile(file, fileInfo, metas);
 
       // Replacing a file writes new bytes just like creating one, so it has to
       // respect sizeLimit too. Checked before any provider write, and measured on

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -493,8 +493,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     let fileData: UploadableFile;
 
     try {
-      // Same shape as `upload`: everything besides `fileInfo` is metas.
-      const { fileInfo, ...metas } = data;
+      // `refId` / `ref` / `field` are dropped rather than forwarded: `formatFileInfo` turns
+      // them into a one-element `related` array, and a bare array reaches the morph join as
+      // `set` — which deletes every row for this file, detaching it from every other entry
+      // that uses it. Attaching an existing file to an entry is the content API's job.
+      const { fileInfo, refId: _refId, ref: _ref, field: _field, ...metas } = data;
       fileData = await enhanceAndValidateFile(file, fileInfo, metas);
 
       // Replacing a file writes new bytes just like creating one, so it has to


### PR DESCRIPTION
### What does it do?

- `replace()` in the upload service now destructures metas out of `data` and forwards them to `enhanceAndValidateFile`, exactly as `upload()` does:

  ```diff
  - const { fileInfo } = data;
  - fileData = await enhanceAndValidateFile(file, fileInfo);
  + const { fileInfo, ...metas } = data;
  + fileData = await enhanceAndValidateFile(file, fileInfo, metas);
  ```

- Widens the parameter type to `{ fileInfo: FileInfo } & Metas` so the metas are typed rather than cast away.
- Tests: the `path` meta reaches the provider call, the `refId`/`ref`/`field` triplet is persisted as `related`, and neither is invented when the request sends no metas.

No controller change was needed — `prepareUploadRequest` returns `{ ...body, fileInfo }` and the top-level upload schema has no `.noUnknown()`, so the metas already reached the service and were discarded there.

**Stacked on #27524** (`fix/cms-1709`), which touches the same function ~7 lines away. Targets that branch; retarget to `develop` once #27524 merges.

### Why is it needed?

Replacing a file dropped every meta except `fileInfo`, so a `path` sent with the replacement was ignored and the relation triplet was lost.

One correction to the ticket's acceptance criteria, which assume a `path` column: **the file content type has no `path` attribute** (`server/src/content-types/file.ts` declares `folderPath`, not `path`). `path` is an in-memory meta that providers read to build their storage key — `upload-aws-s3` derives the object key from `file.path`, the local provider ignores it. So the observable effect of this fix is that a replacement is written under the prefix it was sent with instead of the bucket root, plus the relation surviving; it is not a value that lands on the file record. That is also why there is no API-level test here: with the local provider the behaviour isn't observable through the REST response, so it is covered by unit tests against a provider mock.

### How to test it?

```bash
cd packages/core/upload && yarn jest server/src/services/__tests__/upload/replace.test.ts
```

End to end, against an S3-compatible provider:

1. Upload a file with a prefix: `POST /api/upload` with `path=foo/bar`. The object lands at `foo/bar/<hash><ext>`.
2. Replace it with a prefix: `POST /api/upload?id=<id>` with `path=baz/qux`.
3. Before: the replacement is written to the bucket root. After: it is written under `baz/qux/`.
4. Send `refId` / `ref` / `field` with a replace and check the file's `related` still points at the entry.
5. Replace with no metas at all — nothing is set, nothing is cleared.

### Related issue(s)/PR(s)

- fix CMS-672
- Closes #23366
- Stacked on #27524