### PR TITLE
chore(ci): add the draft-release action and workflow

### DIFF
--- a/.github/actions/draft-release/.eslintrc.cjs
+++ b/.github/actions/draft-release/.eslintrc.cjs
@@ -1,0 +1,27 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  extends: ['eslint-config-custom/back/typescript'],
+  parserOptions: {
+    project: ['./tsconfig.eslint.json'],
+    tsconfigRootDir: __dirname,
+  },
+  ignorePatterns: ['node_modules/', '.eslintrc.cjs', 'dist/', 'lint-staged.config.mjs'],
+  rules: {
+    // Node's type stripping resolves relative specifiers verbatim, so `.ts` extensions are required.
+    'import/extensions': 'off',
+    'node/no-missing-import': 'off',
+    'node/no-unpublished-import': 'off',
+    // The bundler and the test runner are build-time only, so they belong in devDependencies.
+    'import/no-extraneous-dependencies': [
+      'error',
+      { devDependencies: ['scripts/**', '__tests__/**'] },
+    ],
+    // `LOG_FORMAT` reads far better as a joined list than as a template literal.
+    'prefer-template': 'off',
+  },
+};
+
+module.exports = config;

--- a/.github/actions/draft-release/README.md
+++ b/.github/actions/draft-release/README.md
@@ -90,6 +90,25 @@ The pull request body carries a JSON block between `STRAPI_RELEASE_CANDIDATE_STA
 | `expectedExperimentalVersion`         | `0.0.0-experimental.<headSha>`, the artifact published from that commit.  |
 | `pullRequestNumber`, `pullRequestUrl` | The release pull request, both `null` on a dry run.                       |
 
+`pullRequests[].author` carries both halves of an identity:
+
+| Field   | Meaning                                                                        |
+| ------- | ------------------------------------------------------------------------------ |
+| `login` | The GitHub username, from the pull request payload. Empty only if it has none. |
+| `name`  | The display name, or `null` when no commit in the range can vouch for one.     |
+
+A GitHub pull request payload has no display name in it: its `user` is the short user object, and
+asking for the long one costs a request per distinct contributor. Git already has the name, because
+a squash commit is authored by the contributor, so `%an` on the integration commit is the same
+string GitHub renders next to it.
+
+`name` is `null` rather than guessed in the two cases where that string would be someone else's: a
+merge commit, authored by whoever pressed merge, and a squash whose author email is a GitHub noreply
+address naming a different login, which is what a pull request written by several people leaves
+behind. An address that carries no login, a work address for instance, is not evidence against the
+name. The email itself never reaches the payload: it is read as evidence and dropped, because the
+payload is published in a public pull request body.
+
 The experimental version mirrors
 [`publish-pr-experimental.yml`](../../workflows/publish-pr-experimental.yml), which versions on
 `github.event.pull_request.head.sha` with the full 40-character SHA. Changing the scheme there means

--- a/.github/actions/draft-release/README.md
+++ b/.github/actions/draft-release/README.md
@@ -76,6 +76,25 @@ would never run.
 
 `version`, `bump`, `branch`, `pr_number`, `pr_url`, `journal_path`.
 
+## The release candidate block
+
+The pull request body carries a JSON block between `STRAPI_RELEASE_CANDIDATE_START` and
+`STRAPI_RELEASE_CANDIDATE_END`, so later automation reads the release rather than the prose.
+
+`candidate` is the part that identifies the release without re-deriving any of it:
+
+| Field                                 | Meaning                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------- |
+| `branch`                              | The release branch, `releases/x.y.z`.                                     |
+| `headSha`                             | The commit the branch was cut at. Always the same value as `range.toSha`. |
+| `expectedExperimentalVersion`         | `0.0.0-experimental.<headSha>`, the artifact published from that commit.  |
+| `pullRequestNumber`, `pullRequestUrl` | The release pull request, both `null` on a dry run.                       |
+
+The experimental version mirrors
+[`publish-pr-experimental.yml`](../../workflows/publish-pr-experimental.yml), which versions on
+`github.event.pull_request.head.sha` with the full 40-character SHA. Changing the scheme there means
+changing `experimentalVersion` in [`lib/report.ts`](lib/report.ts).
+
 ## The write journal
 
 This action does not roll back. A run that dies halfway leaves the repository half-changed and a

--- a/.github/actions/draft-release/README.md
+++ b/.github/actions/draft-release/README.md
@@ -15,7 +15,7 @@ Triggered by hand from the Actions tab through [`draft-release.yml`](../../workf
 | Version      | Decides `minor` or `patch` from the commits, unless `version` is given.                                      |
 | Milestones   | Renames the open milestone to the shipping version, opens the next patch milestone, closes the shipping one. |
 | Branch       | Pushes `releases/x.y.z` at the pinned SHA.                                                                   |
-| Pull request | Opens the draft PR `[draft] release x.y.z` against `main` and labels it `publish-experimental`.              |
+| Pull request | Opens the draft PR `Release x.y.z` against `main` and labels it `publish-experimental`.                      |
 | Report       | Writes the shipping table and a machine-readable JSON block into the PR body.                                |
 | Cleanup      | Moves open PRs to the next milestone, clears closed-unmerged PRs and every issue, then comments.             |
 

--- a/.github/actions/draft-release/README.md
+++ b/.github/actions/draft-release/README.md
@@ -32,7 +32,7 @@ otherwise                                -> patch
 `enhancement`, `future`, `security`, `fix`, `chore`, `ci`, `docs`, `test` and `revert` never force a
 minor. `feat(i18n)` counts like any other feature.
 
-Two corrections keep the rule honest:
+Three corrections keep the rule honest:
 
 - **Unparsed subjects fall back to the pull request's own commits.** commitlint runs
   `--from base.sha --to head.sha`, so it validates the commits inside a pull request, never the
@@ -42,6 +42,21 @@ Two corrections keep the rule honest:
 - **Release back-merges are ignored.** `chore: release v5.52.3 update develop` is a pull request
   whose head is `main`, carrying the previous release's commits. Counting them would let an already
   shipped `feat` vote for a second minor.
+- **A breaking marker is never dropped for want of a parsable subject.** The body of the landing
+  commit is read on every path, not only when its subject parses. That is where a breaking footer
+  most often ends up: GitHub pre-fills the squash merge box from the pull request's commits, so the
+  subject can read `Feat/new upload flow (#123)` while the body carries `BREAKING CHANGE:` and the
+  inner commits stay `feat:`. An unparsed subject leaves the _type_ unknown; it says nothing about
+  whether the change breaks.
+
+`bumpEvidence` names where each vote was read, so a stop is always traceable to a place a human can
+look:
+
+| `via`          | Read from                                                     |
+| -------------- | ------------------------------------------------------------- |
+| `subject`      | The landing commit's conventional header, including its `!`.  |
+| `pr-commits`   | The commits inside the pull request, headers and bodies both. |
+| `landing-body` | The body of the landing commit itself.                        |
 
 ## Attribution rule
 

--- a/.github/actions/draft-release/README.md
+++ b/.github/actions/draft-release/README.md
@@ -1,0 +1,181 @@
+# Draft release
+
+Prepares a Strapi CMS release candidate. It pins the shipping range against the published npm
+baseline, decides the version from the commits that landed, cuts `releases/x.y.z`, opens the draft
+pull request against `main`, attributes every shipping pull request, and reconciles milestones.
+
+Triggered by hand from the Actions tab through [`draft-release.yml`](../../workflows/draft-release.yml).
+
+## What it does
+
+| Step         | Effect                                                                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------------------ |
+| Pin          | Resolves the npm `latest` baseline, the `v<latest>` tag and the source branch head to fixed SHAs.            |
+| Attribute    | Resolves each first-parent integration to the pull request that produced it.                                 |
+| Version      | Decides `minor` or `patch` from the commits, unless `version` is given.                                      |
+| Milestones   | Renames the open milestone to the shipping version, opens the next patch milestone, closes the shipping one. |
+| Branch       | Pushes `releases/x.y.z` at the pinned SHA.                                                                   |
+| Pull request | Opens the draft PR `[draft] release x.y.z` against `main` and labels it `publish-experimental`.              |
+| Report       | Writes the shipping table and a machine-readable JSON block into the PR body.                                |
+| Cleanup      | Moves open PRs to the next milestone, clears closed-unmerged PRs and every issue, then comments.             |
+
+## Version rule
+
+When `version` is empty, the commits decide and nothing overrides them:
+
+```text
+any BREAKING CHANGE or `!` in the range  -> stop
+any `feat` in the range                  -> minor
+otherwise                                -> patch
+```
+
+`enhancement`, `future`, `security`, `fix`, `chore`, `ci`, `docs`, `test` and `revert` never force a
+minor. `feat(i18n)` counts like any other feature.
+
+Two corrections keep the rule honest:
+
+- **Unparsed subjects fall back to the pull request's own commits.** commitlint runs
+  `--from base.sha --to head.sha`, so it validates the commits inside a pull request, never the
+  squash subject that lands on `develop`. Subjects such as
+  `Feat/e2e critical ctb add fields (#26559)` therefore reach `develop` ungated, and only the pull
+  request's commits are reliable.
+- **Release back-merges are ignored.** `chore: release v5.52.3 update develop` is a pull request
+  whose head is `main`, carrying the previous release's commits. Counting them would let an already
+  shipped `feat` vote for a second minor.
+
+## Attribution rule
+
+A pull request is accepted for an integration only when all of these hold:
+
+1. `merged_at` is set.
+2. `base.ref` is `develop`.
+3. `merge_commit_sha` equals the integration SHA.
+
+Similar titles, authors or dates are never enough. A subject reference such as `(#27482)` is used
+only as a fallback, and only when the referenced pull request carries hard evidence of its own.
+
+Records are reported with one of five statuses: `resolved`, `direct-integration`, `ambiguous`,
+`lookup-failed` and `unresolved`. A `lookup-failed` record stops the run, because a failed API call
+must never be mistaken for a commit pushed straight to `develop`.
+
+## Inputs
+
+| Input        | Default   | Purpose                                                              |
+| ------------ | --------- | -------------------------------------------------------------------- |
+| `token`      | required  | GitHub App token.                                                    |
+| `version`    | `''`      | Explicit `x.y.z`. Bypasses the commit rule.                          |
+| `dry_run`    | `true`    | Compute everything, record the planned writes, perform none of them. |
+| `source_ref` | `develop` | Branch the release is cut from.                                      |
+
+The default `GITHUB_TOKEN` is not enough. A pull request opened with it does not trigger
+`pull_request` workflows, so the release PR would get no CI, and a label applied with it does not
+fire the `labeled` event, so [`publish-pr-experimental.yml`](../../workflows/publish-pr-experimental.yml)
+would never run.
+
+## Outputs
+
+`version`, `bump`, `branch`, `pr_number`, `pr_url`, `journal_path`.
+
+## The write journal
+
+This action does not roll back. A run that dies halfway leaves the repository half-changed and a
+human finishes or reverts it, so every mutation is recorded before the next one starts. The journal
+is written to the step summary and uploaded as an artifact whether the run succeeds or fails.
+
+A dry run fills the same structure without calling the API. That is the rehearsal: a reviewable,
+line-by-line list of every milestone rename, pull request reassignment and ref push the real run
+would perform.
+
+### Undoing a partial run
+
+| `op`                    | Undo                                                                          |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `milestone.rename`      | `gh api -X PATCH repos/strapi/strapi/milestones/<n> -f title=<before>`        |
+| `milestone.create`      | `gh api -X DELETE repos/strapi/strapi/milestones/<n>`                         |
+| `milestone.close`       | `gh api -X PATCH repos/strapi/strapi/milestones/<n> -f state=open`            |
+| `issue.milestone.set`   | `gh api -X PATCH repos/strapi/strapi/issues/<n> -F milestone=<before number>` |
+| `issue.milestone.clear` | same, with the milestone number recorded in `before`                          |
+| `branch.push`           | `git push origin --delete releases/<version>`                                 |
+| `pr.create`             | `gh pr close <n> --delete-branch`                                             |
+| `pr.label`              | `gh pr edit <n> --remove-label publish-experimental`                          |
+| `pr.body`, `pr.comment` | Edit or delete by hand.                                                       |
+
+## Stops
+
+The run refuses to continue on any of these:
+
+1. npm `latest` disagrees with the highest published stable version.
+2. The `v<latest>` tag is missing.
+3. The baseline is not an ancestor of the source ref.
+4. Rebase merges are enabled on the repository.
+5. The range carries a breaking change.
+6. The range is empty.
+7. Zero or more than one open milestone.
+8. `releases/<version>` already exists.
+9. The `version` input is malformed or not greater than the baseline.
+10. Any commit-to-pulls lookup failed.
+
+`ambiguous` and `unresolved` records do not stop the run. They are listed in the pull request body
+under "Needs a human".
+
+## Contributing
+
+### Requirements
+
+- Node 22.18 or newer, up to 26. Nothing else has to be installed to run the sources or the tests.
+
+### No build step, no committed bundle
+
+The TypeScript sources run directly through Node's type stripping. `action.yml` is a composite
+action that runs `node index.ts`, so what ships is what you read: no `dist/`, no bundler, and no way
+for a committed artifact to drift from its source.
+
+That is only possible because the action has **no runtime dependencies**. `@actions/core` and
+`@actions/github` were the only reason a bundle existed, and both are replaced by small local
+modules:
+
+- [`lib/actions.ts`](lib/actions.ts) implements the slice of the
+  [workflow command protocol](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions)
+  this action uses: inputs from `INPUT_*`, outputs to `$GITHUB_OUTPUT`, `::warning::` / `::error::`,
+  and the job summary file.
+- [`lib/github.ts`](lib/github.ts) is a dozen REST calls over `fetch`, with `Link`-header
+  pagination.
+
+Both are injected through a stub in their tests, which is how they reach full coverage without a
+network or a process.
+
+Keep it dependency-free. Adding one brings the bundle back.
+
+### Node version
+
+Type stripping needs Node >= 22.18. The action checks this before running and fails with a clear
+message, and the workflow pins the version with `actions/setup-node`.
+
+### Layout
+
+```text
+action.yml       composite action: version guard, then `node index.ts`
+index.ts         entry point: reads inputs, builds adapters, flushes the journal
+lib/types.ts     the domain vocabulary; every runtime union is derived from its `as const` list
+lib/actions.ts   the Actions runtime protocol
+lib/github.ts    the GitHub REST adapter
+lib/range.ts     the Git adapter and the first-parent log parser
+lib/*.ts         one module per decision, pure
+__tests__/*.ts   node:test suites, one per module
+```
+
+Decision functions are pure. The process, the network and Git are reached only through adapters,
+which is what makes every rule testable in isolation.
+
+### TypeScript dialect
+
+`tsconfig.json` enforces what type stripping can erase, with `erasableSyntaxOnly`: no `enum`, no
+`namespace`, no parameter properties, `import type` on every type-only import, and an explicit `.ts`
+extension on every relative import. Literal unions derived from `as const` lists replace the enums
+those rules forbid.
+
+### Commands
+
+- `yarn test:unit`: run the `node:test` suites straight off the TypeScript sources
+- `yarn test:ts`: typecheck
+- `yarn lint`: lint

--- a/.github/actions/draft-release/__tests__/actions.test.ts
+++ b/.github/actions/draft-release/__tests__/actions.test.ts
@@ -1,0 +1,180 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  appendSummary,
+  escapeData,
+  getBooleanInput,
+  getInput,
+  info,
+  inputVariable,
+  repositoryCoords,
+  setFailed,
+  setOutput,
+  warning,
+} from '../lib/actions.ts';
+
+import type { ActionsEnv } from '../lib/actions.ts';
+
+function stubEnv(variables: Record<string, string> = {}): ActionsEnv & {
+  lines: string[];
+  files: Record<string, string>;
+} {
+  const lines: string[] = [];
+  const files: Record<string, string> = {};
+
+  return {
+    lines,
+    files,
+    read: (name) => variables[name],
+    append(path, content) {
+      files[path] = (files[path] ?? '') + content;
+    },
+    log: (line) => lines.push(line),
+  };
+}
+
+describe('inputVariable', () => {
+  it('matches the variable name the runner sets', () => {
+    assert.equal(inputVariable('source_ref'), 'INPUT_SOURCE_REF');
+    assert.equal(inputVariable('dry run'), 'INPUT_DRY_RUN');
+  });
+});
+
+describe('escapeData', () => {
+  it('escapes the characters that would end a workflow command early', () => {
+    assert.equal(escapeData('100% done\r\nnext'), '100%25 done%0D%0Anext');
+  });
+});
+
+describe('getInput', () => {
+  it('trims the value', () => {
+    assert.equal(getInput(stubEnv({ INPUT_VERSION: '  5.53.0 ' }), 'version'), '5.53.0');
+  });
+
+  it('returns an empty string for an absent optional input', () => {
+    assert.equal(getInput(stubEnv(), 'version'), '');
+  });
+
+  it('throws for an absent required input', () => {
+    assert.throws(
+      () => getInput(stubEnv(), 'token', { required: true }),
+      /Input required and not supplied: token/u
+    );
+  });
+});
+
+describe('getBooleanInput', () => {
+  for (const value of ['true', 'True', 'TRUE']) {
+    it(`reads ${value} as true`, () => {
+      assert.equal(getBooleanInput(stubEnv({ INPUT_DRY_RUN: value }), 'dry_run'), true);
+    });
+  }
+
+  for (const value of ['false', 'False', 'FALSE']) {
+    it(`reads ${value} as false`, () => {
+      assert.equal(getBooleanInput(stubEnv({ INPUT_DRY_RUN: value }), 'dry_run'), false);
+    });
+  }
+
+  it('refuses to coerce anything else, rather than silently arming a real run', () => {
+    assert.throws(
+      () => getBooleanInput(stubEnv({ INPUT_DRY_RUN: 'yes' }), 'dry_run'),
+      /Core Schema/u
+    );
+  });
+
+  it('refuses an absent value', () => {
+    assert.throws(() => getBooleanInput(stubEnv(), 'dry_run'), /Input required/u);
+  });
+});
+
+describe('setOutput', () => {
+  it('writes the heredoc form to the output file', () => {
+    const env = stubEnv({ GITHUB_OUTPUT: '/tmp/out' });
+
+    setOutput(env, 'version', '5.53.0', () => 'DELIM');
+
+    assert.equal(env.files['/tmp/out'], 'version<<DELIM\n5.53.0\nDELIM\n');
+  });
+
+  it('keeps a multi-line value in one output', () => {
+    const env = stubEnv({ GITHUB_OUTPUT: '/tmp/out' });
+
+    setOutput(env, 'body', 'first\nsecond', () => 'DELIM');
+
+    assert.equal(env.files['/tmp/out'], 'body<<DELIM\nfirst\nsecond\nDELIM\n');
+  });
+
+  it('refuses a value that contains the delimiter', () => {
+    const env = stubEnv({ GITHUB_OUTPUT: '/tmp/out' });
+
+    assert.throws(
+      () => setOutput(env, 'body', 'contains DELIM here', () => 'DELIM'),
+      /contains its own delimiter/u
+    );
+  });
+});
+
+describe('info and warning', () => {
+  it('logs plainly', () => {
+    const env = stubEnv();
+
+    info(env, 'hello');
+
+    assert.deepEqual(env.lines, ['hello']);
+  });
+
+  it('escapes a warning so a newline cannot forge a second command', () => {
+    const env = stubEnv();
+
+    warning(env, 'careful\nnow');
+
+    assert.deepEqual(env.lines, ['::warning::careful%0Anow']);
+  });
+});
+
+describe('setFailed', () => {
+  it('emits the error command and marks the process failed', () => {
+    const env = stubEnv();
+    const previous = process.exitCode;
+
+    setFailed(env, 'it broke');
+
+    assert.deepEqual(env.lines, ['::error::it broke']);
+    assert.equal(process.exitCode, 1);
+
+    process.exitCode = previous;
+  });
+});
+
+describe('appendSummary', () => {
+  it('appends to the summary file', () => {
+    const env = stubEnv({ GITHUB_STEP_SUMMARY: '/tmp/summary' });
+
+    assert.equal(appendSummary(env, '# Report'), true);
+    assert.equal(env.files['/tmp/summary'], '# Report\n');
+  });
+
+  it('reports the absence of a summary file instead of throwing', () => {
+    const env = stubEnv();
+
+    assert.equal(appendSummary(env, '# Report'), false);
+    assert.deepEqual(env.files, {});
+  });
+});
+
+describe('repositoryCoords', () => {
+  it('splits the owner and repo', () => {
+    assert.deepEqual(repositoryCoords(stubEnv({ GITHUB_REPOSITORY: 'strapi/strapi' })), {
+      owner: 'strapi',
+      repo: 'strapi',
+    });
+  });
+
+  for (const value of ['', 'strapi', '/strapi', 'strapi/']) {
+    it(`rejects ${JSON.stringify(value)}`, () => {
+      assert.throws(() => repositoryCoords(stubEnv({ GITHUB_REPOSITORY: value })), /owner\/repo/u);
+    });
+  }
+});

--- a/.github/actions/draft-release/__tests__/attribution.test.ts
+++ b/.github/actions/draft-release/__tests__/attribution.test.ts
@@ -5,6 +5,8 @@ import {
   assertSupportedMergeMethods,
   checkSecondParent,
   dedupePullRequests,
+  deriveAuthorName,
+  parseNoreplyLogin,
   parseSubjectReference,
   resolveIntegration,
   resolveIntegrations,
@@ -117,12 +119,99 @@ describe('checkSecondParent', () => {
   });
 });
 
+describe('parseNoreplyLogin', () => {
+  it('reads the login out of both noreply forms', () => {
+    assert.equal(parseNoreplyLogin('3693028+Adzouz@users.noreply.github.com'), 'Adzouz');
+    assert.equal(parseNoreplyLogin('Adzouz@users.noreply.github.com'), 'Adzouz');
+  });
+
+  it('says nothing about an address that is not a noreply one', () => {
+    assert.equal(parseNoreplyLogin('ben.irvin@strapi.io'), null);
+    assert.equal(parseNoreplyLogin(''), null);
+  });
+});
+
+describe('deriveAuthorName', () => {
+  it('takes the name off a squash commit, which the contributor authored', () => {
+    assert.equal(
+      deriveAuthorName(
+        integration({ author: 'Nico André', email: '123+nclsndr@users.noreply.github.com' }),
+        'nclsndr'
+      ),
+      'Nico André'
+    );
+  });
+
+  it('matches a login case-insensitively, the way GitHub does', () => {
+    assert.equal(
+      deriveAuthorName(
+        integration({ author: 'Adrien L', email: '3693028+Adzouz@users.noreply.github.com' }),
+        'adzouz'
+      ),
+      'Adrien L'
+    );
+  });
+
+  it('keeps the name when the address carries no login to check it against', () => {
+    assert.equal(
+      deriveAuthorName(
+        integration({ author: 'Ben Irvin', email: 'ben.irvin@strapi.io' }),
+        'innerdvations'
+      ),
+      'Ben Irvin'
+    );
+  });
+
+  it('refuses a merge commit, whose author is whoever pressed merge', () => {
+    assert.equal(
+      deriveAuthorName(
+        integration({
+          author: 'The Merger',
+          email: '1+merger@users.noreply.github.com',
+          parents: ['a'.repeat(40), 'b'.repeat(40)],
+        }),
+        'someone'
+      ),
+      null
+    );
+  });
+
+  it('refuses a squash that took another contributor authorship', () => {
+    assert.equal(
+      deriveAuthorName(
+        integration({ author: 'Co Author', email: '9+co-author@users.noreply.github.com' }),
+        'someone'
+      ),
+      null
+    );
+  });
+
+  it('refuses an empty name rather than reporting one', () => {
+    assert.equal(deriveAuthorName(integration({ author: '', email: '' }), 'someone'), null);
+  });
+});
+
 describe('summarisePull', () => {
+  it('carries the login from the payload and the name from the commit', () => {
+    assert.deepEqual(summarisePull(pull(), integration()).author, {
+      login: 'someone',
+      name: 'Someone Real',
+    });
+  });
+
+  it('keeps the author email out of what gets published', () => {
+    // The payload is embedded in a public pull request body. The email is evidence for the name,
+    // read and dropped, and no summary is allowed to carry it there.
+    const summary = summarisePull(pull(), integration({ email: 'private.address@strapi.io' }));
+
+    assert.equal(JSON.stringify(summary).includes('private.address@strapi.io'), false);
+  });
+
   it('fills every absent field rather than leaking undefined', () => {
-    assert.deepEqual(summarisePull({ number: 1 }), {
+    assert.deepEqual(summarisePull({ number: 1 }, integration({ author: '', email: '' })), {
       number: 1,
       title: '',
-      author: '',
+      author: { login: '', name: null },
       url: '',
       baseRef: '',
       headRef: '',
@@ -282,8 +371,25 @@ describe('resolveIntegrations', () => {
 });
 
 describe('dedupePullRequests', () => {
+  it('keeps the name the first integration that could vouch for one established', () => {
+    const merge = summarisePull(
+      pull({ number: 1 }),
+      integration({ parents: ['a'.repeat(40), 'b'.repeat(40)] })
+    );
+    const squash = summarisePull(pull({ number: 1 }), integration());
+
+    assert.equal(merge.author.name, null);
+
+    const [deduped] = dedupePullRequests([
+      record({ sha: 'a', pull: merge }),
+      record({ sha: 'b', pull: squash }),
+    ]);
+
+    assert.deepEqual(deduped?.author, { login: 'someone', name: 'Someone Real' });
+  });
+
   it('collapses duplicates while keeping every integration SHA', () => {
-    const summary = summarisePull(pull({ number: 1 }));
+    const summary = summarisePull(pull({ number: 1 }), integration());
     const records = [
       record({ sha: 'a', pull: summary }),
       record({ sha: 'b', pull: summary }),

--- a/.github/actions/draft-release/__tests__/attribution.test.ts
+++ b/.github/actions/draft-release/__tests__/attribution.test.ts
@@ -1,0 +1,323 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  assertSupportedMergeMethods,
+  checkSecondParent,
+  dedupePullRequests,
+  parseSubjectReference,
+  resolveIntegration,
+  resolveIntegrations,
+  selectExactCandidates,
+  summarisePull,
+} from '../lib/attribution.ts';
+import { SHA, indirectPull, integration, pull } from '../lib/__fixtures__/fixtures.ts';
+
+import type { AttributionLookup, AttributionRecord, PullPayload } from '../lib/types.ts';
+
+function lookup(
+  options: {
+    pulls?: readonly PullPayload[];
+    byNumber?: Record<number, PullPayload>;
+    fail?: boolean;
+  } = {}
+): AttributionLookup {
+  return {
+    async listPullsForCommit() {
+      if (options.fail === true) {
+        throw new Error('502 Bad Gateway');
+      }
+
+      return [...(options.pulls ?? [])];
+    },
+    async getPull(number) {
+      const found = options.byNumber?.[number];
+
+      if (found === undefined) {
+        throw new Error('404');
+      }
+
+      return found;
+    },
+  };
+}
+
+function record(overrides: Partial<AttributionRecord>): AttributionRecord {
+  return {
+    sha: 'a',
+    subject: '',
+    author: '',
+    authoredAt: '',
+    parents: [],
+    status: 'resolved',
+    basis: 'exact-merge-sha',
+    pull: null,
+    warnings: [],
+    reason: '',
+    ...overrides,
+  };
+}
+
+describe('parseSubjectReference', () => {
+  it('reads an anchored trailing reference', () => {
+    assert.equal(parseSubjectReference('fix(upload): a thing (#27482)'), 27482);
+  });
+
+  it('reads a merge subject reference', () => {
+    assert.equal(parseSubjectReference('Merge pull request #27448 from strapi/fix/x'), 27448);
+  });
+
+  it('ignores a reference in the middle of a subject', () => {
+    assert.equal(parseSubjectReference('fix: revert #27482 for now'), null);
+  });
+
+  it('returns null when there is no reference', () => {
+    assert.equal(parseSubjectReference('future(upload): drawer interaction'), null);
+  });
+});
+
+describe('selectExactCandidates', () => {
+  it('requires merged, target base, and a matching merge SHA', () => {
+    assert.equal(selectExactCandidates(integration(), [pull()], 'develop').length, 1);
+  });
+
+  it('rejects a pull request merged into another base', () => {
+    assert.deepEqual(selectExactCandidates(integration(), [indirectPull()], 'develop'), []);
+  });
+
+  it('rejects a pull request whose merge SHA is a different commit', () => {
+    const other = pull({ merge_commit_sha: 'ffff' });
+
+    assert.deepEqual(selectExactCandidates(integration(), [other], 'develop'), []);
+  });
+
+  it('rejects an unmerged pull request', () => {
+    const open = pull({ merged_at: null });
+
+    assert.deepEqual(selectExactCandidates(integration(), [open], 'develop'), []);
+  });
+});
+
+describe('checkSecondParent', () => {
+  it('says nothing about a single-parent commit', () => {
+    assert.equal(checkSecondParent({ parents: ['one'] }, pull()), null);
+  });
+
+  it('accepts a merge whose second parent is the pull request head', () => {
+    const parents = ['one', '2222222222222222222222222222222222222222'];
+
+    assert.equal(checkSecondParent({ parents }, pull()), null);
+  });
+
+  it('flags a merge whose second parent moved', () => {
+    assert.equal(
+      checkSecondParent({ parents: ['one', 'moved'] }, pull()),
+      'second-parent-mismatch'
+    );
+  });
+});
+
+describe('summarisePull', () => {
+  it('fills every absent field rather than leaking undefined', () => {
+    assert.deepEqual(summarisePull({ number: 1 }), {
+      number: 1,
+      title: '',
+      author: '',
+      url: '',
+      baseRef: '',
+      headRef: '',
+      milestone: null,
+    });
+  });
+});
+
+describe('resolveIntegration', () => {
+  it('resolves a squash commit on an exact merge SHA', async () => {
+    const resolved = await resolveIntegration(
+      integration(),
+      lookup({ pulls: [pull()] }),
+      'develop'
+    );
+
+    assert.equal(resolved.status, 'resolved');
+    assert.equal(resolved.basis, 'exact-merge-sha');
+    assert.equal(resolved.pull?.number, 27482);
+    assert.equal(resolved.pull?.milestone, '5.52.4');
+    assert.deepEqual(resolved.warnings, []);
+  });
+
+  it('resolves a merge commit with no reference in its subject', async () => {
+    const merge = integration({
+      sha: SHA.MERGE,
+      parents: [
+        '1111111111111111111111111111111111111111',
+        '2222222222222222222222222222222222222222',
+      ],
+      subject: 'future(upload): enhance drawer interaction with outside click handling',
+    });
+    const matching = pull({ number: 27448, merge_commit_sha: SHA.MERGE });
+
+    const resolved = await resolveIntegration(merge, lookup({ pulls: [matching] }), 'develop');
+
+    assert.equal(resolved.status, 'resolved');
+    assert.equal(resolved.basis, 'exact-merge-sha');
+    assert.deepEqual(resolved.warnings, []);
+  });
+
+  it('warns, but still resolves, when the head is not the second parent', async () => {
+    const merge = integration({
+      sha: SHA.MERGE,
+      parents: ['1111111111111111111111111111111111111111', 'moved'],
+    });
+
+    const resolved = await resolveIntegration(
+      merge,
+      lookup({ pulls: [pull({ merge_commit_sha: SHA.MERGE })] }),
+      'develop'
+    );
+
+    assert.equal(resolved.status, 'resolved');
+    assert.deepEqual(resolved.warnings, ['second-parent-mismatch']);
+  });
+
+  it('rejects an indirect association from another base', async () => {
+    const backMerge = integration({
+      sha: SHA.BACK_MERGE,
+      subject: "Merge branch 'main' into develop",
+    });
+
+    const resolved = await resolveIntegration(
+      backMerge,
+      lookup({ pulls: [indirectPull()] }),
+      'develop'
+    );
+
+    assert.equal(resolved.status, 'unresolved');
+    assert.match(resolved.reason, /#27470/u);
+  });
+
+  it('separates an empty result from a failed lookup', async () => {
+    const direct = integration({ sha: SHA.DIRECT, subject: 'chore: touch up a comment' });
+
+    const empty = await resolveIntegration(direct, lookup({ pulls: [] }), 'develop');
+    const failed = await resolveIntegration(direct, lookup({ fail: true }), 'develop');
+
+    assert.equal(empty.status, 'direct-integration');
+    assert.equal(failed.status, 'lookup-failed');
+    assert.match(failed.reason, /502 Bad Gateway/u);
+  });
+
+  it('blocks when several merged pull requests claim the same integration', async () => {
+    const duplicate = [pull(), pull({ number: 27483 })];
+
+    const resolved = await resolveIntegration(
+      integration(),
+      lookup({ pulls: duplicate }),
+      'develop'
+    );
+
+    assert.equal(resolved.status, 'ambiguous');
+    assert.equal(resolved.pull, null);
+    assert.match(resolved.reason, /#27482, #27483/u);
+  });
+
+  it('falls back to a subject reference only with hard evidence', async () => {
+    const subject = 'fix(content-type-builder): default new private fields (#27482)';
+    const target = integration({ sha: SHA.SQUASH, subject });
+
+    const withEvidence = await resolveIntegration(
+      target,
+      lookup({ pulls: [], byNumber: { 27482: pull() } }),
+      'develop'
+    );
+
+    assert.equal(withEvidence.status, 'resolved');
+    assert.equal(withEvidence.basis, 'verified-subject');
+
+    const withoutEvidence = await resolveIntegration(
+      target,
+      lookup({ pulls: [], byNumber: { 27482: pull({ merge_commit_sha: 'elsewhere' }) } }),
+      'develop'
+    );
+
+    assert.equal(withoutEvidence.status, 'direct-integration');
+  });
+
+  it('accepts a subject reference whose head is the second parent', async () => {
+    const target = integration({
+      sha: SHA.MERGE,
+      parents: ['one', '2222222222222222222222222222222222222222'],
+      subject: 'Merge pull request #27482 from strapi/fix/ctb-private-searchable',
+    });
+
+    const resolved = await resolveIntegration(
+      target,
+      lookup({ pulls: [], byNumber: { 27482: pull({ merge_commit_sha: 'elsewhere' }) } }),
+      'develop'
+    );
+
+    assert.equal(resolved.basis, 'second-parent-head');
+  });
+
+  it('ignores a subject reference to a pull request that cannot be fetched', async () => {
+    const target = integration({ subject: 'fix(upload): a thing (#99999)' });
+
+    const resolved = await resolveIntegration(target, lookup({ pulls: [] }), 'develop');
+
+    assert.equal(resolved.status, 'direct-integration');
+  });
+});
+
+describe('resolveIntegrations', () => {
+  it('keeps input order', async () => {
+    const integrations = [integration({ sha: 'a' }), integration({ sha: 'b' })];
+
+    const records = await resolveIntegrations(integrations, lookup({ pulls: [] }), 'develop');
+
+    assert.deepEqual(
+      records.map((entry) => entry.sha),
+      ['a', 'b']
+    );
+  });
+});
+
+describe('dedupePullRequests', () => {
+  it('collapses duplicates while keeping every integration SHA', () => {
+    const summary = summarisePull(pull({ number: 1 }));
+    const records = [
+      record({ sha: 'a', pull: summary }),
+      record({ sha: 'b', pull: summary }),
+      record({ sha: 'c', status: 'direct-integration', basis: 'none', pull: null }),
+    ];
+
+    const deduped = dedupePullRequests(records);
+
+    assert.equal(deduped.length, 1);
+    assert.deepEqual(deduped[0]?.integrationShas, ['a', 'b']);
+    assert.equal(deduped[0]?.number, 1);
+  });
+});
+
+describe('assertSupportedMergeMethods', () => {
+  it('accepts the current Strapi configuration', () => {
+    assert.doesNotThrow(() =>
+      assertSupportedMergeMethods({
+        allow_merge_commit: true,
+        allow_squash_merge: true,
+        allow_rebase_merge: false,
+      })
+    );
+  });
+
+  it('blocks explicitly when rebase merges are enabled', () => {
+    assert.throws(
+      () =>
+        assertSupportedMergeMethods({
+          allow_merge_commit: true,
+          allow_squash_merge: true,
+          allow_rebase_merge: true,
+        }),
+      /Rebase merges are enabled/u
+    );
+  });
+});

--- a/.github/actions/draft-release/__tests__/bump.test.ts
+++ b/.github/actions/draft-release/__tests__/bump.test.ts
@@ -307,6 +307,78 @@ describe('classifyIntegrations', () => {
   });
 });
 
+describe('classifyIntegrations — a breaking footer on the landing commit', () => {
+  const BODY = 'Rework the upload flow.\n\nBREAKING CHANGE: the provider config shape moved.';
+
+  it('stops an unparsed squash subject whose body breaks, even with inner feats', async () => {
+    // The path this action exists to correct: commitlint never sees the squash subject, so
+    // `Feat/...` lands unparsed while the footer sits in the body GitHub pre-filled.
+    const entry = integration({ subject: 'Feat/new upload flow (#123)', body: BODY });
+
+    const classification = await classifyIntegrations(
+      [entry],
+      records([[entry, summary(123, 'feat/new-upload-flow')]]),
+      async () => pullCommits(['feat(upload): rework the flow'])
+    );
+
+    assert.deepEqual(classification.breaking, [
+      { sha: entry.sha, pr: 123, subject: entry.subject, via: 'landing-body' },
+    ]);
+    assert.deepEqual(classification.unparsed, []);
+    assert.throws(() => decideBump(classification), /carries a breaking change/u);
+  });
+
+  it('stops an unparsed direct commit whose body breaks', async () => {
+    const entry = integration({ subject: 'Rework the upload flow', body: BODY });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.deepEqual(classification.breaking, [
+      { sha: entry.sha, pr: null, subject: entry.subject, via: 'landing-body' },
+    ]);
+    assert.deepEqual(classification.unparsed, []);
+    assert.throws(() => decideBump(classification), /carries a breaking change/u);
+  });
+
+  it('keeps a breaking marker found in pull request commits that all failed to parse', async () => {
+    // `readPullCommitHeaders` reads the footer off every commit body, parsed header or not. Only
+    // the type classification depends on a header, so an empty header list must not discard it.
+    const entry = integration({ subject: 'Rework the upload flow (#124)', body: '' });
+
+    const classification = await classifyIntegrations(
+      [entry],
+      records([[entry, summary(124, 'rework/upload')]]),
+      async () => pullCommits(['wip\n\nBREAKING CHANGE: the provider config shape moved.'])
+    );
+
+    assert.deepEqual(classification.breaking, [
+      { sha: entry.sha, pr: 124, subject: entry.subject, via: 'pr-commits' },
+    ]);
+    assert.deepEqual(classification.unparsed, []);
+    assert.throws(() => decideBump(classification), /carries a breaking change/u);
+  });
+
+  it('names the subject as the source when the header carries the bang', async () => {
+    const entry = integration({ subject: 'feat(upload)!: rework the flow', body: BODY });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.equal(classification.breaking[0]?.via, 'subject');
+  });
+
+  it('still reports an unparsed integration whose body does not break', async () => {
+    const entry = integration({ subject: 'Rework the upload flow', body: 'No footer here.' });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.deepEqual(classification.breaking, []);
+    assert.deepEqual(classification.unparsed, [
+      { sha: entry.sha, pr: null, subject: entry.subject },
+    ]);
+    assert.equal(decideBump(classification), 'patch');
+  });
+});
+
 describe('decideBump', () => {
   const empty: BumpClassification = { features: [], breaking: [], ignored: [], unparsed: [] };
 

--- a/.github/actions/draft-release/__tests__/bump.test.ts
+++ b/.github/actions/draft-release/__tests__/bump.test.ts
@@ -25,7 +25,15 @@ function records(pairs: readonly [Integration, StubbedRecord['pull']][]): Stubbe
 }
 
 function summary(number: number, headRef: string): StubbedRecord['pull'] {
-  return { number, title: '', author: '', url: '', baseRef: 'develop', headRef, milestone: null };
+  return {
+    number,
+    title: '',
+    author: { login: '', name: null },
+    url: '',
+    baseRef: 'develop',
+    headRef,
+    milestone: null,
+  };
 }
 
 const noCommits = async (): Promise<PullCommit[]> => [];

--- a/.github/actions/draft-release/__tests__/bump.test.ts
+++ b/.github/actions/draft-release/__tests__/bump.test.ts
@@ -1,0 +1,317 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  classifyIntegrations,
+  decideBump,
+  hasBreakingFooter,
+  ignoreReason,
+  parseConventionalSubject,
+  readPullCommitHeaders,
+} from '../lib/bump.ts';
+import { SHA, integration, pullCommits } from '../lib/__fixtures__/fixtures.ts';
+
+import type {
+  AttributionRecord,
+  BumpClassification,
+  Integration,
+  PullCommit,
+} from '../lib/types.ts';
+
+type StubbedRecord = Pick<AttributionRecord, 'sha' | 'pull'>;
+
+function records(pairs: readonly [Integration, StubbedRecord['pull']][]): StubbedRecord[] {
+  return pairs.map(([entry, pull]) => ({ sha: entry.sha, pull }));
+}
+
+function summary(number: number, headRef: string): StubbedRecord['pull'] {
+  return { number, title: '', author: '', url: '', baseRef: 'develop', headRef, milestone: null };
+}
+
+const noCommits = async (): Promise<PullCommit[]> => [];
+
+describe('parseConventionalSubject', () => {
+  const parsed: [string, string, string | null, boolean][] = [
+    ['feat(content-releases): record release actions', 'feat', 'content-releases', false],
+    ['feat(*): introduce MCP server (#26371)', 'feat', '*', false],
+    ['feat!: drop node 20', 'feat', null, true],
+    ['chore: release v5.52.3 update develop', 'chore', null, false],
+    ['FIX(upload): casing is normalised', 'fix', 'upload', false],
+    ['i18n: add translations', 'i18n', null, false],
+  ];
+
+  for (const [subject, type, scope, breaking] of parsed) {
+    it(`parses "${subject}"`, () => {
+      assert.deepEqual(parseConventionalSubject(subject), { type, scope, breaking });
+    });
+  }
+
+  const unparsed = [
+    'Feat/e2e critical ctb add fields (#26559)',
+    "Merge branch 'main' into develop",
+    'Chore/cm combined performance fixes',
+    '',
+  ];
+
+  for (const subject of unparsed) {
+    it(`does not parse "${subject}"`, () => {
+      assert.equal(parseConventionalSubject(subject), null);
+    });
+  }
+});
+
+describe('hasBreakingFooter', () => {
+  for (const body of [
+    'BREAKING CHANGE: gone',
+    'BREAKING-CHANGE: gone',
+    'body\n\nBREAKING CHANGE: gone',
+  ]) {
+    it(`detects "${body}"`, () => {
+      assert.equal(hasBreakingFooter(body), true);
+    });
+  }
+
+  it('ignores a mention inside prose', () => {
+    assert.equal(hasBreakingFooter('this is not a BREAKING CHANGE really'), false);
+  });
+});
+
+describe('ignoreReason', () => {
+  it('names a release commit', () => {
+    assert.equal(ignoreReason({ subject: 'release: 5.52.3' }, { pull: null }), 'release-commit');
+  });
+
+  it('names a back-merge from a release branch', () => {
+    assert.equal(
+      ignoreReason({ subject: 'anything' }, { pull: summary(1, 'releases/5.52.2') }),
+      'back-merge'
+    );
+  });
+
+  it('leaves a normal integration alone', () => {
+    assert.equal(
+      ignoreReason({ subject: 'fix(upload): a thing' }, { pull: summary(1, 'fix/x') }),
+      null
+    );
+  });
+});
+
+describe('readPullCommitHeaders', () => {
+  it('reads the commitlint-gated commits inside a pull request', () => {
+    const { headers, breaking } = readPullCommitHeaders(
+      pullCommits(['feat(e2e): add ctb fields\n\nbody', 'test(e2e): stabilise'])
+    );
+
+    assert.deepEqual(
+      headers.map((header) => header.type),
+      ['feat', 'test']
+    );
+    assert.equal(breaking, false);
+  });
+
+  it('surfaces a breaking footer from a commit body', () => {
+    const { breaking } = readPullCommitHeaders(
+      pullCommits(['fix(api): tighten validation\n\nBREAKING CHANGE: rejects empty ids'])
+    );
+
+    assert.equal(breaking, true);
+  });
+
+  it('surfaces a bang marker on a commit inside the pull request', () => {
+    assert.equal(readPullCommitHeaders(pullCommits(['feat!: drop node 20'])).breaking, true);
+  });
+});
+
+describe('classifyIntegrations', () => {
+  it('lets a feat vote for a minor', async () => {
+    const entry = integration({
+      sha: SHA.SQUASH_FEAT,
+      subject: 'feat(content-releases): record release actions in audit logs (#27436)',
+    });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.deepEqual(classification.features, [
+      {
+        sha: SHA.SQUASH_FEAT,
+        pr: null,
+        subject: 'feat(content-releases): record release actions in audit logs (#27436)',
+        via: 'subject',
+      },
+    ]);
+    assert.equal(decideBump(classification), 'minor');
+  });
+
+  it('counts feat(i18n) like any other feature', async () => {
+    const entry = integration({ subject: 'feat(i18n): complete Korean (ko) translation (#26941)' });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.equal(decideBump(classification), 'minor');
+  });
+
+  it('keeps enhancement, future and security a patch', async () => {
+    const entries = [
+      integration({ sha: 'a', subject: 'enhancement(utils): memoize scope decisions (#27145)' }),
+      integration({ sha: 'b', subject: 'future(upload): right-click actions (#27451)' }),
+      integration({ sha: 'c', subject: 'security(deps): bump the sdk (#27301)' }),
+      integration({ sha: 'd', subject: 'fix(upload): bound the focal point (#27496)' }),
+    ];
+
+    const classification = await classifyIntegrations(
+      entries,
+      records(entries.map((entry) => [entry, null])),
+      noCommits
+    );
+
+    assert.deepEqual(classification.features, []);
+    assert.equal(decideBump(classification), 'patch');
+  });
+
+  it('ignores the release commit', async () => {
+    const entry = integration({ sha: SHA.RELEASE, subject: 'release: 5.52.3' });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.deepEqual(classification.ignored, [
+      { sha: SHA.RELEASE, reason: 'release-commit', subject: 'release: 5.52.3' },
+    ]);
+  });
+
+  it('ignores a release back-merge, so an already shipped feat cannot vote twice', async () => {
+    const entry = integration({
+      sha: SHA.BACK_MERGE,
+      subject: 'chore: release v5.52.3 update develop',
+    });
+
+    const classification = await classifyIntegrations(
+      [entry],
+      records([[entry, summary(27527, 'main')]]),
+      async () => pullCommits(['feat(admin): something that already shipped'])
+    );
+
+    assert.equal(classification.ignored[0]?.reason, 'back-merge');
+    assert.deepEqual(classification.features, []);
+  });
+
+  it('ignores a plain branch sync with no pull request', async () => {
+    const entry = integration({ subject: "Merge branch 'main' into develop" });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.equal(classification.ignored[0]?.reason, 'branch-merge');
+  });
+
+  it('falls back to the pull request commits when the squash subject does not parse', async () => {
+    const entry = integration({
+      sha: SHA.UNPARSED,
+      subject: 'Feat/e2e critical ctb add fields (#26559)',
+    });
+
+    const classification = await classifyIntegrations(
+      [entry],
+      records([[entry, summary(26559, 'feat/e2e-ctb')]]),
+      async () => pullCommits(['feat(e2e): add ctb fields'])
+    );
+
+    assert.deepEqual(classification.features, [
+      {
+        sha: SHA.UNPARSED,
+        pr: 26559,
+        subject: 'Feat/e2e critical ctb add fields (#26559)',
+        via: 'pr-commits',
+      },
+    ]);
+  });
+
+  it('reports an unparsed subject when the pull request commits say nothing either', async () => {
+    const entry = integration({
+      sha: SHA.UNPARSED,
+      subject: 'Chore/cm combined performance fixes',
+    });
+
+    const classification = await classifyIntegrations(
+      [entry],
+      records([[entry, summary(25678, 'chore/cm')]]),
+      async () => pullCommits(['wip', 'more wip'])
+    );
+
+    assert.deepEqual(classification.unparsed, [
+      { sha: SHA.UNPARSED, pr: 25678, subject: 'Chore/cm combined performance fixes' },
+    ]);
+    assert.equal(decideBump(classification), 'patch');
+  });
+
+  it('reports an unparsed subject with no pull request at all', async () => {
+    const entry = integration({
+      sha: SHA.UNPARSED,
+      subject: 'Chore/cm combined performance fixes',
+    });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.deepEqual(classification.unparsed, [
+      { sha: SHA.UNPARSED, pr: null, subject: 'Chore/cm combined performance fixes' },
+    ]);
+  });
+
+  it('treats an integration with no attribution record as unattributed', async () => {
+    const entry = integration({ sha: 'orphan', subject: 'Chore/no record' });
+
+    const classification = await classifyIntegrations([entry], [], noCommits);
+
+    assert.deepEqual(classification.unparsed, [
+      { sha: 'orphan', pr: null, subject: 'Chore/no record' },
+    ]);
+  });
+
+  it('collects a breaking marker from the subject', async () => {
+    const entry = integration({ sha: 'x', subject: 'feat!: drop node 20' });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.equal(classification.breaking.length, 1);
+    assert.equal(classification.features.length, 1);
+  });
+
+  it('collects a breaking footer from the integration body', async () => {
+    const entry = integration({
+      sha: 'x',
+      subject: 'fix(api): tighten validation',
+      body: 'BREAKING CHANGE: rejects empty ids',
+    });
+
+    const classification = await classifyIntegrations([entry], records([[entry, null]]), noCommits);
+
+    assert.equal(classification.breaking.length, 1);
+  });
+
+  it('collects a breaking marker found only in the pull request commits', async () => {
+    const entry = integration({ sha: 'x', subject: 'Chore/big change' });
+
+    const classification = await classifyIntegrations(
+      [entry],
+      records([[entry, summary(1, 'chore/big')]]),
+      async () => pullCommits(['fix(api)!: drop the legacy route'])
+    );
+
+    assert.equal(classification.breaking[0]?.via, 'pr-commits');
+  });
+});
+
+describe('decideBump', () => {
+  const empty: BumpClassification = { features: [], breaking: [], ignored: [], unparsed: [] };
+
+  it('stops on a breaking change instead of proposing a major', () => {
+    const classification: BumpClassification = {
+      ...empty,
+      breaking: [{ sha: 'abcdef1234', pr: 1, subject: 'feat!: drop node 20', via: 'subject' }],
+    };
+
+    assert.throws(() => decideBump(classification), /breaking change \(abcdef12\)/u);
+  });
+
+  it('falls back to a patch when nothing voted', () => {
+    assert.equal(decideBump(empty), 'patch');
+  });
+});

--- a/.github/actions/draft-release/__tests__/github.test.ts
+++ b/.github/actions/draft-release/__tests__/github.test.ts
@@ -144,7 +144,7 @@ describe('createGithubAdapter', () => {
     await createGithubAdapter('t', coords, request).createPull({
       head: 'releases/5.53.0',
       base: 'main',
-      title: '[draft] release 5.53.0',
+      title: 'Release 5.53.0',
       body: 'x',
     });
 

--- a/.github/actions/draft-release/__tests__/github.test.ts
+++ b/.github/actions/draft-release/__tests__/github.test.ts
@@ -1,0 +1,170 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createGithubAdapter, createRestClient, parseNextLink } from '../lib/github.ts';
+
+import type { HttpRequest, HttpResponse } from '../lib/github.ts';
+
+type Call = {
+  url: string;
+  method: string;
+  body: string | undefined;
+  headers: Record<string, string>;
+};
+
+function response(overrides: Partial<HttpResponse> & { payload?: unknown } = {}): HttpResponse {
+  return {
+    ok: overrides.ok ?? true,
+    status: overrides.status ?? 200,
+    headers: overrides.headers ?? { get: () => null },
+    json: overrides.json ?? (async () => overrides.payload ?? {}),
+    text: overrides.text ?? (async () => JSON.stringify(overrides.payload ?? {})),
+  };
+}
+
+function stubRequest(responses: HttpResponse[]): { request: HttpRequest; calls: Call[] } {
+  const calls: Call[] = [];
+  let index = 0;
+
+  return {
+    calls,
+    async request(url, init) {
+      calls.push({ url, method: init.method, body: init.body, headers: init.headers });
+      const next = responses[index] ?? response();
+      index += 1;
+
+      return next;
+    },
+  };
+}
+
+describe('parseNextLink', () => {
+  it('finds the next cursor', () => {
+    const header =
+      '<https://api.github.com/x?page=2>; rel="next", <https://api.github.com/x?page=9>; rel="last"';
+
+    assert.equal(parseNextLink(header), 'https://api.github.com/x?page=2');
+  });
+
+  it('returns null on the last page', () => {
+    assert.equal(parseNextLink('<https://api.github.com/x?page=1>; rel="prev"'), null);
+  });
+
+  it('returns null when there is no header at all', () => {
+    assert.equal(parseNextLink(null), null);
+    assert.equal(parseNextLink(''), null);
+  });
+});
+
+describe('createRestClient', () => {
+  it('authenticates and pins the API version', async () => {
+    const { request, calls } = stubRequest([response({ payload: { ok: true } })]);
+
+    await createRestClient('secret-token', request).get('/repos/strapi/strapi');
+
+    assert.equal(calls[0]?.url, 'https://api.github.com/repos/strapi/strapi');
+    assert.equal(calls[0]?.headers['authorization'], 'Bearer secret-token');
+    assert.equal(calls[0]?.headers['x-github-api-version'], '2022-11-28');
+  });
+
+  it('serialises a body for a write', async () => {
+    const { request, calls } = stubRequest([response()]);
+
+    await createRestClient('t', request).send('PATCH', '/repos/a/b/milestones/1', {
+      title: '5.53.0',
+    });
+
+    assert.equal(calls[0]?.method, 'PATCH');
+    assert.equal(calls[0]?.body, '{"title":"5.53.0"}');
+  });
+
+  it('surfaces the API message on a failure', async () => {
+    const { request } = stubRequest([
+      response({ ok: false, status: 401, payload: { message: 'Bad credentials' } }),
+    ]);
+
+    await assert.rejects(
+      () => createRestClient('t', request).get('/repos/a/b'),
+      /GitHub GET \/repos\/a\/b failed: 401 Bad credentials/u
+    );
+  });
+
+  it('surfaces a non-JSON failure body verbatim', async () => {
+    const { request } = stubRequest([
+      response({ ok: false, status: 502, text: async () => 'bad gateway' }),
+    ]);
+
+    await assert.rejects(() => createRestClient('t', request).get('/x'), /502 bad gateway/u);
+  });
+
+  it('follows the server cursor until it stops offering one', async () => {
+    const { request, calls } = stubRequest([
+      response({
+        payload: [{ number: 1 }],
+        headers: { get: () => '<https://api.github.com/next-page>; rel="next"' },
+      }),
+      response({ payload: [{ number: 2 }] }),
+    ]);
+
+    const items = await createRestClient('t', request).paginate('/repos/a/b/milestones');
+
+    assert.deepEqual(items, [{ number: 1 }, { number: 2 }]);
+    assert.deepEqual(
+      calls.map((call) => call.url),
+      ['https://api.github.com/repos/a/b/milestones', 'https://api.github.com/next-page']
+    );
+  });
+});
+
+describe('createGithubAdapter', () => {
+  const coords = { owner: 'strapi', repo: 'strapi' };
+
+  it('asks for the pull requests associated with a commit', async () => {
+    const { request, calls } = stubRequest([response({ payload: [] })]);
+
+    await createGithubAdapter('t', coords, request).listPullsForCommit('abc');
+
+    assert.equal(
+      calls[0]?.url,
+      'https://api.github.com/repos/strapi/strapi/commits/abc/pulls?per_page=100'
+    );
+  });
+
+  it('asks for every milestone item in any state', async () => {
+    const { request, calls } = stubRequest([response({ payload: [] })]);
+
+    await createGithubAdapter('t', coords, request).listMilestoneItems(430);
+
+    assert.match(calls[0]?.url ?? '', /\/issues\?milestone=430&state=all&per_page=100$/u);
+  });
+
+  it('opens the release pull request as a draft', async () => {
+    const { request, calls } = stubRequest([response({ payload: { number: 1 } })]);
+
+    await createGithubAdapter('t', coords, request).createPull({
+      head: 'releases/5.53.0',
+      base: 'main',
+      title: '[draft] release 5.53.0',
+      body: 'x',
+    });
+
+    assert.equal(JSON.parse(calls[0]?.body ?? '{}').draft, true);
+  });
+
+  it('clears a milestone by sending null', async () => {
+    const { request, calls } = stubRequest([response()]);
+
+    await createGithubAdapter('t', coords, request).setIssueMilestone(27601, null);
+
+    assert.equal(calls[0]?.body, '{"milestone":null}');
+  });
+
+  it('adds labels through the labels endpoint', async () => {
+    const { request, calls } = stubRequest([response({ payload: [] })]);
+
+    await createGithubAdapter('t', coords, request).addLabels(27700, ['publish-experimental']);
+
+    assert.match(calls[0]?.url ?? '', /\/issues\/27700\/labels$/u);
+    assert.equal(calls[0]?.body, '{"labels":["publish-experimental"]}');
+  });
+});

--- a/.github/actions/draft-release/__tests__/journal.test.ts
+++ b/.github/actions/draft-release/__tests__/journal.test.ts
@@ -1,0 +1,86 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createJournal } from '../lib/journal.ts';
+
+const clock = (): string => '2026-09-06T17:57:00Z';
+
+describe('createJournal', () => {
+  it('records the intent and performs nothing on a dry run', async () => {
+    const journal = createJournal({ apply: false, clock });
+    const performed: string[] = [];
+
+    const result = await journal.write(
+      { op: 'milestone.rename', target: 'milestone/430', before: '5.52.4', after: '5.53.0' },
+      async () => {
+        performed.push('rename');
+
+        return { number: 430 };
+      }
+    );
+
+    assert.deepEqual(performed, []);
+    assert.equal(result, null);
+    assert.deepEqual(journal.toJSON(), {
+      mode: 'planned',
+      entries: [
+        {
+          op: 'milestone.rename',
+          target: 'milestone/430',
+          before: '5.52.4',
+          after: '5.53.0',
+          detail: null,
+          at: '2026-09-06T17:57:00Z',
+          applied: false,
+        },
+      ],
+    });
+  });
+
+  it('records before it performs, and returns the result', async () => {
+    const journal = createJournal({ apply: true, clock });
+    let recordedWhilePerforming = 0;
+
+    const result = await journal.write({ op: 'pr.create', target: 'pulls/<new>' }, async () => {
+      recordedWhilePerforming = journal.entries().length;
+
+      return { number: 27600 };
+    });
+
+    assert.equal(recordedWhilePerforming, 1);
+    assert.deepEqual(result, { number: 27600 });
+    assert.equal(journal.toJSON().mode, 'applied');
+  });
+
+  it('keeps the intent on record when the write throws', async () => {
+    const journal = createJournal({ apply: true, clock });
+
+    await assert.rejects(
+      () =>
+        journal.write({ op: 'branch.push', target: 'refs/heads/releases/5.53.0' }, async () => {
+          throw new Error('protected branch');
+        }),
+      /protected branch/u
+    );
+
+    assert.equal(journal.entries().length, 1);
+    assert.equal(journal.entries()[0]?.op, 'branch.push');
+  });
+
+  it('hands back a copy of the entries', async () => {
+    const journal = createJournal({ apply: false, clock });
+
+    await journal.write({ op: 'pr.comment', target: 'pulls/1' }, async () => null);
+    journal.entries().pop();
+
+    assert.equal(journal.entries().length, 1);
+  });
+
+  it('stamps a real clock when none is injected', async () => {
+    const journal = createJournal({ apply: false });
+
+    await journal.write({ op: 'pr.comment', target: 'pulls/1' }, async () => null);
+
+    assert.match(journal.entries()[0]?.at ?? '', /^\d{4}-\d{2}-\d{2}T/u);
+  });
+});

--- a/.github/actions/draft-release/__tests__/milestones.test.ts
+++ b/.github/actions/draft-release/__tests__/milestones.test.ts
@@ -1,0 +1,124 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { planCleanup, planMilestones, reconcile } from '../lib/milestones.ts';
+import { milestoneItem, pullRequestItem } from '../lib/__fixtures__/fixtures.ts';
+
+describe('planMilestones', () => {
+  const open = [{ number: 430, title: '5.52.4', state: 'open' }];
+
+  it('renames the open milestone to the version that actually ships', () => {
+    const plan = planMilestones(open, '5.53.0', open);
+
+    assert.deepEqual(plan.shipping, {
+      action: 'rename',
+      number: 430,
+      currentTitle: '5.52.4',
+      title: '5.53.0',
+    });
+    assert.deepEqual(plan.next, { action: 'create', number: null, title: '5.53.1' });
+  });
+
+  it('leaves the title alone when it already matches', () => {
+    const plan = planMilestones(open, '5.52.4', open);
+
+    assert.equal(plan.shipping.action, 'keep');
+    assert.equal(plan.next.title, '5.52.5');
+  });
+
+  it('reuses an existing next milestone in any state', () => {
+    const all = [...open, { number: 431, title: '5.53.1', state: 'closed' }];
+
+    assert.deepEqual(planMilestones(open, '5.53.0', all).next, {
+      action: 'reuse',
+      number: 431,
+      title: '5.53.1',
+    });
+  });
+
+  it('creates the shipping milestone when none is open', () => {
+    assert.deepEqual(planMilestones([], '5.53.0', []).shipping, {
+      action: 'create',
+      number: null,
+      currentTitle: null,
+      title: '5.53.0',
+    });
+  });
+
+  it('stops when several milestones are open', () => {
+    const many = [
+      { number: 430, title: '5.52.4' },
+      { number: 431, title: '5.53.0' },
+    ];
+
+    assert.throws(
+      () => planMilestones(many, '5.53.0', many),
+      /Expected at most one open milestone, found 2 \(5\.52\.4, 5\.53\.0\)/u
+    );
+  });
+});
+
+describe('planCleanup', () => {
+  const items = [
+    pullRequestItem(1, 'closed', '2026-09-05T10:00:00Z'),
+    pullRequestItem(2, 'closed', null),
+    pullRequestItem(3, 'open', null),
+    milestoneItem({ number: 4, state: 'open' }),
+    milestoneItem({ number: 5, state: 'closed' }),
+  ];
+
+  it('keeps merged pull requests, moves open ones, clears the rest', () => {
+    const planned = planCleanup(items, 431).map(({ number, kind, action, to }) => ({
+      number,
+      kind,
+      action,
+      to,
+    }));
+
+    assert.deepEqual(planned, [
+      { number: 1, kind: 'pull', action: 'keep', to: null },
+      { number: 2, kind: 'pull', action: 'clear', to: null },
+      { number: 3, kind: 'pull', action: 'move', to: 431 },
+      { number: 4, kind: 'issue', action: 'clear', to: null },
+      { number: 5, kind: 'issue', action: 'clear', to: null },
+    ]);
+  });
+
+  it('explains every decision', () => {
+    assert.equal(
+      planCleanup(items, 431).every((item) => item.reason.length > 0),
+      true
+    );
+  });
+});
+
+describe('reconcile', () => {
+  it('reports both directions', () => {
+    const attributed = [{ number: 1 }, { number: 2 }];
+    const items = [
+      pullRequestItem(2, 'closed', '2026-09-05T10:00:00Z'),
+      pullRequestItem(9, 'closed', '2026-09-04T10:00:00Z'),
+      pullRequestItem(7, 'open', null),
+    ];
+
+    assert.deepEqual(reconcile(attributed, items), {
+      inHistoryNotInMilestone: [1],
+      inMilestoneNotInHistory: [9],
+    });
+  });
+
+  it('is empty when history and the milestone agree', () => {
+    const items = [pullRequestItem(5, 'closed', '2026-09-05T10:00:00Z')];
+
+    assert.deepEqual(reconcile([{ number: 5 }], items), {
+      inHistoryNotInMilestone: [],
+      inMilestoneNotInHistory: [],
+    });
+  });
+
+  it('sorts numerically, not lexically', () => {
+    const attributed = [{ number: 100 }, { number: 9 }];
+
+    assert.deepEqual(reconcile(attributed, []).inHistoryNotInMilestone, [9, 100]);
+  });
+});

--- a/.github/actions/draft-release/__tests__/npm.test.ts
+++ b/.github/actions/draft-release/__tests__/npm.test.ts
@@ -60,16 +60,34 @@ describe('resolveLatestVersion', () => {
 });
 
 describe('fetchPackument', () => {
-  it('escapes the scope separator and returns the parsed body', async () => {
+  function recording(): { seen: string[]; request: RegistryRequest } {
     const seen: string[] = [];
-    const request: RegistryRequest = async (url) => {
-      seen.push(url);
 
-      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    return {
+      seen,
+      async request(url) {
+        seen.push(url);
+
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      },
     };
+  }
+
+  it('encodes the package name and returns the parsed body', async () => {
+    const { seen, request } = recording();
 
     assert.deepEqual(await fetchPackument(request), { ok: true });
-    assert.deepEqual(seen, ['https://registry.npmjs.org/@strapi%2fstrapi']);
+    assert.deepEqual(seen, ['https://registry.npmjs.org/%40strapi%2Fstrapi']);
+  });
+
+  it('encodes every reserved character, not just the first separator', async () => {
+    // A substitution of the one separator a scoped name happens to have leaves anything after it
+    // raw, and the request then addresses a path the caller never asked for.
+    const { seen, request } = recording();
+
+    await fetchPackument(request, '@scope/name/extra?x=1');
+
+    assert.deepEqual(seen, ['https://registry.npmjs.org/%40scope%2Fname%2Fextra%3Fx%3D1']);
   });
 
   it('surfaces a registry error', async () => {

--- a/.github/actions/draft-release/__tests__/npm.test.ts
+++ b/.github/actions/draft-release/__tests__/npm.test.ts
@@ -1,0 +1,84 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { fetchPackument, resolveLatestVersion } from '../lib/npm.ts';
+
+import type { RegistryRequest } from '../lib/npm.ts';
+
+function packument(latest: unknown, versions: readonly string[]): unknown {
+  return {
+    'dist-tags': { latest },
+    versions: Object.fromEntries(versions.map((version) => [version, {}])),
+  };
+}
+
+describe('resolveLatestVersion', () => {
+  it('accepts a latest dist-tag that is also the highest stable version', () => {
+    assert.equal(
+      resolveLatestVersion(packument('5.52.3', ['5.52.1', '5.52.2', '5.52.3'])),
+      '5.52.3'
+    );
+  });
+
+  it('ignores prereleases when comparing', () => {
+    assert.equal(
+      resolveLatestVersion(
+        packument('5.52.3', ['5.52.3', '5.53.0-beta.1', '0.0.0-experimental.x'])
+      ),
+      '5.52.3'
+    );
+  });
+
+  it('stops when the dist-tag lags behind the highest published version', () => {
+    assert.throws(
+      () => resolveLatestVersion(packument('5.52.1', ['5.52.1', '5.52.3'])),
+      /the "latest" dist-tag is 5\.52\.1 but the highest published stable version is 5\.52\.3/u
+    );
+  });
+
+  it('stops when the dist-tag is a prerelease', () => {
+    assert.throws(
+      () => resolveLatestVersion(packument('5.53.0-beta.1', ['5.52.3'])),
+      /not a stable version/u
+    );
+  });
+
+  it('stops when nothing is published', () => {
+    assert.throws(() => resolveLatestVersion(packument('5.52.3', [])), /no published versions/u);
+  });
+
+  it('stops when only prereleases are published', () => {
+    assert.throws(
+      () => resolveLatestVersion(packument('5.52.3', ['0.0.0-experimental.x'])),
+      /no stable published version/u
+    );
+  });
+
+  it('stops when the response is not an object', () => {
+    assert.throws(() => resolveLatestVersion(null), /not an object/u);
+  });
+});
+
+describe('fetchPackument', () => {
+  it('escapes the scope separator and returns the parsed body', async () => {
+    const seen: string[] = [];
+    const request: RegistryRequest = async (url) => {
+      seen.push(url);
+
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    };
+
+    assert.deepEqual(await fetchPackument(request), { ok: true });
+    assert.deepEqual(seen, ['https://registry.npmjs.org/@strapi%2fstrapi']);
+  });
+
+  it('surfaces a registry error', async () => {
+    const request: RegistryRequest = async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+
+    await assert.rejects(() => fetchPackument(request), /answered 503/u);
+  });
+});

--- a/.github/actions/draft-release/__tests__/pipeline.test.ts
+++ b/.github/actions/draft-release/__tests__/pipeline.test.ts
@@ -316,7 +316,7 @@ describe('runDraftRelease', () => {
 
     assert.equal(result.payload.candidate.headSha, result.payload.range.toSha);
     assert.equal(result.payload.candidate.branch, result.branch);
-    assert.equal(result.payload.schemaVersion, 3);
+    assert.equal(result.payload.schemaVersion, 4);
   });
 
   it('reports no pull request for a candidate a dry run only planned', async () => {
@@ -362,6 +362,33 @@ describe('runDraftRelease', () => {
 
   it('rejects a malformed version input', async () => {
     await assert.rejects(() => run({ dryRun: true, version: '5.53' }), /not a stable x\.y\.z/u);
+  });
+
+  it('stops the whole run when only the landing commit body says the range breaks', async () => {
+    // End to end, not just the classifier: an unparsed squash subject with a breaking footer in
+    // the body has to fail the run before any branch is cut or milestone touched.
+    await assert.rejects(
+      () =>
+        run(
+          { dryRun: true },
+          {
+            git: {
+              listIntegrations: () => [
+                {
+                  sha: FEAT_SHA,
+                  parents: [FIX_SHA],
+                  author: 'Dev B',
+                  email: 'dev-b@strapi.io',
+                  authoredAt: '2026-09-03T10:00:00Z',
+                  subject: 'Feat/record release actions (#27436)',
+                  body: 'Adds audit logs.\n\nBREAKING CHANGE: the audit log payload shape moved.',
+                },
+              ],
+            },
+          }
+        ),
+      /carries a breaking change/u
+    );
   });
 
   it('stops instead of reporting a failed lookup as a direct commit', async () => {

--- a/.github/actions/draft-release/__tests__/pipeline.test.ts
+++ b/.github/actions/draft-release/__tests__/pipeline.test.ts
@@ -41,7 +41,8 @@ function scenario(overrides: Overrides = {}): {
     {
       sha: BACK_MERGE_SHA,
       parents: ['0'.repeat(40), '9'.repeat(40)],
-      author: 'strapi-bot',
+      author: 'Strapi Bot',
+      email: 'strapi-bot@users.noreply.github.com',
       authoredAt: '2026-09-01T10:00:00Z',
       subject: 'chore: release v5.52.3 update develop',
       body: '',
@@ -49,7 +50,8 @@ function scenario(overrides: Overrides = {}): {
     {
       sha: FIX_SHA,
       parents: [BACK_MERGE_SHA],
-      author: 'dev-a',
+      author: 'Dev A',
+      email: '11+dev-a@users.noreply.github.com',
       authoredAt: '2026-09-02T10:00:00Z',
       subject: 'fix(upload): reserve list space for the bulk actions bar (#27509)',
       body: '',
@@ -57,7 +59,8 @@ function scenario(overrides: Overrides = {}): {
     {
       sha: FEAT_SHA,
       parents: [FIX_SHA],
-      author: 'dev-b',
+      author: 'Dev B',
+      email: 'dev-b@strapi.io',
       authoredAt: '2026-09-03T10:00:00Z',
       subject: 'feat(content-releases): record release actions in audit logs (#27436)',
       body: '',
@@ -288,6 +291,18 @@ describe('runDraftRelease', () => {
     });
   });
 
+  it('names every shipping author by display name and login', async () => {
+    const { result } = await run({ dryRun: false });
+
+    assert.deepEqual(
+      result.payload.pullRequests.map((pull) => pull.author),
+      [
+        { login: 'dev-a', name: 'Dev A' },
+        { login: 'dev-b', name: 'Dev B' },
+      ]
+    );
+  });
+
   it('identifies the candidate it just created', async () => {
     const { result } = await run({ dryRun: false });
 
@@ -301,7 +316,7 @@ describe('runDraftRelease', () => {
 
     assert.equal(result.payload.candidate.headSha, result.payload.range.toSha);
     assert.equal(result.payload.candidate.branch, result.branch);
-    assert.equal(result.payload.schemaVersion, 2);
+    assert.equal(result.payload.schemaVersion, 3);
   });
 
   it('reports no pull request for a candidate a dry run only planned', async () => {

--- a/.github/actions/draft-release/__tests__/pipeline.test.ts
+++ b/.github/actions/draft-release/__tests__/pipeline.test.ts
@@ -288,6 +288,34 @@ describe('runDraftRelease', () => {
     });
   });
 
+  it('identifies the candidate it just created', async () => {
+    const { result } = await run({ dryRun: false });
+
+    assert.deepEqual(result.payload.candidate, {
+      branch: 'releases/5.53.0',
+      headSha: FEAT_SHA,
+      expectedExperimentalVersion: `0.0.0-experimental.${FEAT_SHA}`,
+      pullRequestNumber: 27700,
+      pullRequestUrl: 'https://github.com/strapi/strapi/pull/27700',
+    });
+
+    assert.equal(result.payload.candidate.headSha, result.payload.range.toSha);
+    assert.equal(result.payload.candidate.branch, result.branch);
+    assert.equal(result.payload.schemaVersion, 2);
+  });
+
+  it('reports no pull request for a candidate a dry run only planned', async () => {
+    const { result } = await run({ dryRun: true });
+
+    assert.deepEqual(result.payload.candidate, {
+      branch: 'releases/5.53.0',
+      headSha: FEAT_SHA,
+      expectedExperimentalVersion: `0.0.0-experimental.${FEAT_SHA}`,
+      pullRequestNumber: null,
+      pullRequestUrl: null,
+    });
+  });
+
   it('embeds a machine-readable payload in the pull request body', async () => {
     const { result } = await run({ dryRun: true });
     const body = renderBody({

--- a/.github/actions/draft-release/__tests__/pipeline.test.ts
+++ b/.github/actions/draft-release/__tests__/pipeline.test.ts
@@ -1,0 +1,428 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createJournal } from '../lib/journal.ts';
+import { EXPERIMENTAL_LABEL, runDraftRelease } from '../lib/pipeline.ts';
+import { renderBody } from '../lib/report.ts';
+import { SHA } from '../lib/__fixtures__/fixtures.ts';
+
+import type { RegistryRequest } from '../lib/npm.ts';
+import type { DraftReleaseResult } from '../lib/pipeline.ts';
+import type {
+  GitAdapter,
+  GithubAdapter,
+  Integration,
+  MilestoneItem,
+  PullPayload,
+} from '../lib/types.ts';
+
+const CLOCK = (): string => '2026-09-06T17:57:00Z';
+
+const FEAT_SHA = 'f'.repeat(40);
+const FIX_SHA = '1'.repeat(40);
+const BACK_MERGE_SHA = SHA.BACK_MERGE;
+
+type Overrides = {
+  gh?: Partial<GithubAdapter>;
+  git?: Partial<GitAdapter>;
+};
+
+/**
+ * A range that mirrors the live situation: a `feat` landed since `v5.52.3`, the only open milestone
+ * still says `5.52.4`, and a release back-merge sits in the range.
+ */
+function scenario(overrides: Overrides = {}): {
+  calls: string[];
+  git: GitAdapter;
+  gh: GithubAdapter;
+  request: RegistryRequest;
+} {
+  const integrations: Integration[] = [
+    {
+      sha: BACK_MERGE_SHA,
+      parents: ['0'.repeat(40), '9'.repeat(40)],
+      author: 'strapi-bot',
+      authoredAt: '2026-09-01T10:00:00Z',
+      subject: 'chore: release v5.52.3 update develop',
+      body: '',
+    },
+    {
+      sha: FIX_SHA,
+      parents: [BACK_MERGE_SHA],
+      author: 'dev-a',
+      authoredAt: '2026-09-02T10:00:00Z',
+      subject: 'fix(upload): reserve list space for the bulk actions bar (#27509)',
+      body: '',
+    },
+    {
+      sha: FEAT_SHA,
+      parents: [FIX_SHA],
+      author: 'dev-b',
+      authoredAt: '2026-09-03T10:00:00Z',
+      subject: 'feat(content-releases): record release actions in audit logs (#27436)',
+      body: '',
+    },
+  ];
+
+  const pullsByCommit: Record<string, PullPayload[]> = {
+    [BACK_MERGE_SHA]: [
+      {
+        number: 27527,
+        title: 'chore: release v5.52.3 update develop',
+        html_url: 'https://github.com/strapi/strapi/pull/27527',
+        merged_at: '2026-09-01T09:00:00Z',
+        merge_commit_sha: BACK_MERGE_SHA,
+        base: { ref: 'develop' },
+        head: { ref: 'main', sha: '9'.repeat(40) },
+        user: { login: 'strapi-bot' },
+        milestone: null,
+      },
+    ],
+    [FIX_SHA]: [
+      {
+        number: 27509,
+        title: 'fix(upload): reserve list space for the bulk actions bar',
+        html_url: 'https://github.com/strapi/strapi/pull/27509',
+        merged_at: '2026-09-02T09:00:00Z',
+        merge_commit_sha: FIX_SHA,
+        base: { ref: 'develop' },
+        head: { ref: 'fix/upload-bulk-bar', sha: 'a'.repeat(40) },
+        user: { login: 'dev-a' },
+        milestone: { title: '5.52.4' },
+      },
+    ],
+    [FEAT_SHA]: [
+      {
+        number: 27436,
+        title: 'feat(content-releases): record release actions in audit logs',
+        html_url: 'https://github.com/strapi/strapi/pull/27436',
+        merged_at: '2026-09-03T09:00:00Z',
+        merge_commit_sha: FEAT_SHA,
+        base: { ref: 'develop' },
+        head: { ref: 'feat/audit-logs', sha: 'b'.repeat(40) },
+        user: { login: 'dev-b' },
+        milestone: { title: '5.52.4' },
+      },
+    ],
+  };
+
+  const milestoneItems: MilestoneItem[] = [
+    { number: 27436, title: 'audit logs', state: 'closed', pull_request: { merged_at: 'x' } },
+    { number: 27509, title: 'bulk bar', state: 'closed', pull_request: { merged_at: 'x' } },
+    { number: 27600, title: 'still open', state: 'open', pull_request: { merged_at: null } },
+    { number: 27601, title: 'abandoned', state: 'closed', pull_request: { merged_at: null } },
+    { number: 26000, title: 'an issue', state: 'open' },
+  ];
+
+  const calls: string[] = [];
+
+  const gh: GithubAdapter = {
+    coords: { owner: 'strapi', repo: 'strapi' },
+    getRepository: async () => ({
+      allow_merge_commit: true,
+      allow_squash_merge: true,
+      allow_rebase_merge: false,
+    }),
+    listPullsForCommit: async (sha) => pullsByCommit[sha] ?? [],
+    async getPull() {
+      throw new Error('404');
+    },
+    listPullCommits: async () => [],
+    listMilestones: async () => [{ number: 430, title: '5.52.4', state: 'open' }],
+    async createMilestone(title) {
+      calls.push(`createMilestone:${title}`);
+
+      return { number: 431, title };
+    },
+    async updateMilestone(number, patch) {
+      calls.push(`updateMilestone:${number}:${JSON.stringify(patch)}`);
+
+      return { number, title: patch.title ?? '' };
+    },
+    listMilestoneItems: async () => milestoneItems,
+    async setIssueMilestone(issueNumber, milestoneNumber) {
+      calls.push(`setIssueMilestone:${issueNumber}:${milestoneNumber}`);
+    },
+    async createPull(input) {
+      calls.push(`createPull:${input.title}`);
+
+      return { number: 27700, html_url: 'https://github.com/strapi/strapi/pull/27700' };
+    },
+    async updatePullBody(number) {
+      calls.push(`updatePullBody:${number}`);
+    },
+    async addLabels(number, labels) {
+      calls.push(`addLabels:${number}:${labels.join(',')}`);
+    },
+    async createComment(number) {
+      calls.push(`createComment:${number}`);
+    },
+    ...overrides.gh,
+  };
+
+  const git: GitAdapter = {
+    refExists: () => true,
+    resolveSha: (ref) => (ref === 'v5.52.3' ? '0'.repeat(40) : FEAT_SHA),
+    isAncestor: () => true,
+    listIntegrations: () => integrations,
+    remoteBranchExists: () => false,
+    pushBranch(sha, branch) {
+      calls.push(`pushBranch:${branch}:${sha}`);
+    },
+    ...overrides.git,
+  };
+
+  const request: RegistryRequest = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      'dist-tags': { latest: '5.52.3' },
+      versions: { '5.52.1': {}, '5.52.2': {}, '5.52.3': {} },
+    }),
+  });
+
+  return { calls, git, gh, request };
+}
+
+async function run(
+  inputs: { dryRun: boolean; version?: string },
+  overrides: Overrides = {}
+): Promise<{ calls: string[]; result: DraftReleaseResult }> {
+  const context = scenario(overrides);
+  const journal = createJournal({ apply: inputs.dryRun === false, clock: CLOCK });
+
+  const result = await runDraftRelease({
+    inputs: { version: '', sourceRef: 'develop', ...inputs },
+    git: context.git,
+    gh: context.gh,
+    journal,
+    request: context.request,
+    logger: { info() {} },
+    clock: CLOCK,
+  });
+
+  return { calls: context.calls, result };
+}
+
+describe('runDraftRelease', () => {
+  it('computes a minor from the feat that landed, ignoring the release back-merge', async () => {
+    const { result } = await run({ dryRun: true });
+
+    assert.equal(result.version, '5.53.0');
+    assert.equal(result.bump, 'minor');
+    assert.equal(result.payload.release.source, 'computed');
+    assert.deepEqual(result.payload.bumpEvidence.ignored, [
+      {
+        sha: BACK_MERGE_SHA,
+        reason: 'back-merge',
+        subject: 'chore: release v5.52.3 update develop',
+      },
+    ]);
+  });
+
+  it('performs no write on a dry run and still reports every planned one', async () => {
+    const { calls, result } = await run({ dryRun: true });
+
+    assert.deepEqual(calls, []);
+    assert.equal(result.journal.mode, 'planned');
+    assert.deepEqual(
+      result.journal.entries.map((entry) => entry.op),
+      [
+        'milestone.rename',
+        'milestone.create',
+        'milestone.close',
+        'branch.push',
+        'pr.create',
+        'pr.label',
+        'pr.body',
+        'issue.milestone.set',
+        'issue.milestone.clear',
+        'issue.milestone.clear',
+        'pr.comment',
+      ]
+    );
+  });
+
+  it('renames, opens the next milestone, then closes the shipping one', async () => {
+    const { calls } = await run({ dryRun: false });
+
+    assert.deepEqual(calls.slice(0, 3), [
+      'updateMilestone:430:{"title":"5.53.0"}',
+      'createMilestone:5.53.1',
+      'updateMilestone:430:{"state":"closed"}',
+    ]);
+  });
+
+  it('cuts the branch at the pinned SHA and labels the PR for the experimental publish', async () => {
+    const { calls } = await run({ dryRun: false });
+
+    assert.equal(calls.includes(`pushBranch:releases/5.53.0:${FEAT_SHA}`), true);
+    assert.equal(calls.includes('createPull:[draft] release 5.53.0'), true);
+    assert.equal(calls.includes(`addLabels:27700:${EXPERIMENTAL_LABEL}`), true);
+    assert.equal(calls.includes('updatePullBody:27700'), true);
+    assert.equal(calls.includes('createComment:27700'), true);
+  });
+
+  it('moves open pull requests forward, clears closed ones and every issue', async () => {
+    const { calls } = await run({ dryRun: false });
+
+    assert.equal(calls.includes('setIssueMilestone:27600:431'), true);
+    assert.equal(calls.includes('setIssueMilestone:27601:null'), true);
+    assert.equal(calls.includes('setIssueMilestone:26000:null'), true);
+    assert.equal(
+      calls.some((call) => call.startsWith('setIssueMilestone:27436')),
+      false
+    );
+  });
+
+  it('keeps the release back-merge out of the shipping set and out of the drift report', async () => {
+    const { result } = await run({ dryRun: true });
+
+    assert.deepEqual(
+      result.payload.pullRequests.map((pull) => pull.number),
+      [27509, 27436]
+    );
+    assert.deepEqual(result.payload.reconciliation, {
+      inHistoryNotInMilestone: [],
+      inMilestoneNotInHistory: [],
+    });
+  });
+
+  it('embeds a machine-readable payload in the pull request body', async () => {
+    const { result } = await run({ dryRun: true });
+    const body = renderBody({
+      payload: result.payload,
+      pullRequests: result.payload.pullRequests,
+      attention: result.payload.attention,
+    });
+
+    assert.match(body, /"version": "5\.53\.0"/u);
+    assert.match(body, /"renamedFrom": "5\.52\.4"/u);
+    assert.match(body, /"title": "5\.53\.1"/u);
+  });
+
+  it('bypasses the commit rule when a version is given', async () => {
+    const { result } = await run({ dryRun: true, version: '5.52.4' });
+
+    assert.equal(result.version, '5.52.4');
+    assert.equal(result.bump, 'patch');
+    assert.equal(result.payload.release.source, 'version-input');
+    assert.equal(result.payload.milestones.next.title, '5.52.5');
+  });
+
+  it('rejects a version input that does not move forward', async () => {
+    await assert.rejects(
+      () => run({ dryRun: true, version: '5.52.3' }),
+      /not greater than the published baseline/u
+    );
+  });
+
+  it('rejects a malformed version input', async () => {
+    await assert.rejects(() => run({ dryRun: true, version: '5.53' }), /not a stable x\.y\.z/u);
+  });
+
+  it('stops instead of reporting a failed lookup as a direct commit', async () => {
+    await assert.rejects(
+      () =>
+        run(
+          { dryRun: true },
+          {
+            gh: {
+              async listPullsForCommit() {
+                throw new Error('502 Bad Gateway');
+              },
+            },
+          }
+        ),
+      /lookups failed/u
+    );
+  });
+
+  it('stops when the release branch already exists', async () => {
+    await assert.rejects(
+      () => run({ dryRun: true }, { git: { remoteBranchExists: () => true } }),
+      /already exists/u
+    );
+  });
+
+  it('stops when the range is empty', async () => {
+    await assert.rejects(
+      () => run({ dryRun: true }, { git: { listIntegrations: () => [] } }),
+      /Nothing to release/u
+    );
+  });
+
+  it('stops when rebase merges are enabled', async () => {
+    await assert.rejects(
+      () =>
+        run(
+          { dryRun: true },
+          {
+            gh: {
+              getRepository: async () => ({
+                allow_merge_commit: true,
+                allow_squash_merge: true,
+                allow_rebase_merge: true,
+              }),
+            },
+          }
+        ),
+      /Rebase merges are enabled/u
+    );
+  });
+
+  it('stops when more than one milestone is open', async () => {
+    await assert.rejects(
+      () =>
+        run(
+          { dryRun: true },
+          {
+            gh: {
+              listMilestones: async () => [
+                { number: 430, title: '5.52.4', state: 'open' },
+                { number: 431, title: '5.53.0', state: 'open' },
+              ],
+            },
+          }
+        ),
+      /Expected at most one open milestone/u
+    );
+  });
+
+  it('reports a second-parent mismatch as a warning rather than failing', async () => {
+    const { result } = await run(
+      { dryRun: true },
+      {
+        gh: {
+          listPullsForCommit: async (sha) =>
+            sha === BACK_MERGE_SHA
+              ? [
+                  {
+                    number: 27527,
+                    title: 'chore: release v5.52.3 update develop',
+                    merged_at: 'x',
+                    merge_commit_sha: BACK_MERGE_SHA,
+                    base: { ref: 'develop' },
+                    head: { ref: 'main', sha: 'moved' },
+                    user: { login: 'strapi-bot' },
+                  },
+                ]
+              : [],
+        },
+      }
+    );
+
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0] ?? '', /second-parent-mismatch/u);
+  });
+
+  it('lists a direct commit for a human instead of silently dropping it', async () => {
+    const { result } = await run({ dryRun: true }, { gh: { listPullsForCommit: async () => [] } });
+
+    assert.equal(
+      result.payload.attention.every((record) => record.status === 'direct-integration'),
+      true
+    );
+    assert.equal(result.payload.attention.length, 3);
+  });
+});

--- a/.github/actions/draft-release/__tests__/pipeline.test.ts
+++ b/.github/actions/draft-release/__tests__/pipeline.test.ts
@@ -257,7 +257,7 @@ describe('runDraftRelease', () => {
     const { calls } = await run({ dryRun: false });
 
     assert.equal(calls.includes(`pushBranch:releases/5.53.0:${FEAT_SHA}`), true);
-    assert.equal(calls.includes('createPull:[draft] release 5.53.0'), true);
+    assert.equal(calls.includes('createPull:Release 5.53.0'), true);
     assert.equal(calls.includes(`addLabels:27700:${EXPERIMENTAL_LABEL}`), true);
     assert.equal(calls.includes('updatePullBody:27700'), true);
     assert.equal(calls.includes('createComment:27700'), true);

--- a/.github/actions/draft-release/__tests__/range.test.ts
+++ b/.github/actions/draft-release/__tests__/range.test.ts
@@ -18,8 +18,24 @@ function log(records: readonly (readonly string[])[]): string {
 describe('parseFirstParentLog', () => {
   it('reads one record per integration', () => {
     const stdout = log([
-      ['abc', 'def', 'Alice', '2026-09-05T10:00:00Z', 'fix(upload): a thing (#1)', ''],
-      ['fed', 'cba 999', 'Bob', '2026-09-05T11:00:00Z', 'Merge pull request #2 from strapi/x', ''],
+      [
+        'abc',
+        'def',
+        'Alice',
+        'alice@example.com',
+        '2026-09-05T10:00:00Z',
+        'fix(upload): a thing (#1)',
+        '',
+      ],
+      [
+        'fed',
+        'cba 999',
+        'Bob',
+        'bob@example.com',
+        '2026-09-05T11:00:00Z',
+        'Merge pull request #2 from strapi/x',
+        '',
+      ],
     ]);
 
     assert.deepEqual(parseFirstParentLog(stdout), [
@@ -27,6 +43,7 @@ describe('parseFirstParentLog', () => {
         sha: 'abc',
         parents: ['def'],
         author: 'Alice',
+        email: 'alice@example.com',
         authoredAt: '2026-09-05T10:00:00Z',
         subject: 'fix(upload): a thing (#1)',
         body: '',
@@ -35,6 +52,7 @@ describe('parseFirstParentLog', () => {
         sha: 'fed',
         parents: ['cba', '999'],
         author: 'Bob',
+        email: 'bob@example.com',
         authoredAt: '2026-09-05T11:00:00Z',
         subject: 'Merge pull request #2 from strapi/x',
         body: '',
@@ -48,6 +66,7 @@ describe('parseFirstParentLog', () => {
         'abc',
         'def',
         'Alice',
+        'alice@example.com',
         '2026-09-05T10:00:00Z',
         'feat!: drop node 20',
         'BREAKING CHANGE: gone\n\nmore',

--- a/.github/actions/draft-release/__tests__/range.test.ts
+++ b/.github/actions/draft-release/__tests__/range.test.ts
@@ -1,0 +1,166 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  FIELD_SEPARATOR,
+  RECORD_SEPARATOR,
+  createGitAdapter,
+  parseFirstParentLog,
+  pinRange,
+} from '../lib/range.ts';
+
+import type { ExecResult, GitAdapter, GitExec } from '../lib/types.ts';
+
+function log(records: readonly (readonly string[])[]): string {
+  return records.map((fields) => fields.join(FIELD_SEPARATOR) + RECORD_SEPARATOR).join('\n');
+}
+
+describe('parseFirstParentLog', () => {
+  it('reads one record per integration', () => {
+    const stdout = log([
+      ['abc', 'def', 'Alice', '2026-09-05T10:00:00Z', 'fix(upload): a thing (#1)', ''],
+      ['fed', 'cba 999', 'Bob', '2026-09-05T11:00:00Z', 'Merge pull request #2 from strapi/x', ''],
+    ]);
+
+    assert.deepEqual(parseFirstParentLog(stdout), [
+      {
+        sha: 'abc',
+        parents: ['def'],
+        author: 'Alice',
+        authoredAt: '2026-09-05T10:00:00Z',
+        subject: 'fix(upload): a thing (#1)',
+        body: '',
+      },
+      {
+        sha: 'fed',
+        parents: ['cba', '999'],
+        author: 'Bob',
+        authoredAt: '2026-09-05T11:00:00Z',
+        subject: 'Merge pull request #2 from strapi/x',
+        body: '',
+      },
+    ]);
+  });
+
+  it('keeps a multi-line body intact', () => {
+    const stdout = log([
+      [
+        'abc',
+        'def',
+        'Alice',
+        '2026-09-05T10:00:00Z',
+        'feat!: drop node 20',
+        'BREAKING CHANGE: gone\n\nmore',
+      ],
+    ]);
+
+    assert.equal(parseFirstParentLog(stdout)[0]?.body, 'BREAKING CHANGE: gone\n\nmore');
+  });
+
+  it('returns nothing for an empty range', () => {
+    assert.deepEqual(parseFirstParentLog(''), []);
+  });
+});
+
+describe('createGitAdapter', () => {
+  function execStub(responses: Record<string, ExecResult>): GitExec {
+    return (args) => {
+      const command = args.join(' ');
+      const key = Object.keys(responses).find((prefix) => command.startsWith(prefix));
+
+      return responses[key ?? ''] ?? { status: 1, stdout: '', stderr: 'unexpected' };
+    };
+  }
+
+  it('reports a non-zero exit as a boolean, not an exception', () => {
+    const exec = execStub({ 'merge-base': { status: 1, stdout: '', stderr: '' } });
+
+    assert.equal(createGitAdapter(exec).isAncestor('a', 'b'), false);
+  });
+
+  it('turns a failed command into an error naming the command', () => {
+    const exec = execStub({ 'rev-parse': { status: 128, stdout: '', stderr: 'bad revision' } });
+
+    assert.throws(
+      () => createGitAdapter(exec).resolveSha('nope'),
+      /git rev-parse .* bad revision/u
+    );
+  });
+
+  it('reports a missing remote branch when ls-remote finds nothing', () => {
+    const exec = execStub({ 'ls-remote': { status: 2, stdout: '', stderr: '' } });
+
+    assert.equal(createGitAdapter(exec).remoteBranchExists('releases/5.53.0'), false);
+  });
+
+  it('trims the resolved SHA', () => {
+    const exec = execStub({ 'rev-parse': { status: 0, stdout: 'abc123\n', stderr: '' } });
+
+    assert.equal(createGitAdapter(exec).resolveSha('develop'), 'abc123');
+  });
+
+  it('walks first-parent only, oldest first', () => {
+    const seen: string[] = [];
+    const exec: GitExec = (args) => {
+      seen.push(args.join(' '));
+
+      return { status: 0, stdout: '', stderr: '' };
+    };
+
+    createGitAdapter(exec).listIntegrations('from', 'to');
+
+    assert.equal(seen[0]?.includes('--first-parent'), true);
+    assert.equal(seen[0]?.includes('--reverse'), true);
+    assert.equal(seen[0]?.endsWith('from..to'), true);
+  });
+});
+
+describe('pinRange', () => {
+  function gitStub(overrides: Partial<GitAdapter> = {}): GitAdapter {
+    return {
+      refExists: () => true,
+      resolveSha: (ref) => `sha-of-${ref}`,
+      isAncestor: () => true,
+      listIntegrations: () => [],
+      pushBranch() {},
+      remoteBranchExists: () => false,
+      ...overrides,
+    };
+  }
+
+  it('resolves both ends once and returns the pinned pair', () => {
+    assert.deepEqual(pinRange(gitStub(), { baselineVersion: '5.52.3', sourceRef: 'develop' }), {
+      fromRef: 'v5.52.3',
+      fromSha: 'sha-of-v5.52.3',
+      toRef: 'origin/develop',
+      toSha: 'sha-of-origin/develop',
+    });
+  });
+
+  it('stops when the baseline tag is missing', () => {
+    const git = gitStub({ refExists: (ref) => ref !== 'v5.52.3' });
+
+    assert.throws(
+      () => pinRange(git, { baselineVersion: '5.52.3', sourceRef: 'develop' }),
+      /baseline tag v5\.52\.3 is missing/u
+    );
+  });
+
+  it('stops when the source ref does not exist', () => {
+    const git = gitStub({ refExists: (ref) => ref !== 'origin/develop' });
+
+    assert.throws(
+      () => pinRange(git, { baselineVersion: '5.52.3', sourceRef: 'develop' }),
+      /source ref origin\/develop does not exist/u
+    );
+  });
+
+  it('stops when the baseline is not an ancestor of the source ref', () => {
+    const git = gitStub({ isAncestor: () => false });
+
+    assert.throws(
+      () => pinRange(git, { baselineVersion: '5.52.3', sourceRef: 'develop' }),
+      /is not an ancestor of/u
+    );
+  });
+});

--- a/.github/actions/draft-release/__tests__/report.test.ts
+++ b/.github/actions/draft-release/__tests__/report.test.ts
@@ -137,6 +137,29 @@ describe('renderPullRequestTable', () => {
     assert.match(table, /Someone Real \(@someone\)/u);
   });
 
+  it('escapes the backslash before the pipe, so a subject cannot break the table', () => {
+    // Escaping the pipe first would leave `a\\|b`: a literal backslash, then a bare pipe, and the
+    // row ends one cell early.
+    const pull = {
+      number: 1,
+      title: 'fix(admin): handle a \\| b',
+      author: { login: 'x', name: null },
+      url: 'u',
+      baseRef: 'develop',
+      headRef: 'fix/x',
+      milestone: null,
+      status: 'resolved',
+      basis: 'none',
+      integrationShas: ['a'],
+    } satisfies AttributedPull;
+
+    const table = renderPullRequestTable([pull]);
+
+    assert.match(table, /handle a \\\\\\\| b/u);
+    assert.equal(table.split('\n').length, 3);
+    assert.equal(table.split('\n')[2]?.split(/(?<!\\)\|/u).length, 7);
+  });
+
   it('escapes a pipe so a title cannot break the table', () => {
     const pull = {
       number: 1,

--- a/.github/actions/draft-release/__tests__/report.test.ts
+++ b/.github/actions/draft-release/__tests__/report.test.ts
@@ -1,0 +1,285 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  BLOCK_END,
+  BLOCK_START,
+  buildPayload,
+  extractJsonBlock,
+  renderAttentionTable,
+  renderBody,
+  renderJournalTable,
+  renderMilestoneComment,
+  renderPullRequestTable,
+  renderStepSummary,
+  withoutTrailingReference,
+} from '../lib/report.ts';
+
+import type { AttributedPull, JournalEntry } from '../lib/types.ts';
+import type { PayloadInput } from '../lib/report.ts';
+
+function payloadInput(overrides: Partial<PayloadInput> = {}): PayloadInput {
+  return {
+    generatedAt: '2026-09-06T17:57:00Z',
+    coords: { owner: 'strapi', repo: 'strapi' },
+    dryRun: false,
+    version: '5.53.0',
+    bump: 'minor',
+    previousVersion: '5.52.3',
+    versionSource: 'computed',
+    range: {
+      fromRef: 'v5.52.3',
+      fromSha: 'a'.repeat(40),
+      toRef: 'origin/develop',
+      toSha: 'b'.repeat(40),
+    },
+    integrationCount: 12,
+    classification: {
+      features: [
+        {
+          sha: 'c'.repeat(40),
+          pr: 27436,
+          subject: 'feat(content-releases): audit logs',
+          via: 'subject',
+        },
+      ],
+      breaking: [],
+      ignored: [],
+      unparsed: [],
+    },
+    pullRequests: [
+      {
+        number: 27436,
+        title: 'feat(content-releases): audit logs',
+        author: 'someone',
+        url: 'https://github.com/strapi/strapi/pull/27436',
+        baseRef: 'develop',
+        headRef: 'feat/audit-logs',
+        milestone: '5.52.4',
+        status: 'resolved',
+        basis: 'exact-merge-sha',
+        integrationShas: ['c'.repeat(40)],
+      },
+    ],
+    attention: [],
+    milestones: {
+      shipping: { number: 430, title: '5.53.0', renamedFrom: '5.52.4', state: 'closed' },
+      next: { number: 431, title: '5.53.1', created: true },
+    },
+    reconciliation: { inHistoryNotInMilestone: [], inMilestoneNotInHistory: [] },
+    ...overrides,
+  };
+}
+
+function journalEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
+  return {
+    op: 'milestone.rename',
+    target: 'milestone/430',
+    before: '5.52.4',
+    after: '5.53.0',
+    detail: null,
+    at: '2026-09-06T17:57:00Z',
+    applied: true,
+    ...overrides,
+  };
+}
+
+describe('withoutTrailingReference', () => {
+  it('strips a repeated reference left by a squash on a squash', () => {
+    assert.equal(
+      withoutTrailingReference('feat(content-releases): audit logs (#27436) (#27436)'),
+      'feat(content-releases): audit logs'
+    );
+  });
+
+  it('leaves a subject with no trailing reference alone', () => {
+    assert.equal(
+      withoutTrailingReference('future(upload): drawer interaction'),
+      'future(upload): drawer interaction'
+    );
+  });
+
+  it('keeps a reference that is not at the end', () => {
+    assert.equal(
+      withoutTrailingReference('fix: revert (#1) then move on'),
+      'fix: revert (#1) then move on'
+    );
+  });
+});
+
+describe('renderPullRequestTable', () => {
+  it('escapes a pipe so a title cannot break the table', () => {
+    const pull = {
+      number: 1,
+      title: 'fix: a | b',
+      author: 'x',
+      url: 'u',
+      baseRef: 'develop',
+      headRef: 'fix/x',
+      milestone: null,
+      status: 'resolved',
+      basis: 'none',
+      integrationShas: ['a'],
+    } satisfies AttributedPull;
+
+    const table = renderPullRequestTable([pull]);
+
+    assert.match(table, /fix: a \\\| b/u);
+    assert.equal(table.split('\n').length, 3);
+  });
+
+  it('says so when nothing resolved', () => {
+    assert.equal(renderPullRequestTable([]), '_No pull request resolved in this range._');
+  });
+});
+
+describe('renderAttentionTable', () => {
+  it('is empty when everything resolved', () => {
+    assert.equal(renderAttentionTable([]), '');
+  });
+});
+
+describe('renderJournalTable', () => {
+  it('says so when nothing was recorded', () => {
+    assert.equal(renderJournalTable([]), '_No write recorded._');
+  });
+
+  it('renders an absent value as a dash', () => {
+    assert.match(renderJournalTable([journalEntry({ before: null })]), /\| — \|/u);
+  });
+});
+
+describe('renderBody', () => {
+  const payload = buildPayload(payloadInput());
+
+  it('carries a JSON block that round-trips through the markers', () => {
+    const body = renderBody({ payload, pullRequests: payload.pullRequests, attention: [] });
+
+    assert.equal(body.includes(BLOCK_START), true);
+    assert.equal(body.includes(BLOCK_END), true);
+    assert.deepEqual(extractJsonBlock(body), JSON.parse(JSON.stringify(payload)));
+  });
+
+  it('explains a minor with the commits that caused it', () => {
+    const body = renderBody({ payload, pullRequests: payload.pullRequests, attention: [] });
+
+    assert.match(body, /## Why this is a minor/u);
+    assert.match(body, /feat\(content-releases\): audit logs \(#27436\)/u);
+  });
+
+  it('names the version input when a human decided', () => {
+    const overridden = buildPayload(payloadInput({ versionSource: 'version-input' }));
+    const body = renderBody({ payload: overridden, pullRequests: [], attention: [] });
+
+    assert.match(body, /decided from the `version` input/u);
+  });
+
+  it('surfaces reconciliation differences only when there are any', () => {
+    const clean = renderBody({ payload, pullRequests: payload.pullRequests, attention: [] });
+
+    assert.equal(clean.includes('## Milestone reconciliation'), false);
+
+    const drifted = buildPayload(
+      payloadInput({
+        reconciliation: { inHistoryNotInMilestone: [27509], inMilestoneNotInHistory: [27123] },
+      })
+    );
+
+    const body = renderBody({
+      payload: drifted,
+      pullRequests: drifted.pullRequests,
+      attention: [],
+    });
+
+    assert.match(body, /In history, not in the milestone: #27509/u);
+    assert.match(body, /not in this range: #27123/u);
+  });
+
+  it('lists the records a human still has to settle', () => {
+    const body = renderBody({
+      payload,
+      pullRequests: payload.pullRequests,
+      attention: [
+        {
+          sha: 'd'.repeat(40),
+          subject: 'chore: direct push',
+          status: 'direct-integration',
+          reason: 'no associated pull request',
+        },
+      ],
+      warnings: ['`abcd1234` head is not the second parent.'],
+    });
+
+    assert.match(body, /### Needs a human/u);
+    assert.match(body, /direct-integration/u);
+    assert.match(body, /### Warnings/u);
+  });
+});
+
+describe('extractJsonBlock', () => {
+  it('returns null when the markers are missing', () => {
+    assert.equal(extractJsonBlock('just prose'), null);
+  });
+
+  it('returns null when the markers are inverted', () => {
+    assert.equal(extractJsonBlock(`${BLOCK_END}\n${BLOCK_START}`), null);
+  });
+
+  it('returns null when the block carries no fence', () => {
+    assert.equal(extractJsonBlock(`${BLOCK_START}\nnothing\n${BLOCK_END}`), null);
+  });
+
+  it('returns null when the block is not valid JSON', () => {
+    const body = [BLOCK_START, '```json', '{ nope', '```', BLOCK_END].join('\n');
+
+    assert.equal(extractJsonBlock(body), null);
+  });
+});
+
+describe('renderMilestoneComment', () => {
+  it('reports only the milestone writes, and says when nothing was applied', () => {
+    const comment = renderMilestoneComment({
+      version: '5.53.0',
+      nextTitle: '5.53.1',
+      dryRun: true,
+      entries: [
+        journalEntry(),
+        journalEntry({ op: 'branch.push', target: 'refs/heads/releases/5.53.0' }),
+        journalEntry({ op: 'issue.milestone.set', target: 'issues/27600' }),
+      ],
+    });
+
+    assert.match(comment, /Dry run\. Nothing below was applied\./u);
+    assert.match(comment, /milestone\.rename/u);
+    assert.match(comment, /issue\.milestone\.set/u);
+    assert.equal(comment.includes('branch.push'), false);
+  });
+
+  it('states the closed milestone when the run applied', () => {
+    const comment = renderMilestoneComment({
+      version: '5.53.0',
+      nextTitle: '5.53.1',
+      dryRun: false,
+      entries: [],
+    });
+
+    assert.match(comment, /`5\.53\.0` is closed/u);
+  });
+});
+
+describe('renderStepSummary', () => {
+  it('labels a dry run as planned', () => {
+    const payload = buildPayload(payloadInput({ dryRun: true }));
+    const summary = renderStepSummary({ payload, entries: [] });
+
+    assert.match(summary, /Dry run\./u);
+    assert.match(summary, /## Planned writes/u);
+  });
+
+  it('labels a real run as applied', () => {
+    const payload = buildPayload(payloadInput());
+    const summary = renderStepSummary({ payload, entries: [journalEntry()] });
+
+    assert.match(summary, /## Applied writes/u);
+  });
+});

--- a/.github/actions/draft-release/__tests__/report.test.ts
+++ b/.github/actions/draft-release/__tests__/report.test.ts
@@ -203,7 +203,7 @@ describe('renderJournalTable', () => {
 
 describe('buildPayload', () => {
   it('carries the schema version later automation reads', () => {
-    assert.equal(buildPayload(payloadInput()).schemaVersion, 3);
+    assert.equal(buildPayload(payloadInput()).schemaVersion, 4);
   });
 
   it('identifies the candidate by its branch, its pinned head and its pull request', () => {

--- a/.github/actions/draft-release/__tests__/report.test.ts
+++ b/.github/actions/draft-release/__tests__/report.test.ts
@@ -5,6 +5,7 @@ import {
   BLOCK_END,
   BLOCK_START,
   buildPayload,
+  experimentalVersion,
   extractJsonBlock,
   renderAttentionTable,
   renderBody,
@@ -34,6 +35,9 @@ function payloadInput(overrides: Partial<PayloadInput> = {}): PayloadInput {
       toSha: 'b'.repeat(40),
     },
     integrationCount: 12,
+    branch: 'releases/5.53.0',
+    pullNumber: 27700,
+    pullUrl: 'https://github.com/strapi/strapi/pull/27700',
     classification: {
       features: [
         {
@@ -149,6 +153,49 @@ describe('renderJournalTable', () => {
   });
 });
 
+describe('buildPayload', () => {
+  it('carries the schema version later automation reads', () => {
+    assert.equal(buildPayload(payloadInput()).schemaVersion, 2);
+  });
+
+  it('identifies the candidate by its branch, its pinned head and its pull request', () => {
+    const payload = buildPayload(payloadInput());
+
+    assert.deepEqual(payload.candidate, {
+      branch: 'releases/5.53.0',
+      headSha: 'b'.repeat(40),
+      expectedExperimentalVersion: `0.0.0-experimental.${'b'.repeat(40)}`,
+      pullRequestNumber: 27700,
+      pullRequestUrl: 'https://github.com/strapi/strapi/pull/27700',
+    });
+  });
+
+  it('pins the head to the SHA the range ended at', () => {
+    const payload = buildPayload(payloadInput());
+
+    assert.equal(payload.candidate.headSha, payload.range.toSha);
+  });
+
+  it('reports no pull request on a dry run, and still identifies the candidate', () => {
+    const payload = buildPayload(payloadInput({ dryRun: true, pullNumber: null, pullUrl: null }));
+
+    assert.equal(payload.candidate.pullRequestNumber, null);
+    assert.equal(payload.candidate.pullRequestUrl, null);
+    assert.equal(payload.candidate.branch, 'releases/5.53.0');
+    assert.equal(payload.candidate.headSha, 'b'.repeat(40));
+    assert.equal(
+      payload.candidate.expectedExperimentalVersion,
+      `0.0.0-experimental.${'b'.repeat(40)}`
+    );
+  });
+});
+
+describe('experimentalVersion', () => {
+  it('mirrors the workflow, which versions on the full head SHA', () => {
+    assert.equal(experimentalVersion('b'.repeat(40)), `0.0.0-experimental.${'b'.repeat(40)}`);
+  });
+});
+
 describe('renderBody', () => {
   const payload = buildPayload(payloadInput());
 
@@ -217,6 +264,14 @@ describe('renderBody', () => {
 });
 
 describe('extractJsonBlock', () => {
+  it('round-trips a body carrying the candidate block', () => {
+    const payload = buildPayload(payloadInput());
+    const body = renderBody({ payload, pullRequests: payload.pullRequests, attention: [] });
+
+    assert.deepEqual(extractJsonBlock(body), JSON.parse(JSON.stringify(payload)));
+    assert.match(body, /"expectedExperimentalVersion": "0\.0\.0-experimental\.b{40}"/u);
+  });
+
   it('returns null when the markers are missing', () => {
     assert.equal(extractJsonBlock('just prose'), null);
   });

--- a/.github/actions/draft-release/__tests__/report.test.ts
+++ b/.github/actions/draft-release/__tests__/report.test.ts
@@ -8,6 +8,7 @@ import {
   experimentalVersion,
   extractJsonBlock,
   renderAttentionTable,
+  renderAuthor,
   renderBody,
   renderJournalTable,
   renderMilestoneComment,
@@ -55,7 +56,7 @@ function payloadInput(overrides: Partial<PayloadInput> = {}): PayloadInput {
       {
         number: 27436,
         title: 'feat(content-releases): audit logs',
-        author: 'someone',
+        author: { login: 'someone', name: 'Someone Real' },
         url: 'https://github.com/strapi/strapi/pull/27436',
         baseRef: 'develop',
         headRef: 'feat/audit-logs',
@@ -111,12 +112,36 @@ describe('withoutTrailingReference', () => {
   });
 });
 
+describe('renderAuthor', () => {
+  it('puts the display name in front of the login that identifies it', () => {
+    assert.equal(renderAuthor({ login: 'nclsndr', name: 'Nico André' }), 'Nico André (@nclsndr)');
+  });
+
+  it('falls back to the login alone when no commit vouched for a name', () => {
+    assert.equal(renderAuthor({ login: 'nclsndr', name: null }), '@nclsndr');
+  });
+
+  it('says so rather than rendering an empty mention', () => {
+    assert.equal(renderAuthor({ login: '', name: null }), '_unknown_');
+  });
+
+  it('escapes a pipe so a name cannot break the table', () => {
+    assert.equal(renderAuthor({ login: 'x', name: 'A | B' }), 'A \\| B (@x)');
+  });
+});
+
 describe('renderPullRequestTable', () => {
+  it('names the author with their display name and their login', () => {
+    const table = renderPullRequestTable(payloadInput().pullRequests);
+
+    assert.match(table, /Someone Real \(@someone\)/u);
+  });
+
   it('escapes a pipe so a title cannot break the table', () => {
     const pull = {
       number: 1,
       title: 'fix: a | b',
-      author: 'x',
+      author: { login: 'x', name: null },
       url: 'u',
       baseRef: 'develop',
       headRef: 'fix/x',
@@ -155,7 +180,7 @@ describe('renderJournalTable', () => {
 
 describe('buildPayload', () => {
   it('carries the schema version later automation reads', () => {
-    assert.equal(buildPayload(payloadInput()).schemaVersion, 2);
+    assert.equal(buildPayload(payloadInput()).schemaVersion, 3);
   });
 
   it('identifies the candidate by its branch, its pinned head and its pull request', () => {

--- a/.github/actions/draft-release/__tests__/semver.test.ts
+++ b/.github/actions/draft-release/__tests__/semver.test.ts
@@ -1,0 +1,86 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  compareStable,
+  formatStable,
+  highestStable,
+  increment,
+  nextPatchOf,
+  parseStable,
+} from '../lib/semver.ts';
+
+describe('parseStable', () => {
+  it('parses a stable version', () => {
+    assert.deepEqual(parseStable('5.52.3'), { major: 5, minor: 52, patch: 3 });
+  });
+
+  const rejected = ['5.52', '5.52.3-beta.1', '0.0.0-experimental.abc', 'v5.52.3', '', null, 42];
+
+  for (const value of rejected) {
+    it(`rejects ${JSON.stringify(value)}`, () => {
+      assert.equal(parseStable(value), null);
+    });
+  }
+});
+
+describe('formatStable', () => {
+  it('round-trips a parsed version', () => {
+    assert.equal(formatStable({ major: 5, minor: 52, patch: 3 }), '5.52.3');
+  });
+});
+
+describe('compareStable', () => {
+  it('orders field by field, not lexically', () => {
+    assert.equal(
+      compareStable({ major: 5, minor: 9, patch: 0 }, { major: 5, minor: 10, patch: 0 }),
+      -1
+    );
+    assert.equal(
+      compareStable({ major: 5, minor: 52, patch: 3 }, { major: 5, minor: 52, patch: 3 }),
+      0
+    );
+    assert.equal(
+      compareStable({ major: 6, minor: 0, patch: 0 }, { major: 5, minor: 99, patch: 99 }),
+      1
+    );
+  });
+});
+
+describe('highestStable', () => {
+  it('ignores prereleases', () => {
+    assert.equal(
+      highestStable(['5.52.1', '5.53.0-beta.1', '5.52.3', '0.0.0-experimental.x']),
+      '5.52.3'
+    );
+  });
+
+  it('returns null when nothing published is stable', () => {
+    assert.equal(highestStable(['0.0.0-experimental.x']), null);
+  });
+
+  it('returns null for an empty list', () => {
+    assert.equal(highestStable([]), null);
+  });
+});
+
+describe('increment', () => {
+  it('resets the patch on a minor', () => {
+    assert.equal(increment('5.52.3', 'minor'), '5.53.0');
+  });
+
+  it('keeps the minor on a patch', () => {
+    assert.equal(increment('5.52.3', 'patch'), '5.52.4');
+  });
+
+  it('refuses a non-stable version', () => {
+    assert.throws(() => increment('5.53.0-beta.1', 'patch'), /non-stable/u);
+  });
+});
+
+describe('nextPatchOf', () => {
+  it('names the milestone that collects the following release', () => {
+    assert.equal(nextPatchOf('5.53.0'), '5.53.1');
+    assert.equal(nextPatchOf('5.43.2'), '5.43.3');
+  });
+});

--- a/.github/actions/draft-release/action.yml
+++ b/.github/actions/draft-release/action.yml
@@ -1,0 +1,72 @@
+name: 'Draft release'
+description: 'Pins the release range, computes the version, cuts the release branch, opens the draft PR and reconciles milestones.'
+
+inputs:
+  token:
+    description: 'GitHub App token. The default GITHUB_TOKEN cannot trigger CI on the release PR nor fire the labeled event.'
+    required: true
+  version:
+    description: 'Explicit x.y.z release version. Leave empty to decide it from the commits in the range.'
+    required: false
+    default: ''
+  dry_run:
+    description: 'Compute everything and record the planned writes without performing any of them.'
+    required: false
+    default: 'true'
+  source_ref:
+    description: 'Branch the release is cut from.'
+    required: false
+    default: 'develop'
+
+outputs:
+  version:
+    description: 'The resolved release version.'
+    value: ${{ steps.draft.outputs.version }}
+  bump:
+    description: 'minor or patch.'
+    value: ${{ steps.draft.outputs.bump }}
+  branch:
+    description: 'The release branch name.'
+    value: ${{ steps.draft.outputs.branch }}
+  pr_number:
+    description: 'The draft release pull request number. Empty on a dry run.'
+    value: ${{ steps.draft.outputs.pr_number }}
+  pr_url:
+    description: 'The draft release pull request URL. Empty on a dry run.'
+    value: ${{ steps.draft.outputs.pr_url }}
+  journal_path:
+    description: 'Path to the write journal, present whether the run succeeded or failed.'
+    value: ${{ steps.draft.outputs.journal_path }}
+
+# The TypeScript sources run directly through Node's type stripping. There is no build step and no
+# committed bundle, which is only possible because the action has no runtime dependencies.
+runs:
+  using: 'composite'
+  steps:
+    - name: Check Node supports type stripping
+      shell: bash
+      run: |
+        node -e '
+          const [major, minor] = process.versions.node.split(".").map(Number);
+          if (major < 22 || (major === 22 && minor < 18)) {
+            console.error(
+              "draft-release needs Node >= 22.18 to run TypeScript directly, found " +
+                process.versions.node + ". Add actions/setup-node before this action."
+            );
+            process.exit(1);
+          }
+        '
+
+    - name: Draft the release
+      id: draft
+      shell: bash
+      run: node "$GITHUB_ACTION_PATH/index.ts"
+      env:
+        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        INPUT_SOURCE_REF: ${{ inputs.source_ref }}
+
+branding:
+  icon: 'tag'
+  color: 'blue'

--- a/.github/actions/draft-release/index.ts
+++ b/.github/actions/draft-release/index.ts
@@ -1,0 +1,113 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  appendSummary,
+  createActionsEnv,
+  getBooleanInput,
+  getInput,
+  info,
+  repositoryCoords,
+  setFailed,
+  setOutput,
+  warning,
+} from './lib/actions.ts';
+import { createGithubAdapter } from './lib/github.ts';
+import { createGitAdapter, createGitExec } from './lib/range.ts';
+import { createJournal } from './lib/journal.ts';
+import { renderJournalTable } from './lib/report.ts';
+import { runDraftRelease } from './lib/pipeline.ts';
+
+import type { ActionsEnv } from './lib/actions.ts';
+
+const JOURNAL_FILENAME = 'draft-release-journal.json';
+
+/**
+ * The journal is always written to disk, so a run that dies halfway still says what it did. The
+ * workflow uploads it with `if: always()`.
+ */
+function resolveJournalPath(env: ActionsEnv): string {
+  const directory = env.read('RUNNER_TEMP') ?? env.read('GITHUB_WORKSPACE') ?? process.cwd();
+
+  return join(directory, JOURNAL_FILENAME);
+}
+
+function writeJournal(target: string, payload: unknown): void {
+  writeFileSync(target, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Publishes the step summary without letting it mask the run's own outcome.
+ *
+ * A missing summary file must never turn a precise error into a reporting failure.
+ */
+function publishSummary(env: ActionsEnv, markdown: string): void {
+  if (appendSummary(env, markdown) === false) {
+    warning(env, 'No step summary file is available, so the report was not published.');
+  }
+}
+
+async function main(env: ActionsEnv): Promise<void> {
+  const journalPath = resolveJournalPath(env);
+  const journal = createJournal({ apply: getBooleanInput(env, 'dry_run') === false });
+
+  setOutput(env, 'journal_path', journalPath);
+
+  try {
+    const result = await runDraftRelease({
+      inputs: {
+        version: getInput(env, 'version'),
+        dryRun: getBooleanInput(env, 'dry_run'),
+        sourceRef: getInput(env, 'source_ref') || 'develop',
+      },
+      git: createGitAdapter(createGitExec()),
+      gh: createGithubAdapter(
+        getInput(env, 'token', { required: true }),
+        repositoryCoords(env),
+        (url, init) => fetch(url, init)
+      ),
+      journal,
+      request: (url) => fetch(url, { headers: { accept: 'application/json' } }),
+      logger: { info: (message) => info(env, message) },
+    });
+
+    writeJournal(journalPath, { status: 'succeeded', ...result.journal });
+
+    setOutput(env, 'version', result.version);
+    setOutput(env, 'bump', result.bump);
+    setOutput(env, 'branch', result.branch);
+    setOutput(env, 'pr_number', result.pullNumber === null ? '' : String(result.pullNumber));
+    setOutput(env, 'pr_url', result.pullUrl ?? '');
+
+    result.warnings.forEach((entry) => warning(env, entry));
+
+    publishSummary(env, result.summary);
+  } catch (error) {
+    // The action never rolls back. Persisting what was already written is what makes finishing by
+    // hand mechanical, so the journal is flushed before the failure surfaces.
+    const message = describe(error);
+
+    writeJournal(journalPath, { status: 'failed', error: message, ...journal.toJSON() });
+
+    publishSummary(
+      env,
+      [
+        '# draft-release failed',
+        '',
+        message,
+        '',
+        '## Writes performed before the failure',
+        '',
+        renderJournalTable(journal.entries()),
+      ].join('\n')
+    );
+
+    setFailed(env, message);
+  }
+}
+
+await main(createActionsEnv());

--- a/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
+++ b/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
@@ -1,0 +1,82 @@
+import type { Integration, MilestoneItem, PullCommit, PullPayload } from '../types.ts';
+
+/**
+ * Fixtures modelled on the real `v5.52.3..develop` range, including the cases that proved the
+ * resolver rules: a squash commit with a subject reference, a merge commit with no reference, a
+ * release back-merge, and an indirect association from another base.
+ */
+
+export const SHA = {
+  BACK_MERGE: 'ca560c0d681a696a497cb1a68245b002fd9810bf',
+  DIRECT: 'aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000',
+  MERGE: 'b912880160c178af6171de530e830b3174a2b1d4',
+  RELEASE: 'cccc0000cccc0000cccc0000cccc0000cccc0000',
+  SQUASH: 'e4d1416374000000000000000000000000000000',
+  SQUASH_FEAT: 'ad3782818e000000000000000000000000000000',
+  UNPARSED: 'dddd0000dddd0000dddd0000dddd0000dddd0000',
+} as const;
+
+export function integration(overrides: Partial<Integration> = {}): Integration {
+  return {
+    sha: SHA.SQUASH,
+    parents: ['1111111111111111111111111111111111111111'],
+    author: 'someone',
+    authoredAt: '2026-09-05T10:00:00Z',
+    subject: 'fix(content-type-builder): default new private fields to not searchable (#27482)',
+    body: '',
+    ...overrides,
+  };
+}
+
+export function pull(overrides: Partial<PullPayload> = {}): PullPayload {
+  return {
+    number: 27482,
+    title: 'fix(content-type-builder): default new private fields to not searchable',
+    html_url: 'https://github.com/strapi/strapi/pull/27482',
+    merged_at: '2026-09-05T09:59:00Z',
+    merge_commit_sha: SHA.SQUASH,
+    base: { ref: 'develop' },
+    head: { ref: 'fix/ctb-private-searchable', sha: '2222222222222222222222222222222222222222' },
+    user: { login: 'someone' },
+    milestone: { title: '5.52.4' },
+    ...overrides,
+  };
+}
+
+/** A pull request merged into `main`, only indirectly associated with a develop integration. */
+export function indirectPull(): PullPayload {
+  return pull({
+    number: 27470,
+    title: 'Releases/5.52.2',
+    merge_commit_sha: '9999999999999999999999999999999999999999',
+    base: { ref: 'main' },
+    head: { ref: 'releases/5.52.2', sha: '8888888888888888888888888888888888888888' },
+  });
+}
+
+/** The release back-merge: head is `main`, so its commits already shipped. */
+export function backMergePull(): PullPayload {
+  return pull({
+    number: 27527,
+    title: 'chore: release v5.52.3 update develop',
+    merge_commit_sha: SHA.BACK_MERGE,
+    base: { ref: 'develop' },
+    head: { ref: 'main', sha: '7777777777777777777777777777777777777777' },
+  });
+}
+
+export function pullCommits(messages: readonly string[]): PullCommit[] {
+  return messages.map((message) => ({ commit: { message } }));
+}
+
+export function milestoneItem(overrides: Partial<MilestoneItem> = {}): MilestoneItem {
+  return { number: 100, title: 'Some work', state: 'open', ...overrides };
+}
+
+export function pullRequestItem(
+  number: number,
+  state: string,
+  mergedAt: string | null
+): MilestoneItem {
+  return milestoneItem({ number, state, pull_request: { merged_at: mergedAt } });
+}

--- a/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
+++ b/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
@@ -20,7 +20,8 @@ export function integration(overrides: Partial<Integration> = {}): Integration {
   return {
     sha: SHA.SQUASH,
     parents: ['1111111111111111111111111111111111111111'],
-    author: 'someone',
+    author: 'Someone Real',
+    email: '4242+someone@users.noreply.github.com',
     authoredAt: '2026-09-05T10:00:00Z',
     subject: 'fix(content-type-builder): default new private fields to not searchable (#27482)',
     body: '',

--- a/.github/actions/draft-release/lib/actions.ts
+++ b/.github/actions/draft-release/lib/actions.ts
@@ -1,0 +1,162 @@
+import { appendFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+
+import type { RepositoryCoords } from './types.ts';
+
+/**
+ * The slice of the GitHub Actions runtime protocol this action uses.
+ *
+ * `@actions/core` is not a dependency, because a dependency would force this action to ship a
+ * committed bundle. The protocol itself is a documented, stable contract over environment variables
+ * and workflow commands:
+ * https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+ */
+
+/** Environment access, injected so every function here is testable without touching the process. */
+export type ActionsEnv = {
+  read: (name: string) => string | undefined;
+  append: (path: string, content: string) => void;
+  log: (line: string) => void;
+};
+
+// Coverage skip: the one binding to the real process. Every consumer is tested against a stub env.
+/* node:coverage disable */
+export function createActionsEnv(): ActionsEnv {
+  return {
+    read: (name) => process.env[name],
+    append: (path, content) => appendFileSync(path, content, 'utf8'),
+    log: (line) => process.stdout.write(`${line}\n`),
+  };
+}
+/* node:coverage enable */
+
+/** Turns an input name into the environment variable the runner sets for it. */
+export function inputVariable(name: string): string {
+  return `INPUT_${name.replace(/ /gu, '_').toUpperCase()}`;
+}
+
+/**
+ * Escapes a value for a workflow command.
+ *
+ * An unescaped newline would end the command early and let the rest of the message be interpreted
+ * as workflow output.
+ */
+export function escapeData(value: string): string {
+  return value.replace(/%/gu, '%25').replace(/\r/gu, '%0D').replace(/\n/gu, '%0A');
+}
+
+export function getInput(env: ActionsEnv, name: string, options?: { required?: boolean }): string {
+  const value = (env.read(inputVariable(name)) ?? '').trim();
+
+  if (options?.required === true && value === '') {
+    throw new Error(`Input required and not supplied: ${name}`);
+  }
+
+  return value;
+}
+
+const TRUE_VALUES = new Set(['true', 'True', 'TRUE']);
+const FALSE_VALUES = new Set(['false', 'False', 'FALSE']);
+
+/**
+ * Reads a boolean input under the YAML 1.2 core schema, exactly as the runner does.
+ *
+ * Anything else is rejected rather than coerced: a typo in a workflow must not silently arm a run
+ * that was meant to be a rehearsal.
+ */
+export function getBooleanInput(env: ActionsEnv, name: string): boolean {
+  const value = getInput(env, name, { required: true });
+
+  if (TRUE_VALUES.has(value) === true) {
+    return true;
+  }
+
+  if (FALSE_VALUES.has(value) === true) {
+    return false;
+  }
+
+  throw new Error(
+    `Input does not meet YAML 1.2 "Core Schema" specification: ${name}. ` +
+      'Support boolean input list: `true | True | TRUE | false | False | FALSE`'
+  );
+}
+
+/**
+ * Writes a step output.
+ *
+ * The heredoc form is used for every value, not only multi-line ones, so a value containing `=` or
+ * a newline can never be misread as another output.
+ */
+export function setOutput(
+  env: ActionsEnv,
+  name: string,
+  value: string,
+  newDelimiter: () => string = () => `ghadelimiter_${randomUUID()}`
+): void {
+  const target = env.read('GITHUB_OUTPUT');
+
+  if (target === undefined || target === '') {
+    // Coverage skip: the pre-2022 fallback. Every supported runner sets GITHUB_OUTPUT.
+    /* node:coverage disable */
+    env.log(`::set-output name=${name}::${escapeData(value)}`);
+
+    return;
+    /* node:coverage enable */
+  }
+
+  const delimiter = newDelimiter();
+
+  if (name.includes(delimiter) === true || value.includes(delimiter) === true) {
+    throw new Error(`The output ${name} contains its own delimiter and cannot be written.`);
+  }
+
+  env.append(target, `${name}<<${delimiter}\n${value}\n${delimiter}\n`);
+}
+
+export function info(env: ActionsEnv, message: string): void {
+  env.log(message);
+}
+
+export function warning(env: ActionsEnv, message: string): void {
+  env.log(`::warning::${escapeData(message)}`);
+}
+
+/**
+ * Reports a failure to the runner.
+ *
+ * The exit code is set rather than thrown, so anything already queued for stdout still flushes.
+ */
+export function setFailed(env: ActionsEnv, message: string): void {
+  env.log(`::error::${escapeData(message)}`);
+  process.exitCode = 1;
+}
+
+/**
+ * Appends Markdown to the job summary.
+ *
+ * @returns `false` when the runner exposes no summary file, so the caller can warn instead of
+ * failing a run over a report it could not publish.
+ */
+export function appendSummary(env: ActionsEnv, markdown: string): boolean {
+  const target = env.read('GITHUB_STEP_SUMMARY');
+
+  if (target === undefined || target === '') {
+    return false;
+  }
+
+  env.append(target, `${markdown}\n`);
+
+  return true;
+}
+
+/** Reads the `owner/repo` the workflow is running against. */
+export function repositoryCoords(env: ActionsEnv): RepositoryCoords {
+  const value = env.read('GITHUB_REPOSITORY') ?? '';
+  const [owner, repo] = value.split('/');
+
+  if (owner === undefined || owner === '' || repo === undefined || repo === '') {
+    throw new Error(`GITHUB_REPOSITORY is not an "owner/repo" pair (got "${value}").`);
+  }
+
+  return { owner, repo };
+}

--- a/.github/actions/draft-release/lib/attribution.ts
+++ b/.github/actions/draft-release/lib/attribution.ts
@@ -1,0 +1,308 @@
+import type {
+  AttributedPull,
+  AttributionLookup,
+  AttributionRecord,
+  Integration,
+  PullPayload,
+  PullSummary,
+  RepositoryMergeSettings,
+} from './types.ts';
+
+/**
+ * Resolves each first-parent integration to the pull request that produced it.
+ *
+ * GitHub already stores the authoritative relation, so nothing here guesses. A pull request is
+ * accepted only when it is merged, targets the release base branch, and its `merge_commit_sha` is
+ * the integration commit itself. Similar titles, authors or dates are never enough.
+ */
+
+const TRAILING_REFERENCE = /\(#(\d+)\)\s*$/u;
+const MERGE_REFERENCE = /^Merge pull request #(\d+)\b/u;
+
+const SECOND_PARENT_MISMATCH = 'second-parent-mismatch';
+
+/**
+ * Reads an anchored pull request number out of a commit subject.
+ *
+ * Anchored on purpose: a `#123` mentioned mid-sentence is a cross-reference, not the integration
+ * that produced the commit.
+ */
+export function parseSubjectReference(subject: string): number | null {
+  const trailing = TRAILING_REFERENCE.exec(subject ?? '');
+
+  if (trailing !== null) {
+    return Number(trailing[1]);
+  }
+
+  const merge = MERGE_REFERENCE.exec(subject ?? '');
+
+  if (merge !== null) {
+    return Number(merge[1]);
+  }
+
+  return null;
+}
+
+function isMerged(pull: PullPayload): boolean {
+  return pull.merged_at !== null && pull.merged_at !== undefined;
+}
+
+/**
+ * Selects the pull requests that satisfy the exact rule. Every clause is required.
+ *
+ * `base.ref` alone rejects a pull request merged into `main` and later carried into the release
+ * base by a direct branch merge. `merge_commit_sha` alone rejects a pull request that is merely
+ * associated with the commit.
+ */
+export function selectExactCandidates(
+  integration: Pick<Integration, 'sha'>,
+  pulls: readonly PullPayload[],
+  targetBase: string
+): PullPayload[] {
+  return pulls.filter(
+    (pull) =>
+      isMerged(pull) === true &&
+      pull.base?.ref === targetBase &&
+      pull.merge_commit_sha === integration.sha
+  );
+}
+
+/**
+ * Checks that a two-parent merge has the pull request head as its second parent.
+ *
+ * This is corroborating evidence, not the decision. A merged pull request keeps its last known head
+ * SHA, so a force-push to the branch after the merge can move it. Reporting a warning is therefore
+ * the correct response, not failing the release.
+ *
+ * @returns A warning code, or `null` when nothing is wrong.
+ */
+export function checkSecondParent(
+  integration: Pick<Integration, 'parents'>,
+  pull: PullPayload
+): string | null {
+  const headSha = pull.head?.sha;
+
+  if (integration.parents.length !== 2 || typeof headSha !== 'string') {
+    return null;
+  }
+
+  return integration.parents[1] === headSha ? null : SECOND_PARENT_MISMATCH;
+}
+
+/** Projects the fields the report needs out of a raw pull request payload. */
+export function summarisePull(pull: PullPayload): PullSummary {
+  return {
+    number: pull.number,
+    title: pull.title ?? '',
+    author: pull.user?.login ?? '',
+    url: pull.html_url ?? '',
+    baseRef: pull.base?.ref ?? '',
+    headRef: pull.head?.ref ?? '',
+    milestone: pull.milestone?.title ?? null,
+  };
+}
+
+/** The part of a record the deterministic fallback can decide on its own. */
+type FallbackVerdict = Pick<AttributionRecord, 'status' | 'basis' | 'pull' | 'reason'>;
+
+/**
+ * The one deterministic fallback.
+ *
+ * A subject reference alone proves nothing, so the referenced pull request still has to carry hard
+ * evidence: the same merge SHA, or a head equal to the second parent of a merge commit.
+ */
+async function resolveBySubject(
+  integration: Integration,
+  lookup: AttributionLookup,
+  targetBase: string
+): Promise<FallbackVerdict | null> {
+  const referenced = parseSubjectReference(integration.subject);
+
+  if (referenced === null) {
+    return null;
+  }
+
+  const pull = await lookup.getPull(referenced).catch(() => null);
+
+  if (pull === null || isMerged(pull) === false || pull.base?.ref !== targetBase) {
+    return null;
+  }
+
+  if (pull.merge_commit_sha === integration.sha) {
+    return {
+      status: 'resolved',
+      basis: 'verified-subject',
+      pull: summarisePull(pull),
+      reason: `The subject references #${referenced}, whose merge SHA is this integration.`,
+    };
+  }
+
+  if (integration.parents.length === 2 && integration.parents[1] === pull.head?.sha) {
+    return {
+      status: 'resolved',
+      basis: 'second-parent-head',
+      pull: summarisePull(pull),
+      reason: `The subject references #${referenced}, whose head is the second parent of this merge.`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resolves one integration.
+ *
+ * Never throws for a lookup problem: a failed API call is reported as `lookup-failed` so it can
+ * never be mistaken for a commit pushed straight to the base branch.
+ */
+export async function resolveIntegration(
+  integration: Integration,
+  lookup: AttributionLookup,
+  targetBase: string
+): Promise<AttributionRecord> {
+  const base = {
+    sha: integration.sha,
+    subject: integration.subject,
+    author: integration.author,
+    authoredAt: integration.authoredAt,
+    parents: integration.parents,
+    pull: null,
+    warnings: [],
+  } satisfies Omit<AttributionRecord, 'status' | 'basis' | 'reason'>;
+
+  const pulls = await lookup
+    .listPullsForCommit(integration.sha)
+    .then((found) => ({ ok: true as const, found }))
+    .catch((error: Error) => ({ ok: false as const, error }));
+
+  if (pulls.ok === false) {
+    return {
+      ...base,
+      status: 'lookup-failed',
+      basis: 'none',
+      reason: `The commit-to-pulls lookup failed: ${pulls.error.message}`,
+    };
+  }
+
+  const exact = selectExactCandidates(integration, pulls.found, targetBase);
+  const [first] = exact;
+
+  if (exact.length === 1 && first !== undefined) {
+    const warning = checkSecondParent(integration, first);
+
+    return {
+      ...base,
+      status: 'resolved',
+      basis: 'exact-merge-sha',
+      pull: summarisePull(first),
+      warnings: warning === null ? [] : [warning],
+      reason: 'Merged into the target base with a merge SHA equal to this integration.',
+    };
+  }
+
+  if (exact.length > 1) {
+    return {
+      ...base,
+      status: 'ambiguous',
+      basis: 'none',
+      reason: `${exact.length} merged pull requests claim this integration: ${formatNumbers(exact)}.`,
+    };
+  }
+
+  const fallback = await resolveBySubject(integration, lookup, targetBase);
+
+  if (fallback !== null) {
+    return { ...base, ...fallback };
+  }
+
+  if (pulls.found.length === 0) {
+    return {
+      ...base,
+      status: 'direct-integration',
+      basis: 'none',
+      reason: 'The lookup succeeded and returned no associated pull request.',
+    };
+  }
+
+  return {
+    ...base,
+    status: 'unresolved',
+    basis: 'none',
+    reason:
+      `Associated pull requests exist (${formatNumbers(pulls.found)}) but none is merged into ` +
+      `${targetBase} with this merge SHA.`,
+  };
+}
+
+function formatNumbers(pulls: readonly PullPayload[]): string {
+  return pulls.map((pull) => `#${pull.number}`).join(', ');
+}
+
+/**
+ * Resolves every integration, sequentially.
+ *
+ * A release range is tens of commits, so one request per integration is cheap and keeps the
+ * secondary rate limit comfortable.
+ */
+export async function resolveIntegrations(
+  integrations: readonly Integration[],
+  lookup: AttributionLookup,
+  targetBase: string
+): Promise<AttributionRecord[]> {
+  const records: AttributionRecord[] = [];
+
+  // Sequential on purpose: parallel commit lookups trip GitHub's secondary rate limit.
+  for (const integration of integrations) {
+    records.push(await resolveIntegration(integration, lookup, targetBase));
+  }
+
+  return records;
+}
+
+/**
+ * Collapses records to one entry per pull request while keeping every integration SHA attributed
+ * to it.
+ *
+ * Rebase merges are disabled today, but keeping the provenance list means enabling them later does
+ * not change the data model.
+ */
+export function dedupePullRequests(records: readonly AttributionRecord[]): AttributedPull[] {
+  const byNumber = records.reduce<Map<number, AttributedPull>>((accumulator, record) => {
+    if (record.pull === null) {
+      return accumulator;
+    }
+
+    const existing = accumulator.get(record.pull.number);
+
+    if (existing === undefined) {
+      return accumulator.set(record.pull.number, {
+        ...record.pull,
+        status: record.status,
+        basis: record.basis,
+        integrationShas: [record.sha],
+      });
+    }
+
+    return accumulator.set(record.pull.number, {
+      ...existing,
+      integrationShas: [...existing.integrationShas, record.sha],
+    });
+  }, new Map());
+
+  return [...byNumber.values()];
+}
+
+/**
+ * Version 1 only understands the merge methods Strapi has enabled today.
+ *
+ * Rebase merges would turn one pull request into several first-parent commits with no merge SHA to
+ * match, which this resolver cannot yet group.
+ */
+export function assertSupportedMergeMethods(repository: RepositoryMergeSettings): void {
+  if (repository.allow_rebase_merge === true) {
+    throw new Error(
+      'Rebase merges are enabled on this repository. The attribution resolver cannot group ' +
+        'rebased commits into one pull request. Disable rebase merges or extend the resolver first.'
+    );
+  }
+}

--- a/.github/actions/draft-release/lib/attribution.ts
+++ b/.github/actions/draft-release/lib/attribution.ts
@@ -20,6 +20,7 @@ const TRAILING_REFERENCE = /\(#(\d+)\)\s*$/u;
 const MERGE_REFERENCE = /^Merge pull request #(\d+)\b/u;
 
 const SECOND_PARENT_MISMATCH = 'second-parent-mismatch';
+const NOREPLY_ADDRESS = /^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/iu;
 
 /**
  * Reads an anchored pull request number out of a commit subject.
@@ -89,12 +90,62 @@ export function checkSecondParent(
   return integration.parents[1] === headSha ? null : SECOND_PARENT_MISMATCH;
 }
 
-/** Projects the fields the report needs out of a raw pull request payload. */
-export function summarisePull(pull: PullPayload): PullSummary {
+/**
+ * Reads the login out of a GitHub noreply address.
+ *
+ * Both forms are in the history: `login@users.noreply.github.com` and the numbered
+ * `1234567+login@users.noreply.github.com` GitHub hands out today.
+ *
+ * @returns `null` for any address that is not a noreply one, which says nothing either way.
+ */
+export function parseNoreplyLogin(email: string): string | null {
+  const match = NOREPLY_ADDRESS.exec(email ?? '');
+
+  return match?.[1] ?? null;
+}
+
+/**
+ * The display name for a pull request, when the history can vouch for it.
+ *
+ * A squash commit is authored by the contributor, so its `%an` is the name GitHub itself renders.
+ * Two other cases are refused rather than guessed, because a plausible wrong name is worse than a
+ * missing one:
+ *
+ * - a merge commit is authored by whoever pressed merge, and says nothing about who wrote the work;
+ * - a noreply email naming a different login means the squash took someone else's authorship,
+ *   which happens on a pull request written by several people.
+ *
+ * An address that carries no login, a work address for instance, is not evidence against the name.
+ *
+ * @returns `null` when nothing vouches for a name.
+ */
+export function deriveAuthorName(integration: Integration, login: string): string | null {
+  if (integration.parents.length !== 1 || integration.author === '') {
+    return null;
+  }
+
+  const committed = parseNoreplyLogin(integration.email);
+
+  if (committed !== null && login !== '' && committed.toLowerCase() !== login.toLowerCase()) {
+    return null;
+  }
+
+  return integration.author;
+}
+
+/**
+ * Projects the fields the report needs out of a raw pull request payload.
+ *
+ * The integration is passed in because the payload alone cannot answer who wrote the pull request
+ * by name. See {@link deriveAuthorName}.
+ */
+export function summarisePull(pull: PullPayload, integration: Integration): PullSummary {
+  const login = pull.user?.login ?? '';
+
   return {
     number: pull.number,
     title: pull.title ?? '',
-    author: pull.user?.login ?? '',
+    author: { login, name: deriveAuthorName(integration, login) },
     url: pull.html_url ?? '',
     baseRef: pull.base?.ref ?? '',
     headRef: pull.head?.ref ?? '',
@@ -132,7 +183,7 @@ async function resolveBySubject(
     return {
       status: 'resolved',
       basis: 'verified-subject',
-      pull: summarisePull(pull),
+      pull: summarisePull(pull, integration),
       reason: `The subject references #${referenced}, whose merge SHA is this integration.`,
     };
   }
@@ -141,7 +192,7 @@ async function resolveBySubject(
     return {
       status: 'resolved',
       basis: 'second-parent-head',
-      pull: summarisePull(pull),
+      pull: summarisePull(pull, integration),
       reason: `The subject references #${referenced}, whose head is the second parent of this merge.`,
     };
   }
@@ -194,7 +245,7 @@ export async function resolveIntegration(
       ...base,
       status: 'resolved',
       basis: 'exact-merge-sha',
-      pull: summarisePull(first),
+      pull: summarisePull(first, integration),
       warnings: warning === null ? [] : [warning],
       reason: 'Merged into the target base with a merge SHA equal to this integration.',
     };
@@ -285,6 +336,9 @@ export function dedupePullRequests(records: readonly AttributionRecord[]): Attri
 
     return accumulator.set(record.pull.number, {
       ...existing,
+      // The first integration that could vouch for a name keeps it. A later one that could not is
+      // silent about the author, not a retraction of what an earlier one established.
+      author: existing.author.name === null ? record.pull.author : existing.author,
       integrationShas: [...existing.integrationShas, record.sha],
     });
   }, new Map());

--- a/.github/actions/draft-release/lib/bump.ts
+++ b/.github/actions/draft-release/lib/bump.ts
@@ -144,30 +144,46 @@ async function classifyOne(
   const prNumber = record.pull?.number ?? null;
   const header = parseConventionalSubject(integration.subject);
 
-  if (header !== null) {
-    const breaking = header.breaking === true || hasBreakingFooter(integration.body);
+  // The landing commit's own body is breaking evidence whatever its subject parses to, so it is
+  // read on every path below rather than only the one where the subject happened to parse.
+  //
+  // A squash body is where a breaking footer most often ends up. commitlint validates the commits
+  // inside a pull request, never the squash subject, and GitHub pre-fills the merge box from those
+  // commits, so a subject can read `Feat/new upload flow (#123)` while the body carries the footer
+  // and the inner commits stay `feat:`.
+  const landingBreak = hasBreakingFooter(integration.body)
+    ? vote(integration, prNumber, 'landing-body')
+    : null;
 
+  if (header !== null) {
     return {
       kind: 'classified',
       feature: header.type === FEATURE_TYPE ? vote(integration, prNumber, 'subject') : null,
-      breaking: breaking === true ? vote(integration, prNumber, 'subject') : null,
+      breaking: header.breaking === true ? vote(integration, prNumber, 'subject') : landingBreak,
     };
   }
 
+  // An unparsed subject leaves the type unknown. It is not a reason to drop a breaking marker:
+  // reporting one as `unparsed` would let the range cut a release with a break in it.
   if (prNumber === null) {
-    return {
-      kind: 'unparsed',
-      entry: { sha: integration.sha, pr: null, subject: integration.subject },
-    };
+    return landingBreak === null
+      ? {
+          kind: 'unparsed',
+          entry: { sha: integration.sha, pr: null, subject: integration.subject },
+        }
+      : { kind: 'classified', feature: null, breaking: landingBreak };
   }
 
   const { headers, breaking } = readPullCommitHeaders(await listPullCommits(prNumber));
+  const anyBreak = breaking === true ? vote(integration, prNumber, 'pr-commits') : landingBreak;
 
   if (headers.length === 0) {
-    return {
-      kind: 'unparsed',
-      entry: { sha: integration.sha, pr: prNumber, subject: integration.subject },
-    };
+    return anyBreak === null
+      ? {
+          kind: 'unparsed',
+          entry: { sha: integration.sha, pr: prNumber, subject: integration.subject },
+        }
+      : { kind: 'classified', feature: null, breaking: anyBreak };
   }
 
   return {
@@ -175,7 +191,7 @@ async function classifyOne(
     feature: headers.some((entry) => entry.type === FEATURE_TYPE)
       ? vote(integration, prNumber, 'pr-commits')
       : null,
-    breaking: breaking === true ? vote(integration, prNumber, 'pr-commits') : null,
+    breaking: anyBreak,
   };
 }
 

--- a/.github/actions/draft-release/lib/bump.ts
+++ b/.github/actions/draft-release/lib/bump.ts
@@ -1,0 +1,243 @@
+import type {
+  AttributionRecord,
+  BumpClassification,
+  BumpKind,
+  BumpVote,
+  ConventionalHeader,
+  IgnoreReason,
+  Integration,
+  PullCommit,
+} from './types.ts';
+
+/**
+ * Decides the release increment from what actually landed in the pinned range.
+ *
+ * The rule is deliberately small:
+ *
+ *   any breaking marker -> stop
+ *   any `feat`          -> minor
+ *   otherwise           -> patch
+ *
+ * `enhancement`, `future`, `security`, `fix`, `chore`, `ci`, `docs`, `test` and `revert` never
+ * force a minor.
+ */
+
+const CONVENTIONAL_SUBJECT =
+  /^(?<type>[a-zA-Z][a-zA-Z0-9]*)(?:\((?<scope>[^)]*)\))?(?<breaking>!)?:[ \t]*(?<description>.*)$/u;
+
+const BREAKING_FOOTER = /^BREAKING[ -]CHANGE[ \t]*:/mu;
+
+const BRANCH_MERGE_SUBJECT = /^Merge (?:remote-tracking )?branch '[^']+'(?: into .+)?$/u;
+
+export const FEATURE_TYPE = 'feat';
+
+/** Types whose integration is bookkeeping for a release that already happened. */
+export const IGNORED_TYPES: ReadonlySet<string> = new Set(['release']);
+
+/** Head branches that carry commits which already shipped. */
+export const BACK_MERGE_HEAD_REFS = /^(?:main|releases\/)/u;
+
+/** Parses a conventional commit header. Returns `null` for anything that is not one. */
+export function parseConventionalSubject(subject: string): ConventionalHeader | null {
+  const match = CONVENTIONAL_SUBJECT.exec((subject ?? '').trim());
+
+  if (match === null || match.groups === undefined) {
+    return null;
+  }
+
+  return {
+    type: (match.groups['type'] ?? '').toLowerCase(),
+    scope: match.groups['scope'] ?? null,
+    breaking: match.groups['breaking'] === '!',
+  };
+}
+
+/** Detects an anchored `BREAKING CHANGE:` footer, not a mention of the phrase in prose. */
+export function hasBreakingFooter(body: string): boolean {
+  return BREAKING_FOOTER.test(body ?? '');
+}
+
+/**
+ * Explains why an integration carries no product change of its own.
+ *
+ * Back-merges matter most. `chore: release v5.52.3 update develop` is a pull request whose head is
+ * `main`, and its commits are the previous release's commits. Counting them would let an already
+ * shipped `feat` vote for a second minor.
+ *
+ * @returns `null` when the integration does carry product change.
+ */
+export function ignoreReason(
+  integration: Pick<Integration, 'subject'>,
+  record: Pick<AttributionRecord, 'pull'>
+): IgnoreReason | null {
+  const header = parseConventionalSubject(integration.subject);
+
+  if (header !== null && IGNORED_TYPES.has(header.type) === true) {
+    return 'release-commit';
+  }
+
+  if (record.pull !== null && BACK_MERGE_HEAD_REFS.test(record.pull.headRef) === true) {
+    return 'back-merge';
+  }
+
+  if (record.pull === null && BRANCH_MERGE_SUBJECT.test(integration.subject) === true) {
+    return 'branch-merge';
+  }
+
+  return null;
+}
+
+/**
+ * Reads conventional headers out of the commits inside a pull request.
+ *
+ * This is the correction the rule needs. commitlint runs `--from base.sha --to head.sha`, so it
+ * validates the commits inside a pull request, never the squash subject that lands on the base
+ * branch. Subjects such as `Feat/e2e critical ctb add fields (#26559)` therefore reach the base
+ * branch unparsed, and only the pull request's own commits are gated.
+ */
+export function readPullCommitHeaders(commits: readonly PullCommit[]): {
+  headers: ConventionalHeader[];
+  breaking: boolean;
+} {
+  return (commits ?? []).reduce<{ headers: ConventionalHeader[]; breaking: boolean }>(
+    (accumulator, entry) => {
+      const message = entry?.commit?.message ?? '';
+      const [subject = '', ...rest] = message.split('\n');
+      const header = parseConventionalSubject(subject);
+
+      return {
+        headers: header === null ? accumulator.headers : [...accumulator.headers, header],
+        breaking:
+          accumulator.breaking ||
+          (header !== null && header.breaking === true) ||
+          hasBreakingFooter(rest.join('\n')),
+      };
+    },
+    { headers: [], breaking: false }
+  );
+}
+
+/** What one integration contributes to the bump decision. */
+type IntegrationVerdict =
+  | { kind: 'ignored'; entry: BumpClassification['ignored'][number] }
+  | { kind: 'unparsed'; entry: BumpClassification['unparsed'][number] }
+  | { kind: 'classified'; feature: BumpVote | null; breaking: BumpVote | null };
+
+function vote(integration: Integration, pr: number | null, via: BumpVote['via']): BumpVote {
+  return { sha: integration.sha, pr, subject: integration.subject, via };
+}
+
+async function classifyOne(
+  integration: Integration,
+  record: Pick<AttributionRecord, 'pull'>,
+  listPullCommits: (pullNumber: number) => Promise<PullCommit[]>
+): Promise<IntegrationVerdict> {
+  const skip = ignoreReason(integration, record);
+
+  if (skip !== null) {
+    return {
+      kind: 'ignored',
+      entry: { sha: integration.sha, reason: skip, subject: integration.subject },
+    };
+  }
+
+  const prNumber = record.pull?.number ?? null;
+  const header = parseConventionalSubject(integration.subject);
+
+  if (header !== null) {
+    const breaking = header.breaking === true || hasBreakingFooter(integration.body);
+
+    return {
+      kind: 'classified',
+      feature: header.type === FEATURE_TYPE ? vote(integration, prNumber, 'subject') : null,
+      breaking: breaking === true ? vote(integration, prNumber, 'subject') : null,
+    };
+  }
+
+  if (prNumber === null) {
+    return {
+      kind: 'unparsed',
+      entry: { sha: integration.sha, pr: null, subject: integration.subject },
+    };
+  }
+
+  const { headers, breaking } = readPullCommitHeaders(await listPullCommits(prNumber));
+
+  if (headers.length === 0) {
+    return {
+      kind: 'unparsed',
+      entry: { sha: integration.sha, pr: prNumber, subject: integration.subject },
+    };
+  }
+
+  return {
+    kind: 'classified',
+    feature: headers.some((entry) => entry.type === FEATURE_TYPE)
+      ? vote(integration, prNumber, 'pr-commits')
+      : null,
+    breaking: breaking === true ? vote(integration, prNumber, 'pr-commits') : null,
+  };
+}
+
+function fold(accumulator: BumpClassification, verdict: IntegrationVerdict): BumpClassification {
+  switch (verdict.kind) {
+    case 'ignored':
+      return { ...accumulator, ignored: [...accumulator.ignored, verdict.entry] };
+    case 'unparsed':
+      return { ...accumulator, unparsed: [...accumulator.unparsed, verdict.entry] };
+    case 'classified':
+      return {
+        ...accumulator,
+        features:
+          verdict.feature === null
+            ? accumulator.features
+            : [...accumulator.features, verdict.feature],
+        breaking:
+          verdict.breaking === null
+            ? accumulator.breaking
+            : [...accumulator.breaking, verdict.breaking],
+      };
+    default: {
+      const exhaustive: never = verdict;
+
+      return exhaustive;
+    }
+  }
+}
+
+/** Classifies every integration in the range, keeping the evidence behind each vote. */
+export async function classifyIntegrations(
+  integrations: readonly Integration[],
+  records: readonly Pick<AttributionRecord, 'sha' | 'pull'>[],
+  listPullCommits: (pullNumber: number) => Promise<PullCommit[]>
+): Promise<BumpClassification> {
+  const recordBySha = new Map(records.map((record) => [record.sha, record]));
+  const verdicts: IntegrationVerdict[] = [];
+
+  // Sequential on purpose: the fallback issues one API call per unparsed subject.
+  for (const integration of integrations) {
+    const record = recordBySha.get(integration.sha) ?? { pull: null };
+    verdicts.push(await classifyOne(integration, record, listPullCommits));
+  }
+
+  return verdicts.reduce<BumpClassification>(fold, {
+    features: [],
+    breaking: [],
+    ignored: [],
+    unparsed: [],
+  });
+}
+
+/** Applies the rule. A breaking change is a hard stop, never an automatic major. */
+export function decideBump(classification: BumpClassification): BumpKind {
+  if (classification.breaking.length > 0) {
+    const listed = classification.breaking.map((entry) => entry.sha.slice(0, 8)).join(', ');
+
+    throw new Error(
+      `The range carries a breaking change (${listed}). This action never proposes a major on the ` +
+        'v5 line. Decide the version by hand and pass it with the `version` input.'
+    );
+  }
+
+  return classification.features.length > 0 ? 'minor' : 'patch';
+}

--- a/.github/actions/draft-release/lib/github.ts
+++ b/.github/actions/draft-release/lib/github.ts
@@ -1,0 +1,193 @@
+import type { GithubAdapter, RepositoryCoords } from './types.ts';
+
+/**
+ * The GitHub surface this action needs, over plain `fetch`.
+ *
+ * Octokit is not a dependency, because a dependency would force this action to ship a committed
+ * bundle. What is left is a dozen REST calls and `Link`-header pagination, and every decision still
+ * lives in a pure module: this file only moves bytes.
+ */
+
+const API_ROOT = 'https://api.github.com';
+const API_VERSION = '2022-11-28';
+const PAGE_SIZE = 100;
+
+/** The minimum of the fetch response shape this client reads. */
+export type HttpResponse = {
+  ok: boolean;
+  status: number;
+  headers: { get: (name: string) => string | null };
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+export type HttpRequest = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body?: string }
+) => Promise<HttpResponse>;
+
+/**
+ * Reads the next page URL out of a `Link` header.
+ *
+ * Following the server's own cursor is the only correct way to page the GitHub API: the parameters
+ * it embeds are not always reproducible by incrementing `page`.
+ *
+ * @returns `null` on the last page.
+ */
+export function parseNextLink(header: string | null): string | null {
+  if (header === null || header === '') {
+    return null;
+  }
+
+  const next = header
+    .split(',')
+    .map((part) => /<([^>]+)>\s*;\s*rel="([^"]+)"/u.exec(part.trim()))
+    .find((match) => match !== null && match[2] === 'next');
+
+  return next?.[1] ?? null;
+}
+
+async function describeFailure(response: HttpResponse): Promise<string> {
+  const body = await response.text().catch(() => '');
+
+  try {
+    const parsed: unknown = JSON.parse(body);
+    const message =
+      typeof parsed === 'object' && parsed !== null && 'message' in parsed
+        ? String((parsed as { message: unknown }).message)
+        : body;
+
+    return `${response.status} ${message}`;
+  } catch {
+    return `${response.status} ${body}`;
+  }
+}
+
+/** Builds the authenticated REST client the adapter runs on. */
+export function createRestClient(token: string, request: HttpRequest) {
+  const headers = {
+    accept: 'application/vnd.github+json',
+    authorization: `Bearer ${token}`,
+    'x-github-api-version': API_VERSION,
+    'user-agent': 'strapi-draft-release-action',
+    'content-type': 'application/json',
+  };
+
+  async function call(method: string, url: string, body?: unknown): Promise<HttpResponse> {
+    const response = await request(url.startsWith('http') ? url : `${API_ROOT}${url}`, {
+      method,
+      headers,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+
+    if (response.ok === false) {
+      throw new Error(`GitHub ${method} ${url} failed: ${await describeFailure(response)}`);
+    }
+
+    return response;
+  }
+
+  return {
+    async get<T>(path: string): Promise<T> {
+      return (await (await call('GET', path)).json()) as T;
+    },
+
+    async send<T>(method: 'POST' | 'PATCH', path: string, body: unknown): Promise<T> {
+      return (await (await call(method, path, body)).json()) as T;
+    },
+
+    /** Follows `Link: rel="next"` until the server stops offering one. */
+    async paginate<T>(path: string): Promise<T[]> {
+      const items: T[] = [];
+      let url: string | null = path;
+
+      // Sequential by necessity: each page URL is only known once the previous page returns.
+      while (url !== null) {
+        const response: HttpResponse = await call('GET', url);
+        items.push(...((await response.json()) as T[]));
+        url = parseNextLink(response.headers.get('link'));
+      }
+
+      return items;
+    },
+  };
+}
+
+function query(parameters: Record<string, string>): string {
+  return new URLSearchParams({ ...parameters, per_page: String(PAGE_SIZE) }).toString();
+}
+
+export function createGithubAdapter(
+  token: string,
+  coords: RepositoryCoords,
+  request: HttpRequest
+): GithubAdapter {
+  const rest = createRestClient(token, request);
+  const base = `/repos/${coords.owner}/${coords.repo}`;
+
+  return {
+    coords,
+
+    async getRepository() {
+      return rest.get(base);
+    },
+
+    async listPullsForCommit(sha) {
+      return rest.get(`${base}/commits/${sha}/pulls?${query({})}`);
+    },
+
+    async getPull(pullNumber) {
+      return rest.get(`${base}/pulls/${pullNumber}`);
+    },
+
+    async listPullCommits(pullNumber) {
+      return rest.paginate(`${base}/pulls/${pullNumber}/commits?${query({})}`);
+    },
+
+    /**
+     * Paged on purpose. The repository carries hundreds of closed milestones, and an unpaged read
+     * would report a real milestone as missing.
+     */
+    async listMilestones(state) {
+      return rest.paginate(`${base}/milestones?${query({ state })}`);
+    },
+
+    async createMilestone(title) {
+      return rest.send('POST', `${base}/milestones`, { title });
+    },
+
+    async updateMilestone(milestoneNumber, patch) {
+      return rest.send('PATCH', `${base}/milestones/${milestoneNumber}`, patch);
+    },
+
+    /**
+     * Issues and pull requests carrying a milestone, in any state. The issues endpoint returns
+     * pull requests too, distinguishable by the `pull_request` key.
+     */
+    async listMilestoneItems(milestoneNumber) {
+      return rest.paginate(
+        `${base}/issues?${query({ milestone: String(milestoneNumber), state: 'all' })}`
+      );
+    },
+
+    async setIssueMilestone(issueNumber, milestoneNumber) {
+      await rest.send('PATCH', `${base}/issues/${issueNumber}`, { milestone: milestoneNumber });
+    },
+
+    async createPull(input) {
+      return rest.send('POST', `${base}/pulls`, { ...input, draft: true });
+    },
+
+    async updatePullBody(pullNumber, body) {
+      await rest.send('PATCH', `${base}/pulls/${pullNumber}`, { body });
+    },
+
+    async addLabels(issueNumber, labels) {
+      await rest.send('POST', `${base}/issues/${issueNumber}/labels`, { labels });
+    },
+
+    async createComment(issueNumber, body) {
+      await rest.send('POST', `${base}/issues/${issueNumber}/comments`, { body });
+    },
+  };
+}

--- a/.github/actions/draft-release/lib/journal.ts
+++ b/.github/actions/draft-release/lib/journal.ts
@@ -1,0 +1,49 @@
+import type { Clock, Journal, JournalEntry } from './types.ts';
+
+/**
+ * The write journal.
+ *
+ * This action does not roll back. A run that dies halfway leaves the repository half-changed and a
+ * human finishes or reverts it, which is only acceptable if the run says exactly what it did. Every
+ * mutation is recorded before the next one starts, and the journal is written to the step summary
+ * and uploaded as an artifact even when the run fails.
+ *
+ * A dry run fills the same structure without calling the API, which is the rehearsal: a reviewable,
+ * line-by-line list of every milestone rename, pull request reassignment and ref push the real run
+ * would perform.
+ */
+export function createJournal(options: { apply: boolean; clock?: Clock }): Journal {
+  const clock = options.clock ?? ((): string => new Date().toISOString());
+  const mode = options.apply === true ? 'applied' : 'planned';
+  const entries: JournalEntry[] = [];
+
+  return {
+    mode,
+
+    async write(intent, perform) {
+      entries.push({
+        op: intent.op,
+        target: intent.target,
+        before: intent.before ?? null,
+        after: intent.after ?? null,
+        detail: intent.detail ?? null,
+        at: clock(),
+        applied: options.apply,
+      });
+
+      if (options.apply === false) {
+        return null;
+      }
+
+      return perform();
+    },
+
+    entries() {
+      return entries.slice();
+    },
+
+    toJSON() {
+      return { mode, entries: entries.slice() };
+    },
+  };
+}

--- a/.github/actions/draft-release/lib/milestones.ts
+++ b/.github/actions/draft-release/lib/milestones.ts
@@ -1,0 +1,136 @@
+import { nextPatchOf } from './semver.ts';
+
+import type {
+  AttributedPull,
+  CleanupItem,
+  Milestone,
+  MilestoneItem,
+  MilestonePlan,
+  Reconciliation,
+} from './types.ts';
+
+/**
+ * Plans the milestone moves for a release.
+ *
+ * The repository keeps exactly one open milestone, named after the next release. This action makes
+ * that milestone match what actually landed, opens the one that collects the following release, and
+ * closes the shipping one.
+ *
+ * @param allMilestones - Every milestone in any state, so an already created next milestone is
+ * reused instead of duplicated.
+ */
+export function planMilestones(
+  openMilestones: readonly Milestone[],
+  version: string,
+  allMilestones: readonly Milestone[]
+): MilestonePlan {
+  if (openMilestones.length > 1) {
+    const titles = openMilestones.map((milestone) => milestone.title).join(', ');
+
+    throw new Error(
+      `Expected at most one open milestone, found ${openMilestones.length} (${titles}). ` +
+        'Close the extra ones before drafting a release.'
+    );
+  }
+
+  const nextTitle = nextPatchOf(version);
+  const existingNext = allMilestones.find((milestone) => milestone.title === nextTitle);
+  const [open] = openMilestones;
+
+  const shipping =
+    open === undefined
+      ? { action: 'create' as const, number: null, currentTitle: null, title: version }
+      : {
+          action: open.title === version ? ('keep' as const) : ('rename' as const),
+          number: open.number,
+          currentTitle: open.title,
+          title: version,
+        };
+
+  const next =
+    existingNext === undefined
+      ? { action: 'create' as const, number: null, title: nextTitle }
+      : { action: 'reuse' as const, number: existingNext.number, title: nextTitle };
+
+  return { shipping, next };
+}
+
+function isMerged(item: MilestoneItem): boolean {
+  return item.pull_request?.merged_at !== null && item.pull_request?.merged_at !== undefined;
+}
+
+/**
+ * Plans the cleanup of the milestone that is being closed.
+ *
+ * A closed milestone should describe exactly one thing: the pull requests that shipped in that
+ * release. Everything else moves on or is cleared.
+ */
+export function planCleanup(
+  items: readonly MilestoneItem[],
+  nextMilestoneNumber: number | null
+): CleanupItem[] {
+  return items.map((item) => {
+    const common = { number: item.number, title: item.title ?? '', to: null };
+
+    if (item.pull_request === null || item.pull_request === undefined) {
+      return {
+        ...common,
+        kind: 'issue',
+        action: 'clear',
+        reason: 'Issues are planning artifacts, not shipped work.',
+      };
+    }
+
+    if (isMerged(item) === true) {
+      return {
+        ...common,
+        kind: 'pull',
+        action: 'keep',
+        reason: 'Merged, so it belongs to this release.',
+      };
+    }
+
+    if (item.state === 'open') {
+      return {
+        ...common,
+        kind: 'pull',
+        action: 'move',
+        to: nextMilestoneNumber,
+        reason: 'Still open, so it targets the next release.',
+      };
+    }
+
+    return {
+      ...common,
+      kind: 'pull',
+      action: 'clear',
+      reason: 'Closed without merging, so it shipped nothing.',
+    };
+  });
+}
+
+/**
+ * Compares what history says shipped against what the milestone claims.
+ *
+ * Git history is the authority for what landed. The milestone is intent. Reporting both directions
+ * answers the question people actually ask during a release: did anything slip.
+ */
+export function reconcile(
+  attributed: readonly Pick<AttributedPull, 'number'>[],
+  milestoneItems: readonly MilestoneItem[]
+): Reconciliation {
+  const attributedNumbers = new Set(attributed.map((pull) => pull.number));
+  const milestoneMerged = milestoneItems.filter(isMerged).map((item) => item.number);
+  const milestoneNumbers = new Set(milestoneMerged);
+
+  const ascending = (left: number, right: number): number => left - right;
+
+  return {
+    inHistoryNotInMilestone: [...attributedNumbers]
+      .filter((number) => milestoneNumbers.has(number) === false)
+      .sort(ascending),
+    inMilestoneNotInHistory: milestoneMerged
+      .filter((number) => attributedNumbers.has(number) === false)
+      .sort(ascending),
+  };
+}

--- a/.github/actions/draft-release/lib/npm.ts
+++ b/.github/actions/draft-release/lib/npm.ts
@@ -1,0 +1,87 @@
+import { compareStable, highestStable, parseStable } from './semver.ts';
+
+export const REGISTRY_URL = 'https://registry.npmjs.org';
+export const PACKAGE_NAME = '@strapi/strapi';
+
+/** The narrow read of an npm packument this action depends on. */
+type Packument = {
+  'dist-tags'?: { latest?: unknown } | null;
+  versions?: Record<string, unknown> | null;
+};
+
+function fail(reason: string): never {
+  throw new Error(`Cannot resolve the published ${PACKAGE_NAME} baseline: ${reason}.`);
+}
+
+function isPackument(value: unknown): value is Packument {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Resolves the released baseline from an npm packument.
+ *
+ * The `latest` dist-tag alone is not trusted. A rolled-back or mis-targeted dist-tag would point
+ * the release range at the wrong commit and silently produce a release containing work that already
+ * shipped, so `latest` must also be the highest published stable version.
+ */
+export function resolveLatestVersion(packument: unknown): string {
+  if (isPackument(packument) === false) {
+    return fail('the registry response is not an object');
+  }
+
+  const latest = packument['dist-tags']?.latest;
+  const parsedLatest = parseStable(latest);
+
+  if (parsedLatest === null) {
+    return fail(`the "latest" dist-tag is not a stable version (got ${JSON.stringify(latest)})`);
+  }
+
+  const published = Object.keys(packument.versions ?? {});
+
+  if (published.length === 0) {
+    return fail('the registry response carries no published versions');
+  }
+
+  const highest = highestStable(published);
+  const parsedHighest = highest === null ? null : parseStable(highest);
+
+  if (parsedHighest === null) {
+    return fail('the registry response carries no stable published version');
+  }
+
+  if (compareStable(parsedLatest, parsedHighest) !== 0) {
+    return fail(
+      `the "latest" dist-tag is ${String(latest)} but the highest published stable version is ` +
+        `${highest}. Resolve the dist-tag before drafting a release`
+    );
+  }
+
+  return String(latest).trim();
+}
+
+/** The HTTP surface used to read the registry, so tests never touch the network. */
+export type RegistryRequest = (url: string) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+/**
+ * Reads a packument over plain HTTP.
+ *
+ * The package is public, so no credentials are involved and the workspace does not need to be
+ * installed for this step.
+ */
+export async function fetchPackument(
+  request: RegistryRequest,
+  name: string = PACKAGE_NAME
+): Promise<unknown> {
+  const url = `${REGISTRY_URL}/${name.replace('/', '%2f')}`;
+  const response = await request(url);
+
+  if (response.ok === false) {
+    throw new Error(`The npm registry answered ${response.status} for ${name}.`);
+  }
+
+  return response.json();
+}

--- a/.github/actions/draft-release/lib/npm.ts
+++ b/.github/actions/draft-release/lib/npm.ts
@@ -76,7 +76,11 @@ export async function fetchPackument(
   request: RegistryRequest,
   name: string = PACKAGE_NAME
 ): Promise<unknown> {
-  const url = `${REGISTRY_URL}/${name.replace('/', '%2f')}`;
+  // `encodeURIComponent`, not a substitution of the one separator a scoped name happens to have.
+  // A hand-written substitution encodes the first occurrence only, so any further reserved
+  // character in the name would reach the registry raw and address a different path than this
+  // function was asked for.
+  const url = `${REGISTRY_URL}/${encodeURIComponent(name)}`;
   const response = await request(url);
 
   if (response.ok === false) {

--- a/.github/actions/draft-release/lib/pipeline.ts
+++ b/.github/actions/draft-release/lib/pipeline.ts
@@ -1,0 +1,468 @@
+import {
+  assertSupportedMergeMethods,
+  dedupePullRequests,
+  resolveIntegrations,
+} from './attribution.ts';
+import { classifyIntegrations, decideBump } from './bump.ts';
+import { planCleanup, planMilestones, reconcile } from './milestones.ts';
+import { fetchPackument, resolveLatestVersion } from './npm.ts';
+import { pinRange } from './range.ts';
+import { buildPayload, renderBody, renderMilestoneComment, renderStepSummary } from './report.ts';
+import { compareStable, increment, parseStable } from './semver.ts';
+
+import type { RegistryRequest } from './npm.ts';
+import type {
+  AttentionRecord,
+  AttributionRecord,
+  AttributionStatus,
+  BumpClassification,
+  BumpKind,
+  CleanupItem,
+  Clock,
+  DraftReleaseInputs,
+  GitAdapter,
+  GithubAdapter,
+  Integration,
+  Journal,
+  JournalSnapshot,
+  Logger,
+  MilestonePlan,
+  ReleasePayload,
+  VersionSource,
+} from './types.ts';
+
+export const TARGET_BASE = 'develop';
+export const RELEASE_BASE = 'main';
+export const EXPERIMENTAL_LABEL = 'publish-experimental';
+
+/** Statuses that do not stop the run but do need a human to look. */
+const ATTENTION_STATUSES: ReadonlySet<AttributionStatus> = new Set([
+  'ambiguous',
+  'unresolved',
+  'direct-integration',
+]);
+
+export type DraftReleaseDeps = {
+  inputs: DraftReleaseInputs;
+  git: GitAdapter;
+  gh: GithubAdapter;
+  journal: Journal;
+  request: RegistryRequest;
+  logger: Logger;
+  clock?: Clock;
+};
+
+export type DraftReleaseResult = {
+  branch: string;
+  bump: BumpKind;
+  cleanup: CleanupItem[];
+  journal: JournalSnapshot;
+  payload: ReleasePayload;
+  pullNumber: number | null;
+  pullUrl: string | null;
+  summary: string;
+  version: string;
+  warnings: string[];
+};
+
+/**
+ * Orders the whole run.
+ *
+ * The order matters in two places. The range is pinned before anything else, so a pull request
+ * merged while the action runs falls outside the release however long the run takes. And the
+ * milestone moves happen before the branch and the pull request, so work in flight has somewhere to
+ * go as early as possible: `check-pr-status` fails any pull request targeting `develop` without a
+ * milestone.
+ */
+export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftReleaseResult> {
+  const { inputs, git, gh, journal, request, logger } = deps;
+  const generatedAt = (deps.clock ?? ((): string => new Date().toISOString()))();
+
+  // 0. Pin the range.
+  assertSupportedMergeMethods(await gh.getRepository());
+
+  const previousVersion = resolveLatestVersion(await fetchPackument(request));
+  logger.info(`Published baseline: ${previousVersion}`);
+
+  const pinned = pinRange(git, {
+    baselineVersion: previousVersion,
+    sourceRef: inputs.sourceRef,
+  });
+  logger.info(`Range pinned: ${pinned.fromRef} (${pinned.fromSha}) → ${pinned.toSha}`);
+
+  const integrations = git.listIntegrations(pinned.fromSha, pinned.toSha);
+
+  if (integrations.length === 0) {
+    throw new Error(
+      `Nothing to release: ${pinned.fromRef} and ${pinned.toRef} are the same commit.`
+    );
+  }
+
+  logger.info(`${integrations.length} integrations to attribute`);
+
+  // 1. Attribution.
+  const records = await resolveIntegrations(
+    integrations,
+    { listPullsForCommit: gh.listPullsForCommit, getPull: gh.getPull },
+    TARGET_BASE
+  );
+
+  assertNoFailedLookups(records);
+
+  const attention = toAttentionRecords(records);
+  const warnings = toWarnings(records);
+
+  // 2. Version.
+  const { version, bumpKind, classification, versionSource } = await resolveVersion({
+    inputs,
+    previousVersion,
+    integrations,
+    records,
+    listPullCommits: gh.listPullCommits,
+  });
+
+  logger.info(`Release version: ${version} (${bumpKind}, ${versionSource})`);
+
+  // An integration that carries no product change of its own is not part of the shipping set
+  // either. Listing a release back-merge as a shipping pull request would also report it as
+  // milestone drift, because it never belonged to the milestone.
+  const ignoredShas = new Set(classification.ignored.map((entry) => entry.sha));
+  const pullRequests = dedupePullRequests(
+    records.filter((record) => ignoredShas.has(record.sha) === false)
+  );
+
+  // 3. Milestones.
+  const allMilestones = await gh.listMilestones('all');
+  const openMilestones = allMilestones.filter((milestone) => milestone.state === 'open');
+  const milestonePlan = planMilestones(openMilestones, version, allMilestones);
+
+  const shippingNumber = await applyShippingMilestone(journal, gh, milestonePlan.shipping);
+  const nextNumber = await applyNextMilestone(journal, gh, milestonePlan.next);
+
+  const milestoneItems = shippingNumber === null ? [] : await gh.listMilestoneItems(shippingNumber);
+
+  await journal.write(
+    {
+      op: 'milestone.close',
+      target: `milestone/${shippingNumber ?? '<new>'}`,
+      before: 'open',
+      after: 'closed',
+      detail: milestonePlan.shipping.title,
+    },
+    async () => {
+      if (shippingNumber === null) {
+        return null;
+      }
+
+      return gh.updateMilestone(shippingNumber, { state: 'closed' });
+    }
+  );
+
+  // 4. Branch, pull request, experimental label.
+  const branch = `releases/${version}`;
+
+  if (git.remoteBranchExists(branch) === true) {
+    throw new Error(`The branch ${branch} already exists. Delete it or pick another version.`);
+  }
+
+  await journal.write(
+    {
+      op: 'branch.push',
+      target: `refs/heads/${branch}`,
+      after: pinned.toSha,
+      detail: `cut from ${pinned.toRef}`,
+    },
+    async () => git.pushBranch(pinned.toSha, branch)
+  );
+
+  const title = `[draft] release ${version}`;
+  const createdPull = await journal.write(
+    { op: 'pr.create', target: `${branch} → ${RELEASE_BASE}`, after: title },
+    async () =>
+      gh.createPull({
+        head: branch,
+        base: RELEASE_BASE,
+        title,
+        body: `Release \`${version}\`. The attribution report lands here once the run finishes.`,
+      })
+  );
+
+  const pullNumber = createdPull?.number ?? null;
+
+  await journal.write(
+    { op: 'pr.label', target: pullTarget(pullNumber), after: EXPERIMENTAL_LABEL },
+    async () => {
+      if (pullNumber === null) {
+        return;
+      }
+
+      await gh.addLabels(pullNumber, [EXPERIMENTAL_LABEL]);
+    }
+  );
+
+  // 5. Report.
+  const payload = buildPayload({
+    generatedAt,
+    coords: gh.coords,
+    dryRun: inputs.dryRun,
+    version,
+    bump: bumpKind,
+    previousVersion,
+    versionSource,
+    range: pinned,
+    integrationCount: integrations.length,
+    classification,
+    pullRequests,
+    attention,
+    milestones: {
+      shipping: {
+        number: shippingNumber,
+        title: milestonePlan.shipping.title,
+        renamedFrom:
+          milestonePlan.shipping.action === 'rename' ? milestonePlan.shipping.currentTitle : null,
+        state: 'closed',
+      },
+      next: {
+        number: nextNumber,
+        title: milestonePlan.next.title,
+        created: milestonePlan.next.action === 'create',
+      },
+    },
+    reconciliation: reconcile(pullRequests, milestoneItems),
+  });
+
+  const body = renderBody({ payload, pullRequests, attention, warnings });
+
+  await journal.write({ op: 'pr.body', target: pullTarget(pullNumber), after: title }, async () => {
+    if (pullNumber === null) {
+      return;
+    }
+
+    await gh.updatePullBody(pullNumber, body);
+  });
+
+  // 6. Milestone cleanup and comment.
+  const cleanup = planCleanup(milestoneItems, nextNumber);
+
+  await applyCleanup(journal, gh, cleanup, milestonePlan);
+
+  const comment = renderMilestoneComment({
+    version,
+    nextTitle: milestonePlan.next.title,
+    entries: journal.entries(),
+    dryRun: inputs.dryRun,
+  });
+
+  await journal.write({ op: 'pr.comment', target: pullTarget(pullNumber) }, async () => {
+    if (pullNumber === null) {
+      return;
+    }
+
+    await gh.createComment(pullNumber, comment);
+  });
+
+  return {
+    branch,
+    bump: bumpKind,
+    cleanup,
+    journal: journal.toJSON(),
+    payload,
+    pullNumber,
+    pullUrl: createdPull?.html_url ?? null,
+    summary: renderStepSummary({ payload, entries: journal.entries() }),
+    version,
+    warnings,
+  };
+}
+
+function pullTarget(pullNumber: number | null): string {
+  return pullNumber === null ? 'pulls/<new>' : `pulls/${pullNumber}`;
+}
+
+/** A failed API call must never be reported as a commit pushed straight to the base branch. */
+function assertNoFailedLookups(records: readonly AttributionRecord[]): void {
+  const failed = records.filter((record) => record.status === 'lookup-failed');
+
+  if (failed.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `${failed.length} commit-to-pulls lookups failed ` +
+      `(${failed.map((record) => record.sha.slice(0, 8)).join(', ')}). ` +
+      'A failed lookup must never be reported as a direct commit. Re-run the action.'
+  );
+}
+
+function toAttentionRecords(records: readonly AttributionRecord[]): AttentionRecord[] {
+  return records
+    .filter((record) => ATTENTION_STATUSES.has(record.status) === true)
+    .map((record) => ({
+      sha: record.sha,
+      subject: record.subject,
+      status: record.status,
+      reason: record.reason,
+    }));
+}
+
+function toWarnings(records: readonly AttributionRecord[]): string[] {
+  return records.flatMap((record) =>
+    record.warnings.length === 0 || record.pull === null
+      ? []
+      : [
+          `\`${record.sha.slice(0, 8)}\` resolved to #${record.pull.number} but its head is not ` +
+            `the second parent (${record.warnings.join(', ')}).`,
+        ]
+  );
+}
+
+type VersionDecision = {
+  version: string;
+  bumpKind: BumpKind;
+  classification: BumpClassification;
+  versionSource: VersionSource;
+};
+
+/**
+ * Decides the release version.
+ *
+ * The explicit `version` input bypasses the commit rule. Everything else is decided from what
+ * landed in the range. The classification is computed either way, because the report carries the
+ * evidence even when a human overrode the answer.
+ */
+export async function resolveVersion(input: {
+  inputs: Pick<DraftReleaseInputs, 'version'>;
+  previousVersion: string;
+  integrations: readonly Integration[];
+  records: readonly AttributionRecord[];
+  listPullCommits: GithubAdapter['listPullCommits'];
+}): Promise<VersionDecision> {
+  const classification = await classifyIntegrations(
+    input.integrations,
+    input.records,
+    input.listPullCommits
+  );
+
+  const previous = parseStable(input.previousVersion);
+
+  if (previous === null) {
+    throw new Error(`The published baseline "${input.previousVersion}" is not a stable version.`);
+  }
+
+  if (input.inputs.version !== '') {
+    const parsed = parseStable(input.inputs.version);
+
+    if (parsed === null) {
+      throw new Error(`The version input "${input.inputs.version}" is not a stable x.y.z version.`);
+    }
+
+    if (compareStable(parsed, previous) !== 1) {
+      throw new Error(
+        `The version input ${input.inputs.version} is not greater than the published baseline ` +
+          `${input.previousVersion}.`
+      );
+    }
+
+    return {
+      version: input.inputs.version,
+      bumpKind: parsed.minor === previous.minor ? 'patch' : 'minor',
+      classification,
+      versionSource: 'version-input',
+    };
+  }
+
+  const bumpKind = decideBump(classification);
+
+  return {
+    version: increment(input.previousVersion, bumpKind),
+    bumpKind,
+    classification,
+    versionSource: 'computed',
+  };
+}
+
+/** @returns The shipping milestone number, or `null` on a dry run that would have created it. */
+async function applyShippingMilestone(
+  journal: Journal,
+  gh: GithubAdapter,
+  plan: MilestonePlan['shipping']
+): Promise<number | null> {
+  if (plan.action === 'keep') {
+    return plan.number;
+  }
+
+  if (plan.action === 'rename') {
+    await journal.write(
+      {
+        op: 'milestone.rename',
+        target: `milestone/${plan.number ?? '<new>'}`,
+        before: plan.currentTitle,
+        after: plan.title,
+      },
+      async () => {
+        if (plan.number === null) {
+          return null;
+        }
+
+        return gh.updateMilestone(plan.number, { title: plan.title });
+      }
+    );
+
+    return plan.number;
+  }
+
+  const created = await journal.write(
+    { op: 'milestone.create', target: 'milestones', after: plan.title, detail: 'shipping' },
+    async () => gh.createMilestone(plan.title)
+  );
+
+  return created?.number ?? null;
+}
+
+/** @returns The next milestone number, or `null` on a dry run that would have created it. */
+async function applyNextMilestone(
+  journal: Journal,
+  gh: GithubAdapter,
+  plan: MilestonePlan['next']
+): Promise<number | null> {
+  if (plan.action === 'reuse') {
+    return plan.number;
+  }
+
+  const created = await journal.write(
+    { op: 'milestone.create', target: 'milestones', after: plan.title, detail: 'next' },
+    async () => gh.createMilestone(plan.title)
+  );
+
+  return created?.number ?? null;
+}
+
+async function applyCleanup(
+  journal: Journal,
+  gh: GithubAdapter,
+  cleanup: readonly CleanupItem[],
+  milestonePlan: MilestonePlan
+): Promise<void> {
+  // Sequential on purpose: a release milestone carries dozens of items and GitHub throttles
+  // parallel issue writes.
+  for (const item of cleanup) {
+    if (item.action === 'keep') {
+      continue;
+    }
+
+    const moving = item.action === 'move';
+
+    await journal.write(
+      {
+        op: moving === true ? 'issue.milestone.set' : 'issue.milestone.clear',
+        target: `issues/${item.number}`,
+        before: milestonePlan.shipping.title,
+        after: moving === true ? milestonePlan.next.title : null,
+        detail: item.reason,
+      },
+      async () => {
+        await gh.setIssueMilestone(item.number, moving === true ? item.to : null);
+      }
+    );
+  }
+}

--- a/.github/actions/draft-release/lib/pipeline.ts
+++ b/.github/actions/draft-release/lib/pipeline.ts
@@ -189,6 +189,7 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
   );
 
   const pullNumber = createdPull?.number ?? null;
+  const pullUrl = createdPull?.html_url ?? null;
 
   await journal.write(
     { op: 'pr.label', target: pullTarget(pullNumber), after: EXPERIMENTAL_LABEL },
@@ -212,6 +213,9 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
     versionSource,
     range: pinned,
     integrationCount: integrations.length,
+    branch,
+    pullNumber,
+    pullUrl,
     classification,
     pullRequests,
     attention,
@@ -269,7 +273,7 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
     journal: journal.toJSON(),
     payload,
     pullNumber,
-    pullUrl: createdPull?.html_url ?? null,
+    pullUrl,
     summary: renderStepSummary({ payload, entries: journal.entries() }),
     version,
     warnings,

--- a/.github/actions/draft-release/lib/pipeline.ts
+++ b/.github/actions/draft-release/lib/pipeline.ts
@@ -33,6 +33,7 @@ import type {
 
 export const TARGET_BASE = 'develop';
 export const RELEASE_BASE = 'main';
+export const RELEASE_BRANCH_NAME = 'releases';
 export const EXPERIMENTAL_LABEL = 'publish-experimental';
 
 /** Statuses that do not stop the run but do need a human to look. */
@@ -159,7 +160,7 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
   );
 
   // 4. Branch, pull request, experimental label.
-  const branch = `releases/${version}`;
+  const branch = `${RELEASE_BRANCH_NAME}/${version}`;
 
   if (git.remoteBranchExists(branch) === true) {
     throw new Error(`The branch ${branch} already exists. Delete it or pick another version.`);
@@ -175,7 +176,7 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
     async () => git.pushBranch(pinned.toSha, branch)
   );
 
-  const title = `[draft] release ${version}`;
+  const title = `Release ${version}`;
   const createdPull = await journal.write(
     { op: 'pr.create', target: `${branch} → ${RELEASE_BASE}`, after: title },
     async () =>

--- a/.github/actions/draft-release/lib/range.ts
+++ b/.github/actions/draft-release/lib/range.ts
@@ -6,9 +6,9 @@ export const RECORD_SEPARATOR = '\x1e';
 export const FIELD_SEPARATOR = '\x1f';
 
 /** `%x1f` and `%x1e` make git emit the separators, so no control byte is embedded in this source. */
-export const LOG_FORMAT = ['%H', '%P', '%an', '%aI', '%s', '%b'].join('%x1f') + '%x1e';
+export const LOG_FORMAT = ['%H', '%P', '%an', '%ae', '%aI', '%s', '%b'].join('%x1f') + '%x1e';
 
-const BODY_FIELD_INDEX = 5;
+const BODY_FIELD_INDEX = 6;
 
 /**
  * Parses the first-parent log into integration records.
@@ -28,8 +28,9 @@ export function parseFirstParentLog(stdout: string): Integration[] {
         sha: fields[0] ?? '',
         parents: (fields[1] ?? '').split(' ').filter((parent) => parent !== ''),
         author: fields[2] ?? '',
-        authoredAt: fields[3] ?? '',
-        subject: fields[4] ?? '',
+        email: fields[3] ?? '',
+        authoredAt: fields[4] ?? '',
+        subject: fields[5] ?? '',
         body: fields.slice(BODY_FIELD_INDEX).join(FIELD_SEPARATOR).trim(),
       };
     });

--- a/.github/actions/draft-release/lib/range.ts
+++ b/.github/actions/draft-release/lib/range.ts
@@ -1,0 +1,165 @@
+import { execFileSync } from 'node:child_process';
+
+import type { GitAdapter, GitExec, Integration, PinnedRange } from './types.ts';
+
+export const RECORD_SEPARATOR = '\x1e';
+export const FIELD_SEPARATOR = '\x1f';
+
+/** `%x1f` and `%x1e` make git emit the separators, so no control byte is embedded in this source. */
+export const LOG_FORMAT = ['%H', '%P', '%an', '%aI', '%s', '%b'].join('%x1f') + '%x1e';
+
+const BODY_FIELD_INDEX = 5;
+
+/**
+ * Parses the first-parent log into integration records.
+ *
+ * The body is the last field on purpose: it is the only field that can contain newlines, so
+ * everything before it stays unambiguous.
+ */
+export function parseFirstParentLog(stdout: string): Integration[] {
+  return stdout
+    .split(RECORD_SEPARATOR)
+    .map((chunk) => chunk.replace(/^[\r\n]+/u, ''))
+    .filter((chunk) => chunk.trim() !== '')
+    .map((chunk) => {
+      const fields = chunk.split(FIELD_SEPARATOR);
+
+      return {
+        sha: fields[0] ?? '',
+        parents: (fields[1] ?? '').split(' ').filter((parent) => parent !== ''),
+        author: fields[2] ?? '',
+        authoredAt: fields[3] ?? '',
+        subject: fields[4] ?? '',
+        body: fields.slice(BODY_FIELD_INDEX).join(FIELD_SEPARATOR).trim(),
+      };
+    });
+}
+
+/**
+ * Builds the real process surface.
+ *
+ * It reports a failure rather than throwing, so each adapter method decides for itself what a
+ * non-zero exit means.
+ */
+// Coverage skip: thin `execFileSync` passthrough. Every consumer is tested against a stub GitExec.
+/* node:coverage disable */
+export function createGitExec(cwd: string = process.cwd()): GitExec {
+  return (args) => {
+    try {
+      const stdout = execFileSync('git', args, {
+        cwd,
+        encoding: 'utf8',
+        maxBuffer: 64 * 1024 * 1024,
+      });
+
+      return { status: 0, stdout, stderr: '' };
+    } catch (error) {
+      const failure = error as {
+        status?: number;
+        stdout?: string;
+        stderr?: string;
+        message?: string;
+      };
+
+      return {
+        status: typeof failure.status === 'number' ? failure.status : 1,
+        stdout: failure.stdout ?? '',
+        stderr: failure.stderr ?? String(failure.message ?? error),
+      };
+    }
+  };
+}
+/* node:coverage enable */
+
+/** Wraps a process surface into the Git operations this action performs. */
+export function createGitAdapter(exec: GitExec): GitAdapter {
+  function run(args: string[]): string {
+    const result = exec(args);
+
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${result.stderr.trim()}`);
+    }
+
+    return result.stdout;
+  }
+
+  return {
+    resolveSha(ref) {
+      return run(['rev-parse', '--verify', `${ref}^{commit}`]).trim();
+    },
+
+    refExists(ref) {
+      return exec(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`]).status === 0;
+    },
+
+    isAncestor(ancestor, descendant) {
+      return exec(['merge-base', '--is-ancestor', ancestor, descendant]).status === 0;
+    },
+
+    /**
+     * Enumerates one record per integration, oldest first.
+     *
+     * First-parent traversal turns a merged pull request into a single record instead of every
+     * commit on its side branch. Walking locally also avoids the 250-commit truncation of the
+     * GitHub compare endpoint.
+     */
+    listIntegrations(fromSha, toSha) {
+      return parseFirstParentLog(
+        run([
+          'log',
+          '--first-parent',
+          '--reverse',
+          `--format=${LOG_FORMAT}`,
+          `${fromSha}..${toSha}`,
+        ])
+      );
+    },
+
+    pushBranch(sha, branch) {
+      run(['push', 'origin', `${sha}:refs/heads/${branch}`]);
+    },
+
+    remoteBranchExists(branch) {
+      const result = exec(['ls-remote', '--exit-code', '--heads', 'origin', branch]);
+
+      return result.status === 0 && result.stdout.trim() !== '';
+    },
+  };
+}
+
+/**
+ * Pins the release range once, so every later step reads SHAs instead of moving branch names.
+ *
+ * A pull request merged into the source branch while the action runs falls outside this range, and
+ * therefore outside the release, however long the run takes.
+ */
+export function pinRange(
+  git: GitAdapter,
+  options: { baselineVersion: string; sourceRef: string }
+): PinnedRange {
+  const fromRef = `v${options.baselineVersion}`;
+
+  if (git.refExists(fromRef) === false) {
+    throw new Error(
+      `The baseline tag ${fromRef} is missing. Check out with fetch-depth: 0 so tags are available.`
+    );
+  }
+
+  const fromSha = git.resolveSha(fromRef);
+  const toRef = `origin/${options.sourceRef}`;
+
+  if (git.refExists(toRef) === false) {
+    throw new Error(`The source ref ${toRef} does not exist.`);
+  }
+
+  const toSha = git.resolveSha(toRef);
+
+  if (git.isAncestor(fromSha, toSha) === false) {
+    throw new Error(
+      `${fromRef} (${fromSha}) is not an ancestor of ${toRef} (${toSha}). ` +
+        'The range is not a fast-forward.'
+    );
+  }
+
+  return { fromRef, fromSha, toRef, toSha };
+}

--- a/.github/actions/draft-release/lib/report.ts
+++ b/.github/actions/draft-release/lib/report.ts
@@ -1,0 +1,311 @@
+import type {
+  AttentionRecord,
+  AttributedPull,
+  BumpClassification,
+  BumpKind,
+  JournalEntry,
+  PinnedRange,
+  ReleasePayload,
+  Reconciliation,
+  RepositoryCoords,
+  VersionSource,
+} from './types.ts';
+
+export const SCHEMA_VERSION = 1;
+export const BLOCK_START = '<!-- STRAPI_RELEASE_CANDIDATE_START -->';
+export const BLOCK_END = '<!-- STRAPI_RELEASE_CANDIDATE_END -->';
+
+const SHORT_SHA_LENGTH = 8;
+
+/** Escapes the characters that would break out of a Markdown table cell. */
+function cell(value: unknown): string {
+  return String(value ?? '')
+    .replace(/\|/gu, '\\|')
+    .replace(/[\r\n]+/gu, ' ')
+    .trim();
+}
+
+function short(sha: string): string {
+  return sha.slice(0, SHORT_SHA_LENGTH);
+}
+
+/**
+ * Drops a trailing `(#N)` so a rendered reference is never printed twice.
+ *
+ * Some squash subjects on `develop` already carry the reference, and a few carry it twice.
+ */
+export function withoutTrailingReference(subject: string): string {
+  return String(subject ?? '')
+    .replace(/(?:\s*\(#\d+\))+\s*$/u, '')
+    .trim();
+}
+
+function table(header: readonly string[], rows: readonly string[]): string {
+  return [`| ${header.join(' | ')} |`, `| ${header.map(() => '---').join(' | ')} |`, ...rows].join(
+    '\n'
+  );
+}
+
+/** The shipping table, one row per attributed pull request. */
+export function renderPullRequestTable(pullRequests: readonly AttributedPull[]): string {
+  if (pullRequests.length === 0) {
+    return '_No pull request resolved in this range._';
+  }
+
+  return table(
+    ['PR', 'Title', 'Author', 'Milestone', 'Basis'],
+    pullRequests.map(
+      (pull) =>
+        `| [#${pull.number}](${pull.url}) | ${cell(pull.title)} | @${cell(pull.author)} | ` +
+        `${cell(pull.milestone ?? '—')} | ${cell(pull.basis)} |`
+    )
+  );
+}
+
+/** The records a human still has to settle. Empty when everything resolved. */
+export function renderAttentionTable(records: readonly AttentionRecord[]): string {
+  if (records.length === 0) {
+    return '';
+  }
+
+  return [
+    '### Needs a human',
+    '',
+    table(
+      ['Commit', 'Subject', 'Status', 'Why'],
+      records.map(
+        (record) =>
+          `| \`${short(record.sha)}\` | ${cell(record.subject)} | ${record.status} | ` +
+          `${cell(record.reason)} |`
+      )
+    ),
+  ].join('\n');
+}
+
+/** Every mutation, planned or applied, as a table. */
+export function renderJournalTable(entries: readonly JournalEntry[]): string {
+  if (entries.length === 0) {
+    return '_No write recorded._';
+  }
+
+  return table(
+    ['Operation', 'Target', 'Before', 'After'],
+    entries.map(
+      (entry) =>
+        `| ${entry.op} | ${cell(entry.target)} | ${cell(entry.before ?? '—')} | ` +
+        `${cell(entry.after ?? '—')} |`
+    )
+  );
+}
+
+export type PayloadInput = {
+  generatedAt: string;
+  coords: RepositoryCoords;
+  dryRun: boolean;
+  version: string;
+  bump: BumpKind;
+  previousVersion: string;
+  versionSource: VersionSource;
+  range: PinnedRange;
+  integrationCount: number;
+  classification: BumpClassification;
+  pullRequests: AttributedPull[];
+  attention: AttentionRecord[];
+  milestones: ReleasePayload['milestones'];
+  reconciliation: Reconciliation;
+};
+
+/** Builds the machine-readable payload embedded in the pull request body. */
+export function buildPayload(input: PayloadInput): ReleasePayload {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: input.generatedAt,
+    repository: `${input.coords.owner}/${input.coords.repo}`,
+    dryRun: input.dryRun,
+    release: {
+      version: input.version,
+      bump: input.bump,
+      previousVersion: input.previousVersion,
+      source: input.versionSource,
+    },
+    range: { ...input.range, integrationCount: input.integrationCount },
+    bumpEvidence: {
+      featureIntegrations: input.classification.features,
+      breakingIntegrations: input.classification.breaking,
+      ignored: input.classification.ignored,
+      unparsed: input.classification.unparsed,
+    },
+    pullRequests: input.pullRequests,
+    attention: input.attention,
+    milestones: input.milestones,
+    reconciliation: input.reconciliation,
+  };
+}
+
+/** Wraps the payload in the markers later automation reads. */
+export function renderJsonBlock(payload: ReleasePayload): string {
+  return [BLOCK_START, '```json', JSON.stringify(payload, null, 2), '```', BLOCK_END].join('\n');
+}
+
+/**
+ * Reads a payload back out of a pull request body.
+ *
+ * The markers exist so later automation does not have to parse prose.
+ *
+ * @returns `null` when the markers are absent or the block is not valid JSON.
+ */
+export function extractJsonBlock(body: string): unknown {
+  const start = body.indexOf(BLOCK_START);
+  const end = body.indexOf(BLOCK_END);
+
+  if (start === -1 || end === -1 || end < start) {
+    return null;
+  }
+
+  const inner = body.slice(start + BLOCK_START.length, end);
+  const fenced = /```json\s*([\s\S]*?)```/u.exec(inner);
+
+  if (fenced === null) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fenced[1] ?? '');
+  } catch {
+    return null;
+  }
+}
+
+function formatNumbers(numbers: readonly number[]): string {
+  return numbers.length === 0 ? '_none_' : numbers.map((number) => `#${number}`).join(', ');
+}
+
+export type BodyInput = {
+  payload: ReleasePayload;
+  pullRequests: readonly AttributedPull[];
+  attention: readonly AttentionRecord[];
+  warnings?: readonly string[];
+};
+
+/** The pull request body: a human summary, the shipping table, then the machine-readable block. */
+export function renderBody(input: BodyInput): string {
+  const { payload, pullRequests, attention } = input;
+  const warnings = input.warnings ?? [];
+  const decidedBy =
+    payload.release.source === 'computed' ? 'the commits in the range' : 'the `version` input';
+
+  const summary = [
+    `# Release ${payload.release.version}`,
+    '',
+    `\`${payload.release.previousVersion}\` → \`${payload.release.version}\` ` +
+      `(**${payload.release.bump}**, decided from ${decidedBy}).`,
+    '',
+    table(
+      ['', ''],
+      [
+        `| **Range** | \`${payload.range.fromRef}\` → \`${payload.range.toRef}\` |`,
+        `| **From** | \`${payload.range.fromSha}\` |`,
+        `| **To** | \`${payload.range.toSha}\` |`,
+        `| **Integrations** | ${payload.range.integrationCount} |`,
+        `| **Pull requests** | ${pullRequests.length} |`,
+        `| **Milestone** | ${payload.milestones.shipping.title} (closed) → ` +
+          `${payload.milestones.next.title} |`,
+      ]
+    ),
+    '',
+    '## Shipping pull requests',
+    '',
+    renderPullRequestTable(pullRequests),
+  ];
+
+  const evidence =
+    payload.bumpEvidence.featureIntegrations.length === 0
+      ? []
+      : [
+          '',
+          '## Why this is a minor',
+          '',
+          ...payload.bumpEvidence.featureIntegrations.map(
+            (entry) =>
+              `- \`${short(entry.sha)}\` ${cell(withoutTrailingReference(entry.subject))}` +
+              `${entry.pr === null ? '' : ` (#${entry.pr})`} — via ${entry.via}`
+          ),
+        ];
+
+  const { inHistoryNotInMilestone, inMilestoneNotInHistory } = payload.reconciliation;
+  const drift =
+    inHistoryNotInMilestone.length === 0 && inMilestoneNotInHistory.length === 0
+      ? []
+      : [
+          '',
+          '## Milestone reconciliation',
+          '',
+          `- In history, not in the milestone: ${formatNumbers(inHistoryNotInMilestone)}`,
+          `- Merged in the milestone, not in this range: ${formatNumbers(inMilestoneNotInHistory)}`,
+        ];
+
+  const needsHuman = attention.length === 0 ? [] : ['', renderAttentionTable(attention)];
+  const warned =
+    warnings.length === 0
+      ? []
+      : ['', '### Warnings', '', ...warnings.map((warning) => `- ${warning}`)];
+
+  return [
+    ...summary,
+    ...evidence,
+    ...drift,
+    ...needsHuman,
+    ...warned,
+    '',
+    renderJsonBlock(payload),
+    '',
+  ].join('\n');
+}
+
+/** The single comment posted on the release pull request after the milestone work. */
+export function renderMilestoneComment(input: {
+  version: string;
+  nextTitle: string;
+  entries: readonly JournalEntry[];
+  dryRun: boolean;
+}): string {
+  const milestoneEntries = input.entries.filter(
+    (entry) => entry.op.startsWith('milestone.') === true || entry.op.startsWith('issue.') === true
+  );
+
+  return [
+    `## Milestone reconciliation for ${input.version}`,
+    '',
+    input.dryRun === true
+      ? `Dry run. Nothing below was applied. Work now collects in \`${input.nextTitle}\`.`
+      : `\`${input.version}\` is closed. Work now collects in \`${input.nextTitle}\`.`,
+    '',
+    renderJournalTable(milestoneEntries),
+  ].join('\n');
+}
+
+/** The Actions step summary, which is the whole report when the run is a dry run. */
+export function renderStepSummary(input: {
+  payload: ReleasePayload;
+  entries: readonly JournalEntry[];
+}): string {
+  const { payload, entries } = input;
+  const mode = payload.dryRun === true ? 'Dry run' : 'Applied';
+  const heading = payload.dryRun === true ? 'Planned' : 'Applied';
+
+  return [
+    `# draft-release — ${payload.release.version} (${payload.release.bump})`,
+    '',
+    `${mode}. Baseline \`${payload.release.previousVersion}\`, range \`${payload.range.fromRef}\` → ` +
+      `\`${short(payload.range.toSha)}\`, ${payload.range.integrationCount} integrations, ` +
+      `${payload.pullRequests.length} pull requests.`,
+    '',
+    `## ${heading} writes`,
+    '',
+    renderJournalTable(entries),
+    '',
+    '## Shipping pull requests',
+    '',
+    renderPullRequestTable(payload.pullRequests),
+  ].join('\n');
+}

--- a/.github/actions/draft-release/lib/report.ts
+++ b/.github/actions/draft-release/lib/report.ts
@@ -28,9 +28,16 @@ export function experimentalVersion(headSha: string): string {
   return `0.0.0-experimental.${headSha}`;
 }
 
-/** Escapes the characters that would break out of a Markdown table cell. */
+/**
+ * Escapes the characters that would break out of a Markdown table cell.
+ *
+ * Backslashes go first, because the backslash is the escape character. Escaping the pipe of `a\|b`
+ * without them yields `a\\|b`, which renders as a literal backslash followed by an unescaped pipe,
+ * and the cell the value was meant to sit inside ends early.
+ */
 function cell(value: unknown): string {
   return String(value ?? '')
+    .replace(/\\/gu, '\\\\')
     .replace(/\|/gu, '\\|')
     .replace(/[\r\n]+/gu, ' ')
     .trim();

--- a/.github/actions/draft-release/lib/report.ts
+++ b/.github/actions/draft-release/lib/report.ts
@@ -1,6 +1,7 @@
 import type {
   AttentionRecord,
   AttributedPull,
+  Author,
   BumpClassification,
   BumpKind,
   JournalEntry,
@@ -11,7 +12,7 @@ import type {
   VersionSource,
 } from './types.ts';
 
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 export const BLOCK_START = '<!-- STRAPI_RELEASE_CANDIDATE_START -->';
 export const BLOCK_END = '<!-- STRAPI_RELEASE_CANDIDATE_END -->';
 
@@ -56,6 +57,18 @@ function table(header: readonly string[], rows: readonly string[]): string {
   );
 }
 
+/**
+ * An author, as one table cell.
+ *
+ * The login is the identity and is always rendered; the display name is only ever added in front of
+ * it, so a row stays readable and linkable when git could not vouch for a name.
+ */
+export function renderAuthor(author: Author): string {
+  const login = author.login === '' ? '_unknown_' : `@${cell(author.login)}`;
+
+  return author.name === null ? login : `${cell(author.name)} (${login})`;
+}
+
 /** The shipping table, one row per attributed pull request. */
 export function renderPullRequestTable(pullRequests: readonly AttributedPull[]): string {
   if (pullRequests.length === 0) {
@@ -66,7 +79,7 @@ export function renderPullRequestTable(pullRequests: readonly AttributedPull[]):
     ['PR', 'Title', 'Author', 'Milestone', 'Basis'],
     pullRequests.map(
       (pull) =>
-        `| [#${pull.number}](${pull.url}) | ${cell(pull.title)} | @${cell(pull.author)} | ` +
+        `| [#${pull.number}](${pull.url}) | ${cell(pull.title)} | ${renderAuthor(pull.author)} | ` +
         `${cell(pull.milestone ?? '—')} | ${cell(pull.basis)} |`
     )
   );

--- a/.github/actions/draft-release/lib/report.ts
+++ b/.github/actions/draft-release/lib/report.ts
@@ -12,7 +12,7 @@ import type {
   VersionSource,
 } from './types.ts';
 
-export const SCHEMA_VERSION = 3;
+export const SCHEMA_VERSION = 4;
 export const BLOCK_START = '<!-- STRAPI_RELEASE_CANDIDATE_START -->';
 export const BLOCK_END = '<!-- STRAPI_RELEASE_CANDIDATE_END -->';
 

--- a/.github/actions/draft-release/lib/report.ts
+++ b/.github/actions/draft-release/lib/report.ts
@@ -11,11 +11,21 @@ import type {
   VersionSource,
 } from './types.ts';
 
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 export const BLOCK_START = '<!-- STRAPI_RELEASE_CANDIDATE_START -->';
 export const BLOCK_END = '<!-- STRAPI_RELEASE_CANDIDATE_END -->';
 
 const SHORT_SHA_LENGTH = 8;
+
+/**
+ * The version published from a pull request head by
+ * [`publish-pr-experimental.yml`](../../workflows/publish-pr-experimental.yml), which versions on
+ * `github.event.pull_request.head.sha`. Mirrored here so a consumer of the payload never has to
+ * rebuild the scheme, and only ever from the full SHA the workflow itself uses.
+ */
+export function experimentalVersion(headSha: string): string {
+  return `0.0.0-experimental.${headSha}`;
+}
 
 /** Escapes the characters that would break out of a Markdown table cell. */
 function cell(value: unknown): string {
@@ -108,6 +118,9 @@ export type PayloadInput = {
   versionSource: VersionSource;
   range: PinnedRange;
   integrationCount: number;
+  branch: string;
+  pullNumber: number | null;
+  pullUrl: string | null;
   classification: BumpClassification;
   pullRequests: AttributedPull[];
   attention: AttentionRecord[];
@@ -129,6 +142,13 @@ export function buildPayload(input: PayloadInput): ReleasePayload {
       source: input.versionSource,
     },
     range: { ...input.range, integrationCount: input.integrationCount },
+    candidate: {
+      branch: input.branch,
+      headSha: input.range.toSha,
+      expectedExperimentalVersion: experimentalVersion(input.range.toSha),
+      pullRequestNumber: input.pullNumber,
+      pullRequestUrl: input.pullUrl,
+    },
     bumpEvidence: {
       featureIntegrations: input.classification.features,
       breakingIntegrations: input.classification.breaking,

--- a/.github/actions/draft-release/lib/semver.ts
+++ b/.github/actions/draft-release/lib/semver.ts
@@ -1,0 +1,107 @@
+import type { BumpKind, StableVersion } from './types.ts';
+
+/**
+ * Minimal stable-only semver helpers.
+ *
+ * The release line this action serves only ever produces `x.y.z` versions. Anything carrying a
+ * prerelease or build suffix is rejected on purpose rather than partially supported, so a bad npm
+ * dist-tag can never be mistaken for a release baseline.
+ */
+
+const STABLE_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/u;
+
+const ORDERED_FIELDS = [
+  'major',
+  'minor',
+  'patch',
+] as const satisfies readonly (keyof StableVersion)[];
+
+/**
+ * Parses a strictly stable version.
+ *
+ * @returns `null` for anything that is not a plain release version, including prereleases.
+ */
+export function parseStable(value: unknown): StableVersion | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const match = STABLE_PATTERN.exec(value.trim());
+
+  if (match === null) {
+    return null;
+  }
+
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+/** Renders a parsed version back to its `x.y.z` form. */
+export function formatStable(version: StableVersion): string {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+/**
+ * Orders two stable versions.
+ *
+ * @returns `-1` when `left` is older, `0` when equal, `1` when `left` is newer.
+ */
+export function compareStable(left: StableVersion, right: StableVersion): number {
+  return (
+    ORDERED_FIELDS.reduce<number | null>((decided, field) => {
+      if (decided !== null) {
+        return decided;
+      }
+
+      if (left[field] === right[field]) {
+        return null;
+      }
+
+      return left[field] < right[field] ? -1 : 1;
+    }, null) ?? 0
+  );
+}
+
+/**
+ * The highest stable version in a list.
+ *
+ * Prereleases are skipped rather than ordered, because this action never treats one as a baseline.
+ *
+ * @returns `null` when the list carries no stable version at all.
+ */
+export function highestStable(versions: readonly string[]): string | null {
+  return versions.reduce<string | null>((best, candidate) => {
+    const parsed = parseStable(candidate);
+
+    if (parsed === null) {
+      return best;
+    }
+
+    const incumbent = best === null ? null : parseStable(best);
+
+    if (incumbent === null || compareStable(parsed, incumbent) === 1) {
+      return candidate.trim();
+    }
+
+    return best;
+  }, null);
+}
+
+/** Applies a release increment to a stable version. */
+export function increment(version: string, bump: BumpKind): string {
+  const parsed = parseStable(version);
+
+  if (parsed === null) {
+    throw new Error(`Cannot increment a non-stable version: "${version}"`);
+  }
+
+  if (bump === 'minor') {
+    return formatStable({ major: parsed.major, minor: parsed.minor + 1, patch: 0 });
+  }
+
+  return formatStable({ major: parsed.major, minor: parsed.minor, patch: parsed.patch + 1 });
+}
+
+/** The milestone that collects work for the release after this one. */
+export function nextPatchOf(version: string): string {
+  return increment(version, 'patch');
+}

--- a/.github/actions/draft-release/lib/types.ts
+++ b/.github/actions/draft-release/lib/types.ts
@@ -1,0 +1,349 @@
+/**
+ * The domain vocabulary of a draft release, in one place.
+ *
+ * GitHub payloads are described structurally by the fields this action actually reads, rather than
+ * pulled in wholesale from Octokit. The adapters are the only place those payloads arrive, so a
+ * narrow shape keeps every decision function checkable on its own.
+ *
+ * Every union that also exists at runtime is derived from its `as const` list, never written twice.
+ */
+
+/** Statuses an integration can end up with. */
+export const ATTRIBUTION_STATUSES = [
+  'resolved',
+  'direct-integration',
+  'ambiguous',
+  'lookup-failed',
+  'unresolved',
+] as const;
+
+export type AttributionStatus = (typeof ATTRIBUTION_STATUSES)[number];
+
+/** The rule that decided an attribution. `none` means nothing decided it. */
+export const ATTRIBUTION_BASES = [
+  'exact-merge-sha',
+  'verified-subject',
+  'second-parent-head',
+  'none',
+] as const;
+
+export type AttributionBasis = (typeof ATTRIBUTION_BASES)[number];
+
+/** The only two increments this action produces. A major is always a hard stop. */
+export const BUMP_KINDS = ['minor', 'patch'] as const;
+
+export type BumpKind = (typeof BUMP_KINDS)[number];
+
+/** Where the release version came from. */
+export const VERSION_SOURCES = ['computed', 'version-input'] as const;
+
+export type VersionSource = (typeof VERSION_SOURCES)[number];
+
+/** Why an integration carries no product change of its own. */
+export const IGNORE_REASONS = ['release-commit', 'back-merge', 'branch-merge'] as const;
+
+export type IgnoreReason = (typeof IGNORE_REASONS)[number];
+
+/** Every mutation the action can perform, as recorded in the write journal. */
+export const JOURNAL_OPS = [
+  'branch.push',
+  'issue.milestone.clear',
+  'issue.milestone.set',
+  'milestone.close',
+  'milestone.create',
+  'milestone.rename',
+  'pr.body',
+  'pr.comment',
+  'pr.create',
+  'pr.label',
+] as const;
+
+export type JournalOp = (typeof JOURNAL_OPS)[number];
+
+export const CLEANUP_ACTIONS = ['keep', 'move', 'clear'] as const;
+
+export type CleanupAction = (typeof CLEANUP_ACTIONS)[number];
+
+/** A stable `x.y.z` release version, parsed. */
+export type StableVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+/** One first-parent commit on the source branch. */
+export type Integration = {
+  sha: string;
+  parents: string[];
+  author: string;
+  authoredAt: string;
+  subject: string;
+  body: string;
+};
+
+/** The fields of a GitHub pull request payload this action reads. */
+export type PullPayload = {
+  number: number;
+  title?: string | null;
+  html_url?: string | null;
+  merged_at?: string | null;
+  merge_commit_sha?: string | null;
+  base?: { ref?: string | null } | null;
+  head?: { ref?: string | null; sha?: string | null } | null;
+  user?: { login?: string | null } | null;
+  milestone?: { title?: string | null } | null;
+};
+
+/** The projection of a pull request that reaches the report. */
+export type PullSummary = {
+  number: number;
+  title: string;
+  author: string;
+  url: string;
+  baseRef: string;
+  headRef: string;
+  milestone: string | null;
+};
+
+/** One integration, decided. Always carries the rule that decided it. */
+export type AttributionRecord = {
+  sha: string;
+  subject: string;
+  author: string;
+  authoredAt: string;
+  parents: string[];
+  status: AttributionStatus;
+  basis: AttributionBasis;
+  pull: PullSummary | null;
+  warnings: string[];
+  reason: string;
+};
+
+/** A pull request with every integration attributed to it. */
+export type AttributedPull = PullSummary & {
+  status: AttributionStatus;
+  basis: AttributionBasis;
+  integrationShas: string[];
+};
+
+/** A record a human still has to settle. */
+export type AttentionRecord = {
+  sha: string;
+  subject: string;
+  status: AttributionStatus;
+  reason: string;
+};
+
+export type ConventionalHeader = {
+  type: string;
+  scope: string | null;
+  breaking: boolean;
+};
+
+/** One integration voting for a bump, with the evidence that made it vote. */
+export type BumpVote = {
+  sha: string;
+  pr: number | null;
+  subject: string;
+  via: 'subject' | 'pr-commits';
+};
+
+export type BumpClassification = {
+  features: BumpVote[];
+  breaking: BumpVote[];
+  ignored: { sha: string; reason: IgnoreReason; subject: string }[];
+  unparsed: { sha: string; pr: number | null; subject: string }[];
+};
+
+/** A GitHub milestone, as far as this action cares. */
+export type Milestone = {
+  number: number;
+  title: string;
+  state?: string;
+};
+
+export type MilestonePlan = {
+  shipping: {
+    action: 'create' | 'rename' | 'keep';
+    number: number | null;
+    currentTitle: string | null;
+    title: string;
+  };
+  next: {
+    action: 'create' | 'reuse';
+    number: number | null;
+    title: string;
+  };
+};
+
+/** An issue or pull request carrying a milestone, as returned by the issues endpoint. */
+export type MilestoneItem = {
+  number: number;
+  title?: string | null;
+  state?: string;
+  pull_request?: { merged_at?: string | null } | null;
+};
+
+export type CleanupItem = {
+  number: number;
+  title: string;
+  kind: 'issue' | 'pull';
+  action: CleanupAction;
+  to: number | null;
+  reason: string;
+};
+
+export type Reconciliation = {
+  inHistoryNotInMilestone: number[];
+  inMilestoneNotInHistory: number[];
+};
+
+/** What a mutation intends to do, before it is attempted. */
+export type JournalIntent = {
+  op: JournalOp;
+  target: string;
+  before?: string | null;
+  after?: string | null;
+  detail?: string | null;
+};
+
+export type JournalEntry = {
+  op: JournalOp;
+  target: string;
+  before: string | null;
+  after: string | null;
+  detail: string | null;
+  at: string;
+  applied: boolean;
+};
+
+export type JournalSnapshot = {
+  mode: 'applied' | 'planned';
+  entries: JournalEntry[];
+};
+
+export type Journal = {
+  mode: 'applied' | 'planned';
+  /** Records the intent, then performs it only when the run is applying. */
+  write: <T>(intent: JournalIntent, perform: () => Promise<T>) => Promise<T | null>;
+  entries: () => JournalEntry[];
+  toJSON: () => JournalSnapshot;
+};
+
+export type PinnedRange = {
+  fromRef: string;
+  fromSha: string;
+  toRef: string;
+  toSha: string;
+};
+
+/** The machine-readable payload embedded in the release pull request body. */
+export type ReleasePayload = {
+  schemaVersion: number;
+  generatedAt: string;
+  repository: string;
+  dryRun: boolean;
+  release: {
+    version: string;
+    bump: BumpKind;
+    previousVersion: string;
+    source: VersionSource;
+  };
+  range: PinnedRange & { integrationCount: number };
+  bumpEvidence: {
+    featureIntegrations: BumpVote[];
+    breakingIntegrations: BumpVote[];
+    ignored: BumpClassification['ignored'];
+    unparsed: BumpClassification['unparsed'];
+  };
+  pullRequests: AttributedPull[];
+  attention: AttentionRecord[];
+  milestones: {
+    shipping: {
+      number: number | null;
+      title: string;
+      renamedFrom: string | null;
+      state: 'closed';
+    };
+    next: {
+      number: number | null;
+      title: string;
+      created: boolean;
+    };
+  };
+  reconciliation: Reconciliation;
+};
+
+export type RepositoryMergeSettings = {
+  allow_merge_commit?: boolean;
+  allow_squash_merge?: boolean;
+  allow_rebase_merge?: boolean;
+};
+
+export type RepositoryCoords = {
+  owner: string;
+  repo: string;
+};
+
+/** One commit inside a pull request, as returned by the pull commits endpoint. */
+export type PullCommit = {
+  commit?: { message?: string | null } | null;
+};
+
+/** The result of a shell command. The exec surface never throws; the adapter decides. */
+export type ExecResult = {
+  status: number;
+  stdout: string;
+  stderr: string;
+};
+
+export type GitExec = (args: string[]) => ExecResult;
+
+export type GitAdapter = {
+  resolveSha: (ref: string) => string;
+  refExists: (ref: string) => boolean;
+  isAncestor: (ancestor: string, descendant: string) => boolean;
+  listIntegrations: (fromSha: string, toSha: string) => Integration[];
+  pushBranch: (sha: string, branch: string) => void;
+  remoteBranchExists: (branch: string) => boolean;
+};
+
+export type GithubAdapter = {
+  coords: RepositoryCoords;
+  getRepository: () => Promise<RepositoryMergeSettings>;
+  listPullsForCommit: (sha: string) => Promise<PullPayload[]>;
+  getPull: (pullNumber: number) => Promise<PullPayload>;
+  listPullCommits: (pullNumber: number) => Promise<PullCommit[]>;
+  listMilestones: (state: 'open' | 'closed' | 'all') => Promise<Milestone[]>;
+  createMilestone: (title: string) => Promise<Milestone>;
+  updateMilestone: (
+    milestoneNumber: number,
+    patch: { title?: string; state?: 'open' | 'closed' }
+  ) => Promise<Milestone>;
+  listMilestoneItems: (milestoneNumber: number) => Promise<MilestoneItem[]>;
+  setIssueMilestone: (issueNumber: number, milestoneNumber: number | null) => Promise<void>;
+  createPull: (input: {
+    head: string;
+    base: string;
+    title: string;
+    body: string;
+  }) => Promise<{ number: number; html_url?: string | null }>;
+  updatePullBody: (pullNumber: number, body: string) => Promise<void>;
+  addLabels: (issueNumber: number, labels: string[]) => Promise<void>;
+  createComment: (issueNumber: number, body: string) => Promise<void>;
+};
+
+/** The commit-to-pull lookups the resolver needs, narrowed from the full adapter. */
+export type AttributionLookup = Pick<GithubAdapter, 'listPullsForCommit' | 'getPull'>;
+
+export type Logger = {
+  info: (message: string) => void;
+};
+
+export type Clock = () => string;
+
+export type DraftReleaseInputs = {
+  version: string;
+  dryRun: boolean;
+  sourceRef: string;
+};

--- a/.github/actions/draft-release/lib/types.ts
+++ b/.github/actions/draft-release/lib/types.ts
@@ -163,12 +163,22 @@ export type ConventionalHeader = {
   breaking: boolean;
 };
 
+/**
+ * Where the evidence behind a bump vote was read.
+ *
+ * `landing-body` is the body of the first-parent commit itself, which is the only place a breaking
+ * footer can be found when the subject does not parse as a conventional header.
+ */
+export const BUMP_VOTE_SOURCES = ['subject', 'pr-commits', 'landing-body'] as const;
+
+export type BumpVoteSource = (typeof BUMP_VOTE_SOURCES)[number];
+
 /** One integration voting for a bump, with the evidence that made it vote. */
 export type BumpVote = {
   sha: string;
   pr: number | null;
   subject: string;
-  via: 'subject' | 'pr-commits';
+  via: BumpVoteSource;
 };
 
 export type BumpClassification = {

--- a/.github/actions/draft-release/lib/types.ts
+++ b/.github/actions/draft-release/lib/types.ts
@@ -75,10 +75,32 @@ export type StableVersion = {
 export type Integration = {
   sha: string;
   parents: string[];
+  /** The git author name, `%an`. On a squash commit this is the contributor's display name. */
   author: string;
+  /** The git author email, `%ae`. Never leaves this action: it is evidence, not payload. */
+  email: string;
   authoredAt: string;
   subject: string;
   body: string;
+};
+
+/**
+ * Who wrote a pull request.
+ *
+ * A GitHub pull request payload only ever carries a login. Its `user` is the short user object,
+ * which has no display name in it, and asking for one costs a request per distinct contributor.
+ * Git already has the name: a squash commit is authored by the contributor, so `%an` on the
+ * integration commit is the same string GitHub renders next to it.
+ *
+ * The email that comes with it is deliberately not part of this type. It is read to decide whether
+ * the name can be trusted, and then dropped, because the payload is published in a public pull
+ * request body and a work address does not belong there.
+ */
+export type Author = {
+  /** The GitHub username. Empty only when the pull request payload carries no user. */
+  login: string;
+  /** The display name, `null` when no commit in the range can vouch for one. */
+  name: string | null;
 };
 
 /** The fields of a GitHub pull request payload this action reads. */
@@ -98,7 +120,7 @@ export type PullPayload = {
 export type PullSummary = {
   number: number;
   title: string;
-  author: string;
+  author: Author;
   url: string;
   baseRef: string;
   headRef: string;
@@ -109,6 +131,7 @@ export type PullSummary = {
 export type AttributionRecord = {
   sha: string;
   subject: string;
+  /** The commit's own git author name, not the pull request's. `pull.author` is that one. */
   author: string;
   authoredAt: string;
   parents: string[];

--- a/.github/actions/draft-release/lib/types.ts
+++ b/.github/actions/draft-release/lib/types.ts
@@ -250,6 +250,18 @@ export type ReleasePayload = {
     source: VersionSource;
   };
   range: PinnedRange & { integrationCount: number };
+  /** What later automation needs to find this candidate again, without re-deriving any of it. */
+  candidate: {
+    /** The release branch this candidate lives on, e.g. `releases/5.53.0`. */
+    branch: string;
+    /** The pinned commit the branch was cut at. Same value as `range.toSha`. */
+    headSha: string;
+    /** The artifact `publish-pr-experimental.yml` publishes from `headSha`. */
+    expectedExperimentalVersion: string;
+    /** The release pull request, `null` on a dry run where no pull request is created. */
+    pullRequestNumber: number | null;
+    pullRequestUrl: string | null;
+  };
   bumpEvidence: {
     featureIntegrations: BumpVote[];
     breakingIntegrations: BumpVote[];

--- a/.github/actions/draft-release/lint-staged.config.mjs
+++ b/.github/actions/draft-release/lint-staged.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '../../../lint-staged.shared.mjs';

--- a/.github/actions/draft-release/package.json
+++ b/.github/actions/draft-release/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "draft-release",
+  "version": "5.52.3",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0 <=26.x.x"
+  },
+  "scripts": {
+    "lint": "run -T eslint . --max-warnings=0",
+    "test:ts": "run -T tsc --noEmit --project tsconfig.json",
+    "test:unit": "node --test \"__tests__/**/*.test.ts\"",
+    "test:unit:watch": "node --test --watch \"__tests__/**/*.test.ts\""
+  },
+  "devDependencies": {
+    "@types/node": "20.19.41",
+    "typescript": "5.9.3"
+  }
+}

--- a/.github/actions/draft-release/tsconfig.eslint.json
+++ b/.github/actions/draft-release/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["index.ts", "lib/**/*.ts", "__tests__/**/*.ts", "scripts/**/*.ts", ".eslintrc.cjs"]
+}

--- a/.github/actions/draft-release/tsconfig.eslint.json
+++ b/.github/actions/draft-release/tsconfig.eslint.json
@@ -1,4 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "include": ["index.ts", "lib/**/*.ts", "__tests__/**/*.ts", "scripts/**/*.ts", ".eslintrc.cjs"]
+  "extends": "./tsconfig.json"
 }

--- a/.github/actions/draft-release/tsconfig.json
+++ b/.github/actions/draft-release/tsconfig.json
@@ -30,6 +30,6 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["index.ts", "lib/**/*.ts", "__tests__/**/*.ts", "scripts/**/*.ts"],
+  "include": ["index.ts", "lib/**/*.ts", "__tests__/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/.github/actions/draft-release/tsconfig.json
+++ b/.github/actions/draft-release/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+
+    // The action runs from a bundle, and the sources run under Node's type stripping during tests.
+    // Both need TypeScript that erases without emitting: no enums, no namespaces, no parameter
+    // properties, and explicit `.ts` specifiers on relative imports.
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["index.ts", "lib/**/*.ts", "__tests__/**/*.ts", "scripts/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,68 @@
+name: 'Draft release'
+
+# Prepares a release candidate: pins the range against the published npm baseline, decides the
+# version from the commits that landed, cuts `releases/x.y.z`, opens the draft PR against `main`,
+# attributes every shipping PR, and reconciles milestones.
+#
+# Defaults to a dry run. A dry run performs no write at all and reports the exact list of writes the
+# real run would perform.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Explicit x.y.z version. Leave empty to decide it from the commits.'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Rehearse without writing anything.'
+        type: boolean
+        required: false
+        default: true
+      source_ref:
+        description: 'Branch to cut the release from.'
+        required: false
+        default: 'develop'
+
+permissions:
+  contents: read
+
+jobs:
+  draft:
+    name: 'Draft'
+    runs-on: ubuntu-latest
+    if: github.repository == 'strapi/strapi'
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_SECRET }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0 # tags and full first-parent history are both required
+
+      # The action runs its TypeScript sources directly through Node's type stripping, which needs
+      # Node >= 22.18. Pinned here rather than left to the runner image default.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Draft the release
+        id: draft
+        uses: ./.github/actions/draft-release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          version: ${{ inputs.version }}
+          dry_run: ${{ inputs.dry_run }}
+          source_ref: ${{ inputs.source_ref }}
+
+      - name: Upload the write journal
+        if: always() && steps.draft.outputs.journal_path != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: draft-release-journal
+          path: ${{ steps.draft.outputs.journal_path }}
+          if-no-files-found: warn

--- a/yarn.lock
+++ b/yarn.lock
@@ -16178,6 +16178,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"draft-release@workspace:.github/actions/draft-release":
+  version: 0.0.0-use.local
+  resolution: "draft-release@workspace:.github/actions/draft-release"
+  dependencies:
+    "@types/node": "npm:20.19.41"
+    typescript: "npm:5.9.3"
+  languageName: unknown
+  linkType: soft
+
 "dset@npm:^3.1.2":
   version: 3.1.4
   resolution: "dset@npm:3.1.4"


### PR DESCRIPTION
### What does it do?

Adds a `draft-release` composite action and the `Draft release` workflow that runs it. Together they prepare a release candidate in one manual dispatch.

The action does six things, in this order:

1. **Pins the range.** It reads the published baseline from the npm registry, resolves that tag, and pins both ends of the range to commit SHAs. A pull request that merges during the run stays outside the release, however long the run takes.
2. **Decides the version.** It classifies each first-parent commit in the range by its Conventional Commit header. A feature makes a minor, everything else makes a patch, and a breaking change stops the run. When a squash subject is not parsable, it reads the commits inside the pull request instead. An explicit `version` input overrides the decision.
3. **Attributes every commit.** Each first-parent commit resolves to the pull request that produced it. A pull request is accepted only if it is merged, targets `develop`, and its `merge_commit_sha` is that commit. Similar titles, authors, or dates are never sufficient. A commit that does not resolve is reported, not guessed.
4. **Reconciles milestones.** It closes the shipping milestone, creates or reuses the next one, and moves open work into it. It also reports both directions of drift: merged work absent from the milestone, and milestone work absent from the range.
5. **Cuts the branch and opens the pull request.** It pushes `releases/x.y.z` at the pinned SHA, opens a draft pull request against `main` titled `Release x.y.z`, and applies the `publish-experimental` label.
6. **Writes the report.** The pull request body carries a human summary and a machine-readable JSON block between `STRAPI_RELEASE_CANDIDATE_START` and `STRAPI_RELEASE_CANDIDATE_END`. Release tooling reads the block instead of parsing prose.

Two properties are worth calling out:

**Dry run is the default.** A dry run computes everything and performs no write. It reports the exact list of milestone renames, pull request reassignments, and ref pushes that a real run would perform.

**Every write is journaled before it is attempted.** The action does not roll back. A run that fails halfway leaves the repository half-changed, so a human finishes or reverts it. The journal is uploaded as an artifact whether the run succeeds or fails, and the action README documents the undo command for each operation.

Implementation notes:

- No runtime dependencies, so there is no committed `dist/` bundle to keep in sync with the sources. The TypeScript runs directly through Node type stripping, which is why the workflow pins Node 24.
- The GitHub surface is about a dozen REST calls over `fetch`, with `Link` header pagination. Every decision lives in a pure module that its tests call directly.
- 215 unit tests. The action is excluded from the repository ESLint project through a pass-through `tsconfig.eslint.json`, because its sources are outside the workspace graph.

### Why is it needed?

Drafting a release is manual today. The person doing it reads the commits, decides the bump, cuts the branch, opens the pull request, and moves the milestone by hand. Three parts of that are error-prone:

- **The range moves while you work.** Anything that merges between reading the log and cutting the branch either ships without being reviewed for the release, or is reviewed and then does not ship.
- **Attribution is done by eye.** A commit whose subject carries no pull request reference, or carries the wrong one, is easy to attribute to the wrong pull request. Nothing catches it afterwards.
- **The result is prose.** Release QA has to re-derive the shipping list from the release branch, because there is no machine-readable statement of what the release contains.

The JSON block addresses the last one. It is the audited output of the steps above, so anything downstream reads what the action decided instead of deciding it again.

This changes the drafting side only. `publish-release.yml` and the other publish workflows are untouched.

### How to test it?

The action has never run in CI. It is dispatch-only and defaults to a dry run, so the first real exercise is safe to observe.

**Unit tests**

```bash
cd .github/actions/draft-release
node --test --experimental-strip-types __tests__/*.test.ts   # 215 tests
npx tsc --noEmit -p .
```

**Dry run in CI**

Run `Draft release` from the Actions tab with `dry_run` left at `true`. Then check that:

- the step summary reports the resolved version and bump, and lists every planned write;
- the shipping pull request table matches `git log --first-parent v<previous>..develop`;
- the `draft-release-journal` artifact is present, with `"mode": "planned"` and no applied entry;
- nothing changed: no `releases/x.y.z` branch, no new pull request, no milestone edit.

A breaking change in the range must fail the run rather than produce a major.

**Real run**

Run it again with `dry_run` set to `false`. It creates `releases/x.y.z` and a draft pull request against `main`. Check that the pull request body carries the JSON block, that `candidate.headSha` equals `range.toSha`, and that the `publish-experimental` label produced `0.0.0-experimental.<headSha>` on npm.

To undo, delete the branch, close the pull request, and reverse the milestone entries in the journal using the table in the action README.

### Related issue(s)/PR(s)

None.

---
_AI assisted_
