### PR TITLE
fix(strapi): --sourcemap flag has no effect on the admin build

### DIFF
--- a/docs/docs/docs/01-core/strapi/commands/01-build.md
+++ b/docs/docs/docs/01-core/strapi/commands/01-build.md
@@ -158,6 +158,14 @@ await build(args);
 ```ts
 interface BuildOptions extends CLIContext {
   /**
+   * The directory to build the command was ran from
+   */
+  cwd: string;
+  /**
+   * The logger to use.
+   */
+  logger: Logger;
+  /**
    * Which bundler to use for building.
    *
    * @default vite
@@ -183,17 +191,6 @@ interface BuildOptions extends CLIContext {
    * @default false
    */
   installDeps?: boolean;
-}
-
-interface CLIContext {
-  /**
-   * The directory the command was ran from
-   */
-  cwd: string;
-  /**
-   * The logger to use.
-   */
-  logger: Logger;
   /**
    * The tsconfig to use for the build. If undefined, this is not a TS project.
    */

--- a/docs/docs/docs/01-core/strapi/commands/01-build.md
+++ b/docs/docs/docs/01-core/strapi/commands/01-build.md
@@ -96,7 +96,7 @@ interface BuildContext {
   /**
    * The build options
    */
-  options: Pick<BuildOptions, 'minify' | 'sourcemaps' | 'stats'> & Pick<DevelopOptions, 'open'>;
+  options: Pick<BuildOptions, 'minify' | 'sourcemap' | 'stats'> & Pick<DevelopOptions, 'open'>;
   /**
    * The plugins to be included in the JS bundle
    * incl. internal plugins, third party plugins & local plugins
@@ -163,7 +163,7 @@ interface BuildOptions extends CLIContext {
   /**
    * Generate sourcemaps – useful for debugging bugs in the admin panel UI.
    */
-  sourcemaps?: boolean;
+  sourcemap?: boolean;
   /**
    * Print stats for build
    */

--- a/docs/docs/docs/01-core/strapi/commands/01-build.md
+++ b/docs/docs/docs/01-core/strapi/commands/01-build.md
@@ -59,28 +59,7 @@ We run a prompt to encourage the user to install these deps – however, this fu
 The build context is the heart of how the admin builds, as said above it's agnostic, it doesn't care if we're using webpack or vite or parcel. It's an object of data that can be used to preapre any bundler. It's shape looks like:
 
 ```ts
-interface BuildContext extends BaseContext {
-  /**
-   * The customisations defined by the user in their app.js file
-   */
-  customisations?: AppFile;
-  /**
-   * Features object with future flags
-   */
-  features?: Modules.Features.FeaturesService['config'];
-  /**
-   * The build options
-   */
-  options: Pick<BuildOptions, 'bundler' | 'minify' | 'sourcemap' | 'stats'> &
-    Pick<DevelopOptions, 'open'>;
-  /**
-   * The plugins to be included in the JS bundle
-   * incl. internal plugins, third party plugins & local plugins
-   */
-  plugins: PluginMeta[];
-}
-
-interface BaseContext {
+interface BuildContext {
   /**
    * The absolute path to the app directory defined by the Strapi instance
    */
@@ -98,6 +77,10 @@ interface BaseContext {
    * The bundler to use for building & watching
    */
   bundler: 'webpack' | 'vite';
+  /**
+   * The customisations defined by the user in their app.js file
+   */
+  customisations?: AppFile;
   /**
    * The current working directory
    */
@@ -118,7 +101,21 @@ interface BaseContext {
    * The environment variables to be included in the JS bundle
    */
   env: Record<string, string>;
+  /**
+   * Features object with future flags
+   */
+  features?: Modules.Features.FeaturesService['config'];
   logger: CLIContext['logger'];
+  /**
+   * The build options
+   */
+  options: Pick<BuildOptions, 'bundler' | 'minify' | 'sourcemap' | 'stats'> &
+    Pick<DevelopOptions, 'open'>;
+  /**
+   * The plugins to be included in the JS bundle
+   * incl. internal plugins, third party plugins & local plugins
+   */
+  plugins: PluginMeta[];
   /**
    * The absolute path to the runtime directory
    */
@@ -133,47 +130,6 @@ interface BaseContext {
   target: string[];
   tsconfig?: CLIContext['tsconfig'];
 }
-
-type PluginMeta = LocalPluginMeta | ModulePluginMeta;
-
-interface LocalPluginMeta {
-  name: string;
-  /**
-   * camelCased version of the plugin name
-   */
-  importName: string;
-  /**
-   * The path to the plugin, relative to the app's root directory
-   * in system format
-   */
-  path: string;
-  /**
-   * The path to the plugin, relative to the runtime directory
-   * in module format (i.e. with forward slashes) because thats
-   * where it should be used as an import
-   */
-  modulePath: string;
-  type: 'local';
-}
-
-interface ModulePluginMeta {
-  name: string;
-  /**
-   * camelCased version of the plugin name
-   */
-  importName: string;
-  /**
-   * Modules don't have a path because we never resolve them to their node_modules
-   * because we simply do not require it.
-   */
-  path?: never;
-  /**
-   * The path to the plugin, relative to the app's root directory
-   * in module format (i.e. with forward slashes)
-   */
-  modulePath: string;
-  type: 'module';
-}
 ```
 
 ### Static Files
@@ -187,13 +143,11 @@ We currently support both `webpack` & `vite` bundlers, with `vite` being the def
 ## Node Usage
 
 ```ts
-// `node/build` has no entry in the @strapi/strapi exports map, so it is only
-// reachable from inside the package – see cli/commands/build.ts for the CLI wiring
+// internal to @strapi/strapi – the CLI command imports it directly
 import { build, type BuildOptions } from '../../node/build';
 
 const args: BuildOptions = {
-  cwd: process.cwd(),
-  logger,
+  // ...
 };
 
 await build(args);

--- a/docs/docs/docs/01-core/strapi/commands/01-build.md
+++ b/docs/docs/docs/01-core/strapi/commands/01-build.md
@@ -21,13 +21,14 @@ strapi build
 Build the strapi admin app
 
 Options:
-  -d, --debug        Enable debugging mode with verbose logs (default: false)
-  --minify           Minify the output (default: true)
-  --no-optimization  [deprecated]: use minify instead
-  --silent           Don't log anything (default: false)
-  --sourcemap        Produce sourcemaps (default: false)
-  --stats            Print build statistics to the console (default: false)
-  -h, --help         Display help for command
+  --bundler [bundler]  Bundler to use (webpack or vite) (default: "vite")
+  -d, --debug          Enable debugging mode with verbose logs (default: false)
+  --minify             Minify the output (default: true)
+  --silent             Don't log anything (default: false)
+  --sourcemap          Produce sourcemaps (default: false)
+  --stats              Print build statistics to the console (default: false)
+  --install-deps       Auto-install missing admin dependencies (default: false)
+  -h, --help           display help for command
 ```
 
 ## How it works
@@ -58,7 +59,28 @@ We run a prompt to encourage the user to install these deps – however, this fu
 The build context is the heart of how the admin builds, as said above it's agnostic, it doesn't care if we're using webpack or vite or parcel. It's an object of data that can be used to preapre any bundler. It's shape looks like:
 
 ```ts
-interface BuildContext {
+interface BuildContext extends BaseContext {
+  /**
+   * The customisations defined by the user in their app.js file
+   */
+  customisations?: AppFile;
+  /**
+   * Features object with future flags
+   */
+  features?: Modules.Features.FeaturesService['config'];
+  /**
+   * The build options
+   */
+  options: Pick<BuildOptions, 'bundler' | 'minify' | 'sourcemap' | 'stats'> &
+    Pick<DevelopOptions, 'open'>;
+  /**
+   * The plugins to be included in the JS bundle
+   * incl. internal plugins, third party plugins & local plugins
+   */
+  plugins: PluginMeta[];
+}
+
+interface BaseContext {
   /**
    * The absolute path to the app directory defined by the Strapi instance
    */
@@ -69,9 +91,13 @@ interface BuildContext {
    */
   basePath: string;
   /**
-   * The customisations defined by the user in their app.js file
+   * internal path to serve the admin panel
    */
-  customisations?: AppFile;
+  adminPath: string;
+  /**
+   * The bundler to use for building & watching
+   */
+  bundler: 'webpack' | 'vite';
   /**
    * The current working directory
    */
@@ -94,43 +120,59 @@ interface BuildContext {
   env: Record<string, string>;
   logger: CLIContext['logger'];
   /**
-   * The build options
-   */
-  options: BaseOptions;
-  /**
-   * The plugins to be included in the JS bundle
-   * incl. internal plugins, third party plugins & local plugins
-   */
-  plugins: Array<{
-    path: string;
-    name: string;
-    importName: string;
-  }>;
-  /**
    * The absolute path to the runtime directory
    */
   runtimeDir: string;
   /**
    * The Strapi instance
    */
-  strapi: Strapi;
+  strapi: Core.Strapi;
   /**
    * The browserslist target either loaded from the user's workspace or falling back to the default
    */
   target: string[];
   tsconfig?: CLIContext['tsconfig'];
 }
-```
 
-`options` holds the flags shared by `build` and `develop`, named exactly as the CLI declares them:
+type PluginMeta = LocalPluginMeta | ModulePluginMeta;
 
-```ts
-interface BaseOptions {
-  stats?: boolean;
-  minify?: boolean;
-  sourcemap?: boolean;
-  bundler?: 'webpack' | 'vite';
-  open?: boolean;
+interface LocalPluginMeta {
+  name: string;
+  /**
+   * camelCased version of the plugin name
+   */
+  importName: string;
+  /**
+   * The path to the plugin, relative to the app's root directory
+   * in system format
+   */
+  path: string;
+  /**
+   * The path to the plugin, relative to the runtime directory
+   * in module format (i.e. with forward slashes) because thats
+   * where it should be used as an import
+   */
+  modulePath: string;
+  type: 'local';
+}
+
+interface ModulePluginMeta {
+  name: string;
+  /**
+   * camelCased version of the plugin name
+   */
+  importName: string;
+  /**
+   * Modules don't have a path because we never resolve them to their node_modules
+   * because we simply do not require it.
+   */
+  path?: never;
+  /**
+   * The path to the plugin, relative to the app's root directory
+   * in module format (i.e. with forward slashes)
+   */
+  modulePath: string;
+  type: 'module';
 }
 ```
 
@@ -145,10 +187,13 @@ We currently support both `webpack` & `vite` bundlers, with `vite` being the def
 ## Node Usage
 
 ```ts
-import { build, BuildOptions } from '@strapi/admin/_internal';
+// `node/build` has no entry in the @strapi/strapi exports map, so it is only
+// reachable from inside the package – see cli/commands/build.ts for the CLI wiring
+import { build, type BuildOptions } from '../../node/build';
 
 const args: BuildOptions = {
-  // ...
+  cwd: process.cwd(),
+  logger,
 };
 
 await build(args);
@@ -159,13 +204,11 @@ await build(args);
 ```ts
 interface BuildOptions extends CLIContext {
   /**
-   * The directory to build the command was ran from
+   * Which bundler to use for building.
+   *
+   * @default vite
    */
-  cwd: string;
-  /**
-   * The logger to use.
-   */
-  logger: Logger;
+  bundler?: 'webpack' | 'vite';
   /**
    * Minify the output
    *
@@ -181,6 +224,23 @@ interface BuildOptions extends CLIContext {
    */
   stats?: boolean;
   /**
+   * Auto-install missing admin dependencies
+   *
+   * @default false
+   */
+  installDeps?: boolean;
+}
+
+interface CLIContext {
+  /**
+   * The directory the command was ran from
+   */
+  cwd: string;
+  /**
+   * The logger to use.
+   */
+  logger: Logger;
+  /**
    * The tsconfig to use for the build. If undefined, this is not a TS project.
    */
   tsconfig?: TsConfig;
@@ -191,10 +251,15 @@ interface Logger {
   errors: number;
   debug: (...args: unknown[]) => void;
   info: (...args: unknown[]) => void;
+  success: (...args: unknown[]) => void;
   warn: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
   log: (...args: unknown[]) => void;
-  spinner: (text: string) => Pick<ora.Ora, 'succeed' | 'fail' | 'start' | 'text'>;
+  spinner: (text: string) => Pick<ora.Ora, 'succeed' | 'fail' | 'start' | 'text' | 'isSpinning'>;
+  progressBar: (
+    totalSize: number,
+    text: string
+  ) => Pick<cliProgress.SingleBar, 'start' | 'stop' | 'update'>;
 }
 
 interface TsConfig {

--- a/docs/docs/docs/01-core/strapi/commands/01-build.md
+++ b/docs/docs/docs/01-core/strapi/commands/01-build.md
@@ -96,7 +96,7 @@ interface BuildContext {
   /**
    * The build options
    */
-  options: Pick<BuildOptions, 'minify' | 'sourcemap' | 'stats'> & Pick<DevelopOptions, 'open'>;
+  options: BaseOptions;
   /**
    * The plugins to be included in the JS bundle
    * incl. internal plugins, third party plugins & local plugins
@@ -119,6 +119,18 @@ interface BuildContext {
    */
   target: string[];
   tsconfig?: CLIContext['tsconfig'];
+}
+```
+
+`options` holds the flags shared by `build` and `develop`, named exactly as the CLI declares them:
+
+```ts
+interface BaseOptions {
+  stats?: boolean;
+  minify?: boolean;
+  sourcemap?: boolean;
+  bundler?: 'webpack' | 'vite';
+  open?: boolean;
 }
 ```
 

--- a/packages/core/strapi/src/node/build.ts
+++ b/packages/core/strapi/src/node/build.ts
@@ -9,7 +9,7 @@ interface BuildOptions extends CLIContext {
   /**
    * Which bundler to use for building.
    *
-   * @default webpack
+   * @default vite
    */
   bundler?: 'webpack' | 'vite';
   /**

--- a/packages/core/strapi/src/node/build.ts
+++ b/packages/core/strapi/src/node/build.ts
@@ -21,7 +21,7 @@ interface BuildOptions extends CLIContext {
   /**
    * Generate sourcemaps – useful for debugging bugs in the admin panel UI.
    */
-  sourcemaps?: boolean;
+  sourcemap?: boolean;
   /**
    * Print stats for build
    */

--- a/packages/core/strapi/src/node/create-build-context.ts
+++ b/packages/core/strapi/src/node/create-build-context.ts
@@ -15,12 +15,12 @@ import type { BaseContext } from './types';
 interface BaseOptions {
   stats?: boolean;
   minify?: boolean;
-  sourcemaps?: boolean;
+  sourcemap?: boolean;
   bundler?: 'webpack' | 'vite';
   open?: boolean;
 }
 
-interface BuildContext<TOptions = unknown> extends BaseContext {
+interface BuildContext extends BaseContext {
   /**
    * The customisations defined by the user in their app.js file
    */
@@ -32,7 +32,7 @@ interface BuildContext<TOptions = unknown> extends BaseContext {
   /**
    * The build options
    */
-  options: BaseOptions & TOptions;
+  options: BaseOptions;
   /**
    * The plugins to be included in the JS bundle
    * incl. internal plugins, third party plugins & local plugins
@@ -40,9 +40,9 @@ interface BuildContext<TOptions = unknown> extends BaseContext {
   plugins: PluginMeta[];
 }
 
-interface CreateBuildContextArgs<TOptions = unknown> extends CLIContext {
+interface CreateBuildContextArgs extends CLIContext {
   strapi?: Core.Strapi;
-  options?: TOptions;
+  options?: BaseOptions;
 }
 
 const DEFAULT_BROWSERSLIST = [
@@ -52,13 +52,13 @@ const DEFAULT_BROWSERSLIST = [
   'not dead',
 ];
 
-const createBuildContext = async <TOptions extends BaseOptions>({
+const createBuildContext = async ({
   cwd,
   logger,
   tsconfig,
   strapi,
-  options = {} as TOptions,
-}: CreateBuildContextArgs<TOptions>): Promise<BuildContext<TOptions>> => {
+  options = {},
+}: CreateBuildContextArgs): Promise<BuildContext> => {
   /**
    * If you make a new strapi instance when one already exists,
    * you will overwrite the global and the app will _most likely_
@@ -156,7 +156,7 @@ const createBuildContext = async <TOptions extends BaseOptions>({
 
   const { bundler = 'vite', ...restOptions } = options;
 
-  const buildContext = {
+  const buildContext: BuildContext = {
     appDir,
     adminPath,
     basePath: adminPublicPath,
@@ -169,13 +169,13 @@ const createBuildContext = async <TOptions extends BaseOptions>({
     env,
     features,
     logger,
-    options: restOptions as BaseOptions & TOptions,
+    options: restOptions,
     plugins: pluginsWithFront,
     runtimeDir,
     strapi: strapiInstance,
     target,
     tsconfig,
-  } satisfies BuildContext<TOptions>;
+  };
 
   return buildContext;
 };

--- a/packages/core/strapi/src/node/develop.ts
+++ b/packages/core/strapi/src/node/develop.ts
@@ -33,7 +33,7 @@ interface DevelopOptions extends CLIContext {
   /**
    * Which bundler to use for building.
    *
-   * @default webpack
+   * @default vite
    */
   bundler?: 'webpack' | 'vite';
   polling?: boolean;

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -164,7 +164,7 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
 
 const resolveProductionConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
   const {
-    options: { minify, sourcemaps },
+    options: { minify, sourcemap },
   } = ctx;
 
   const baseConfig = await resolveBaseConfig(ctx);
@@ -177,7 +177,7 @@ const resolveProductionConfig = async (ctx: BuildContext): Promise<InlineConfig>
       ...baseConfig.build,
       assetsDir: '',
       minify,
-      sourcemap: sourcemaps,
+      sourcemap,
       rollupOptions: {
         input: {
           strapi: ctx.entry,

--- a/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
+++ b/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
@@ -40,6 +40,41 @@ describe('Vite admin configuration', () => {
     expect(config.publicDir).toBe(false);
   });
 
+  it.each([true, false])(
+    'passes options.sourcemap through to the production build config (%s)',
+    async (sourcemap) => {
+      const ctx = {
+        cwd: process.cwd(),
+        target: ['last 3 major versions'],
+        basePath: '/admin',
+        adminPath: '/admin',
+        distDir: 'dist/build',
+        appDir: process.cwd(),
+        entry: '.strapi/client/app.js',
+        distPath: `${process.cwd()}/dist/build`,
+        env: {},
+        runtimeDir: `${process.cwd()}/.strapi/client`,
+        logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn() },
+        strapi: { internal_config: {}, server: { httpServer: http.createServer() } },
+        bundler: 'vite' as const,
+        // The CLI flag is `--sourcemap`, so commander stores the value on `options.sourcemap`.
+        // Reading `options.sourcemaps` here silently produced `undefined` and no .map files (#22632).
+        options: {
+          minify: true,
+          sourcemap,
+        },
+        plugins: [],
+        tsconfig: undefined,
+        customisations: undefined,
+        features: undefined,
+      } as unknown as BuildContext;
+
+      const config = await resolveProductionConfig(ctx);
+
+      expect(config.build?.sourcemap).toBe(sourcemap);
+    }
+  );
+
   it('allows proxied hosts and pins HMR to the Strapi HTTP server without a separate clientPort (#23491)', async () => {
     const mockHttpServer = http.createServer();
     const ctx = {

--- a/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
+++ b/packages/core/strapi/src/node/vite/resolve-development-config.test.ts
@@ -27,7 +27,7 @@ describe('Vite admin configuration', () => {
       bundler: 'vite' as const,
       options: {
         minify: true,
-        sourcemaps: false,
+        sourcemap: false,
       },
       plugins: [],
       tsconfig: undefined,

--- a/packages/core/strapi/src/node/webpack/config.ts
+++ b/packages/core/strapi/src/node/webpack/config.ts
@@ -116,7 +116,7 @@ const resolveBaseConfig = async (ctx: BuildContext) => {
             configFile: ctx.tsconfig.path,
             configOverwrite: {
               compilerOptions: {
-                sourceMap: ctx.options.sourcemaps,
+                sourceMap: ctx.options.sourcemap,
               },
             },
           },
@@ -191,7 +191,7 @@ const resolveProductionConfig = async (ctx: BuildContext): Promise<Configuration
     stats: 'errors-only',
     mode: 'production',
     bail: true,
-    devtool: ctx.options.sourcemaps ? 'source-map' : false,
+    devtool: ctx.options.sourcemap ? 'source-map' : false,
     output: {
       path: ctx.distPath,
       publicPath: `${ctx.basePath.replace(/\/$/, '')}/`,

--- a/packages/core/strapi/src/node/webpack/resolve-production-config.test.ts
+++ b/packages/core/strapi/src/node/webpack/resolve-production-config.test.ts
@@ -1,0 +1,47 @@
+import http from 'node:http';
+
+import { resolveProductionConfig } from './config';
+import type { BuildContext } from '../create-build-context';
+
+jest.mock('browserslist-to-esbuild', () => ({
+  __esModule: true,
+  default: jest.fn(() => ['chrome100']),
+}));
+
+const createContext = (options: Record<string, unknown>) =>
+  ({
+    cwd: process.cwd(),
+    target: ['last 3 major versions'],
+    basePath: '/admin',
+    adminPath: '/admin',
+    distDir: 'dist/build',
+    appDir: process.cwd(),
+    entry: '.strapi/client/app.js',
+    distPath: `${process.cwd()}/dist/build`,
+    env: {},
+    runtimeDir: `${process.cwd()}/.strapi/client`,
+    logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn() },
+    strapi: { internal_config: {}, server: { httpServer: http.createServer() } },
+    bundler: 'webpack' as const,
+    options,
+    plugins: [],
+    tsconfig: undefined,
+    customisations: undefined,
+    features: undefined,
+  }) as unknown as BuildContext;
+
+describe('Webpack admin configuration', () => {
+  // The CLI flag is `--sourcemap`, so commander stores the value on `options.sourcemap`. Reading
+  // `options.sourcemaps` here left devtool permanently disabled and emitted no .map files (#22632).
+  it('enables the source-map devtool when options.sourcemap is true', async () => {
+    const config = await resolveProductionConfig(createContext({ minify: true, sourcemap: true }));
+
+    expect(config.devtool).toBe('source-map');
+  });
+
+  it('disables devtool when options.sourcemap is false', async () => {
+    const config = await resolveProductionConfig(createContext({ minify: true, sourcemap: false }));
+
+    expect(config.devtool).toBe(false);
+  });
+});


### PR DESCRIPTION
### What does it do?

The `strapi build` command declares a `--sourcemap` flag, so commander stores the parsed value on `options.sourcemap`. The build option types and every consumer read `options.sourcemaps` instead, with a trailing `s`. The value was therefore always `undefined`, and neither bundler ever emitted sourcemaps.

- Renames the option to `sourcemap` in `BuildOptions` (`node/build.ts`) and `BaseOptions` (`node/create-build-context.ts`), matching the CLI flag.
- Reads `ctx.options.sourcemap` in the vite production config, and in webpack for both `devtool` and the `sourceMap` compiler option handed to `fork-ts-checker-webpack-plugin`.
- Removes the `TOptions` type parameter from `BuildContext`, `CreateBuildContextArgs` and `createBuildContext`, annotates the assembled context as `BuildContext`, and drops the `as BaseOptions & TOptions` assertion.
- Adds tests for the wiring: vite `build.sourcemap` and webpack `devtool` are asserted with the option both on and off, in `vite/resolve-development-config.test.ts` and the new `webpack/resolve-production-config.test.ts`. Nothing in the suite failed on the old spelling.

The generic is what let the bug survive. `options` was typed as `BaseOptions & TOptions` and the finished context was cast with `as`, so any extra or misspelled key still type checked. With the type parameter gone the option names are checked against `BaseOptions` directly. `options` stays optional on `createBuildContext` and keeps its `{}` default, so no call site changes.

The contributor docs for the command are corrected alongside it, since every code block in `docs/docs/docs/01-core/strapi/commands/01-build.md` had drifted from the source it describes:

- The CLI options block is taken from `strapi build --help`. It gains `--bundler` and `--install-deps`, and loses `--no-optimization`, which the command no longer declares.
- `BuildContext` gains `adminPath`, `bundler` and `features`, types `plugins` as `PluginMeta[]` instead of an outdated inline shape, and its `options` entry names the four `BuildOptions` members it actually picks.
- `BuildOptions` gains `bundler` and `installDeps`, and `Logger` gains `success`, `progressBar` and the `isSpinning` spinner key.
- The Node usage snippet imported `build` from `@strapi/admin/_internal`, which only exports `DefaultDocument`. It now shows the internal `node/build` import the CLI command uses.

Both commands default `bundler` to vite, while the `BuildOptions` and `DevelopOptions` comments said webpack, so those two comments are corrected too.

### Why is it needed?

`strapi build --sourcemap` silently produces no `.map` files, which makes debugging admin panel issues in a built app much harder than it should be. Reported in #22632, which was closed as not planned while the mismatch was still present on `develop`.

### How to test it?

In a Strapi app built from this branch:

```
strapi build --sourcemap
```

`.map` files should appear next to the emitted admin bundles in `dist/build`, and no `.map` files without the flag. The same holds with `--bundler webpack`, where `devtool` becomes `source-map`.

Automated coverage, from `packages/core/strapi`:

```
npx jest src/node/vite src/node/webpack
```

Types:

```
yarn nx run @strapi/strapi:test:ts
```

### Related issue(s)/PR(s)

Fix #22632

This sits alongside three other open CLI pull requests of mine. It does not depend on any of them and can be reviewed and merged on its own.

- #27315 restructures the same `BuildOptions` interface in `node/build.ts` and also touches `node/develop.ts`, so whichever of the two lands second will need a small rebase. The overlap is confined to those two interfaces.
- #27313 upgrades commander, the library that maps `--sourcemap` to `options.sourcemap` in the first place.
- #27316 centralises the Strapi project check across commands. No file overlap, listed only so the CLI work can be reviewed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKPj8YnEP4R1YRUvZHguTb
