### PR TITLE
fix(core/core): media document ids cannot be linked with document service

### DIFF
--- a/packages/core/core/src/services/document-service/transform/__tests__/id-transform-media.test.ts
+++ b/packages/core/core/src/services/document-service/transform/__tests__/id-transform-media.test.ts
@@ -1,0 +1,179 @@
+import type { Core, Internal, Schema } from '@strapi/types';
+
+import { transformParamsDocumentId } from '../id-transform';
+
+const ARTICLE_UID = 'api::article.article' as Internal.UID.ContentType;
+const MEDIA_COMPONENT_UID = 'shared.media' as Internal.UID.Component;
+const UPLOAD_UID = 'plugin::upload.file' as Internal.UID.ContentType;
+
+const models = {
+  [ARTICLE_UID]: {
+    uid: ARTICLE_UID,
+    modelType: 'contentType',
+    kind: 'collectionType',
+    modelName: 'article',
+    globalId: 'Article',
+    info: {
+      displayName: 'Article',
+      singularName: 'article',
+      pluralName: 'articles',
+    },
+    options: {
+      draftAndPublish: true,
+    },
+    attributes: {
+      cover: {
+        type: 'media',
+        multiple: false,
+      },
+      gallery: {
+        type: 'media',
+        multiple: true,
+      },
+      mediaComponent: {
+        type: 'component',
+        component: MEDIA_COMPONENT_UID,
+        repeatable: false,
+      },
+      blocks: {
+        type: 'dynamiczone',
+        components: [MEDIA_COMPONENT_UID],
+      },
+    },
+  },
+  [MEDIA_COMPONENT_UID]: {
+    uid: MEDIA_COMPONENT_UID,
+    modelType: 'component',
+    modelName: 'media',
+    globalId: 'ComponentSharedMedia',
+    category: 'shared',
+    info: {
+      displayName: 'Media',
+    },
+    attributes: {
+      cover: {
+        type: 'media',
+        multiple: false,
+      },
+      gallery: {
+        type: 'media',
+        multiple: true,
+      },
+    },
+  },
+  [UPLOAD_UID]: {
+    uid: UPLOAD_UID,
+    modelType: 'contentType',
+    kind: 'collectionType',
+    modelName: 'file',
+    globalId: 'UploadFile',
+    info: {
+      displayName: 'File',
+      singularName: 'file',
+      pluralName: 'files',
+    },
+    options: {
+      draftAndPublish: false,
+    },
+    attributes: {
+      documentId: {
+        type: 'string',
+      },
+    },
+  },
+} as unknown as Record<string, Schema.ContentType | Schema.Component>;
+
+const findMedia = jest.fn();
+
+describe('Transform media data', () => {
+  beforeAll(() => {
+    global.strapi = {
+      getModel: (uid: string) => models[uid],
+      plugins: {
+        i18n: {
+          services: {
+            'content-types': {
+              isLocalizedContentType() {
+                return false;
+              },
+            },
+            locales: {
+              getDefaultLocale() {
+                return 'en';
+              },
+            },
+          },
+        },
+      },
+      db: {
+        query: jest.fn(() => ({ findMany: findMedia })),
+      },
+    } as unknown as Core.Strapi;
+  });
+
+  beforeEach(() => {
+    findMedia.mockReset();
+    findMedia.mockResolvedValue([
+      { id: 1, documentId: 'cover-doc' },
+      { id: 2, documentId: 'gallery-doc' },
+      { id: 3, documentId: 'component-cover-doc' },
+      { id: 4, documentId: 'component-gallery-doc' },
+      { id: 5, documentId: 'dz-cover-doc' },
+      { id: 6, documentId: 'dz-gallery-doc' },
+    ]);
+  });
+
+  it('maps media documentIds in direct, component, and dynamic-zone single/multiple inputs', async () => {
+    const { data } = await transformParamsDocumentId(ARTICLE_UID, {
+      data: {
+        cover: 'cover-doc',
+        gallery: [{ documentId: 'gallery-doc' }, 20],
+        mediaComponent: {
+          cover: { documentId: 'component-cover-doc' },
+          gallery: ['component-gallery-doc', { id: 21 }],
+        },
+        blocks: [
+          {
+            __component: MEDIA_COMPONENT_UID,
+            cover: 'dz-cover-doc',
+            gallery: [{ documentId: 'dz-gallery-doc' }, 22],
+          },
+        ],
+      },
+      status: 'draft',
+    });
+
+    expect(data).toEqual({
+      cover: { set: [{ id: 1 }] },
+      gallery: { set: [{ id: 2 }, { id: 20 }] },
+      mediaComponent: {
+        cover: { set: [{ id: 3 }] },
+        gallery: { set: [{ id: 4 }, { id: 21 }] },
+      },
+      blocks: [
+        {
+          __component: MEDIA_COMPONENT_UID,
+          cover: { set: [{ id: 5 }] },
+          gallery: { set: [{ id: 6 }, { id: 22 }] },
+        },
+      ],
+    });
+    expect(findMedia).toHaveBeenCalledTimes(1);
+    expect(findMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          documentId: {
+            $in: [
+              'cover-doc',
+              'gallery-doc',
+              'component-cover-doc',
+              'component-gallery-doc',
+              'dz-cover-doc',
+              'dz-gallery-doc',
+            ],
+          },
+        },
+      })
+    );
+  });
+});

--- a/packages/core/core/src/services/document-service/transform/relations/extract/data-ids.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/extract/data-ids.ts
@@ -10,6 +10,7 @@ import { normalizeXToOneRelationValue } from '../utils/xto-one';
 import { LongHandDocument } from '../utils/types';
 
 const { isPolymorphic } = relations;
+const MEDIA_UID = 'plugin::upload.file' as UID.ContentType;
 
 interface Options {
   uid: UID.Schema;
@@ -46,7 +47,7 @@ const addRelationDocId = curry(
 );
 
 /**
- * Iterate over all relations of a data object and extract all relational document ids.
+ * Iterate over all relations and media of a data object and extract their document ids.
  * Those will later be transformed to entity ids.
  */
 const extractDataIds = (idMap: IdMap, data: Record<string, any>, source: Options) => {
@@ -68,7 +69,14 @@ const extractDataIds = (idMap: IdMap, data: Record<string, any>, source: Options
 
         // Regular relations will always target the same target
         // if its a polymorphic relation we need to get it from the data itself
-        const targetUid = isPolymorphicRelation ? relation.__type : attribute.target;
+        let targetUid: UID.Schema;
+        if (attribute.type === 'media') {
+          targetUid = MEDIA_UID;
+        } else if (isPolymorphicRelation) {
+          targetUid = relation.__type;
+        } else {
+          targetUid = attribute.target;
+        }
 
         addDocId(targetUid, relation);
 
@@ -92,7 +100,11 @@ const extractDataIds = (idMap: IdMap, data: Record<string, any>, source: Options
         return relation;
       }, normalizedValue as any);
     },
-    { schema: strapi.getModel(source.uid), getModel: strapi.getModel.bind(strapi) },
+    {
+      schema: strapi.getModel(source.uid),
+      getModel: strapi.getModel.bind(strapi),
+      includeMedia: true,
+    },
     data
   );
 };

--- a/packages/core/core/src/services/document-service/transform/relations/transform/data-ids.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/transform/data-ids.ts
@@ -11,6 +11,7 @@ import { mapRelation, traverseEntityRelations } from '../utils/map-relation';
 import { normalizeXToOneRelationValue } from '../utils/xto-one';
 
 const { isPolymorphic } = relations;
+const MEDIA_UID = 'plugin::upload.file' as UID.ContentType;
 
 interface Options {
   uid: UID.Schema;
@@ -65,7 +66,7 @@ const getRelationIds = curry(
 );
 
 /**
- * Iterate over all relations of a data object and transform all relational document ids to entity ids.
+ * Iterate over all relations and media of a data object and transform document ids to entity ids.
  */
 const transformDataIdsVisitor = (idMap: IdMap, data: Record<string, any>, source: Options) => {
   return traverseEntityRelations(
@@ -87,7 +88,14 @@ const transformDataIdsVisitor = (idMap: IdMap, data: Record<string, any>, source
 
         // Find relational attributes, and return the document ids
         // if its a polymorphic relation we need to get it from the data itself
-        const targetUid: UID.Schema = isPolymorphicRelation ? relation.__type : attribute.target;
+        let targetUid: UID.Schema;
+        if (attribute.type === 'media') {
+          targetUid = MEDIA_UID;
+        } else if (isPolymorphicRelation) {
+          targetUid = relation.__type;
+        } else {
+          targetUid = attribute.target;
+        }
         const ids: ID[] = getIds(targetUid, relation);
 
         // Handle positional arguments
@@ -129,7 +137,11 @@ const transformDataIdsVisitor = (idMap: IdMap, data: Record<string, any>, source
 
       set(key, newRelation as any);
     },
-    { schema: strapi.getModel(source.uid), getModel: strapi.getModel.bind(strapi) },
+    {
+      schema: strapi.getModel(source.uid),
+      getModel: strapi.getModel.bind(strapi),
+      includeMedia: true,
+    },
     data
   );
 };

--- a/packages/core/core/src/services/document-service/transform/relations/utils/map-relation.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/utils/map-relation.ts
@@ -114,15 +114,18 @@ const mapRelation = async (
 };
 
 type TraverseEntity = Parameters<typeof traverseEntity>;
+type TraverseEntityRelationsOptions = TraverseEntity[1] & { includeMedia?: boolean };
 
 /**
- * Utility function, same as `traverseEntity` but only for relations.
+ * Utility function, same as `traverseEntity` but only for relations and, when requested, media.
  */
 const traverseEntityRelations = async (
   visitor: TraverseEntity[0],
-  options: TraverseEntity[1],
+  options: TraverseEntityRelationsOptions,
   data: TraverseEntity[2]
 ) => {
+  const { includeMedia = false, ...traverseOptions } = options;
+
   return traverseEntity(
     async (options, utils) => {
       const { attribute } = options;
@@ -131,23 +134,25 @@ const traverseEntityRelations = async (
         return;
       }
 
-      if (attribute.type !== 'relation') {
+      if (attribute.type !== 'relation' && !(includeMedia && attribute.type === 'media')) {
         return;
       }
 
-      // TODO: Handle join columns
-      if (attribute.useJoinTable === false) {
-        return;
-      }
+      if (attribute.type === 'relation') {
+        // TODO: Handle join columns
+        if (attribute.useJoinTable === false) {
+          return;
+        }
 
-      // morphToOne uses morphColumn (inline columns on the entity), handled directly in processData
-      if (attribute.relation === 'morphToOne') {
-        return;
+        // morphToOne uses morphColumn (inline columns on the entity), handled directly in processData
+        if (attribute.relation === 'morphToOne') {
+          return;
+        }
       }
 
       return visitor(options, utils);
     },
-    options,
+    traverseOptions,
     data
   );
 };

--- a/tests/api/core/strapi/document-service/resources/types/contentTypes.d.ts
+++ b/tests/api/core/strapi/document-service/resources/types/contentTypes.d.ts
@@ -792,6 +792,7 @@ export interface ApiMixedContentMixedContent extends Struct.CollectionTypeSchema
           localized: false;
         };
       }>;
+    images: Schema.Attribute.Component<'mixed-content.mixed-content-nested-media-leaf', true>;
     createdAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     publishedAt: Schema.Attribute.DateTime;

--- a/tests/api/core/strapi/document-service/update.test.api.ts
+++ b/tests/api/core/strapi/document-service/update.test.api.ts
@@ -36,6 +36,11 @@ const resources = {
               },
             },
           },
+          images: {
+            type: 'component',
+            component: 'mixed-content.mixed-content-nested-media-leaf',
+            repeatable: true,
+          },
         },
       },
     },
@@ -206,6 +211,47 @@ describe('Document Service', () => {
         localizedText: 'Original Text',
         sharedText: 'Shared Content',
       });
+    });
+
+    it('Links media by documentId inside a repeatable component', async () => {
+      const MIXED_CONTENT_UID = 'api::mixed-content.mixed-content';
+      const uploadedFile = await strapi.db.query('plugin::upload.file').create({
+        data: {
+          name: 'thumbnail.jpg',
+          alternativeText: 'thumbnail',
+          caption: 'thumbnail',
+          folderPath: '/',
+          hash: 'thumbnail_hash',
+          ext: '.jpg',
+          mime: 'image/jpeg',
+          size: 1,
+          provider: 'local',
+          url: '/uploads/thumbnail.jpg',
+          publishedAt: new Date(),
+        },
+      });
+      const originalDoc = await strapi.documents(MIXED_CONTENT_UID).create({
+        data: {
+          localizedText: 'Original Text',
+        },
+      });
+
+      const updatedDoc = await strapi.documents(MIXED_CONTENT_UID).update({
+        documentId: originalDoc.documentId,
+        data: {
+          images: [{ media: uploadedFile.documentId }],
+        },
+        populate: ['images.media'],
+      });
+
+      expect(updatedDoc.images).toEqual([
+        expect.objectContaining({
+          media: expect.objectContaining({
+            id: uploadedFile.id,
+            documentId: uploadedFile.documentId,
+          }),
+        }),
+      ]);
     });
 
     it('Preserves non-localized media fields when creating a new locale', async () => {


### PR DESCRIPTION
### What does it do?

Allows Document Service create/update data transformation to resolve upload-file `documentId` values supplied to media fields, including media nested in components and dynamic zones. It reuses existing relation ID mapping and keeps numeric upload-file IDs compatible.

### Why is it needed?

Document Service previously skipped media fields while converting document IDs to entity IDs. A media `documentId` was consequently validated as though it were a numeric upload-file ID, causing valid media links to fail with a nonexistent-relation validation error.

### How to test it?

  1. Create a content type with a repeatable component containing a single-media field.
  2. Upload a file and create a parent document.
  3. Call `strapi.documents(<uid>).update()` with the parent `documentId`, passing the uploaded file’s `documentId` to the component media field and populating that field.
  4. Confirm the update succeeds and the populated media contains both the upload file’s numeric `id` and `documentId`.
  5. Repeat with the numeric upload-file `id` and confirm it remains supported.

### Related issue(s)/PR(s)

Fixes #22271.

Related context: #21078.

