### PR TITLE
test: add regression coverage for hidden content type relation mainField

### DIFF
--- a/tests/api/core/content-manager/api/hidden-content-type-relation-mainfield.test.api.js
+++ b/tests/api/core/content-manager/api/hidden-content-type-relation-mainfield.test.api.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+const { createUtils } = require('api-tests/utils');
+
+let strapi;
+let utils;
+let rq;
+let rqRestricted;
+let restrictedUserId;
+let restrictedRoleId;
+let article;
+let globalComponent;
+
+const articleModel = {
+  attributes: {
+    title: {
+      type: 'string',
+    },
+  },
+  displayName: 'Article',
+  singularName: 'article',
+  pluralName: 'articles',
+  description: '',
+  collectionName: '',
+  pluginOptions: {
+    'content-manager': {
+      visible: false,
+    },
+  },
+};
+
+const globalComponentModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    related_article: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: 'api::article.article',
+    },
+  },
+  displayName: 'GlobalComponent',
+  singularName: 'global-component',
+  pluralName: 'global-components',
+};
+
+describe('CM API - relation mainField for hidden content type (#27560)', () => {
+  const builder = createTestBuilder();
+
+  beforeAll(async () => {
+    await builder.addContentTypes([articleModel, globalComponentModel]).build();
+
+    strapi = await createStrapiInstance();
+    utils = createUtils(strapi);
+    rq = await createAuthRequest({ strapi });
+
+    const restrictedRole = await utils.createRole({
+      name: 'restricted-hidden-relation',
+      description: 'Can read the global-component but not the hidden article content type',
+    });
+    restrictedRoleId = restrictedRole.id;
+
+    await utils.assignPermissionsToRole(restrictedRole.id, [
+      {
+        action: 'plugin::content-manager.explorer.read',
+        subject: 'api::global-component.global-component',
+      },
+    ]);
+
+    const restrictedUser = await utils.createUser({
+      email: 'restricted-hidden-relation@test.com',
+      firstname: 'Restricted',
+      lastname: 'HiddenRelation',
+      roles: [restrictedRole.id],
+    });
+    restrictedUserId = restrictedUser.id;
+
+    rqRestricted = await createAuthRequest({
+      strapi,
+      userInfo: { email: 'restricted-hidden-relation@test.com' },
+    });
+
+    article = await strapi.documents('api::article.article').create({
+      data: { title: 'Human Readable Article Title' },
+      status: 'published',
+    });
+
+    globalComponent = await strapi.documents('api::global-component.global-component').create({
+      data: { name: 'GC', related_article: article.documentId },
+      status: 'published',
+    });
+  });
+
+  afterAll(async () => {
+    if (restrictedUserId) {
+      await utils.deleteUserById(restrictedUserId);
+    }
+    if (restrictedRoleId) {
+      await utils.deleteRolesById([restrictedRoleId]);
+    }
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('super admin sees the mainField for a relation targeting a hidden content type', async () => {
+    const res = await rq({
+      method: 'GET',
+      url: `/content-manager/relations/api::global-component.global-component/${globalComponent.documentId}/related_article`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0]).toEqual(
+      expect.objectContaining({
+        documentId: article.documentId,
+        title: 'Human Readable Article Title',
+      })
+    );
+  });
+
+  test('super admin has explorer.read permission registered for the hidden content type', async () => {
+    const { body } = await rq({
+      method: 'GET',
+      url: '/admin/roles/1/permissions',
+    });
+
+    const hasReadPermission = body.data.some(
+      (p) =>
+        p.action === 'plugin::content-manager.explorer.read' && p.subject === 'api::article.article'
+    );
+
+    expect(hasReadPermission).toBe(true);
+  });
+
+  test('restricted user without explicit read on the hidden content type does not see its mainField', async () => {
+    const res = await rqRestricted({
+      method: 'GET',
+      url: `/content-manager/relations/api::global-component.global-component/${globalComponent.documentId}/related_article`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0].documentId).toBe(article.documentId);
+    expect(res.body.results[0].title).toBeUndefined();
+  });
+});


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds API integration tests covering the `GET /content-manager/relations/:uid/:id/:field` mainField-resolution path for a content type hidden via `pluginOptions['content-manager'].visible: false`. Three cases:
- Super admin gets the resolved `mainField` (`title`) for a relation targeting the hidden type, not just `documentId`.
- Super admin's permission set includes `plugin::content-manager.explorer.read` on the hidden type.
- A role *without* that explicit permission still only gets `documentId` (RBAC boundary stays intact).

### Why is it needed?

#27560 reports that setting `visible: false` on a content type strips it from RBAC's `explorer.read` subjects, so any relation pointing at it falls back to showing `documentId` instead of its configured `mainField`, for every role, including super admin.

I reproduced this issue (as described in the issue statement) and traced it to already being fixed by #26844, which registers `explorer.read` for all content types instead of only displayed ones, so `resetSuperAdminPermissions` grants it to super admin automatically. That fix shipped in v5.50.1.

The existing regression test for #26844 (`hidden-content-type-read.test.api.js`) only covers a direct `collection-types` read. It doesn't cover the `/content-manager/relations` mainField path that #27560 actually reports, so this PR closes that coverage gap.

### How to test it?

```bash
yarn test:api --testPathPattern="hidden-content-type-relation-mainfield"
```

The steps provided to reproduce the issue are correct and are a little different when testing the changes made, the reporter's original steps create the linked entries via the content-manager API, which still 403s on create for a hidden content type (unrelated to this fix); the test seeds them via the Document Service instead, then follows the same read/permission checks as the original repro.

### Related issue(s)/PR(s)

Fixes #27560
