### PR TITLE
fix(utils): escape the dot in parseType's time regex

### DIFF
--- a/packages/core/database/src/fields/shared/__tests__/parsers.vitest.test.ts
+++ b/packages/core/database/src/fields/shared/__tests__/parsers.vitest.test.ts
@@ -43,6 +43,15 @@ describe('field parsers', () => {
       expect(() => parseTime('12:60:00')).toThrow(InvalidTimeError);
       expect(() => parseTime(123)).toThrow(InvalidTimeError);
     });
+
+    // The fraction separator must be a literal dot; an unescaped `.` in the
+    // regex previously let any character (and trailing junk) through.
+    it.each(['12:31:11x2', '12:31:11,2', '12:31:11 2'])(
+      'throws InvalidTimeError when the fraction separator is not a dot (%s)',
+      (input) => {
+        expect(() => parseTime(input)).toThrow(InvalidTimeError);
+      }
+    );
   });
 
   describe('parseDateTimeOrTimestamp', () => {

--- a/packages/core/database/src/fields/shared/parsers.ts
+++ b/packages/core/database/src/fields/shared/parsers.ts
@@ -9,7 +9,7 @@ const isDate = (value: unknown): value is Date => {
 
 const DATE_REGEX = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$/;
 const PARTIAL_DATE_REGEX = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])/g;
-const TIME_REGEX = /^(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]{1,3})?$/;
+const TIME_REGEX = /^(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]{1,3})?$/;
 
 export const parseDateTimeOrTimestamp = (value: unknown): Date => {
   if (isDate(value)) {

--- a/packages/core/utils/src/__tests__/parse-type.test.ts
+++ b/packages/core/utils/src/__tests__/parse-type.test.ts
@@ -85,6 +85,11 @@ describe('parseType', () => {
       expect(() => parseType({ type: 'time', value: 122 })).toThrow();
       expect(() => parseType({ type: 'time', value: {} })).toThrow();
       expect(() => parseType({ type: 'time', value: [] })).toThrow();
+
+      // The millisecond separator must be a literal ".", not any character
+      expect(() => parseType({ type: 'time', value: '12:31:11x2' })).toThrow();
+      expect(() => parseType({ type: 'time', value: '12:31:11,2' })).toThrow();
+      expect(() => parseType({ type: 'time', value: '12:31:11 2' })).toThrow();
     });
   });
 

--- a/packages/core/utils/src/parse-type.ts
+++ b/packages/core/utils/src/parse-type.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import * as dates from 'date-fns';
 
-const timeRegex = /^(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]{1,3})?$/;
+const timeRegex = /^(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]{1,3})?$/;
 
 const isDate = (v: unknown): v is Date => {
   return dates.isDate(v);


### PR DESCRIPTION
### What does it do?

Escapes the dot in `parseType`'s time-validation regex (`packages/core/utils`):

```diff
-const timeRegex = /^(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]{1,3})?$/;
+const timeRegex = /^(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]{1,3})?$/;
```

The millisecond separator used an unescaped `.`, which matches **any** character rather than a literal `.`.

### Why is it needed?

Because of that, malformed time values were accepted and silently coerced instead of rejected. `parseTime` slices off the separator char and pads the fraction, so:

| Input | Before | After |
|---|---|---|
| `12:31:11x2` | `12:31:11.200` ✅ accepted | throws ✅ rejected |
| `12:31:11,2` | `12:31:11.200` ✅ accepted | throws ✅ rejected |
| `12:31:11 2` | `12:31:11.200` ✅ accepted | throws ✅ rejected |
| `12:31:11.2` | `12:31:11.200` | `12:31:11.200` (unchanged) |
| `12:31:11` | `12:31:11.000` | `12:31:11.000` (unchanged) |

So a `time` attribute would accept and store values like `12:31:11x2`. All valid `HH:mm:ss[.SSS]` inputs are unaffected.

### How to test it?

`packages/core/utils` unit tests:

```
yarn workspace @strapi/utils test parse-type
```

Added regression assertions in `parse-type.test.ts` (non-dot separators must throw). Full `parse-type` suite passes (32 tests), existing behavior unchanged.

### Related issue(s)/PR(s)

None — small self-contained fix.
