### PR TITLE
fix: transfer configuration import discards the error that caused it

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore-configuration.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore-configuration.test.ts
@@ -1,0 +1,94 @@
+import { Writable } from 'stream';
+import type { Core } from '@strapi/types';
+
+import { createConfigurationWriteStream } from '../strategies/restore/configuration';
+import type { IConfiguration, Transaction } from '../../../../../types';
+
+const create = jest.fn();
+
+jest.mock('../../../utils/project-settings-logos', () => ({
+  restoreProjectSettingsRow: jest.fn(async (_strapi: unknown, row: unknown) => row),
+}));
+
+const createStrapi = () =>
+  ({
+    db: {
+      query: jest.fn(() => ({ create })),
+    },
+  }) as unknown as Core.Strapi;
+
+const createTransaction = () =>
+  ({
+    attach: jest.fn(async (fn: () => Promise<void>) => fn()),
+  }) as unknown as Transaction;
+
+const writeConfig = (stream: Writable, config: IConfiguration) =>
+  new Promise<Error | null | undefined>((resolve) => {
+    // a callback error is also emitted on the stream; swallow it so the rejection
+    // under test does not surface as an unhandled 'error' event
+    stream.on('error', () => {});
+    stream.write(config, undefined, (error) => resolve(error));
+  });
+
+const coreStoreConfig = {
+  type: 'core-store',
+  value: { id: 82, key: 'plugin_upload_settings', value: { sizeOptimization: true } },
+} as unknown as IConfiguration;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Restore configuration', () => {
+  test('resolves without an error when the row is created', async () => {
+    create.mockResolvedValue({ id: 1 });
+
+    const stream = await createConfigurationWriteStream(createStrapi(), createTransaction());
+    const error = await writeConfig(stream, coreStoreConfig);
+
+    expect(error).toBeFalsy();
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  test('includes the underlying error message when the row cannot be created', async () => {
+    create.mockRejectedValue(new Error('duplicate key value violates unique constraint'));
+
+    const stream = await createConfigurationWriteStream(createStrapi(), createTransaction());
+    const error = await writeConfig(stream, coreStoreConfig);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toContain('duplicate key value violates unique constraint');
+  });
+
+  test('identifies the configuration that failed', async () => {
+    create.mockRejectedValue(new Error('boom'));
+
+    const stream = await createConfigurationWriteStream(createStrapi(), createTransaction());
+    const error = await writeConfig(stream, coreStoreConfig);
+
+    expect(error?.message).toContain('core-store');
+    expect(error?.message).toContain('82');
+  });
+
+  test('balances the parentheses around the configuration id', async () => {
+    create.mockRejectedValue(new Error('boom'));
+
+    const stream = await createConfigurationWriteStream(createStrapi(), createTransaction());
+    const error = await writeConfig(stream, coreStoreConfig);
+
+    const message = error?.message ?? '';
+    const open = (message.match(/\(/g) ?? []).length;
+    const close = (message.match(/\)/g) ?? []).length;
+
+    expect(close).toBe(open);
+  });
+
+  test('reports non-Error rejections', async () => {
+    create.mockRejectedValue('plain string failure');
+
+    const stream = await createConfigurationWriteStream(createStrapi(), createTransaction());
+    const error = await writeConfig(stream, coreStoreConfig);
+
+    expect(error?.message).toContain('plain string failure');
+  });
+});

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/configuration.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/configuration.ts
@@ -52,12 +52,12 @@ export const createConfigurationWriteStream = async (
       await transaction?.attach(async () => {
         try {
           await restoreConfigs(strapi, config);
-        } catch {
+        } catch (error) {
           return callback(
             new ProviderTransferError(
               `Failed to import ${chalk.yellowBright(config.type)} (${chalk.greenBright(
                 config.value.id
-              )}`
+              )}): ${error instanceof Error ? error.message : String(error)}`
             )
           );
         }


### PR DESCRIPTION
### What does it do?

Binds the caught error in `createConfigurationWriteStream` and appends its message to the `ProviderTransferError`, and closes the parenthesis that the template opens around the configuration id.

```diff
-        } catch {
+        } catch (error) {
           return callback(
             new ProviderTransferError(
               `Failed to import ${chalk.yellowBright(config.type)} (${chalk.greenBright(
                 config.value.id
-              )}`
+              )}): ${error instanceof Error ? error.message : String(error)}`
             )
           );
         }
```

Before:

```
Failed to import core-store (82
```

After:

```
Failed to import core-store (82): duplicate key value violates unique constraint "..."
```

Adds `restore-configuration.test.ts` covering the success path, that the underlying message is propagated, that the failing configuration is still identified, that the parentheses balance, and that a non-`Error` rejection is reported rather than printed as `[object Object]`.

### Why is it needed?

`catch {` binds nothing, so the database error that caused the failure is discarded. Every distinct cause — unique-constraint violation, serialization failure, dropped connection — produces the same opaque line, and the unclosed `(` leaves it ending mid-token.

This is the only signal an operator gets. The restore rolls back on this error, but the CLI still prints `Transfer process has been completed successfully!` afterwards, so the message is the sole indication that anything went wrong. Hitting this on a real transfer, the only way I could identify the cause was to patch `node_modules` to re-add the error binding and log it.

### How to test it?

```
yarn test:unit --testPathPattern restore-configuration
```

Or against a real transfer: make `restoreCoreStore` fail — e.g. run into a destination whose `strapi_core_store_settings` already holds a key the restore re-creates — and confirm the constraint violation now appears in the error line.

### Related issue(s)/PR(s)

Fix #27564
