### PR TITLE
chore(.github/draft-release): run the workflow more than once per release

### DIFF
--- a/.github/actions/draft-release/README.md
+++ b/.github/actions/draft-release/README.md
@@ -30,9 +30,11 @@ makes finishing that by hand mechanical.
 
 ## Running more than once
 
-The open pull request against `main` whose head is `releases/x.y.z` is what identifies the candidate
-in flight. Nothing else works as a key: a release branch outlives its candidate, because the ruleset
-over `releases/*` forbids deleting one, and a milestone is renamed by this very action.
+The open pull request against `main` whose head is `releases/x.y.z` and lives in this repository is
+what identifies the candidate in flight. A pull request from a fork is never a candidate, whatever
+its branch is named, because anyone can open one. Nothing else works as a key: a release branch
+outlives its candidate, because the ruleset over `releases/*` forbids deleting one, and a milestone
+is renamed by this very action.
 
 | Mode      | When                                                     | What it does                                                                                                                                         |
 | --------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -207,6 +209,10 @@ vouch for whether it landed.
 | `pr.close`              | `gh pr reopen <n>`                                                            |
 | `pr.label`              | `gh pr edit <n> --remove-label publish-experimental`                          |
 | `pr.body`, `pr.comment` | Edit or delete by hand.                                                       |
+
+`branch.delete` is a compare-and-swap on the head the preflight saw: the push carries
+`--force-with-lease` against that SHA, so a commit pushed to the old branch mid-run makes the delete
+fail instead of losing the commit. The same SHA is what `before` records, and what the undo restores.
 
 ## Repository settings this action depends on
 

--- a/.github/actions/draft-release/README.md
+++ b/.github/actions/draft-release/README.md
@@ -4,20 +4,48 @@ Prepares a Strapi CMS release candidate. It pins the shipping range against the 
 baseline, decides the version from the commits that landed, cuts `releases/x.y.z`, opens the draft
 pull request against `main`, attributes every shipping pull request, and reconciles milestones.
 
+It is built to run **more than once per release**. `develop` keeps moving while a candidate is open,
+so a later run folds whatever landed since into the same release rather than starting a new one.
+
 Triggered by hand from the Actions tab through [`draft-release.yml`](../../workflows/draft-release.yml).
 
 ## What it does
 
-| Step         | Effect                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------ |
-| Pin          | Resolves the npm `latest` baseline, the `v<latest>` tag and the source branch head to fixed SHAs.            |
-| Attribute    | Resolves each first-parent integration to the pull request that produced it.                                 |
-| Version      | Decides `minor` or `patch` from the commits, unless `version` is given.                                      |
-| Milestones   | Renames the open milestone to the shipping version, opens the next patch milestone, closes the shipping one. |
-| Branch       | Pushes `releases/x.y.z` at the pinned SHA.                                                                   |
-| Pull request | Opens the draft PR `Release x.y.z` against `main` and labels it `publish-experimental`.                      |
-| Report       | Writes the shipping table and a machine-readable JSON block into the PR body.                                |
-| Cleanup      | Moves open PRs to the next milestone, clears closed-unmerged PRs and every issue, then comments.             |
+| Step         | Effect                                                                                              |
+| ------------ | --------------------------------------------------------------------------------------------------- |
+| Pin          | Resolves the npm `latest` baseline, the `v<latest>` tag and `origin/develop` to fixed SHAs.         |
+| Attribute    | Resolves each first-parent integration to the pull request that produced it.                        |
+| Version      | Decides `minor` or `patch` from the commits, unless `version` is given.                             |
+| Discover     | Finds the candidate already in flight, and decides whether to draft, refresh or redraft.            |
+| Milestones   | Makes the shipping milestone name the version that ships, keeps the next one open, closes shipping. |
+| Realign      | Pulls every pull request that shipped onto the shipping milestone, whatever its author picked.      |
+| Branch       | Pushes `releases/x.y.z` at the pinned SHA, or advances it.                                          |
+| Pull request | Opens the draft PR `Release x.y.z` against `main`, or reuses the one in flight.                     |
+| Report       | Writes the shipping table and a machine-readable JSON block into the PR body.                       |
+| Cleanup      | Moves open PRs to the next milestone, clears closed-unmerged PRs and every issue, then comments.    |
+
+Every refusal happens in the preflight, before the first write. A run that stops leaves the
+repository untouched; only a run that dies mid-write leaves it half-changed, and the journal is what
+makes finishing that by hand mechanical.
+
+## Running more than once
+
+The open pull request against `main` whose head is `releases/x.y.z` is what identifies the candidate
+in flight. Nothing else works as a key: a release branch outlives its candidate, because the ruleset
+over `releases/*` forbids deleting one, and a milestone is renamed by this very action.
+
+| Mode      | When                                                     | What it does                                                                                                                                         |
+| --------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `draft`   | No candidate is open.                                    | Cuts the branch, opens the pull request, closes the shipping milestone.                                                                              |
+| `refresh` | A candidate is open and the version still agrees.        | Fast-forwards the branch, refills the shipping milestone, rewrites the body, comments. The pull request keeps its number, its reviews and its label. |
+| `redraft` | A candidate is open and the commits changed the version. | Renames both milestones, opens a replacement pull request, then comments on, closes and deletes the one it replaced.                                 |
+
+A `refresh` that finds the branch already at `develop`'s head pushes nothing. Pushing would fire
+`synchronize` on the pull request and publish another identical experimental artifact for nothing.
+
+`redraft` is the expensive path. A `feat` landing after a patch was drafted changes the version, and
+the version is in the branch name, so the candidate has to be re-keyed. The replacement is opened
+before the old candidate is retired, so the release is never without one.
 
 ## Version rule
 
@@ -75,12 +103,14 @@ must never be mistaken for a commit pushed straight to `develop`.
 
 ## Inputs
 
-| Input        | Default   | Purpose                                                              |
-| ------------ | --------- | -------------------------------------------------------------------- |
-| `token`      | required  | GitHub App token.                                                    |
-| `version`    | `''`      | Explicit `x.y.z`. Bypasses the commit rule.                          |
-| `dry_run`    | `true`    | Compute everything, record the planned writes, perform none of them. |
-| `source_ref` | `develop` | Branch the release is cut from.                                      |
+| Input     | Default  | Purpose                                                              |
+| --------- | -------- | -------------------------------------------------------------------- |
+| `token`   | required | GitHub App token.                                                    |
+| `version` | `''`     | Explicit `x.y.z`. Bypasses the commit rule.                          |
+| `dry_run` | `true`   | Compute everything, record the planned writes, perform none of them. |
+
+There is no source-branch input. A candidate always comes from the protected `develop` head, so
+nothing about the release content can be chosen at dispatch time.
 
 The default `GITHUB_TOKEN` is not enough. A pull request opened with it does not trigger
 `pull_request` workflows, so the release PR would get no CI, and a label applied with it does not
@@ -89,7 +119,7 @@ would never run.
 
 ## Outputs
 
-`version`, `bump`, `branch`, `pr_number`, `pr_url`, `journal_path`.
+`version`, `bump`, `mode`, `branch`, `pr_number`, `pr_url`, `journal_path`.
 
 ## The release candidate block
 
@@ -98,12 +128,17 @@ The pull request body carries a JSON block between `STRAPI_RELEASE_CANDIDATE_STA
 
 `candidate` is the part that identifies the release without re-deriving any of it:
 
-| Field                                 | Meaning                                                                   |
-| ------------------------------------- | ------------------------------------------------------------------------- |
-| `branch`                              | The release branch, `releases/x.y.z`.                                     |
-| `headSha`                             | The commit the branch was cut at. Always the same value as `range.toSha`. |
-| `expectedExperimentalVersion`         | `0.0.0-experimental.<headSha>`, the artifact published from that commit.  |
-| `pullRequestNumber`, `pullRequestUrl` | The release pull request, both `null` on a dry run.                       |
+| Field                                 | Meaning                                                                                                                  |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `branch`                              | The release branch, `releases/x.y.z`.                                                                                    |
+| `headSha`                             | The commit the branch points at. Always the same value as `range.toSha`.                                                 |
+| `expectedExperimentalVersion`         | `0.0.0-experimental.<headSha>`, the artifact published from that commit.                                                 |
+| `branchAdvanced`                      | Whether this run moved the branch. `false` means the artifact a reader may already have tested is still the current one. |
+| `pullRequestNumber`, `pullRequestUrl` | The release pull request, both `null` on a dry run.                                                                      |
+
+`release.mode` says whether the run opened the candidate, advanced it or replaced it. The body is
+rewritten wholesale on every run, so it is always the current truth; the comments are the per-run
+record of which run pulled which work in, and they are never rewritten.
 
 `pullRequests[].author` carries both halves of an identity:
 
@@ -135,11 +170,29 @@ This action does not roll back. A run that dies halfway leaves the repository ha
 human finishes or reverts it, so every mutation is recorded before the next one starts. The journal
 is written to the step summary and uploaded as an artifact whether the run succeeds or fails.
 
+Each entry carries how far it got, so it never claims more certainty than the run has:
+
+| `state`         | Meaning                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------- |
+| `planned`       | A dry run recorded it and called nothing.                                                |
+| `attempted`     | The call left and has not come back. Only ever seen on a journal flushed mid-write.      |
+| `applied`       | The call returned. This is the only state worth undoing.                                 |
+| `failed`        | The server or git answered with a refusal, so nothing changed. The answer is in `error`. |
+| `indeterminate` | The call failed in a way that proves nothing, a socket closed after the request left.    |
+
+A GitHub response status and a git exit code both mean the operation reached a verdict, and git
+updates a ref atomically, so a push that exits non-zero left the ref alone. An error carrying
+neither is `indeterminate` rather than assumed harmless.
+
 A dry run fills the same structure without calling the API. That is the rehearsal: a reviewable,
 line-by-line list of every milestone rename, pull request reassignment and ref push the real run
 would perform.
 
 ### Undoing a partial run
+
+Undo an entry only when its `state` is `applied`. A `failed` entry changed nothing. An
+`indeterminate` one has to be checked against GitHub before anything is touched, because nobody can
+vouch for whether it landed.
 
 | `op`                    | Undo                                                                          |
 | ----------------------- | ----------------------------------------------------------------------------- |
@@ -149,24 +202,43 @@ would perform.
 | `issue.milestone.set`   | `gh api -X PATCH repos/strapi/strapi/issues/<n> -F milestone=<before number>` |
 | `issue.milestone.clear` | same, with the milestone number recorded in `before`                          |
 | `branch.push`           | `git push origin --delete releases/<version>`                                 |
+| `branch.delete`         | `git push origin <before sha>:refs/heads/<branch>`                            |
 | `pr.create`             | `gh pr close <n> --delete-branch`                                             |
+| `pr.close`              | `gh pr reopen <n>`                                                            |
 | `pr.label`              | `gh pr edit <n> --remove-label publish-experimental`                          |
 | `pr.body`, `pr.comment` | Edit or delete by hand.                                                       |
 
+## Repository settings this action depends on
+
+`releases/*` is covered by a repository ruleset carrying `deletion`, `non_fast_forward` and
+`required_status_checks`. `required_status_checks` gates ref **updates**, not only pull request
+merges, and the required contexts are all `pull_request` checks that never exist on a `develop`
+commit. The release GitHub App therefore has to be a bypass actor on the ruleset covering
+`releases/*`, or the branch can be neither created nor advanced. Bypass is granted per actor and not
+per rule, so that ruleset should cover `releases/*` alone and leave `main`, `develop` and `v4` with
+no bypass actors at all.
+
 ## Stops
 
-The run refuses to continue on any of these:
+The run refuses to continue on any of these, all of them before the first write:
 
 1. npm `latest` disagrees with the highest published stable version.
 2. The `v<latest>` tag is missing.
-3. The baseline is not an ancestor of the source ref.
+3. The baseline is not an ancestor of `origin/develop`.
 4. Rebase merges are enabled on the repository.
 5. The range carries a breaking change.
 6. The range is empty.
-7. Zero or more than one open milestone.
-8. `releases/<version>` already exists.
+7. More than one open milestone.
+8. `releases/<version>` exists with no open pull request drafting it.
 9. The `version` input is malformed or not greater than the baseline.
 10. Any commit-to-pulls lookup failed.
+11. More than one release pull request is open against `main`.
+12. The candidate's version is at or below the published baseline, so that release already shipped.
+13. The candidate's branch head is not contained in `origin/develop`, so someone pushed to it.
+14. The range now computes a version below the candidate's, so history was rewritten.
+15. No milestone is titled after the candidate's version, or the open one is not the candidate's next.
+16. A milestone already holds the title this run would rename another one onto.
+17. A candidate's pull request is open but its branch is gone from the remote.
 
 `ambiguous` and `unresolved` records do not stop the run. They are listed in the pull request body
 under "Needs a human".
@@ -213,6 +285,8 @@ lib/types.ts     the domain vocabulary; every runtime union is derived from its 
 lib/actions.ts   the Actions runtime protocol
 lib/github.ts    the GitHub REST adapter
 lib/range.ts     the Git adapter and the first-parent log parser
+lib/candidate.ts finding the candidate in flight, and deciding draft / refresh / redraft
+lib/pipeline.ts  `preflightRelease` decides and refuses, `applyRelease` writes
 lib/*.ts         one module per decision, pure
 __tests__/*.ts   node:test suites, one per module
 ```

--- a/.github/actions/draft-release/README.md
+++ b/.github/actions/draft-release/README.md
@@ -17,16 +17,21 @@ Triggered by hand from the Actions tab through [`draft-release.yml`](../../workf
 | Attribute    | Resolves each first-parent integration to the pull request that produced it.                        |
 | Version      | Decides `minor` or `patch` from the commits, unless `version` is given.                             |
 | Discover     | Finds the candidate already in flight, and decides whether to draft, refresh or redraft.            |
-| Milestones   | Makes the shipping milestone name the version that ships, keeps the next one open, closes shipping. |
-| Realign      | Pulls every pull request that shipped onto the shipping milestone, whatever its author picked.      |
 | Branch       | Pushes `releases/x.y.z` at the pinned SHA, or advances it.                                          |
 | Pull request | Opens the draft PR `Release x.y.z` against `main`, or reuses the one in flight.                     |
-| Report       | Writes the shipping table and a machine-readable JSON block into the PR body.                       |
-| Cleanup      | Moves open PRs to the next milestone, clears closed-unmerged PRs and every issue, then comments.    |
+| Milestones   | Makes the shipping milestone name the version that ships, keeps the next one open, closes shipping. |
+| Realign      | Pulls every pull request that shipped onto the shipping milestone, whatever its author picked.      |
+| Cleanup      | Moves open PRs to the next milestone, clears closed-unmerged PRs and every issue.                   |
+| Report       | Writes the shipping table and a machine-readable JSON block into the PR body, then comments.        |
 
 Every refusal happens in the preflight, before the first write. A run that stops leaves the
 repository untouched; only a run that dies mid-write leaves it half-changed, and the journal is what
 makes finishing that by hand mechanical.
+
+The branch push and the pull request are the first writes because they are the two most likely to
+fail on permissions: the push needs a bypass on the ruleset over `releases/*`, and the pull request
+needs the app's scopes. A run that fails there leaves at most one write to undo, where the milestone
+phase alone is dozens.
 
 ## Running more than once
 
@@ -40,7 +45,7 @@ is renamed by this very action.
 | --------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `draft`   | No candidate is open.                                    | Cuts the branch, opens the pull request, closes the shipping milestone.                                                                              |
 | `refresh` | A candidate is open and the version still agrees.        | Fast-forwards the branch, refills the shipping milestone, rewrites the body, comments. The pull request keeps its number, its reviews and its label. |
-| `redraft` | A candidate is open and the commits changed the version. | Renames both milestones, opens a replacement pull request, then comments on, closes and deletes the one it replaced.                                 |
+| `redraft` | A candidate is open and the commits changed the version. | Opens a replacement pull request, renames both milestones, then comments on, closes and deletes the one it replaced.                                 |
 
 A `refresh` that finds the branch already at `develop`'s head pushes nothing. Pushing would fire
 `synchronize` on the pull request and publish another identical experimental artifact for nothing.

--- a/.github/actions/draft-release/__tests__/attribution.test.ts
+++ b/.github/actions/draft-release/__tests__/attribution.test.ts
@@ -94,7 +94,7 @@ describe('selectExactCandidates', () => {
   });
 
   it('rejects an unmerged pull request', () => {
-    const open = pull({ merged_at: null });
+    const open: PullPayload = { ...pull(), merged_at: null };
 
     assert.deepEqual(selectExactCandidates(integration(), [open], 'develop'), []);
   });
@@ -208,7 +208,9 @@ describe('summarisePull', () => {
   });
 
   it('fills every absent field rather than leaking undefined', () => {
-    assert.deepEqual(summarisePull({ number: 1 }, integration({ author: '', email: '' })), {
+    const bare = { number: 1, merged_at: '2026-09-05T09:59:00Z' };
+
+    assert.deepEqual(summarisePull(bare, integration({ author: '', email: '' })), {
       number: 1,
       title: '',
       author: { login: '', name: null },
@@ -216,7 +218,7 @@ describe('summarisePull', () => {
       baseRef: '',
       headRef: '',
       milestone: null,
-      mergedAt: '',
+      mergedAt: '2026-09-05T09:59:00Z',
     });
   });
 });

--- a/.github/actions/draft-release/__tests__/attribution.test.ts
+++ b/.github/actions/draft-release/__tests__/attribution.test.ts
@@ -216,6 +216,7 @@ describe('summarisePull', () => {
       baseRef: '',
       headRef: '',
       milestone: null,
+      mergedAt: '',
     });
   });
 });

--- a/.github/actions/draft-release/__tests__/bump.test.ts
+++ b/.github/actions/draft-release/__tests__/bump.test.ts
@@ -33,6 +33,7 @@ function summary(number: number, headRef: string): StubbedRecord['pull'] {
     baseRef: 'develop',
     headRef,
     milestone: null,
+    mergedAt: '2026-09-05T09:59:00Z',
   };
 }
 

--- a/.github/actions/draft-release/__tests__/candidate.test.ts
+++ b/.github/actions/draft-release/__tests__/candidate.test.ts
@@ -2,32 +2,38 @@ import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
-  assertBranchContained,
   assertCandidateUnpublished,
-  crossCheckCandidate,
   decideMode,
   findCandidate,
   parseReleaseBranch,
+  planBranch,
 } from '../lib/candidate.ts';
-import { candidatePull, pull } from '../lib/__fixtures__/fixtures.ts';
+import {
+  OWN_REPOSITORY,
+  SHA,
+  candidateHead,
+  candidatePull,
+  pull,
+} from '../lib/__fixtures__/fixtures.ts';
 
-import type { Candidate } from '../lib/types.ts';
+import type { Candidate, GitAdapter, PinnedRange, RepositoryCoords } from '../lib/types.ts';
+
+const COORDS: RepositoryCoords = { owner: 'strapi', repo: 'strapi' };
 
 function candidate(overrides: Partial<Candidate> = {}): Candidate {
   return {
     version: '5.53.0',
+    parsedVersion: { major: 5, minor: 53, patch: 0 },
     branch: 'releases/5.53.0',
     pullNumber: 27600,
     pullUrl: 'https://github.com/strapi/strapi/pull/27600',
-    pullHeadSha: 'face0000face0000face0000face0000face0000',
-    payload: null,
     ...overrides,
   };
 }
 
 describe('parseReleaseBranch', () => {
   it('reads the version out of a release branch', () => {
-    assert.equal(parseReleaseBranch('releases/5.53.0'), '5.53.0');
+    assert.deepEqual(parseReleaseBranch('releases/5.53.0'), { major: 5, minor: 53, patch: 0 });
   });
 
   it('refuses anything that is not exactly releases/x.y.z', () => {
@@ -40,39 +46,65 @@ describe('parseReleaseBranch', () => {
 });
 
 describe('findCandidate', () => {
-  it('finds the candidate and reads its payload back', () => {
-    const found = findCandidate([pull(), candidatePull()]);
-
-    assert.equal(found?.version, '5.53.0');
-    assert.equal(found?.branch, 'releases/5.53.0');
-    assert.equal(found?.pullNumber, 27600);
-    assert.deepEqual(found?.payload, {
-      release: { version: '5.53.0' },
-      candidate: { branch: 'releases/5.53.0' },
+  it('finds the candidate by its head ref', () => {
+    assert.deepEqual(findCandidate([pull(), candidatePull()], COORDS), {
+      version: '5.53.0',
+      parsedVersion: { major: 5, minor: 53, patch: 0 },
+      branch: 'releases/5.53.0',
+      pullNumber: 27600,
+      pullUrl: 'https://github.com/strapi/strapi/pull/27600',
     });
   });
 
   it('reports no candidate when none is open', () => {
-    assert.equal(findCandidate([pull()]), null);
+    assert.equal(findCandidate([pull()], COORDS), null);
   });
 
   it('reports no candidate on an empty list', () => {
-    assert.equal(findCandidate([]), null);
+    assert.equal(findCandidate([], COORDS), null);
   });
 
-  it('keeps a null payload when the body carries no readable block', () => {
-    assert.equal(findCandidate([candidatePull({ body: 'no block here' })])?.payload, null);
+  it('ignores a release-named pull request whose head lives in a fork', () => {
+    const fork = candidatePull({
+      head: { ...candidateHead('5.53.0'), repo: { full_name: 'someone/strapi' } },
+    });
+
+    assert.equal(findCandidate([fork], COORDS), null);
+  });
+
+  it('ignores a pull request whose head repository is gone', () => {
+    const orphan = candidatePull({ head: { ...candidateHead('5.53.0'), repo: null } });
+
+    assert.equal(findCandidate([orphan], COORDS), null);
+    assert.equal(
+      findCandidate([candidatePull({ head: { ref: 'releases/5.53.0' } })], COORDS),
+      null
+    );
+  });
+
+  it('matches the repository exactly, not by suffix', () => {
+    assert.equal(OWN_REPOSITORY, `${COORDS.owner}/${COORDS.repo}`);
+    assert.equal(findCandidate([candidatePull()], { owner: 'strapi', repo: 'strapi-fork' }), null);
   });
 
   it('stops on two open release pull requests rather than pick one', () => {
     assert.throws(
       () =>
-        findCandidate([
-          candidatePull(),
-          candidatePull({ number: 27601, head: { ref: 'releases/5.52.4', sha: 'abc' } }),
-        ]),
+        findCandidate(
+          [candidatePull(), candidatePull({ number: 27601, head: candidateHead('5.52.4') })],
+          COORDS
+        ),
       /Found 2 open release pull requests: #27600 \(releases\/5\.53\.0\), #27601 \(releases\/5\.52\.4\)/u
     );
+  });
+
+  it('does not count a fork toward the two-candidates stop', () => {
+    const fork = candidatePull({
+      number: 27601,
+      head: { ...candidateHead('5.52.4'), repo: { full_name: 'someone/strapi' } },
+    });
+
+    assert.equal(findCandidate([candidatePull(), fork], COORDS)?.pullNumber, 27600);
   });
 });
 
@@ -92,30 +124,10 @@ describe('assertCandidateUnpublished', () => {
     assert.throws(() => assertCandidateUnpublished(candidate(), '5.54.0'), /already shipped/u);
   });
 
-  it('stops on a version it cannot compare', () => {
+  it('stops on a baseline it cannot compare', () => {
     assert.throws(
-      () => assertCandidateUnpublished(candidate({ version: '5.53' }), '5.52.3'),
-      /Both have to be plain x\.y\.z versions/u
-    );
-  });
-});
-
-describe('assertBranchContained', () => {
-  const input = {
-    branch: 'releases/5.53.0',
-    branchHeadSha: 'aaaa',
-    sourceRef: 'origin/develop',
-    sourceSha: 'bbbb',
-  };
-
-  it('accepts a branch that is only a pointer into the source', () => {
-    assert.doesNotThrow(() => assertBranchContained({ ...input, contained: true }));
-  });
-
-  it('stops when something was pushed to the release branch directly', () => {
-    assert.throws(
-      () => assertBranchContained({ ...input, contained: false }),
-      /releases\/5\.53\.0 \(aaaa\) is not contained in origin\/develop \(bbbb\)/u
+      () => assertCandidateUnpublished(candidate(), '5.52'),
+      /baseline 5\.52, which is not a plain x\.y\.z version/u
     );
   });
 });
@@ -130,12 +142,17 @@ describe('decideMode', () => {
   });
 
   it('redrafts when the commits that landed changed the version', () => {
-    assert.equal(decideMode(candidate({ version: '5.52.4' }), '5.53.0'), 'redraft');
+    const older = candidate({
+      version: '5.52.4',
+      parsedVersion: { major: 5, minor: 52, patch: 4 },
+    });
+
+    assert.equal(decideMode(older, '5.53.0'), 'redraft');
   });
 
   it('stops on a version below the candidate, which means history was rewritten', () => {
     assert.throws(
-      () => decideMode(candidate({ version: '5.53.0' }), '5.52.4'),
+      () => decideMode(candidate(), '5.52.4'),
       /The range now computes 5\.52\.4, below the candidate 5\.53\.0 on #27600/u
     );
   });
@@ -143,41 +160,140 @@ describe('decideMode', () => {
   it('stops on a version it cannot compare', () => {
     assert.throws(
       () => decideMode(candidate(), 'not-a-version'),
-      /Both have to be plain x\.y\.z versions/u
+      /The recomputed version has to be a plain x\.y\.z version/u
     );
   });
 });
 
-describe('crossCheckCandidate', () => {
-  it('says nothing when the payload agrees with the branch', () => {
-    const found = findCandidate([candidatePull()]);
+describe('planBranch', () => {
+  const DEVELOP_HEAD = 'f'.repeat(40);
 
-    assert.deepEqual(crossCheckCandidate(found!), []);
-  });
+  const range: PinnedRange = {
+    fromRef: 'v5.52.3',
+    fromSha: '0'.repeat(40),
+    toRef: 'origin/develop',
+    toSha: DEVELOP_HEAD,
+  };
 
-  it('warns when the body carries no readable block', () => {
-    assert.match(
-      crossCheckCandidate(candidate())[0] ?? '',
-      /carries no readable release candidate/u
-    );
-  });
+  /** A remote where the candidate's branch exists and sits at `candidateHead`. */
+  function gitStub(
+    candidateHead: string,
+    overrides: Partial<GitAdapter> = {}
+  ): { git: GitAdapter; calls: string[] } {
+    const calls: string[] = [];
+    const git: GitAdapter = {
+      refExists: () => true,
+      resolveSha: (ref) =>
+        ref.startsWith('origin/releases/') === true ? candidateHead : DEVELOP_HEAD,
+      isAncestor: () => true,
+      listIntegrations: () => [],
+      pushBranch() {},
+      deleteBranch() {},
+      fetchBranch(branch) {
+        calls.push(`fetchBranch:${branch}`);
+      },
+      remoteBranchExists: (branch) => branch === 'releases/5.53.0',
+      ...overrides,
+    };
 
-  it('warns on a payload that disagrees, without stopping the run', () => {
-    const warnings = crossCheckCandidate(
-      candidate({
-        payload: { release: { version: '5.52.4' }, candidate: { branch: 'releases/5.52.4' } },
-      })
-    );
+    return { git, calls };
+  }
 
-    assert.equal(warnings.length, 2);
-    assert.match(warnings[0] ?? '', /lives on `releases\/5\.53\.0` but its payload records/u);
-    assert.match(warnings[1] ?? '', /was cut as `5\.53\.0` but its payload records/u);
-  });
+  it('cuts a fresh branch when nothing is in flight', () => {
+    const { git } = gitStub(SHA.CANDIDATE_HEAD, { remoteBranchExists: () => false });
 
-  it('ignores a payload whose fields are absent or not strings', () => {
     assert.deepEqual(
-      crossCheckCandidate(candidate({ payload: { release: { version: 5 }, candidate: {} } })),
-      []
+      planBranch({ git, mode: 'draft', branch: 'releases/5.53.0', candidate: null, range }),
+      { advances: true, candidateHeadSha: null }
+    );
+  });
+
+  it('stops when the branch exists with no pull request drafting it', () => {
+    const { git } = gitStub(SHA.CANDIDATE_HEAD);
+
+    assert.throws(
+      () => planBranch({ git, mode: 'draft', branch: 'releases/5.53.0', candidate: null, range }),
+      /releases\/5\.53\.0 already exists but no open pull request is drafting it/u
+    );
+  });
+
+  it('advances a candidate that fell behind and reports the head it resolved', () => {
+    const { git, calls } = gitStub(SHA.CANDIDATE_HEAD);
+
+    assert.deepEqual(
+      planBranch({
+        git,
+        mode: 'refresh',
+        branch: 'releases/5.53.0',
+        candidate: candidate(),
+        range,
+      }),
+      { advances: true, candidateHeadSha: SHA.CANDIDATE_HEAD }
+    );
+    assert.deepEqual(calls, ['fetchBranch:releases/5.53.0']);
+  });
+
+  it('pushes nothing when the candidate already sits at the pinned head', () => {
+    const { git } = gitStub(DEVELOP_HEAD);
+
+    assert.deepEqual(
+      planBranch({
+        git,
+        mode: 'refresh',
+        branch: 'releases/5.53.0',
+        candidate: candidate(),
+        range,
+      }),
+      { advances: false, candidateHeadSha: DEVELOP_HEAD }
+    );
+  });
+
+  it('always cuts the replacement on a redraft, even from the same head', () => {
+    const { git } = gitStub(DEVELOP_HEAD);
+
+    assert.deepEqual(
+      planBranch({
+        git,
+        mode: 'redraft',
+        branch: 'releases/5.54.0',
+        candidate: candidate(),
+        range,
+      }),
+      { advances: true, candidateHeadSha: DEVELOP_HEAD }
+    );
+  });
+
+  it('stops when the candidate pull request outlived its branch', () => {
+    const { git } = gitStub(SHA.CANDIDATE_HEAD, { remoteBranchExists: () => false });
+
+    assert.throws(
+      () =>
+        planBranch({
+          git,
+          mode: 'refresh',
+          branch: 'releases/5.53.0',
+          candidate: candidate(),
+          range,
+        }),
+      /#27600 is open against releases\/5\.53\.0, but that branch is gone from the remote/u
+    );
+  });
+
+  it('stops when something was pushed to the release branch directly', () => {
+    const { git } = gitStub(SHA.CANDIDATE_HEAD, {
+      isAncestor: (ancestor) => ancestor !== SHA.CANDIDATE_HEAD,
+    });
+
+    assert.throws(
+      () =>
+        planBranch({
+          git,
+          mode: 'refresh',
+          branch: 'releases/5.53.0',
+          candidate: candidate(),
+          range,
+        }),
+      /releases\/5\.53\.0 \(face0000.*\) is not contained in origin\/develop \(f{40}\)/u
     );
   });
 });

--- a/.github/actions/draft-release/__tests__/candidate.test.ts
+++ b/.github/actions/draft-release/__tests__/candidate.test.ts
@@ -1,0 +1,183 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  assertBranchContained,
+  assertCandidateUnpublished,
+  crossCheckCandidate,
+  decideMode,
+  findCandidate,
+  parseReleaseBranch,
+} from '../lib/candidate.ts';
+import { candidatePull, pull } from '../lib/__fixtures__/fixtures.ts';
+
+import type { Candidate } from '../lib/types.ts';
+
+function candidate(overrides: Partial<Candidate> = {}): Candidate {
+  return {
+    version: '5.53.0',
+    branch: 'releases/5.53.0',
+    pullNumber: 27600,
+    pullUrl: 'https://github.com/strapi/strapi/pull/27600',
+    pullHeadSha: 'face0000face0000face0000face0000face0000',
+    payload: null,
+    ...overrides,
+  };
+}
+
+describe('parseReleaseBranch', () => {
+  it('reads the version out of a release branch', () => {
+    assert.equal(parseReleaseBranch('releases/5.53.0'), '5.53.0');
+  });
+
+  it('refuses anything that is not exactly releases/x.y.z', () => {
+    assert.equal(parseReleaseBranch('releases/5.53.0-hotfix'), null);
+    assert.equal(parseReleaseBranch('releases/next'), null);
+    assert.equal(parseReleaseBranch('release/5.53.0'), null);
+    assert.equal(parseReleaseBranch('develop'), null);
+    assert.equal(parseReleaseBranch(''), null);
+  });
+});
+
+describe('findCandidate', () => {
+  it('finds the candidate and reads its payload back', () => {
+    const found = findCandidate([pull(), candidatePull()]);
+
+    assert.equal(found?.version, '5.53.0');
+    assert.equal(found?.branch, 'releases/5.53.0');
+    assert.equal(found?.pullNumber, 27600);
+    assert.deepEqual(found?.payload, {
+      release: { version: '5.53.0' },
+      candidate: { branch: 'releases/5.53.0' },
+    });
+  });
+
+  it('reports no candidate when none is open', () => {
+    assert.equal(findCandidate([pull()]), null);
+  });
+
+  it('reports no candidate on an empty list', () => {
+    assert.equal(findCandidate([]), null);
+  });
+
+  it('keeps a null payload when the body carries no readable block', () => {
+    assert.equal(findCandidate([candidatePull({ body: 'no block here' })])?.payload, null);
+  });
+
+  it('stops on two open release pull requests rather than pick one', () => {
+    assert.throws(
+      () =>
+        findCandidate([
+          candidatePull(),
+          candidatePull({ number: 27601, head: { ref: 'releases/5.52.4', sha: 'abc' } }),
+        ]),
+      /Found 2 open release pull requests: #27600 \(releases\/5\.53\.0\), #27601 \(releases\/5\.52\.4\)/u
+    );
+  });
+});
+
+describe('assertCandidateUnpublished', () => {
+  it('accepts a candidate above the published baseline', () => {
+    assert.doesNotThrow(() => assertCandidateUnpublished(candidate(), '5.52.3'));
+  });
+
+  it('stops when the candidate already shipped', () => {
+    assert.throws(
+      () => assertCandidateUnpublished(candidate(), '5.53.0'),
+      /is not above the published baseline 5\.53\.0, so that release already shipped/u
+    );
+  });
+
+  it('stops when npm moved past the candidate', () => {
+    assert.throws(() => assertCandidateUnpublished(candidate(), '5.54.0'), /already shipped/u);
+  });
+
+  it('stops on a version it cannot compare', () => {
+    assert.throws(
+      () => assertCandidateUnpublished(candidate({ version: '5.53' }), '5.52.3'),
+      /Both have to be plain x\.y\.z versions/u
+    );
+  });
+});
+
+describe('assertBranchContained', () => {
+  const input = {
+    branch: 'releases/5.53.0',
+    branchHeadSha: 'aaaa',
+    sourceRef: 'origin/develop',
+    sourceSha: 'bbbb',
+  };
+
+  it('accepts a branch that is only a pointer into the source', () => {
+    assert.doesNotThrow(() => assertBranchContained({ ...input, contained: true }));
+  });
+
+  it('stops when something was pushed to the release branch directly', () => {
+    assert.throws(
+      () => assertBranchContained({ ...input, contained: false }),
+      /releases\/5\.53\.0 \(aaaa\) is not contained in origin\/develop \(bbbb\)/u
+    );
+  });
+});
+
+describe('decideMode', () => {
+  it('drafts when nothing is in flight', () => {
+    assert.equal(decideMode(null, '5.53.0'), 'draft');
+  });
+
+  it('refreshes when the version still agrees with the candidate', () => {
+    assert.equal(decideMode(candidate(), '5.53.0'), 'refresh');
+  });
+
+  it('redrafts when the commits that landed changed the version', () => {
+    assert.equal(decideMode(candidate({ version: '5.52.4' }), '5.53.0'), 'redraft');
+  });
+
+  it('stops on a version below the candidate, which means history was rewritten', () => {
+    assert.throws(
+      () => decideMode(candidate({ version: '5.53.0' }), '5.52.4'),
+      /The range now computes 5\.52\.4, below the candidate 5\.53\.0 on #27600/u
+    );
+  });
+
+  it('stops on a version it cannot compare', () => {
+    assert.throws(
+      () => decideMode(candidate(), 'not-a-version'),
+      /Both have to be plain x\.y\.z versions/u
+    );
+  });
+});
+
+describe('crossCheckCandidate', () => {
+  it('says nothing when the payload agrees with the branch', () => {
+    const found = findCandidate([candidatePull()]);
+
+    assert.deepEqual(crossCheckCandidate(found!), []);
+  });
+
+  it('warns when the body carries no readable block', () => {
+    assert.match(
+      crossCheckCandidate(candidate())[0] ?? '',
+      /carries no readable release candidate/u
+    );
+  });
+
+  it('warns on a payload that disagrees, without stopping the run', () => {
+    const warnings = crossCheckCandidate(
+      candidate({
+        payload: { release: { version: '5.52.4' }, candidate: { branch: 'releases/5.52.4' } },
+      })
+    );
+
+    assert.equal(warnings.length, 2);
+    assert.match(warnings[0] ?? '', /lives on `releases\/5\.53\.0` but its payload records/u);
+    assert.match(warnings[1] ?? '', /was cut as `5\.53\.0` but its payload records/u);
+  });
+
+  it('ignores a payload whose fields are absent or not strings', () => {
+    assert.deepEqual(
+      crossCheckCandidate(candidate({ payload: { release: { version: 5 }, candidate: {} } })),
+      []
+    );
+  });
+});

--- a/.github/actions/draft-release/__tests__/github.test.ts
+++ b/.github/actions/draft-release/__tests__/github.test.ts
@@ -89,6 +89,17 @@ describe('createRestClient', () => {
     );
   });
 
+  it('carries the response status on the error, so the journal can tell a refusal apart', async () => {
+    const { request } = stubRequest([
+      response({ ok: false, status: 422, payload: { message: 'already_exists' } }),
+    ]);
+
+    await assert.rejects(
+      () => createRestClient('t', request).send('PATCH', '/repos/a/b/milestones/430', {}),
+      (error: unknown) => (error as { status?: unknown }).status === 422
+    );
+  });
+
   it('surfaces a non-JSON failure body verbatim', async () => {
     const { request } = stubRequest([
       response({ ok: false, status: 502, text: async () => 'bad gateway' }),
@@ -166,5 +177,23 @@ describe('createGithubAdapter', () => {
 
     assert.match(calls[0]?.url ?? '', /\/issues\/27700\/labels$/u);
     assert.equal(calls[0]?.body, '{"labels":["publish-experimental"]}');
+  });
+
+  it('lists the pull requests open against one base', async () => {
+    const { request, calls } = stubRequest([response({ payload: [] })]);
+
+    await createGithubAdapter('t', coords, request).listPulls({ state: 'open', base: 'main' });
+
+    assert.match(calls[0]?.url ?? '', /\/pulls\?state=open&base=main&per_page=100$/u);
+  });
+
+  it('closes a pull request without touching its body', async () => {
+    const { request, calls } = stubRequest([response({ payload: { number: 27600 } })]);
+
+    await createGithubAdapter('t', coords, request).closePull(27600);
+
+    assert.match(calls[0]?.url ?? '', /\/pulls\/27600$/u);
+    assert.equal(calls[0]?.method, 'PATCH');
+    assert.equal(calls[0]?.body, '{"state":"closed"}');
   });
 });

--- a/.github/actions/draft-release/__tests__/journal.test.ts
+++ b/.github/actions/draft-release/__tests__/journal.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { createJournal } from '../lib/journal.ts';
+import { classifyFailure, createJournal } from '../lib/journal.ts';
 
 const clock = (): string => '2026-09-06T17:57:00Z';
 
@@ -31,7 +31,8 @@ describe('createJournal', () => {
           after: '5.53.0',
           detail: null,
           at: '2026-09-06T17:57:00Z',
-          applied: false,
+          state: 'planned',
+          error: null,
         },
       ],
     });
@@ -67,6 +68,64 @@ describe('createJournal', () => {
     assert.equal(journal.entries()[0]?.op, 'branch.push');
   });
 
+  it('marks a write applied only once it has returned', async () => {
+    const journal = createJournal({ apply: true, clock });
+    const states: string[] = [];
+
+    await journal.write({ op: 'pr.create', target: 'pulls/<new>' }, async () => {
+      states.push(journal.entries()[0]?.state ?? '');
+
+      return { number: 1 };
+    });
+
+    assert.deepEqual(states, ['attempted']);
+    assert.equal(journal.entries()[0]?.state, 'applied');
+    assert.equal(journal.entries()[0]?.error, null);
+  });
+
+  it('records a refused write as failed, with what the server said', async () => {
+    const journal = createJournal({ apply: true, clock });
+
+    await assert.rejects(() =>
+      journal.write({ op: 'milestone.rename', target: 'milestone/430' }, async () => {
+        throw Object.assign(new Error('GitHub PATCH failed: 422 already_exists'), { status: 422 });
+      })
+    );
+
+    assert.equal(journal.entries()[0]?.state, 'failed');
+    assert.match(journal.entries()[0]?.error ?? '', /422 already_exists/u);
+  });
+
+  it('records a write of unknown outcome as indeterminate', async () => {
+    const journal = createJournal({ apply: true, clock });
+
+    await assert.rejects(() =>
+      journal.write({ op: 'pr.create', target: 'pulls/<new>' }, async () => {
+        throw new TypeError('fetch failed');
+      })
+    );
+
+    assert.equal(journal.entries()[0]?.state, 'indeterminate');
+    assert.match(journal.entries()[0]?.error ?? '', /fetch failed/u);
+  });
+
+  it('keeps a non-Error rejection readable', async () => {
+    const journal = createJournal({ apply: true, clock });
+
+    // A rejection that is not an `Error` is the point of the test: the journal has to keep it
+    // readable rather than record `[object Object]`.
+    const rejectWith = (reason: unknown): Promise<never> =>
+      new Promise((_resolve, reject) => {
+        reject(reason);
+      });
+
+    await assert.rejects(() =>
+      journal.write({ op: 'pr.label', target: 'pulls/1' }, async () => rejectWith('plain string'))
+    );
+
+    assert.equal(journal.entries()[0]?.error, 'plain string');
+  });
+
   it('hands back a copy of the entries', async () => {
     const journal = createJournal({ apply: false, clock });
 
@@ -82,5 +141,22 @@ describe('createJournal', () => {
     await journal.write({ op: 'pr.comment', target: 'pulls/1' }, async () => null);
 
     assert.match(journal.entries()[0]?.at ?? '', /^\d{4}-\d{2}-\d{2}T/u);
+  });
+});
+
+describe('classifyFailure', () => {
+  it('treats a status as proof the operation reached a verdict', () => {
+    assert.equal(classifyFailure(Object.assign(new Error('nope'), { status: 422 })), 'failed');
+    assert.equal(classifyFailure(Object.assign(new Error('nope'), { status: 1 })), 'failed');
+  });
+
+  it('refuses to guess when nothing proves the write did not land', () => {
+    assert.equal(classifyFailure(new Error('socket hang up')), 'indeterminate');
+    assert.equal(
+      classifyFailure(Object.assign(new Error('x'), { status: '422' })),
+      'indeterminate'
+    );
+    assert.equal(classifyFailure(null), 'indeterminate');
+    assert.equal(classifyFailure(undefined), 'indeterminate');
   });
 });

--- a/.github/actions/draft-release/__tests__/milestones.test.ts
+++ b/.github/actions/draft-release/__tests__/milestones.test.ts
@@ -1,47 +1,47 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { planCleanup, planMilestones, reconcile } from '../lib/milestones.ts';
+import { planCleanup, planMilestones, planRealignment, reconcile } from '../lib/milestones.ts';
 import { milestoneItem, pullRequestItem } from '../lib/__fixtures__/fixtures.ts';
 
-describe('planMilestones', () => {
+describe('planMilestones, fresh draft', () => {
   const open = [{ number: 430, title: '5.52.4', state: 'open' }];
 
   it('renames the open milestone to the version that actually ships', () => {
-    const plan = planMilestones(open, '5.53.0', open);
+    const plan = planMilestones({ allMilestones: open, version: '5.53.0', candidateVersion: null });
 
     assert.deepEqual(plan.shipping, {
       action: 'rename',
       number: 430,
       currentTitle: '5.52.4',
       title: '5.53.0',
+      close: true,
     });
-    assert.deepEqual(plan.next, { action: 'create', number: null, title: '5.53.1' });
-  });
-
-  it('leaves the title alone when it already matches', () => {
-    const plan = planMilestones(open, '5.52.4', open);
-
-    assert.equal(plan.shipping.action, 'keep');
-    assert.equal(plan.next.title, '5.52.5');
-  });
-
-  it('reuses an existing next milestone in any state', () => {
-    const all = [...open, { number: 431, title: '5.53.1', state: 'closed' }];
-
-    assert.deepEqual(planMilestones(open, '5.53.0', all).next, {
-      action: 'reuse',
-      number: 431,
+    assert.deepEqual(plan.next, {
+      action: 'create',
+      number: null,
+      currentTitle: null,
       title: '5.53.1',
     });
   });
 
+  it('leaves the title alone when it already matches', () => {
+    const plan = planMilestones({ allMilestones: open, version: '5.52.4', candidateVersion: null });
+
+    assert.equal(plan.shipping.action, 'keep');
+    assert.equal(plan.shipping.close, true);
+    assert.equal(plan.next.title, '5.52.5');
+  });
+
   it('creates the shipping milestone when none is open', () => {
-    assert.deepEqual(planMilestones([], '5.53.0', []).shipping, {
+    const plan = planMilestones({ allMilestones: [], version: '5.53.0', candidateVersion: null });
+
+    assert.deepEqual(plan.shipping, {
       action: 'create',
       number: null,
       currentTitle: null,
       title: '5.53.0',
+      close: true,
     });
   });
 
@@ -52,9 +52,176 @@ describe('planMilestones', () => {
     ];
 
     assert.throws(
-      () => planMilestones(many, '5.53.0', many),
+      () => planMilestones({ allMilestones: many, version: '5.53.0', candidateVersion: null }),
       /Expected at most one open milestone, found 2 \(5\.52\.4, 5\.53\.0\)/u
     );
+  });
+
+  it('stops rather than rename onto a title another milestone already holds', () => {
+    const all = [...open, { number: 431, title: '5.53.0', state: 'closed' }];
+
+    assert.throws(
+      () => planMilestones({ allMilestones: all, version: '5.53.0', candidateVersion: null }),
+      /A milestone titled 5\.53\.0 already exists \(#431, closed\)/u
+    );
+  });
+
+  it('refuses a closed milestone as the next one, because nobody can select it', () => {
+    const all = [...open, { number: 431, title: '5.53.1', state: 'closed' }];
+
+    assert.throws(
+      () => planMilestones({ allMilestones: all, version: '5.53.0', candidateVersion: null }),
+      /the one titled 5\.53\.1 is closed \(#431\)/u
+    );
+  });
+});
+
+describe('planMilestones, candidate in flight', () => {
+  // What the repository looks like while 5.53.0 is drafted: shipping closed, next open.
+  const inFlight = [
+    { number: 430, title: '5.53.0', state: 'closed' },
+    { number: 431, title: '5.53.1', state: 'open' },
+  ];
+
+  it('keeps the closed shipping milestone and does not reopen it', () => {
+    const plan = planMilestones({
+      allMilestones: inFlight,
+      version: '5.53.0',
+      candidateVersion: '5.53.0',
+    });
+
+    assert.deepEqual(plan.shipping, {
+      action: 'keep',
+      number: 430,
+      currentTitle: '5.53.0',
+      title: '5.53.0',
+      close: false,
+    });
+    assert.deepEqual(plan.next, {
+      action: 'reuse',
+      number: 431,
+      currentTitle: '5.53.1',
+      title: '5.53.1',
+    });
+  });
+
+  it('renames both milestones when the version drifted', () => {
+    const drifted = [
+      { number: 430, title: '5.52.4', state: 'closed' },
+      { number: 431, title: '5.52.5', state: 'open' },
+    ];
+
+    const plan = planMilestones({
+      allMilestones: drifted,
+      version: '5.53.0',
+      candidateVersion: '5.52.4',
+    });
+
+    assert.deepEqual(plan.shipping, {
+      action: 'rename',
+      number: 430,
+      currentTitle: '5.52.4',
+      title: '5.53.0',
+      close: false,
+    });
+    assert.deepEqual(plan.next, {
+      action: 'rename',
+      number: 431,
+      currentTitle: '5.52.5',
+      title: '5.53.1',
+    });
+  });
+
+  it('closes a shipping milestone an earlier run left open', () => {
+    const halfDone = [
+      { number: 430, title: '5.53.0', state: 'open' },
+      { number: 431, title: '5.53.1', state: 'open' },
+    ];
+
+    const plan = planMilestones({
+      allMilestones: halfDone,
+      version: '5.53.0',
+      candidateVersion: '5.53.0',
+    });
+
+    assert.equal(plan.shipping.close, true);
+    assert.equal(plan.next.number, 431);
+  });
+
+  it('stops when the shipping milestone was renamed away under it', () => {
+    assert.throws(
+      () =>
+        planMilestones({
+          allMilestones: [{ number: 431, title: '5.53.1', state: 'open' }],
+          version: '5.53.0',
+          candidateVersion: '5.53.0',
+        }),
+      /No milestone is titled 5\.53\.0, the version the open candidate was cut under/u
+    );
+  });
+
+  it('stops when the open milestone is not the candidate’s next one', () => {
+    const wrong = [
+      { number: 430, title: '5.53.0', state: 'closed' },
+      { number: 432, title: '6.0.0', state: 'open' },
+    ];
+
+    assert.throws(
+      () => planMilestones({ allMilestones: wrong, version: '5.53.0', candidateVersion: '5.53.0' }),
+      /The open milestone is 6\.0\.0, but this release expects 5\.53\.1/u
+    );
+  });
+
+  it('creates the next milestone when none is open', () => {
+    const plan = planMilestones({
+      allMilestones: [{ number: 430, title: '5.53.0', state: 'closed' }],
+      version: '5.53.0',
+      candidateVersion: '5.53.0',
+    });
+
+    assert.deepEqual(plan.next, {
+      action: 'create',
+      number: null,
+      currentTitle: null,
+      title: '5.53.1',
+    });
+  });
+
+  it('never picks the shipping milestone as the next one', () => {
+    const single = [{ number: 430, title: '5.53.0', state: 'open' }];
+    const plan = planMilestones({
+      allMilestones: single,
+      version: '5.53.0',
+      candidateVersion: '5.53.0',
+    });
+
+    assert.equal(plan.shipping.number, 430);
+    assert.equal(plan.next.number, null);
+    assert.equal(plan.next.action, 'create');
+  });
+});
+
+describe('planRealignment', () => {
+  const shipping = { number: 430, title: '5.53.0' };
+
+  it('moves everything that does not already carry the shipping milestone', () => {
+    const planned = planRealignment(
+      [
+        { number: 1, milestone: '5.53.0' },
+        { number: 2, milestone: '5.53.1' },
+        { number: 3, milestone: null },
+      ],
+      shipping
+    );
+
+    assert.deepEqual(planned, [
+      { number: 2, from: '5.53.1', toTitle: '5.53.0' },
+      { number: 3, from: null, toTitle: '5.53.0' },
+    ]);
+  });
+
+  it('plans nothing when every pull request already agrees with history', () => {
+    assert.deepEqual(planRealignment([{ number: 1, milestone: '5.53.0' }], shipping), []);
   });
 });
 

--- a/.github/actions/draft-release/__tests__/milestones.test.ts
+++ b/.github/actions/draft-release/__tests__/milestones.test.ts
@@ -98,7 +98,7 @@ describe('planMilestones, candidate in flight', () => {
       close: false,
     });
     assert.deepEqual(plan.next, {
-      action: 'reuse',
+      action: 'keep',
       number: 431,
       currentTitle: '5.53.1',
       title: '5.53.1',

--- a/.github/actions/draft-release/__tests__/pipeline.test.ts
+++ b/.github/actions/draft-release/__tests__/pipeline.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'node:test';
 import { createJournal } from '../lib/journal.ts';
 import { EXPERIMENTAL_LABEL, preflightRelease, runDraftRelease } from '../lib/pipeline.ts';
 import { renderBody } from '../lib/report.ts';
-import { SHA, candidatePull } from '../lib/__fixtures__/fixtures.ts';
+import { SHA, candidateHead, candidatePull } from '../lib/__fixtures__/fixtures.ts';
 
 import type { RegistryRequest } from '../lib/npm.ts';
 import type { DraftReleaseResult } from '../lib/pipeline.ts';
@@ -178,8 +178,8 @@ function scenario(overrides: Overrides = {}): {
     pushBranch(sha, branch) {
       calls.push(`pushBranch:${branch}:${sha}`);
     },
-    deleteBranch(branch) {
-      calls.push(`deleteBranch:${branch}`);
+    deleteBranch(branch, expectedSha) {
+      calls.push(`deleteBranch:${branch}:${expectedSha}`);
     },
     fetchBranch(branch) {
       calls.push(`fetchBranch:${branch}`);
@@ -428,6 +428,24 @@ describe('runDraftRelease', () => {
     );
   });
 
+  it('drafts as if nothing were open when the only release pull request comes from a fork', async () => {
+    const { calls, result } = await run(
+      { dryRun: false },
+      {
+        openPulls: [
+          candidatePull({
+            head: { ...candidateHead('5.53.0'), repo: { full_name: 'someone/strapi' } },
+          }),
+        ],
+      }
+    );
+
+    assert.equal(result.mode, 'draft');
+    assert.equal(result.pullNumber, 27700);
+    assert.equal(calls.includes('createPull:Release 5.53.0'), true);
+    assert.equal(calls.includes('updatePullBody:27600'), false);
+  });
+
   it('stops when a release branch was left behind with no pull request drafting it', async () => {
     await assert.rejects(
       () => run({ dryRun: true }, { git: { remoteBranchExists: () => true } }),
@@ -600,16 +618,6 @@ describe('runDraftRelease, candidate in flight', () => {
     assert.equal(calls.includes('updatePullBody:27600'), true);
   });
 
-  it('warns when the candidate body was hand-edited away from its branch', async () => {
-    const { result } = await run(
-      { dryRun: false },
-      inFlight(SHA.CANDIDATE_HEAD, { openPulls: [candidatePull({ body: 'someone rewrote this' })] })
-    );
-
-    assert.equal(result.warnings.length, 1);
-    assert.match(result.warnings[0] ?? '', /carries no readable release candidate block/u);
-  });
-
   // Only the containment check fails. The range pin asks the same question of the baseline tag,
   // and answering `false` there would stop the run for the wrong reason.
   const diverged: Partial<GitAdapter> = {
@@ -659,9 +667,7 @@ describe('runDraftRelease, candidate in flight', () => {
         run(
           { dryRun: false },
           inFlight(SHA.CANDIDATE_HEAD, {
-            openPulls: [
-              candidatePull({ head: { ref: 'releases/5.52.3', sha: SHA.CANDIDATE_HEAD } }),
-            ],
+            openPulls: [candidatePull({ head: candidateHead('5.52.3') })],
           })
         ),
       /is not above the published baseline 5\.52\.3, so that release already shipped/u
@@ -674,9 +680,7 @@ describe('runDraftRelease, candidate in flight', () => {
         run(
           { dryRun: false },
           inFlight(SHA.CANDIDATE_HEAD, {
-            openPulls: [
-              candidatePull({ head: { ref: 'releases/5.54.0', sha: SHA.CANDIDATE_HEAD } }),
-            ],
+            openPulls: [candidatePull({ head: candidateHead('5.54.0') })],
           })
         ),
       /below the candidate 5\.54\.0/u
@@ -691,10 +695,7 @@ describe('runDraftRelease, candidate in flight', () => {
           inFlight(SHA.CANDIDATE_HEAD, {
             openPulls: [
               candidatePull(),
-              candidatePull({
-                number: 27601,
-                head: { ref: 'releases/5.52.4', sha: SHA.CANDIDATE_HEAD },
-              }),
+              candidatePull({ number: 27601, head: candidateHead('5.52.4') }),
             ],
           })
         ),
@@ -725,12 +726,7 @@ describe('runDraftRelease, redraft', () => {
   /** The version drifted: the candidate was cut as 5.52.4, and a feat has landed since. */
   function drifted(overrides: Overrides = {}): Overrides {
     return {
-      openPulls: [
-        candidatePull({
-          number: 27600,
-          head: { ref: 'releases/5.52.4', sha: SHA.CANDIDATE_HEAD },
-        }),
-      ],
+      openPulls: [candidatePull({ number: 27600, head: candidateHead('5.52.4') })],
       gh: {
         listMilestones: async () => [
           { number: 430, title: '5.52.4', state: 'closed' },
@@ -768,11 +764,19 @@ describe('runDraftRelease, redraft', () => {
 
     const created = calls.indexOf('createPull:Release 5.53.0');
     const closed = calls.indexOf('closePull:27600');
-    const deleted = calls.indexOf('deleteBranch:releases/5.52.4');
+    const deleted = calls.indexOf(`deleteBranch:releases/5.52.4:${SHA.CANDIDATE_HEAD}`);
 
     assert.equal(created > -1, true);
     assert.equal(created < closed, true);
     assert.equal(closed < deleted, true);
+  });
+
+  it('deletes the old branch under a lease on the head the preflight saw', async () => {
+    const { result } = await run({ dryRun: true }, drifted());
+    const entry = result.journal.entries.find((candidate) => candidate.op === 'branch.delete');
+
+    assert.equal(entry?.target, 'refs/heads/releases/5.52.4');
+    assert.equal(entry?.before, SHA.CANDIDATE_HEAD);
   });
 
   it('records the whole sequence in the journal, in order', async () => {

--- a/.github/actions/draft-release/__tests__/pipeline.test.ts
+++ b/.github/actions/draft-release/__tests__/pipeline.test.ts
@@ -243,6 +243,9 @@ describe('runDraftRelease', () => {
     assert.deepEqual(
       result.journal.entries.map((entry) => entry.op),
       [
+        'branch.push',
+        'pr.create',
+        'pr.label',
         'milestone.rename',
         'milestone.create',
         'issue.milestone.set',
@@ -251,20 +254,35 @@ describe('runDraftRelease', () => {
         'issue.milestone.clear',
         'issue.milestone.clear',
         'milestone.close',
-        'branch.push',
-        'pr.create',
-        'pr.label',
         'pr.body',
         'pr.comment',
       ]
     );
   });
 
+  it('pushes the branch and opens the pull request before touching a milestone', async () => {
+    // The two writes most likely to fail on permissions go first, so a failure there leaves at
+    // most one write behind instead of dozens of milestone moves.
+    const { calls } = await run({ dryRun: false });
+
+    const firstMilestoneWrite = calls.findIndex(
+      (call) => call.startsWith('updateMilestone:') === true || call.startsWith('createMilestone:')
+    );
+
+    assert.equal(calls.indexOf(`pushBranch:releases/5.53.0:${FEAT_SHA}`), 0);
+    assert.equal(calls.indexOf('createPull:Release 5.53.0'), 1);
+    assert.equal(calls.indexOf(`addLabels:27700:${EXPERIMENTAL_LABEL}`), 2);
+    assert.equal(firstMilestoneWrite, 3);
+  });
+
   it('renames, opens the next milestone, then closes the shipping one', async () => {
     const { calls } = await run({ dryRun: false });
 
     assert.deepEqual(
-      [calls[0], calls[1], calls.find((call) => call.includes('"state":"closed"'))],
+      calls.filter(
+        (call) =>
+          call.startsWith('updateMilestone:') === true || call.startsWith('createMilestone:')
+      ),
       [
         'updateMilestone:430:{"title":"5.53.0"}',
         'createMilestone:5.53.1',
@@ -785,16 +803,16 @@ describe('runDraftRelease, redraft', () => {
     assert.deepEqual(
       result.journal.entries.map((entry) => entry.op),
       [
-        'milestone.rename',
-        'milestone.rename',
-        'issue.milestone.set',
-        'issue.milestone.set',
-        'issue.milestone.set',
-        'issue.milestone.clear',
-        'issue.milestone.clear',
         'branch.push',
         'pr.create',
         'pr.label',
+        'milestone.rename',
+        'milestone.rename',
+        'issue.milestone.set',
+        'issue.milestone.set',
+        'issue.milestone.set',
+        'issue.milestone.clear',
+        'issue.milestone.clear',
         'pr.body',
         'pr.comment',
         'pr.close',

--- a/.github/actions/draft-release/__tests__/pipeline.test.ts
+++ b/.github/actions/draft-release/__tests__/pipeline.test.ts
@@ -2,9 +2,9 @@ import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import { createJournal } from '../lib/journal.ts';
-import { EXPERIMENTAL_LABEL, runDraftRelease } from '../lib/pipeline.ts';
+import { EXPERIMENTAL_LABEL, preflightRelease, runDraftRelease } from '../lib/pipeline.ts';
 import { renderBody } from '../lib/report.ts';
-import { SHA } from '../lib/__fixtures__/fixtures.ts';
+import { SHA, candidatePull } from '../lib/__fixtures__/fixtures.ts';
 
 import type { RegistryRequest } from '../lib/npm.ts';
 import type { DraftReleaseResult } from '../lib/pipeline.ts';
@@ -25,6 +25,8 @@ const BACK_MERGE_SHA = SHA.BACK_MERGE;
 type Overrides = {
   gh?: Partial<GithubAdapter>;
   git?: Partial<GitAdapter>;
+  /** The pull requests open against `main`, which is where a candidate in flight is found. */
+  openPulls?: PullPayload[];
 };
 
 /**
@@ -131,6 +133,7 @@ function scenario(overrides: Overrides = {}): {
       throw new Error('404');
     },
     listPullCommits: async () => [],
+    listPulls: async () => overrides.openPulls ?? [],
     listMilestones: async () => [{ number: 430, title: '5.52.4', state: 'open' }],
     async createMilestone(title) {
       calls.push(`createMilestone:${title}`);
@@ -154,6 +157,9 @@ function scenario(overrides: Overrides = {}): {
     async updatePullBody(number) {
       calls.push(`updatePullBody:${number}`);
     },
+    async closePull(number) {
+      calls.push(`closePull:${number}`);
+    },
     async addLabels(number, labels) {
       calls.push(`addLabels:${number}:${labels.join(',')}`);
     },
@@ -171,6 +177,12 @@ function scenario(overrides: Overrides = {}): {
     remoteBranchExists: () => false,
     pushBranch(sha, branch) {
       calls.push(`pushBranch:${branch}:${sha}`);
+    },
+    deleteBranch(branch) {
+      calls.push(`deleteBranch:${branch}`);
+    },
+    fetchBranch(branch) {
+      calls.push(`fetchBranch:${branch}`);
     },
     ...overrides.git,
   };
@@ -195,7 +207,7 @@ async function run(
   const journal = createJournal({ apply: inputs.dryRun === false, clock: CLOCK });
 
   const result = await runDraftRelease({
-    inputs: { version: '', sourceRef: 'develop', ...inputs },
+    inputs: { version: '', ...inputs },
     git: context.git,
     gh: context.gh,
     journal,
@@ -233,14 +245,16 @@ describe('runDraftRelease', () => {
       [
         'milestone.rename',
         'milestone.create',
+        'issue.milestone.set',
+        'issue.milestone.set',
+        'issue.milestone.set',
+        'issue.milestone.clear',
+        'issue.milestone.clear',
         'milestone.close',
         'branch.push',
         'pr.create',
         'pr.label',
         'pr.body',
-        'issue.milestone.set',
-        'issue.milestone.clear',
-        'issue.milestone.clear',
         'pr.comment',
       ]
     );
@@ -249,11 +263,14 @@ describe('runDraftRelease', () => {
   it('renames, opens the next milestone, then closes the shipping one', async () => {
     const { calls } = await run({ dryRun: false });
 
-    assert.deepEqual(calls.slice(0, 3), [
-      'updateMilestone:430:{"title":"5.53.0"}',
-      'createMilestone:5.53.1',
-      'updateMilestone:430:{"state":"closed"}',
-    ]);
+    assert.deepEqual(
+      [calls[0], calls[1], calls.find((call) => call.includes('"state":"closed"'))],
+      [
+        'updateMilestone:430:{"title":"5.53.0"}',
+        'createMilestone:5.53.1',
+        'updateMilestone:430:{"state":"closed"}',
+      ]
+    );
   });
 
   it('cuts the branch at the pinned SHA and labels the PR for the experimental publish', async () => {
@@ -272,10 +289,10 @@ describe('runDraftRelease', () => {
     assert.equal(calls.includes('setIssueMilestone:27600:431'), true);
     assert.equal(calls.includes('setIssueMilestone:27601:null'), true);
     assert.equal(calls.includes('setIssueMilestone:26000:null'), true);
-    assert.equal(
-      calls.some((call) => call.startsWith('setIssueMilestone:27436')),
-      false
-    );
+    // 27436 and 27509 shipped, so they are pulled into the shipping milestone rather than left
+    // on the one their authors picked.
+    assert.equal(calls.includes('setIssueMilestone:27436:430'), true);
+    assert.equal(calls.includes('setIssueMilestone:27509:430'), true);
   });
 
   it('keeps the release back-merge out of the shipping set and out of the drift report', async () => {
@@ -310,13 +327,15 @@ describe('runDraftRelease', () => {
       branch: 'releases/5.53.0',
       headSha: FEAT_SHA,
       expectedExperimentalVersion: `0.0.0-experimental.${FEAT_SHA}`,
+      branchAdvanced: true,
       pullRequestNumber: 27700,
       pullRequestUrl: 'https://github.com/strapi/strapi/pull/27700',
     });
 
     assert.equal(result.payload.candidate.headSha, result.payload.range.toSha);
     assert.equal(result.payload.candidate.branch, result.branch);
-    assert.equal(result.payload.schemaVersion, 4);
+    assert.equal(result.payload.release.mode, 'draft');
+    assert.equal(result.payload.schemaVersion, 5);
   });
 
   it('reports no pull request for a candidate a dry run only planned', async () => {
@@ -326,6 +345,7 @@ describe('runDraftRelease', () => {
       branch: 'releases/5.53.0',
       headSha: FEAT_SHA,
       expectedExperimentalVersion: `0.0.0-experimental.${FEAT_SHA}`,
+      branchAdvanced: true,
       pullRequestNumber: null,
       pullRequestUrl: null,
     });
@@ -408,10 +428,10 @@ describe('runDraftRelease', () => {
     );
   });
 
-  it('stops when the release branch already exists', async () => {
+  it('stops when a release branch was left behind with no pull request drafting it', async () => {
     await assert.rejects(
       () => run({ dryRun: true }, { git: { remoteBranchExists: () => true } }),
-      /already exists/u
+      /already exists but no open pull request is drafting it/u
     );
   });
 
@@ -494,5 +514,302 @@ describe('runDraftRelease', () => {
       true
     );
     assert.equal(result.payload.attention.length, 3);
+  });
+});
+
+/**
+ * The second and third runs of a release window.
+ *
+ * `develop` keeps moving while a candidate is open, so the action has to fold what landed since
+ * into the same release. These scenarios start from the repository state the first run leaves
+ * behind: the shipping milestone closed, the next one open, and the release pull request in flight.
+ */
+describe('runDraftRelease, candidate in flight', () => {
+  const CANDIDATE_MILESTONES = [
+    { number: 430, title: '5.53.0', state: 'closed' },
+    { number: 431, title: '5.53.1', state: 'open' },
+  ];
+
+  /** The release branch sits at `head`, which is behind `develop` unless it is `FEAT_SHA`. */
+  function inFlight(head: string, overrides: Overrides = {}): Overrides {
+    return {
+      ...overrides,
+      openPulls: overrides.openPulls ?? [candidatePull()],
+      gh: { listMilestones: async () => CANDIDATE_MILESTONES, ...overrides.gh },
+      git: {
+        remoteBranchExists: () => true,
+        resolveSha(ref) {
+          if (ref === 'v5.52.3') {
+            return '0'.repeat(40);
+          }
+
+          return ref.startsWith('origin/releases/') === true ? head : FEAT_SHA;
+        },
+        ...overrides.git,
+      },
+    };
+  }
+
+  it('advances the candidate instead of opening a second one', async () => {
+    const { calls, result } = await run({ dryRun: false }, inFlight(SHA.CANDIDATE_HEAD));
+
+    assert.equal(result.mode, 'refresh');
+    assert.equal(result.version, '5.53.0');
+    assert.equal(result.pullNumber, 27600);
+    assert.equal(calls.includes(`pushBranch:releases/5.53.0:${FEAT_SHA}`), true);
+    assert.equal(calls.includes('updatePullBody:27600'), true);
+    assert.equal(calls.includes('createComment:27600'), true);
+    assert.equal(
+      calls.some((call) => call.startsWith('createPull:')),
+      false
+    );
+  });
+
+  it('checks the branch is only a pointer into develop before touching it', async () => {
+    const { calls } = await run({ dryRun: false }, inFlight(SHA.CANDIDATE_HEAD));
+
+    assert.equal(calls.includes('fetchBranch:releases/5.53.0'), true);
+  });
+
+  it('leaves the shipping milestone closed and fills it through the API', async () => {
+    const { calls, result } = await run({ dryRun: false }, inFlight(SHA.CANDIDATE_HEAD));
+
+    assert.equal(result.payload.milestones.shipping.number, 430);
+    assert.equal(result.payload.milestones.next.number, 431);
+    assert.equal(calls.includes('setIssueMilestone:27509:430'), true);
+    assert.equal(calls.includes('setIssueMilestone:27436:430'), true);
+    assert.equal(
+      calls.some((call) => call.includes('"state":"closed"')),
+      false
+    );
+    assert.equal(
+      calls.some((call) => call.startsWith('createMilestone:')),
+      false
+    );
+  });
+
+  it('does not push, and says so, when nothing landed since the last run', async () => {
+    const { calls, result } = await run({ dryRun: false }, inFlight(FEAT_SHA));
+
+    assert.equal(result.mode, 'refresh');
+    assert.equal(result.payload.candidate.branchAdvanced, false);
+    assert.equal(
+      calls.some((call) => call.startsWith('pushBranch:')),
+      false
+    );
+    assert.equal(calls.includes('updatePullBody:27600'), true);
+  });
+
+  it('warns when the candidate body was hand-edited away from its branch', async () => {
+    const { result } = await run(
+      { dryRun: false },
+      inFlight(SHA.CANDIDATE_HEAD, { openPulls: [candidatePull({ body: 'someone rewrote this' })] })
+    );
+
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0] ?? '', /carries no readable release candidate block/u);
+  });
+
+  // Only the containment check fails. The range pin asks the same question of the baseline tag,
+  // and answering `false` there would stop the run for the wrong reason.
+  const diverged: Partial<GitAdapter> = {
+    isAncestor: (ancestor) => ancestor !== SHA.CANDIDATE_HEAD,
+  };
+
+  it('stops when something was pushed to the release branch directly', async () => {
+    await assert.rejects(
+      () => run({ dryRun: false }, inFlight(SHA.CANDIDATE_HEAD, { git: diverged })),
+      /releases\/5\.53\.0 \(face0000.*\) is not contained in origin\/develop/u
+    );
+  });
+
+  it('refuses in the preflight, before a single write is attempted', async () => {
+    const context = scenario(inFlight(SHA.CANDIDATE_HEAD, { git: diverged }));
+
+    await assert.rejects(() =>
+      preflightRelease({
+        inputs: { version: '', dryRun: false },
+        git: context.git,
+        gh: context.gh,
+        journal: createJournal({ apply: true, clock: CLOCK }),
+        request: context.request,
+        logger: { info() {} },
+        clock: CLOCK,
+      })
+    );
+
+    // `fetchBranch` is the only call the preflight makes that the stub records, and it is a read.
+    assert.deepEqual(context.calls, ['fetchBranch:releases/5.53.0']);
+  });
+
+  it('stops when the candidate pull request outlived its branch', async () => {
+    await assert.rejects(
+      () =>
+        run(
+          { dryRun: false },
+          inFlight(SHA.CANDIDATE_HEAD, { git: { remoteBranchExists: () => false } })
+        ),
+      /#27600 is open against releases\/5\.53\.0, but that branch is gone from the remote/u
+    );
+  });
+
+  it('stops when the candidate release already published', async () => {
+    await assert.rejects(
+      () =>
+        run(
+          { dryRun: false },
+          inFlight(SHA.CANDIDATE_HEAD, {
+            openPulls: [
+              candidatePull({ head: { ref: 'releases/5.52.3', sha: SHA.CANDIDATE_HEAD } }),
+            ],
+          })
+        ),
+      /is not above the published baseline 5\.52\.3, so that release already shipped/u
+    );
+  });
+
+  it('stops when the version would move backwards', async () => {
+    await assert.rejects(
+      () =>
+        run(
+          { dryRun: false },
+          inFlight(SHA.CANDIDATE_HEAD, {
+            openPulls: [
+              candidatePull({ head: { ref: 'releases/5.54.0', sha: SHA.CANDIDATE_HEAD } }),
+            ],
+          })
+        ),
+      /below the candidate 5\.54\.0/u
+    );
+  });
+
+  it('stops when two release pull requests are open', async () => {
+    await assert.rejects(
+      () =>
+        run(
+          { dryRun: false },
+          inFlight(SHA.CANDIDATE_HEAD, {
+            openPulls: [
+              candidatePull(),
+              candidatePull({
+                number: 27601,
+                head: { ref: 'releases/5.52.4', sha: SHA.CANDIDATE_HEAD },
+              }),
+            ],
+          })
+        ),
+      /Found 2 open release pull requests/u
+    );
+  });
+
+  it('stops when the open milestone is not the candidate’s next one', async () => {
+    await assert.rejects(
+      () =>
+        run(
+          { dryRun: false },
+          inFlight(SHA.CANDIDATE_HEAD, {
+            gh: {
+              listMilestones: async () => [
+                { number: 430, title: '5.53.0', state: 'closed' },
+                { number: 432, title: '6.0.0', state: 'open' },
+              ],
+            },
+          })
+        ),
+      /The open milestone is 6\.0\.0, but this release expects 5\.53\.1/u
+    );
+  });
+});
+
+describe('runDraftRelease, redraft', () => {
+  /** The version drifted: the candidate was cut as 5.52.4, and a feat has landed since. */
+  function drifted(overrides: Overrides = {}): Overrides {
+    return {
+      openPulls: [
+        candidatePull({
+          number: 27600,
+          head: { ref: 'releases/5.52.4', sha: SHA.CANDIDATE_HEAD },
+        }),
+      ],
+      gh: {
+        listMilestones: async () => [
+          { number: 430, title: '5.52.4', state: 'closed' },
+          { number: 431, title: '5.52.5', state: 'open' },
+        ],
+        ...overrides.gh,
+      },
+      git: {
+        remoteBranchExists: (branch) => branch === 'releases/5.52.4',
+        resolveSha(ref) {
+          if (ref === 'v5.52.3') {
+            return '0'.repeat(40);
+          }
+
+          return ref.startsWith('origin/releases/') === true ? SHA.CANDIDATE_HEAD : FEAT_SHA;
+        },
+        ...overrides.git,
+      },
+    };
+  }
+
+  it('renames both milestones onto the version the commits decided', async () => {
+    const { calls, result } = await run({ dryRun: false }, drifted());
+
+    assert.equal(result.mode, 'redraft');
+    assert.equal(result.version, '5.53.0');
+    assert.deepEqual(
+      calls.filter((call) => call.startsWith('updateMilestone:')),
+      ['updateMilestone:430:{"title":"5.53.0"}', 'updateMilestone:431:{"title":"5.53.1"}']
+    );
+  });
+
+  it('opens the replacement before retiring what it replaces', async () => {
+    const { calls } = await run({ dryRun: false }, drifted());
+
+    const created = calls.indexOf('createPull:Release 5.53.0');
+    const closed = calls.indexOf('closePull:27600');
+    const deleted = calls.indexOf('deleteBranch:releases/5.52.4');
+
+    assert.equal(created > -1, true);
+    assert.equal(created < closed, true);
+    assert.equal(closed < deleted, true);
+  });
+
+  it('records the whole sequence in the journal, in order', async () => {
+    const { result } = await run({ dryRun: true }, drifted());
+
+    assert.deepEqual(
+      result.journal.entries.map((entry) => entry.op),
+      [
+        'milestone.rename',
+        'milestone.rename',
+        'issue.milestone.set',
+        'issue.milestone.set',
+        'issue.milestone.set',
+        'issue.milestone.clear',
+        'issue.milestone.clear',
+        'branch.push',
+        'pr.create',
+        'pr.label',
+        'pr.body',
+        'pr.comment',
+        'pr.close',
+        'branch.delete',
+        'pr.comment',
+      ]
+    );
+  });
+
+  it('tells the reader on both pull requests which one replaced which', async () => {
+    const { result } = await run({ dryRun: false }, drifted());
+    const body = renderBody({
+      payload: result.payload,
+      pullRequests: result.payload.pullRequests,
+      attention: result.payload.attention,
+      supersedes: { pullNumber: 27600, branch: 'releases/5.52.4' },
+    });
+
+    assert.match(body, /Supersedes #27600, which was drafted as `releases\/5\.52\.4`/u);
+    assert.match(body, /Redrafted\./u);
   });
 });

--- a/.github/actions/draft-release/__tests__/range.test.ts
+++ b/.github/actions/draft-release/__tests__/range.test.ts
@@ -106,6 +106,44 @@ describe('createGitAdapter', () => {
     );
   });
 
+  it('deletes a remote branch through an explicit ref', () => {
+    const seen: string[] = [];
+    const exec: GitExec = (args) => {
+      seen.push(args.join(' '));
+
+      return { status: 0, stdout: '', stderr: '' };
+    };
+
+    createGitAdapter(exec).deleteBranch('releases/5.52.4');
+
+    assert.equal(seen[0], 'push origin --delete refs/heads/releases/5.52.4');
+  });
+
+  it('forces the remote-tracking ref when fetching a branch, since it is only a read cache', () => {
+    const seen: string[] = [];
+    const exec: GitExec = (args) => {
+      seen.push(args.join(' '));
+
+      return { status: 0, stdout: '', stderr: '' };
+    };
+
+    createGitAdapter(exec).fetchBranch('releases/5.53.0');
+
+    assert.equal(
+      seen[0],
+      'fetch --force origin refs/heads/releases/5.53.0:refs/remotes/origin/releases/5.53.0'
+    );
+  });
+
+  it('carries the exit code on the error, because git updates a ref atomically', () => {
+    const exec = execStub({ push: { status: 1, stdout: '', stderr: 'GH013 rule violations' } });
+
+    assert.throws(
+      () => createGitAdapter(exec).pushBranch('abc', 'releases/5.53.0'),
+      (error: unknown) => (error as { status?: unknown }).status === 1
+    );
+  });
+
   it('reports a missing remote branch when ls-remote finds nothing', () => {
     const exec = execStub({ 'ls-remote': { status: 2, stdout: '', stderr: '' } });
 
@@ -142,6 +180,8 @@ describe('pinRange', () => {
       isAncestor: () => true,
       listIntegrations: () => [],
       pushBranch() {},
+      deleteBranch() {},
+      fetchBranch() {},
       remoteBranchExists: () => false,
       ...overrides,
     };

--- a/.github/actions/draft-release/__tests__/range.test.ts
+++ b/.github/actions/draft-release/__tests__/range.test.ts
@@ -106,17 +106,24 @@ describe('createGitAdapter', () => {
     );
   });
 
-  it('deletes a remote branch through an explicit ref', () => {
-    const seen: string[] = [];
+  it('deletes a remote branch under a lease on the head it expects', () => {
+    const seen: string[][] = [];
     const exec: GitExec = (args) => {
-      seen.push(args.join(' '));
+      seen.push(args);
 
       return { status: 0, stdout: '', stderr: '' };
     };
 
-    createGitAdapter(exec).deleteBranch('releases/5.52.4');
+    createGitAdapter(exec).deleteBranch('releases/5.52.4', 'face0000');
 
-    assert.equal(seen[0], 'push origin --delete refs/heads/releases/5.52.4');
+    assert.deepEqual(seen, [
+      [
+        'push',
+        '--force-with-lease=refs/heads/releases/5.52.4:face0000',
+        'origin',
+        ':refs/heads/releases/5.52.4',
+      ],
+    ]);
   });
 
   it('forces the remote-tracking ref when fetching a branch, since it is only a read cache', () => {

--- a/.github/actions/draft-release/__tests__/report.test.ts
+++ b/.github/actions/draft-release/__tests__/report.test.ts
@@ -17,66 +17,42 @@ import {
   withoutTrailingReference,
 } from '../lib/report.ts';
 
-import type { AttributedPull, JournalEntry } from '../lib/types.ts';
-import type { PayloadInput } from '../lib/report.ts';
+import { releasePlan } from '../lib/__fixtures__/fixtures.ts';
 
-function payloadInput(overrides: Partial<PayloadInput> = {}): PayloadInput {
+import type {
+  AttributedPull,
+  JournalEntry,
+  ReleaseOutcome,
+  ReleasePayload,
+  ReleasePlan,
+} from '../lib/types.ts';
+
+function releaseOutcome(overrides: Partial<ReleaseOutcome> = {}): ReleaseOutcome {
   return {
-    generatedAt: '2026-09-06T17:57:00Z',
-    coords: { owner: 'strapi', repo: 'strapi' },
-    dryRun: false,
-    version: '5.53.0',
-    bump: 'minor',
-    previousVersion: '5.52.3',
-    versionSource: 'computed',
-    mode: 'draft',
-    range: {
-      fromRef: 'v5.52.3',
-      fromSha: 'a'.repeat(40),
-      toRef: 'origin/develop',
-      toSha: 'b'.repeat(40),
-    },
-    integrationCount: 12,
-    branch: 'releases/5.53.0',
-    branchAdvanced: true,
+    shippingNumber: 430,
+    nextNumber: 431,
     pullNumber: 27700,
     pullUrl: 'https://github.com/strapi/strapi/pull/27700',
-    classification: {
-      features: [
-        {
-          sha: 'c'.repeat(40),
-          pr: 27436,
-          subject: 'feat(content-releases): audit logs',
-          via: 'subject',
-        },
-      ],
-      breaking: [],
-      ignored: [],
-      unparsed: [],
-    },
-    pullRequests: [
-      {
-        number: 27436,
-        title: 'feat(content-releases): audit logs',
-        author: { login: 'someone', name: 'Someone Real' },
-        url: 'https://github.com/strapi/strapi/pull/27436',
-        baseRef: 'develop',
-        headRef: 'feat/audit-logs',
-        milestone: '5.52.4',
-        mergedAt: '2026-09-05T09:59:00Z',
-        status: 'resolved',
-        basis: 'exact-merge-sha',
-        integrationShas: ['c'.repeat(40)],
-      },
-    ],
-    attention: [],
-    milestones: {
-      shipping: { number: 430, title: '5.53.0', renamedFrom: '5.52.4', state: 'closed' },
-      next: { number: 431, title: '5.53.1', created: true },
-    },
     reconciliation: { inHistoryNotInMilestone: [], inMilestoneNotInHistory: [] },
     ...overrides,
   };
+}
+
+/** The payload of a fresh draft, built the way the pipeline builds it. */
+function payload(
+  overrides: {
+    plan?: Partial<ReleasePlan>;
+    outcome?: Partial<ReleaseOutcome>;
+    dryRun?: boolean;
+  } = {}
+): ReleasePayload {
+  return buildPayload({
+    plan: releasePlan(overrides.plan),
+    outcome: releaseOutcome(overrides.outcome),
+    generatedAt: '2026-09-06T17:57:00Z',
+    coords: { owner: 'strapi', repo: 'strapi' },
+    dryRun: overrides.dryRun ?? false,
+  });
 }
 
 function journalEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
@@ -136,7 +112,7 @@ describe('renderAuthor', () => {
 
 describe('renderPullRequestTable', () => {
   it('names the author with their display name and their login', () => {
-    const table = renderPullRequestTable(payloadInput().pullRequests);
+    const table = renderPullRequestTable(releasePlan().pullRequests);
 
     assert.match(table, /Someone Real \(@someone\)/u);
   });
@@ -209,13 +185,11 @@ describe('renderJournalTable', () => {
 
 describe('buildPayload', () => {
   it('carries the schema version later automation reads', () => {
-    assert.equal(buildPayload(payloadInput()).schemaVersion, 5);
+    assert.equal(payload().schemaVersion, 5);
   });
 
   it('identifies the candidate by its branch, its pinned head and its pull request', () => {
-    const payload = buildPayload(payloadInput());
-
-    assert.deepEqual(payload.candidate, {
+    assert.deepEqual(payload().candidate, {
       branch: 'releases/5.53.0',
       headSha: 'b'.repeat(40),
       expectedExperimentalVersion: `0.0.0-experimental.${'b'.repeat(40)}`,
@@ -226,22 +200,49 @@ describe('buildPayload', () => {
   });
 
   it('pins the head to the SHA the range ended at', () => {
-    const payload = buildPayload(payloadInput());
+    const built = payload();
 
-    assert.equal(payload.candidate.headSha, payload.range.toSha);
+    assert.equal(built.candidate.headSha, built.range.toSha);
   });
 
   it('reports no pull request on a dry run, and still identifies the candidate', () => {
-    const payload = buildPayload(payloadInput({ dryRun: true, pullNumber: null, pullUrl: null }));
+    const built = payload({ dryRun: true, outcome: { pullNumber: null, pullUrl: null } });
 
-    assert.equal(payload.candidate.pullRequestNumber, null);
-    assert.equal(payload.candidate.pullRequestUrl, null);
-    assert.equal(payload.candidate.branch, 'releases/5.53.0');
-    assert.equal(payload.candidate.headSha, 'b'.repeat(40));
+    assert.equal(built.candidate.pullRequestNumber, null);
+    assert.equal(built.candidate.pullRequestUrl, null);
+    assert.equal(built.candidate.branch, 'releases/5.53.0');
+    assert.equal(built.candidate.headSha, 'b'.repeat(40));
     assert.equal(
-      payload.candidate.expectedExperimentalVersion,
+      built.candidate.expectedExperimentalVersion,
       `0.0.0-experimental.${'b'.repeat(40)}`
     );
+  });
+
+  it('derives the milestone section from the plan and the numbers the writes produced', () => {
+    assert.deepEqual(payload().milestones, {
+      shipping: { number: 430, title: '5.53.0', renamedFrom: '5.52.4', state: 'closed' },
+      next: { number: 431, title: '5.53.1', created: true },
+    });
+  });
+
+  it('reports no rename when both milestones were kept', () => {
+    const built = payload({
+      plan: {
+        milestones: {
+          shipping: {
+            action: 'keep',
+            number: 430,
+            currentTitle: '5.53.0',
+            title: '5.53.0',
+            close: false,
+          },
+          next: { action: 'keep', number: 431, currentTitle: '5.53.1', title: '5.53.1' },
+        },
+      },
+    });
+
+    assert.equal(built.milestones.shipping.renamedFrom, null);
+    assert.equal(built.milestones.next.created, false);
   });
 });
 
@@ -252,40 +253,40 @@ describe('experimentalVersion', () => {
 });
 
 describe('renderBody', () => {
-  const payload = buildPayload(payloadInput());
+  const built = payload();
 
   it('carries a JSON block that round-trips through the markers', () => {
-    const body = renderBody({ payload, pullRequests: payload.pullRequests, attention: [] });
+    const body = renderBody({ payload: built, pullRequests: built.pullRequests, attention: [] });
 
     assert.equal(body.includes(BLOCK_START), true);
     assert.equal(body.includes(BLOCK_END), true);
-    assert.deepEqual(extractJsonBlock(body), JSON.parse(JSON.stringify(payload)));
+    assert.deepEqual(extractJsonBlock(body), JSON.parse(JSON.stringify(built)));
   });
 
   it('explains a minor with the commits that caused it', () => {
-    const body = renderBody({ payload, pullRequests: payload.pullRequests, attention: [] });
+    const body = renderBody({ payload: built, pullRequests: built.pullRequests, attention: [] });
 
     assert.match(body, /## Why this is a minor/u);
     assert.match(body, /feat\(content-releases\): audit logs \(#27436\)/u);
   });
 
   it('names the version input when a human decided', () => {
-    const overridden = buildPayload(payloadInput({ versionSource: 'version-input' }));
+    const overridden = payload({ plan: { versionSource: 'version-input' } });
     const body = renderBody({ payload: overridden, pullRequests: [], attention: [] });
 
     assert.match(body, /decided from the `version` input/u);
   });
 
   it('surfaces reconciliation differences only when there are any', () => {
-    const clean = renderBody({ payload, pullRequests: payload.pullRequests, attention: [] });
+    const clean = renderBody({ payload: built, pullRequests: built.pullRequests, attention: [] });
 
     assert.equal(clean.includes('## Milestone reconciliation'), false);
 
-    const drifted = buildPayload(
-      payloadInput({
+    const drifted = payload({
+      outcome: {
         reconciliation: { inHistoryNotInMilestone: [27509], inMilestoneNotInHistory: [27123] },
-      })
-    );
+      },
+    });
 
     const body = renderBody({
       payload: drifted,
@@ -299,8 +300,8 @@ describe('renderBody', () => {
 
   it('lists the records a human still has to settle', () => {
     const body = renderBody({
-      payload,
-      pullRequests: payload.pullRequests,
+      payload: built,
+      pullRequests: built.pullRequests,
       attention: [
         {
           sha: 'd'.repeat(40),
@@ -320,10 +321,10 @@ describe('renderBody', () => {
 
 describe('extractJsonBlock', () => {
   it('round-trips a body carrying the candidate block', () => {
-    const payload = buildPayload(payloadInput());
-    const body = renderBody({ payload, pullRequests: payload.pullRequests, attention: [] });
+    const built = payload();
+    const body = renderBody({ payload: built, pullRequests: built.pullRequests, attention: [] });
 
-    assert.deepEqual(extractJsonBlock(body), JSON.parse(JSON.stringify(payload)));
+    assert.deepEqual(extractJsonBlock(body), JSON.parse(JSON.stringify(built)));
     assert.match(body, /"expectedExperimentalVersion": "0\.0\.0-experimental\.b{40}"/u);
   });
 
@@ -381,16 +382,14 @@ describe('renderMilestoneComment', () => {
 
 describe('renderStepSummary', () => {
   it('labels a dry run as planned', () => {
-    const payload = buildPayload(payloadInput({ dryRun: true }));
-    const summary = renderStepSummary({ payload, entries: [] });
+    const summary = renderStepSummary({ payload: payload({ dryRun: true }), entries: [] });
 
     assert.match(summary, /Dry run\./u);
     assert.match(summary, /## Planned writes/u);
   });
 
   it('labels a real run as applied', () => {
-    const payload = buildPayload(payloadInput());
-    const summary = renderStepSummary({ payload, entries: [journalEntry()] });
+    const summary = renderStepSummary({ payload: payload(), entries: [journalEntry()] });
 
     assert.match(summary, /## Applied writes/u);
   });

--- a/.github/actions/draft-release/__tests__/report.test.ts
+++ b/.github/actions/draft-release/__tests__/report.test.ts
@@ -29,6 +29,7 @@ function payloadInput(overrides: Partial<PayloadInput> = {}): PayloadInput {
     bump: 'minor',
     previousVersion: '5.52.3',
     versionSource: 'computed',
+    mode: 'draft',
     range: {
       fromRef: 'v5.52.3',
       fromSha: 'a'.repeat(40),
@@ -37,6 +38,7 @@ function payloadInput(overrides: Partial<PayloadInput> = {}): PayloadInput {
     },
     integrationCount: 12,
     branch: 'releases/5.53.0',
+    branchAdvanced: true,
     pullNumber: 27700,
     pullUrl: 'https://github.com/strapi/strapi/pull/27700',
     classification: {
@@ -61,6 +63,7 @@ function payloadInput(overrides: Partial<PayloadInput> = {}): PayloadInput {
         baseRef: 'develop',
         headRef: 'feat/audit-logs',
         milestone: '5.52.4',
+        mergedAt: '2026-09-05T09:59:00Z',
         status: 'resolved',
         basis: 'exact-merge-sha',
         integrationShas: ['c'.repeat(40)],
@@ -84,7 +87,8 @@ function journalEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
     after: '5.53.0',
     detail: null,
     at: '2026-09-06T17:57:00Z',
-    applied: true,
+    state: 'applied',
+    error: null,
     ...overrides,
   };
 }
@@ -148,6 +152,7 @@ describe('renderPullRequestTable', () => {
       baseRef: 'develop',
       headRef: 'fix/x',
       milestone: null,
+      mergedAt: '2026-09-05T09:59:00Z',
       status: 'resolved',
       basis: 'none',
       integrationShas: ['a'],
@@ -157,7 +162,7 @@ describe('renderPullRequestTable', () => {
 
     assert.match(table, /handle a \\\\\\\| b/u);
     assert.equal(table.split('\n').length, 3);
-    assert.equal(table.split('\n')[2]?.split(/(?<!\\)\|/u).length, 7);
+    assert.equal(table.split('\n')[2]?.split(/(?<!\\)\|/u).length, 8);
   });
 
   it('escapes a pipe so a title cannot break the table', () => {
@@ -169,6 +174,7 @@ describe('renderPullRequestTable', () => {
       baseRef: 'develop',
       headRef: 'fix/x',
       milestone: null,
+      mergedAt: '2026-09-05T09:59:00Z',
       status: 'resolved',
       basis: 'none',
       integrationShas: ['a'],
@@ -203,7 +209,7 @@ describe('renderJournalTable', () => {
 
 describe('buildPayload', () => {
   it('carries the schema version later automation reads', () => {
-    assert.equal(buildPayload(payloadInput()).schemaVersion, 4);
+    assert.equal(buildPayload(payloadInput()).schemaVersion, 5);
   });
 
   it('identifies the candidate by its branch, its pinned head and its pull request', () => {
@@ -213,6 +219,7 @@ describe('buildPayload', () => {
       branch: 'releases/5.53.0',
       headSha: 'b'.repeat(40),
       expectedExperimentalVersion: `0.0.0-experimental.${'b'.repeat(40)}`,
+      branchAdvanced: true,
       pullRequestNumber: 27700,
       pullRequestUrl: 'https://github.com/strapi/strapi/pull/27700',
     });
@@ -344,6 +351,7 @@ describe('renderMilestoneComment', () => {
     const comment = renderMilestoneComment({
       version: '5.53.0',
       nextTitle: '5.53.1',
+      mode: 'draft',
       dryRun: true,
       entries: [
         journalEntry(),
@@ -362,6 +370,7 @@ describe('renderMilestoneComment', () => {
     const comment = renderMilestoneComment({
       version: '5.53.0',
       nextTitle: '5.53.1',
+      mode: 'draft',
       dryRun: false,
       entries: [],
     });

--- a/.github/actions/draft-release/action.yml
+++ b/.github/actions/draft-release/action.yml
@@ -1,5 +1,5 @@
 name: 'Draft release'
-description: 'Pins the release range, computes the version, cuts the release branch, opens the draft PR and reconciles milestones.'
+description: 'Pins the release range, computes the version, cuts or advances the release branch, opens or refreshes the draft PR and reconciles milestones.'
 
 inputs:
   token:
@@ -13,10 +13,6 @@ inputs:
     description: 'Compute everything and record the planned writes without performing any of them.'
     required: false
     default: 'true'
-  source_ref:
-    description: 'Branch the release is cut from.'
-    required: false
-    default: 'develop'
 
 outputs:
   version:
@@ -25,14 +21,17 @@ outputs:
   bump:
     description: 'minor or patch.'
     value: ${{ steps.draft.outputs.bump }}
+  mode:
+    description: 'draft, refresh or redraft.'
+    value: ${{ steps.draft.outputs.mode }}
   branch:
     description: 'The release branch name.'
     value: ${{ steps.draft.outputs.branch }}
   pr_number:
-    description: 'The draft release pull request number. Empty on a dry run.'
+    description: 'The release pull request number. Empty on a dry run that would have created one.'
     value: ${{ steps.draft.outputs.pr_number }}
   pr_url:
-    description: 'The draft release pull request URL. Empty on a dry run.'
+    description: 'The release pull request URL. Empty on a dry run that would have created one.'
     value: ${{ steps.draft.outputs.pr_url }}
   journal_path:
     description: 'Path to the write journal, present whether the run succeeded or failed.'
@@ -65,7 +64,6 @@ runs:
         INPUT_TOKEN: ${{ inputs.token }}
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_DRY_RUN: ${{ inputs.dry_run }}
-        INPUT_SOURCE_REF: ${{ inputs.source_ref }}
 
 branding:
   icon: 'tag'

--- a/.github/actions/draft-release/index.ts
+++ b/.github/actions/draft-release/index.ts
@@ -62,7 +62,6 @@ async function main(env: ActionsEnv): Promise<void> {
       inputs: {
         version: getInput(env, 'version'),
         dryRun: getBooleanInput(env, 'dry_run'),
-        sourceRef: getInput(env, 'source_ref') || 'develop',
       },
       git: createGitAdapter(createGitExec()),
       gh: createGithubAdapter(
@@ -79,6 +78,7 @@ async function main(env: ActionsEnv): Promise<void> {
 
     setOutput(env, 'version', result.version);
     setOutput(env, 'bump', result.bump);
+    setOutput(env, 'mode', result.mode);
     setOutput(env, 'branch', result.branch);
     setOutput(env, 'pr_number', result.pullNumber === null ? '' : String(result.pullNumber));
     setOutput(env, 'pr_url', result.pullUrl ?? '');

--- a/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
+++ b/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
@@ -1,4 +1,4 @@
-import type { Integration, MilestoneItem, PullCommit, PullPayload } from '../types.ts';
+import type { Integration, MilestoneItem, PullCommit, PullPayload, ReleasePlan } from '../types.ts';
 
 /**
  * Fixtures modelled on the real `v5.52.3..develop` range, including the cases that proved the
@@ -109,6 +109,70 @@ export function candidatePull(overrides: Partial<PullPayload> = {}): PullPayload
     head: candidateHead(version),
     user: { login: 'strapi-release-bot' },
     milestone: null,
+    ...overrides,
+  };
+}
+
+/** A fresh draft, decided: `5.52.3` → `5.53.0` off one `feat`, the open `5.52.4` milestone renamed. */
+export function releasePlan(overrides: Partial<ReleasePlan> = {}): ReleasePlan {
+  return {
+    mode: 'draft',
+    candidate: null,
+    previousVersion: '5.52.3',
+    version: '5.53.0',
+    bumpKind: 'minor',
+    classification: {
+      features: [
+        {
+          sha: 'c'.repeat(40),
+          pr: 27436,
+          subject: 'feat(content-releases): audit logs',
+          via: 'subject',
+        },
+      ],
+      breaking: [],
+      ignored: [],
+      unparsed: [],
+    },
+    versionSource: 'computed',
+    range: {
+      fromRef: 'v5.52.3',
+      fromSha: 'a'.repeat(40),
+      toRef: 'origin/develop',
+      toSha: 'b'.repeat(40),
+    },
+    integrationCount: 12,
+    pullRequests: [
+      {
+        number: 27436,
+        title: 'feat(content-releases): audit logs',
+        author: { login: 'someone', name: 'Someone Real' },
+        url: 'https://github.com/strapi/strapi/pull/27436',
+        baseRef: 'develop',
+        headRef: 'feat/audit-logs',
+        milestone: '5.52.4',
+        mergedAt: '2026-09-05T09:59:00Z',
+        status: 'resolved',
+        basis: 'exact-merge-sha',
+        integrationShas: ['c'.repeat(40)],
+      },
+    ],
+    attention: [],
+    warnings: [],
+    milestones: {
+      shipping: {
+        action: 'rename',
+        number: 430,
+        currentTitle: '5.52.4',
+        title: '5.53.0',
+        close: true,
+      },
+      next: { action: 'create', number: null, currentTitle: null, title: '5.53.1' },
+    },
+    branch: 'releases/5.53.0',
+    branchAdvances: true,
+    candidateHeadSha: null,
+    realignment: [],
     ...overrides,
   };
 }

--- a/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
+++ b/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
@@ -7,6 +7,8 @@ import type { Integration, MilestoneItem, PullCommit, PullPayload } from '../typ
  */
 
 export const SHA = {
+  /** Where a release branch already points, one integration behind `develop`. */
+  CANDIDATE_HEAD: 'face0000face0000face0000face0000face0000',
   BACK_MERGE: 'ca560c0d681a696a497cb1a68245b002fd9810bf',
   DIRECT: 'aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000',
   MERGE: 'b912880160c178af6171de530e830b3174a2b1d4',
@@ -80,4 +82,36 @@ export function pullRequestItem(
   mergedAt: string | null
 ): MilestoneItem {
   return milestoneItem({ number, state, pull_request: { merged_at: mergedAt } });
+}
+
+/**
+ * The open pull request that identifies a release candidate in flight.
+ *
+ * Its body carries the release candidate block a previous run wrote, because that is what the
+ * cross-check reads back.
+ */
+export function candidatePull(overrides: Partial<PullPayload> = {}): PullPayload {
+  const version = '5.53.0';
+
+  return {
+    number: 27600,
+    title: `Release ${version}`,
+    html_url: 'https://github.com/strapi/strapi/pull/27600',
+    body: [
+      '<!-- STRAPI_RELEASE_CANDIDATE_START -->',
+      '```json',
+      JSON.stringify({
+        release: { version },
+        candidate: { branch: `releases/${version}` },
+      }),
+      '```',
+      '<!-- STRAPI_RELEASE_CANDIDATE_END -->',
+    ].join('\n'),
+    merged_at: null,
+    base: { ref: 'main' },
+    head: { ref: `releases/${version}`, sha: SHA.CANDIDATE_HEAD },
+    user: { login: 'strapi-release-bot' },
+    milestone: null,
+    ...overrides,
+  };
 }

--- a/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
+++ b/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
@@ -1,4 +1,11 @@
-import type { Integration, MilestoneItem, PullCommit, PullPayload, ReleasePlan } from '../types.ts';
+import type {
+  Integration,
+  MergedPull,
+  MilestoneItem,
+  PullCommit,
+  PullPayload,
+  ReleasePlan,
+} from '../types.ts';
 
 /**
  * Fixtures modelled on the real `v5.52.3..develop` range, including the cases that proved the
@@ -31,7 +38,8 @@ export function integration(overrides: Partial<Integration> = {}): Integration {
   };
 }
 
-export function pull(overrides: Partial<PullPayload> = {}): PullPayload {
+/** A merged pull request, because everything attribution accepts has already merged. */
+export function pull(overrides: Partial<MergedPull> = {}): MergedPull {
   return {
     number: 27482,
     title: 'fix(content-type-builder): default new private fields to not searchable',
@@ -47,7 +55,7 @@ export function pull(overrides: Partial<PullPayload> = {}): PullPayload {
 }
 
 /** A pull request merged into `main`, only indirectly associated with a develop integration. */
-export function indirectPull(): PullPayload {
+export function indirectPull(): MergedPull {
   return pull({
     number: 27470,
     title: 'Releases/5.52.2',
@@ -58,7 +66,7 @@ export function indirectPull(): PullPayload {
 }
 
 /** The release back-merge: head is `main`, so its commits already shipped. */
-export function backMergePull(): PullPayload {
+export function backMergePull(): MergedPull {
   return pull({
     number: 27527,
     title: 'chore: release v5.52.3 update develop',

--- a/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
+++ b/.github/actions/draft-release/lib/__fixtures__/fixtures.ts
@@ -84,12 +84,18 @@ export function pullRequestItem(
   return milestoneItem({ number, state, pull_request: { merged_at: mergedAt } });
 }
 
-/**
- * The open pull request that identifies a release candidate in flight.
- *
- * Its body carries the release candidate block a previous run wrote, because that is what the
- * cross-check reads back.
- */
+/** The repository the pipeline fixtures run against, as `head.repo.full_name` spells it. */
+export const OWN_REPOSITORY = 'strapi/strapi';
+
+/** The head of a release pull request cut by this repository's own automation. */
+export function candidateHead(
+  version: string,
+  sha: string = SHA.CANDIDATE_HEAD
+): NonNullable<PullPayload['head']> {
+  return { ref: `releases/${version}`, sha, repo: { full_name: OWN_REPOSITORY } };
+}
+
+/** The open pull request that identifies a release candidate in flight. */
 export function candidatePull(overrides: Partial<PullPayload> = {}): PullPayload {
   const version = '5.53.0';
 
@@ -97,19 +103,10 @@ export function candidatePull(overrides: Partial<PullPayload> = {}): PullPayload
     number: 27600,
     title: `Release ${version}`,
     html_url: 'https://github.com/strapi/strapi/pull/27600',
-    body: [
-      '<!-- STRAPI_RELEASE_CANDIDATE_START -->',
-      '```json',
-      JSON.stringify({
-        release: { version },
-        candidate: { branch: `releases/${version}` },
-      }),
-      '```',
-      '<!-- STRAPI_RELEASE_CANDIDATE_END -->',
-    ].join('\n'),
+    body: `Release \`${version}\`.`,
     merged_at: null,
     base: { ref: 'main' },
-    head: { ref: `releases/${version}`, sha: SHA.CANDIDATE_HEAD },
+    head: candidateHead(version),
     user: { login: 'strapi-release-bot' },
     milestone: null,
     ...overrides,

--- a/.github/actions/draft-release/lib/attribution.ts
+++ b/.github/actions/draft-release/lib/attribution.ts
@@ -150,6 +150,9 @@ export function summarisePull(pull: PullPayload, integration: Integration): Pull
     baseRef: pull.base?.ref ?? '',
     headRef: pull.head?.ref ?? '',
     milestone: pull.milestone?.title ?? null,
+    // Every path into this projection is gated by `isMerged`, so the fallback is unreachable. It
+    // exists because the payload type cannot express that.
+    mergedAt: pull.merged_at ?? '',
   };
 }
 

--- a/.github/actions/draft-release/lib/attribution.ts
+++ b/.github/actions/draft-release/lib/attribution.ts
@@ -3,6 +3,7 @@ import type {
   AttributionLookup,
   AttributionRecord,
   Integration,
+  MergedPull,
   PullPayload,
   PullSummary,
   RepositoryMergeSettings,
@@ -44,8 +45,14 @@ export function parseSubjectReference(subject: string): number | null {
   return null;
 }
 
-function isMerged(pull: PullPayload): boolean {
-  return pull.merged_at !== null && pull.merged_at !== undefined;
+/**
+ * The only place a {@link MergedPull} comes from.
+ *
+ * A guard rather than a boolean check, so the merge timestamp is carried in the type from here on
+ * and no projection downstream has to invent a value for a payload that never merged.
+ */
+function isMerged(pull: PullPayload): pull is MergedPull {
+  return typeof pull.merged_at === 'string';
 }
 
 /**
@@ -59,9 +66,9 @@ export function selectExactCandidates(
   integration: Pick<Integration, 'sha'>,
   pulls: readonly PullPayload[],
   targetBase: string
-): PullPayload[] {
+): MergedPull[] {
   return pulls.filter(
-    (pull) =>
+    (pull): pull is MergedPull =>
       isMerged(pull) === true &&
       pull.base?.ref === targetBase &&
       pull.merge_commit_sha === integration.sha
@@ -139,7 +146,7 @@ export function deriveAuthorName(integration: Integration, login: string): strin
  * The integration is passed in because the payload alone cannot answer who wrote the pull request
  * by name. See {@link deriveAuthorName}.
  */
-export function summarisePull(pull: PullPayload, integration: Integration): PullSummary {
+export function summarisePull(pull: MergedPull, integration: Integration): PullSummary {
   const login = pull.user?.login ?? '';
 
   return {
@@ -150,9 +157,7 @@ export function summarisePull(pull: PullPayload, integration: Integration): Pull
     baseRef: pull.base?.ref ?? '',
     headRef: pull.head?.ref ?? '',
     milestone: pull.milestone?.title ?? null,
-    // Every path into this projection is gated by `isMerged`, so the fallback is unreachable. It
-    // exists because the payload type cannot express that.
-    mergedAt: pull.merged_at ?? '',
+    mergedAt: pull.merged_at,
   };
 }
 
@@ -178,7 +183,11 @@ async function resolveBySubject(
 
   const pull = await lookup.getPull(referenced).catch(() => null);
 
-  if (pull === null || isMerged(pull) === false || pull.base?.ref !== targetBase) {
+  if (pull === null || isMerged(pull) === false) {
+    return null;
+  }
+
+  if (pull.base?.ref !== targetBase) {
     return null;
   }
 

--- a/.github/actions/draft-release/lib/candidate.ts
+++ b/.github/actions/draft-release/lib/candidate.ts
@@ -1,14 +1,23 @@
-import { extractJsonBlock } from './report.ts';
-import { compareStable, parseStable } from './semver.ts';
+import { compareStable, formatStable, parseStable } from './semver.ts';
 
-import type { Candidate, PullPayload, ReleaseMode } from './types.ts';
+import type {
+  Candidate,
+  GitAdapter,
+  PinnedRange,
+  PullPayload,
+  ReleaseMode,
+  RepositoryCoords,
+  StableVersion,
+} from './types.ts';
 
 /**
  * Finding the release candidate that is already in flight.
  *
  * The action runs more than once per release: `develop` keeps moving while a candidate is open, and
  * a later run has to fold what landed since into the same release rather than start a new one. The
- * open pull request is what identifies it.
+ * open pull request is what identifies it, and only one whose head lives in this repository counts.
+ * Anyone can open a pull request from a fork with a branch named `releases/x.y.z`, and a candidate
+ * is something only this repository's own automation can have cut.
  *
  * Nothing else is a usable key. A release branch outlives its candidate, because the ruleset over
  * `releases/*` forbids deletion without a bypass, so a leftover branch says nothing about what is
@@ -24,31 +33,43 @@ const RELEASE_BRANCH_PATTERN = /^releases\/(\d+\.\d+\.\d+)$/u;
  * @returns `null` for any branch that is not exactly `releases/x.y.z`, so a branch such as
  * `releases/5.53.0-hotfix` is not mistaken for a candidate.
  */
-export function parseReleaseBranch(headRef: string): string | null {
-  return RELEASE_BRANCH_PATTERN.exec(headRef ?? '')?.[1] ?? null;
+export function parseReleaseBranch(headRef: string): StableVersion | null {
+  return parseStable(RELEASE_BRANCH_PATTERN.exec(headRef)?.[1]);
 }
 
 /**
  * Finds the candidate among the pull requests open against the release base.
  *
+ * A pull request whose head is not in this repository is skipped, not refused: a fork can name its
+ * branch anything, and stopping on it would let anyone block a release by opening one.
+ *
  * @returns `null` when none is open, which is a fresh draft.
  * @throws When more than one is open. Two candidates mean a human is mid-intervention, and picking
  * one of them would finish the intervention on their behalf.
  */
-export function findCandidate(pulls: readonly PullPayload[]): Candidate | null {
-  const candidates = pulls.flatMap((pull) => {
-    const version = parseReleaseBranch(pull.head?.ref ?? '');
+export function findCandidate(
+  pulls: readonly PullPayload[],
+  coords: RepositoryCoords
+): Candidate | null {
+  const ownRepository = `${coords.owner}/${coords.repo}`;
 
-    return version === null
+  const candidates = pulls.flatMap((pull) => {
+    if (pull.head?.repo?.full_name !== ownRepository) {
+      return [];
+    }
+
+    const branch = pull.head.ref ?? '';
+    const parsedVersion = parseReleaseBranch(branch);
+
+    return parsedVersion === null
       ? []
       : [
           {
-            version,
-            branch: pull.head?.ref ?? '',
+            version: formatStable(parsedVersion),
+            parsedVersion,
+            branch,
             pullNumber: pull.number,
             pullUrl: pull.html_url ?? '',
-            pullHeadSha: pull.head?.sha ?? '',
-            payload: extractJsonBlock(pull.body ?? ''),
           },
         ];
   });
@@ -73,49 +94,22 @@ export function findCandidate(pulls: readonly PullPayload[]): Candidate | null {
  * a branch that `publish.sh` has already tagged.
  */
 export function assertCandidateUnpublished(candidate: Candidate, baselineVersion: string): void {
-  const version = parseStable(candidate.version);
   const baseline = parseStable(baselineVersion);
 
-  if (version === null || baseline === null) {
+  if (baseline === null) {
     throw new Error(
       `Cannot compare the candidate ${candidate.version} with the published baseline ` +
-        `${baselineVersion}. Both have to be plain x.y.z versions.`
+        `${baselineVersion}, which is not a plain x.y.z version.`
     );
   }
 
-  if (compareStable(version, baseline) !== 1) {
+  if (compareStable(candidate.parsedVersion, baseline) !== 1) {
     throw new Error(
       `The candidate ${candidate.version} on #${candidate.pullNumber} is not above the published ` +
         `baseline ${baselineVersion}, so that release already shipped. Close the pull request ` +
         'before drafting the next one.'
     );
   }
-}
-
-/**
- * Refuses a release branch that carries work of its own.
- *
- * A candidate branch is only ever a pointer into `develop`. When its head is not contained in
- * `develop`, somebody pushed to it: a cherry-pick, or the version-bump commit `publish.sh` makes
- * at publish time. Advancing it to `develop`'s head would throw that commit away, and the ruleset
- * would refuse the non-fast-forward push in any case.
- */
-export function assertBranchContained(input: {
-  branch: string;
-  branchHeadSha: string;
-  sourceRef: string;
-  sourceSha: string;
-  contained: boolean;
-}): void {
-  if (input.contained === true) {
-    return;
-  }
-
-  throw new Error(
-    `${input.branch} (${input.branchHeadSha}) is not contained in ${input.sourceRef} ` +
-      `(${input.sourceSha}). Something was pushed to the release branch directly, so this run ` +
-      'would discard it. Resolve the branch by hand.'
-  );
 }
 
 /**
@@ -132,16 +126,15 @@ export function decideMode(candidate: Candidate | null, version: string): Releas
   }
 
   const recomputed = parseStable(version);
-  const current = parseStable(candidate.version);
 
-  if (recomputed === null || current === null) {
+  if (recomputed === null) {
     throw new Error(
       `Cannot compare ${version} with the candidate ${candidate.version}. ` +
-        'Both have to be plain x.y.z versions.'
+        'The recomputed version has to be a plain x.y.z version.'
     );
   }
 
-  const order = compareStable(recomputed, current);
+  const order = compareStable(recomputed, candidate.parsedVersion);
 
   if (order === -1) {
     throw new Error(
@@ -154,46 +147,57 @@ export function decideMode(candidate: Candidate | null, version: string): Releas
   return order === 0 ? 'refresh' : 'redraft';
 }
 
-function readString(source: unknown, path: readonly string[]): string | null {
-  const value = path.reduce<unknown>(
-    (node, key) =>
-      typeof node === 'object' && node !== null
-        ? (node as Record<string, unknown>)[key]
-        : undefined,
-    source
-  );
-
-  return typeof value === 'string' ? value : null;
-}
-
 /**
- * Compares the candidate's own payload with the branch it lives on.
+ * Decides what has to happen to the release branch, and refuses what must not.
  *
- * The branch name is the authority, because it is what the release is published from. A payload
- * that disagrees means the body was hand-edited, which is worth saying out loud and not worth
- * stopping for.
- *
- * @returns One warning per disagreement, empty when the payload is absent or consistent.
+ * @returns `advances: false` when the branch already points at the pinned head, which is the case
+ * where nothing landed since the last run. Pushing anyway would fire `synchronize` on the pull
+ * request and publish another identical experimental artifact for nothing. `candidateHeadSha` is
+ * the head git resolved for the candidate's branch, `null` without a candidate; a redraft deletes
+ * that branch under a lease on exactly this value.
+ * @throws When the candidate's branch carries work of its own. A candidate branch is only ever a
+ * pointer into `develop`, so a head not contained in it means somebody pushed to it: a cherry-pick,
+ * or the version-bump commit `publish.sh` makes at publish time. Advancing or deleting it would
+ * throw that commit away, and the ruleset would refuse the non-fast-forward push in any case.
  */
-export function crossCheckCandidate(candidate: Candidate): string[] {
-  if (candidate.payload === null) {
-    return [
-      `#${candidate.pullNumber} carries no readable release candidate block, so its branch name ` +
-        'is the only evidence of the version it was cut under.',
-    ];
+export function planBranch(input: {
+  git: GitAdapter;
+  mode: ReleaseMode;
+  branch: string;
+  candidate: Candidate | null;
+  range: PinnedRange;
+}): { advances: boolean; candidateHeadSha: string | null } {
+  const { git, mode, branch, candidate, range } = input;
+
+  if (mode !== 'refresh' && git.remoteBranchExists(branch) === true) {
+    throw new Error(
+      `The branch ${branch} already exists but no open pull request is drafting it. ` +
+        'An earlier run left it behind. Delete it, or reopen its pull request, before drafting.'
+    );
   }
 
-  const recordedBranch = readString(candidate.payload, ['candidate', 'branch']);
-  const recordedVersion = readString(candidate.payload, ['release', 'version']);
+  if (candidate === null) {
+    return { advances: true, candidateHeadSha: null };
+  }
 
-  return [
-    recordedBranch === null || recordedBranch === candidate.branch
-      ? null
-      : `#${candidate.pullNumber} lives on \`${candidate.branch}\` but its payload records ` +
-        `\`${recordedBranch}\`.`,
-    recordedVersion === null || recordedVersion === candidate.version
-      ? null
-      : `#${candidate.pullNumber} was cut as \`${candidate.version}\` but its payload records ` +
-        `\`${recordedVersion}\`.`,
-  ].filter((warning): warning is string => warning !== null);
+  if (git.remoteBranchExists(candidate.branch) === false) {
+    throw new Error(
+      `#${candidate.pullNumber} is open against ${candidate.branch}, but that branch is gone from ` +
+        'the remote. Close the pull request, or restore the branch, before drafting.'
+    );
+  }
+
+  git.fetchBranch(candidate.branch);
+
+  const candidateHeadSha = git.resolveSha(`origin/${candidate.branch}`);
+
+  if (git.isAncestor(candidateHeadSha, range.toSha) === false) {
+    throw new Error(
+      `${candidate.branch} (${candidateHeadSha}) is not contained in ${range.toRef} ` +
+        `(${range.toSha}). Something was pushed to the release branch directly, so this run ` +
+        'would discard it. Resolve the branch by hand.'
+    );
+  }
+
+  return { advances: mode === 'redraft' || candidateHeadSha !== range.toSha, candidateHeadSha };
 }

--- a/.github/actions/draft-release/lib/candidate.ts
+++ b/.github/actions/draft-release/lib/candidate.ts
@@ -1,0 +1,199 @@
+import { extractJsonBlock } from './report.ts';
+import { compareStable, parseStable } from './semver.ts';
+
+import type { Candidate, PullPayload, ReleaseMode } from './types.ts';
+
+/**
+ * Finding the release candidate that is already in flight.
+ *
+ * The action runs more than once per release: `develop` keeps moving while a candidate is open, and
+ * a later run has to fold what landed since into the same release rather than start a new one. The
+ * open pull request is what identifies it.
+ *
+ * Nothing else is a usable key. A release branch outlives its candidate, because the ruleset over
+ * `releases/*` forbids deletion without a bypass, so a leftover branch says nothing about what is
+ * in flight. A milestone is renamed by this very action. The pull request is the one artifact whose
+ * lifecycle is the candidate's own.
+ */
+
+const RELEASE_BRANCH_PATTERN = /^releases\/(\d+\.\d+\.\d+)$/u;
+
+/**
+ * The version a release branch name carries.
+ *
+ * @returns `null` for any branch that is not exactly `releases/x.y.z`, so a branch such as
+ * `releases/5.53.0-hotfix` is not mistaken for a candidate.
+ */
+export function parseReleaseBranch(headRef: string): string | null {
+  return RELEASE_BRANCH_PATTERN.exec(headRef ?? '')?.[1] ?? null;
+}
+
+/**
+ * Finds the candidate among the pull requests open against the release base.
+ *
+ * @returns `null` when none is open, which is a fresh draft.
+ * @throws When more than one is open. Two candidates mean a human is mid-intervention, and picking
+ * one of them would finish the intervention on their behalf.
+ */
+export function findCandidate(pulls: readonly PullPayload[]): Candidate | null {
+  const candidates = pulls.flatMap((pull) => {
+    const version = parseReleaseBranch(pull.head?.ref ?? '');
+
+    return version === null
+      ? []
+      : [
+          {
+            version,
+            branch: pull.head?.ref ?? '',
+            pullNumber: pull.number,
+            pullUrl: pull.html_url ?? '',
+            pullHeadSha: pull.head?.sha ?? '',
+            payload: extractJsonBlock(pull.body ?? ''),
+          },
+        ];
+  });
+
+  if (candidates.length > 1) {
+    const listed = candidates.map((entry) => `#${entry.pullNumber} (${entry.branch})`).join(', ');
+
+    throw new Error(
+      `Found ${candidates.length} open release pull requests: ${listed}. ` +
+        'Close the ones that are not the candidate before drafting a release.'
+    );
+  }
+
+  return candidates[0] ?? null;
+}
+
+/**
+ * Refuses a candidate whose release already went out.
+ *
+ * npm is the authority on what shipped. A candidate at or below the published baseline means the
+ * release completed and its pull request was left open, and folding new work into it would rewrite
+ * a branch that `publish.sh` has already tagged.
+ */
+export function assertCandidateUnpublished(candidate: Candidate, baselineVersion: string): void {
+  const version = parseStable(candidate.version);
+  const baseline = parseStable(baselineVersion);
+
+  if (version === null || baseline === null) {
+    throw new Error(
+      `Cannot compare the candidate ${candidate.version} with the published baseline ` +
+        `${baselineVersion}. Both have to be plain x.y.z versions.`
+    );
+  }
+
+  if (compareStable(version, baseline) !== 1) {
+    throw new Error(
+      `The candidate ${candidate.version} on #${candidate.pullNumber} is not above the published ` +
+        `baseline ${baselineVersion}, so that release already shipped. Close the pull request ` +
+        'before drafting the next one.'
+    );
+  }
+}
+
+/**
+ * Refuses a release branch that carries work of its own.
+ *
+ * A candidate branch is only ever a pointer into `develop`. When its head is not contained in
+ * `develop`, somebody pushed to it: a cherry-pick, or the version-bump commit `publish.sh` makes
+ * at publish time. Advancing it to `develop`'s head would throw that commit away, and the ruleset
+ * would refuse the non-fast-forward push in any case.
+ */
+export function assertBranchContained(input: {
+  branch: string;
+  branchHeadSha: string;
+  sourceRef: string;
+  sourceSha: string;
+  contained: boolean;
+}): void {
+  if (input.contained === true) {
+    return;
+  }
+
+  throw new Error(
+    `${input.branch} (${input.branchHeadSha}) is not contained in ${input.sourceRef} ` +
+      `(${input.sourceSha}). Something was pushed to the release branch directly, so this run ` +
+      'would discard it. Resolve the branch by hand.'
+  );
+}
+
+/**
+ * Decides what this run does with the candidate.
+ *
+ * @throws When the recomputed version is below the candidate's. The range only ever grows between
+ * runs, and a revert lands as a `revert` commit rather than removing the `feat` it undoes, so a
+ * lower version means an assumption this action rests on is broken. Renaming a milestone backwards
+ * is not a guess worth making.
+ */
+export function decideMode(candidate: Candidate | null, version: string): ReleaseMode {
+  if (candidate === null) {
+    return 'draft';
+  }
+
+  const recomputed = parseStable(version);
+  const current = parseStable(candidate.version);
+
+  if (recomputed === null || current === null) {
+    throw new Error(
+      `Cannot compare ${version} with the candidate ${candidate.version}. ` +
+        'Both have to be plain x.y.z versions.'
+    );
+  }
+
+  const order = compareStable(recomputed, current);
+
+  if (order === -1) {
+    throw new Error(
+      `The range now computes ${version}, below the candidate ${candidate.version} on ` +
+        `#${candidate.pullNumber}. The release range only ever grows, so this means ${candidate.branch} ` +
+        'was cut from a history that no longer exists. Resolve it by hand.'
+    );
+  }
+
+  return order === 0 ? 'refresh' : 'redraft';
+}
+
+function readString(source: unknown, path: readonly string[]): string | null {
+  const value = path.reduce<unknown>(
+    (node, key) =>
+      typeof node === 'object' && node !== null
+        ? (node as Record<string, unknown>)[key]
+        : undefined,
+    source
+  );
+
+  return typeof value === 'string' ? value : null;
+}
+
+/**
+ * Compares the candidate's own payload with the branch it lives on.
+ *
+ * The branch name is the authority, because it is what the release is published from. A payload
+ * that disagrees means the body was hand-edited, which is worth saying out loud and not worth
+ * stopping for.
+ *
+ * @returns One warning per disagreement, empty when the payload is absent or consistent.
+ */
+export function crossCheckCandidate(candidate: Candidate): string[] {
+  if (candidate.payload === null) {
+    return [
+      `#${candidate.pullNumber} carries no readable release candidate block, so its branch name ` +
+        'is the only evidence of the version it was cut under.',
+    ];
+  }
+
+  const recordedBranch = readString(candidate.payload, ['candidate', 'branch']);
+  const recordedVersion = readString(candidate.payload, ['release', 'version']);
+
+  return [
+    recordedBranch === null || recordedBranch === candidate.branch
+      ? null
+      : `#${candidate.pullNumber} lives on \`${candidate.branch}\` but its payload records ` +
+        `\`${recordedBranch}\`.`,
+    recordedVersion === null || recordedVersion === candidate.version
+      ? null
+      : `#${candidate.pullNumber} was cut as \`${candidate.version}\` but its payload records ` +
+        `\`${recordedVersion}\`.`,
+  ].filter((warning): warning is string => warning !== null);
+}

--- a/.github/actions/draft-release/lib/github.ts
+++ b/.github/actions/draft-release/lib/github.ts
@@ -47,6 +47,16 @@ export function parseNextLink(header: string | null): string | null {
   return next?.[1] ?? null;
 }
 
+/**
+ * A failure the server answered.
+ *
+ * The status travels on the error so the write journal can tell a refused mutation from one whose
+ * outcome nobody can vouch for. See `classifyFailure` in [`journal.ts`](journal.ts).
+ */
+function answeredFailure(message: string, status: number): Error {
+  return Object.assign(new Error(message), { status });
+}
+
 async function describeFailure(response: HttpResponse): Promise<string> {
   const body = await response.text().catch(() => '');
 
@@ -81,7 +91,10 @@ export function createRestClient(token: string, request: HttpRequest) {
     });
 
     if (response.ok === false) {
-      throw new Error(`GitHub ${method} ${url} failed: ${await describeFailure(response)}`);
+      throw answeredFailure(
+        `GitHub ${method} ${url} failed: ${await describeFailure(response)}`,
+        response.status
+      );
     }
 
     return response;
@@ -140,6 +153,14 @@ export function createGithubAdapter(
       return rest.get(`${base}/pulls/${pullNumber}`);
     },
 
+    /**
+     * Pull requests against one base branch. Paged, because the list endpoint returns the body of
+     * every pull request and the release candidate is found by reading it back.
+     */
+    async listPulls({ state, base: baseRef }) {
+      return rest.paginate(`${base}/pulls?${query({ state, base: baseRef })}`);
+    },
+
     async listPullCommits(pullNumber) {
       return rest.paginate(`${base}/pulls/${pullNumber}/commits?${query({})}`);
     },
@@ -180,6 +201,10 @@ export function createGithubAdapter(
 
     async updatePullBody(pullNumber, body) {
       await rest.send('PATCH', `${base}/pulls/${pullNumber}`, { body });
+    },
+
+    async closePull(pullNumber) {
+      await rest.send('PATCH', `${base}/pulls/${pullNumber}`, { state: 'closed' });
     },
 
     async addLabels(issueNumber, labels) {

--- a/.github/actions/draft-release/lib/github.ts
+++ b/.github/actions/draft-release/lib/github.ts
@@ -154,8 +154,8 @@ export function createGithubAdapter(
     },
 
     /**
-     * Pull requests against one base branch. Paged, because the list endpoint returns the body of
-     * every pull request and the release candidate is found by reading it back.
+     * Pull requests against one base branch. Paged, because the candidate is found by head ref and
+     * a run that stops at the first page could miss it behind unrelated pull requests.
      */
     async listPulls({ state, base: baseRef }) {
       return rest.paginate(`${base}/pulls?${query({ state, base: baseRef })}`);

--- a/.github/actions/draft-release/lib/journal.ts
+++ b/.github/actions/draft-release/lib/journal.ts
@@ -1,16 +1,37 @@
-import type { Clock, Journal, JournalEntry } from './types.ts';
+import type { Clock, Journal, JournalEntry, JournalEntryState } from './types.ts';
+
+/**
+ * Whether a rejected write proves that nothing was mutated.
+ *
+ * Both adapters attach the numeric status they got back, and each one means the operation ran to a
+ * verdict: a GitHub response status is the server refusing the write, and a git exit code is git
+ * reporting a ref it did not update, which it does atomically. An error carrying no status proves
+ * nothing either way. A socket closed after the request left is the case that matters, because the
+ * mutation may well have been applied on the other side.
+ */
+export function classifyFailure(
+  error: unknown
+): Extract<JournalEntryState, 'failed' | 'indeterminate'> {
+  const status = (error as { status?: unknown } | null | undefined)?.status;
+
+  return typeof status === 'number' ? 'failed' : 'indeterminate';
+}
 
 /**
  * The write journal.
  *
  * This action does not roll back. A run that dies halfway leaves the repository half-changed and a
  * human finishes or reverts it, which is only acceptable if the run says exactly what it did. Every
- * mutation is recorded before the next one starts, and the journal is written to the step summary
- * and uploaded as an artifact even when the run fails.
+ * mutation is recorded before it is attempted, and the journal is written to the step summary and
+ * uploaded as an artifact even when the run fails.
+ *
+ * The entry is mutated in place as the write progresses, so an entry never claims more certainty
+ * than the run has: `attempted` until the call returns, then `applied`, `failed` or
+ * `indeterminate`. Only an `applied` entry is worth undoing.
  *
  * A dry run fills the same structure without calling the API, which is the rehearsal: a reviewable,
  * line-by-line list of every milestone rename, pull request reassignment and ref push the real run
- * would perform.
+ * would perform. Its entries stay `planned`.
  */
 export function createJournal(options: { apply: boolean; clock?: Clock }): Journal {
   const clock = options.clock ?? ((): string => new Date().toISOString());
@@ -21,21 +42,35 @@ export function createJournal(options: { apply: boolean; clock?: Clock }): Journ
     mode,
 
     async write(intent, perform) {
-      entries.push({
+      const entry: JournalEntry = {
         op: intent.op,
         target: intent.target,
         before: intent.before ?? null,
         after: intent.after ?? null,
         detail: intent.detail ?? null,
         at: clock(),
-        applied: options.apply,
-      });
+        state: options.apply === true ? 'attempted' : 'planned',
+        error: null,
+      };
+
+      entries.push(entry);
 
       if (options.apply === false) {
         return null;
       }
 
-      return perform();
+      try {
+        const result = await perform();
+
+        entry.state = 'applied';
+
+        return result;
+      } catch (error) {
+        entry.state = classifyFailure(error);
+        entry.error = error instanceof Error ? error.message : String(error);
+
+        throw error;
+      }
     },
 
     entries() {

--- a/.github/actions/draft-release/lib/milestones.ts
+++ b/.github/actions/draft-release/lib/milestones.ts
@@ -164,16 +164,19 @@ function planNext(
   }
 
   if (open.title === title) {
-    return { action: 'reuse', number: open.number, currentTitle: open.title, title };
+    return { action: 'keep', number: open.number, currentTitle: open.title, title };
   }
 
-  // On a fresh draft the open milestone becomes the shipping one, so the next milestone is always
-  // created or reused, never renamed. A rename here only ever means the version drifted.
-  const expected = candidateVersion === null ? null : nextPatchOf(candidateVersion);
+  // On a fresh draft the open milestone became the shipping one, and `soleOpenMilestone` refused a
+  // second, so an open milestone here always belongs to a candidate in flight. The next milestone
+  // is therefore created or kept on a fresh draft, never renamed, and a rename here only ever means
+  // the version drifted: the open milestone still names the next patch of the version the candidate
+  // was cut under. The fresh-draft arm of the ternary is never taken; it narrows the type.
+  const expected = candidateVersion === null ? title : nextPatchOf(candidateVersion);
 
-  if (expected === null || open.title !== expected) {
+  if (open.title !== expected) {
     throw new Error(
-      `The open milestone is ${open.title}, but this release expects ${expected ?? title}. ` +
+      `The open milestone is ${open.title}, but this release expects ${expected}. ` +
         'Resolve the milestones by hand before drafting.'
     );
   }

--- a/.github/actions/draft-release/lib/milestones.ts
+++ b/.github/actions/draft-release/lib/milestones.ts
@@ -7,52 +7,237 @@ import type {
   MilestoneItem,
   MilestonePlan,
   Reconciliation,
+  RealignItem,
 } from './types.ts';
+
+function isOpen(milestone: Milestone): boolean {
+  return milestone.state !== 'closed';
+}
+
+function findByTitle(milestones: readonly Milestone[], title: string): Milestone | undefined {
+  return milestones.find((milestone) => milestone.title === title);
+}
+
+/**
+ * Refuses to rename a milestone onto a title that is already taken.
+ *
+ * GitHub rejects a duplicate title, so this only turns a 422 into a sentence that says which
+ * milestone is in the way. It is also the one check that catches a half-finished earlier run.
+ */
+function assertTitleFree(
+  milestones: readonly Milestone[],
+  title: string,
+  keeping: number | null
+): void {
+  const taken = findByTitle(milestones, title);
+
+  if (taken === undefined || taken.number === keeping) {
+    return;
+  }
+
+  throw new Error(
+    `A milestone titled ${title} already exists (#${taken.number}, ${taken.state ?? 'open'}). ` +
+      'Rename or delete it before drafting this release.'
+  );
+}
+
+/** The single open milestone, which is where work in flight collects. */
+function soleOpenMilestone(
+  milestones: readonly Milestone[],
+  excluding: number | null
+): Milestone | undefined {
+  const open = milestones.filter(
+    (milestone) => isOpen(milestone) === true && milestone.number !== excluding
+  );
+
+  if (open.length > 1) {
+    const titles = open.map((milestone) => milestone.title).join(', ');
+
+    throw new Error(
+      `Expected at most one open milestone, found ${open.length} (${titles}). ` +
+        'Close the extra ones before drafting a release.'
+    );
+  }
+
+  return open[0];
+}
+
+/**
+ * Plans the shipping milestone: the one that names this release.
+ *
+ * On a fresh draft it is the open milestone, renamed to whatever the commits decided. On a run that
+ * revisits a candidate it is the milestone the candidate was cut under, found by title, and it is
+ * already closed. A closed milestone still accepts item assignments through the REST API, so a
+ * later run keeps filling it without reopening it.
+ */
+function planShipping(
+  allMilestones: readonly Milestone[],
+  version: string,
+  candidateVersion: string | null
+): MilestonePlan['shipping'] {
+  if (candidateVersion === null) {
+    const open = soleOpenMilestone(allMilestones, null);
+
+    if (open === undefined) {
+      assertTitleFree(allMilestones, version, null);
+
+      return { action: 'create', number: null, currentTitle: null, title: version, close: true };
+    }
+
+    if (open.title === version) {
+      return {
+        action: 'keep',
+        number: open.number,
+        currentTitle: open.title,
+        title: version,
+        close: true,
+      };
+    }
+
+    assertTitleFree(allMilestones, version, open.number);
+
+    return {
+      action: 'rename',
+      number: open.number,
+      currentTitle: open.title,
+      title: version,
+      close: true,
+    };
+  }
+
+  const shipping = findByTitle(allMilestones, candidateVersion);
+
+  if (shipping === undefined) {
+    throw new Error(
+      `No milestone is titled ${candidateVersion}, the version the open candidate was cut under. ` +
+        'It was renamed or deleted after the candidate was drafted. Resolve it by hand.'
+    );
+  }
+
+  if (candidateVersion === version) {
+    return {
+      action: 'keep',
+      number: shipping.number,
+      currentTitle: shipping.title,
+      title: version,
+      close: isOpen(shipping),
+    };
+  }
+
+  assertTitleFree(allMilestones, version, shipping.number);
+
+  return {
+    action: 'rename',
+    number: shipping.number,
+    currentTitle: shipping.title,
+    title: version,
+    close: isOpen(shipping),
+  };
+}
+
+/**
+ * Plans the next milestone: the one that collects work for the release after this one.
+ *
+ * It has to be open, because GitHub only offers open milestones when someone opens a pull request,
+ * and `check-pr-status` fails any pull request against `develop` without one.
+ */
+function planNext(
+  allMilestones: readonly Milestone[],
+  version: string,
+  candidateVersion: string | null,
+  shippingNumber: number | null
+): MilestonePlan['next'] {
+  const title = nextPatchOf(version);
+  const open = soleOpenMilestone(allMilestones, shippingNumber);
+
+  if (open === undefined) {
+    const existing = findByTitle(allMilestones, title);
+
+    if (existing !== undefined) {
+      throw new Error(
+        `No milestone is open, and the one titled ${title} is closed (#${existing.number}). ` +
+          'Reopen it, or delete it, before drafting this release.'
+      );
+    }
+
+    return { action: 'create', number: null, currentTitle: null, title };
+  }
+
+  if (open.title === title) {
+    return { action: 'reuse', number: open.number, currentTitle: open.title, title };
+  }
+
+  // On a fresh draft the open milestone becomes the shipping one, so the next milestone is always
+  // created or reused, never renamed. A rename here only ever means the version drifted.
+  const expected = candidateVersion === null ? null : nextPatchOf(candidateVersion);
+
+  if (expected === null || open.title !== expected) {
+    throw new Error(
+      `The open milestone is ${open.title}, but this release expects ${expected ?? title}. ` +
+        'Resolve the milestones by hand before drafting.'
+    );
+  }
+
+  assertTitleFree(allMilestones, title, open.number);
+
+  return { action: 'rename', number: open.number, currentTitle: open.title, title };
+}
 
 /**
  * Plans the milestone moves for a release.
  *
  * The repository keeps exactly one open milestone, named after the next release. This action makes
- * that milestone match what actually landed, opens the one that collects the following release, and
- * closes the shipping one.
+ * the shipping milestone match what actually landed, keeps the one that collects the following
+ * release open, and closes the shipping one.
  *
- * @param allMilestones - Every milestone in any state, so an already created next milestone is
- * reused instead of duplicated.
+ * @param allMilestones - Every milestone in any state. The shipping one is closed for most of a
+ * candidate's life, so a state filter would hide it.
+ * @param candidateVersion - The version an open candidate was cut under, `null` on a fresh draft.
+ * When it differs from `version`, the release drifted and both milestones are renamed.
  */
-export function planMilestones(
-  openMilestones: readonly Milestone[],
-  version: string,
-  allMilestones: readonly Milestone[]
-): MilestonePlan {
-  if (openMilestones.length > 1) {
-    const titles = openMilestones.map((milestone) => milestone.title).join(', ');
+export function planMilestones(input: {
+  allMilestones: readonly Milestone[];
+  version: string;
+  candidateVersion: string | null;
+}): MilestonePlan {
+  const shipping = planShipping(input.allMilestones, input.version, input.candidateVersion);
 
-    throw new Error(
-      `Expected at most one open milestone, found ${openMilestones.length} (${titles}). ` +
-        'Close the extra ones before drafting a release.'
-    );
-  }
-
-  const nextTitle = nextPatchOf(version);
-  const existingNext = allMilestones.find((milestone) => milestone.title === nextTitle);
-  const [open] = openMilestones;
-
-  const shipping =
-    open === undefined
-      ? { action: 'create' as const, number: null, currentTitle: null, title: version }
-      : {
-          action: open.title === version ? ('keep' as const) : ('rename' as const),
-          number: open.number,
-          currentTitle: open.title,
-          title: version,
-        };
-
-  const next =
-    existingNext === undefined
-      ? { action: 'create' as const, number: null, title: nextTitle }
-      : { action: 'reuse' as const, number: existingNext.number, title: nextTitle };
+  // The two can never be the same milestone: `planNext` is told which one shipping took, and every
+  // path it can return either excludes that number or carries none at all. Closing the shipping
+  // milestone therefore always leaves one open for work in flight.
+  const next = planNext(
+    input.allMilestones,
+    input.version,
+    input.candidateVersion,
+    shipping.number
+  );
 
   return { shipping, next };
+}
+
+/**
+ * Plans the milestone corrections for the pull requests that shipped.
+ *
+ * A pull request merged while a candidate is in flight carries the next release's milestone,
+ * because that is the only one GitHub offers. It ships in this release regardless: `develop` is
+ * what the release is cut from. History is therefore the authority and the milestone is corrected,
+ * which also covers a pull request that carries no milestone or the wrong one entirely.
+ */
+export function planRealignment(
+  pullRequests: readonly Pick<AttributedPull, 'number' | 'milestone'>[],
+  shipping: { number: number | null; title: string }
+): RealignItem[] {
+  return pullRequests.flatMap((pull) =>
+    pull.milestone === shipping.title
+      ? []
+      : [
+          {
+            number: pull.number,
+            from: pull.milestone,
+            toTitle: shipping.title,
+          },
+        ]
+  );
 }
 
 function isMerged(item: MilestoneItem): boolean {

--- a/.github/actions/draft-release/lib/pipeline.ts
+++ b/.github/actions/draft-release/lib/pipeline.ts
@@ -4,13 +4,7 @@ import {
   resolveIntegrations,
 } from './attribution.ts';
 import { classifyIntegrations, decideBump } from './bump.ts';
-import {
-  assertBranchContained,
-  assertCandidateUnpublished,
-  crossCheckCandidate,
-  decideMode,
-  findCandidate,
-} from './candidate.ts';
+import { assertCandidateUnpublished, decideMode, findCandidate, planBranch } from './candidate.ts';
 import { planCleanup, planMilestones, planRealignment, reconcile } from './milestones.ts';
 import { fetchPackument, resolveLatestVersion } from './npm.ts';
 import { pinRange } from './range.ts';
@@ -94,6 +88,13 @@ export type ReleasePlan = {
   branch: string;
   /** `false` when the branch already points at the pinned head, so nothing has to be pushed. */
   branchAdvances: boolean;
+  /**
+   * The head git resolved for the candidate's branch during preflight, `null` without a candidate.
+   *
+   * A redraft deletes that branch under a lease on this value, so a commit pushed to it after the
+   * preflight fails the delete instead of being lost.
+   */
+  candidateHeadSha: string | null;
   realignment: RealignItem[];
 };
 
@@ -162,7 +163,10 @@ export async function preflightRelease(deps: DraftReleaseDeps): Promise<ReleaseP
     records.filter((record) => ignoredShas.has(record.sha) === false)
   );
 
-  const candidate = findCandidate(await gh.listPulls({ state: 'open', base: RELEASE_BASE }));
+  const candidate = findCandidate(
+    await gh.listPulls({ state: 'open', base: RELEASE_BASE }),
+    gh.coords
+  );
 
   if (candidate !== null) {
     assertCandidateUnpublished(candidate, previousVersion);
@@ -177,7 +181,7 @@ export async function preflightRelease(deps: DraftReleaseDeps): Promise<ReleaseP
       : `Candidate ${candidate.version} on #${candidate.pullNumber}: ${mode}`
   );
 
-  const branchAdvances = planBranch({ git, mode, branch, candidate, range });
+  const branchPlan = planBranch({ git, mode, branch, candidate, range });
   const milestones = planMilestones({
     allMilestones: await gh.listMilestones('all'),
     version,
@@ -196,67 +200,13 @@ export async function preflightRelease(deps: DraftReleaseDeps): Promise<ReleaseP
     integrationCount: integrations.length,
     pullRequests,
     attention: toAttentionRecords(records),
-    warnings: [
-      ...toWarnings(records),
-      ...(candidate === null ? [] : crossCheckCandidate(candidate)),
-    ],
+    warnings: toWarnings(records),
     milestones,
     branch,
-    branchAdvances,
+    branchAdvances: branchPlan.advances,
+    candidateHeadSha: branchPlan.candidateHeadSha,
     realignment: planRealignment(pullRequests, milestones.shipping),
   };
-}
-
-/**
- * Decides what has to happen to the release branch, and refuses what must not.
- *
- * @returns `false` when the branch already points at the pinned head, which is the case where
- * nothing landed since the last run. Pushing anyway would fire `synchronize` on the pull request
- * and publish another identical experimental artifact for nothing.
- */
-function planBranch(input: {
-  git: GitAdapter;
-  mode: ReleaseMode;
-  branch: string;
-  candidate: Candidate | null;
-  range: PinnedRange;
-}): boolean {
-  const { git, mode, branch, candidate, range } = input;
-
-  if (mode !== 'refresh' && git.remoteBranchExists(branch) === true) {
-    throw new Error(
-      `The branch ${branch} already exists but no open pull request is drafting it. ` +
-        'An earlier run left it behind. Delete it, or reopen its pull request, before drafting.'
-    );
-  }
-
-  if (candidate === null) {
-    return true;
-  }
-
-  if (git.remoteBranchExists(candidate.branch) === false) {
-    throw new Error(
-      `#${candidate.pullNumber} is open against ${candidate.branch}, but that branch is gone from ` +
-        'the remote. Close the pull request, or restore the branch, before drafting.'
-    );
-  }
-
-  // The branch a candidate lives on is only ever a pointer into `develop`. Whether this run
-  // advances it or replaces it, a commit pushed to it directly would be discarded, so both paths
-  // refuse before writing anything.
-  git.fetchBranch(candidate.branch);
-
-  const branchHeadSha = git.resolveSha(`origin/${candidate.branch}`);
-
-  assertBranchContained({
-    branch: candidate.branch,
-    branchHeadSha,
-    sourceRef: range.toRef,
-    sourceSha: range.toSha,
-    contained: git.isAncestor(branchHeadSha, range.toSha),
-  });
-
-  return mode === 'redraft' || branchHeadSha !== range.toSha;
 }
 
 /**
@@ -397,8 +347,8 @@ export async function applyRelease(
   );
 
   // 5. Retire the candidate this run replaced, once its replacement exists.
-  if (plan.mode === 'redraft' && plan.candidate !== null) {
-    await applySupersede(journal, gh, git, plan.candidate, { pullNumber, branch: plan.branch });
+  if (plan.mode === 'redraft') {
+    await applySupersede(journal, gh, git, plan, pullNumber);
   }
 
   // 6. The per-run record of what this run pulled in.
@@ -717,14 +667,27 @@ async function applyPullRequest(
  *
  * Only reached once the replacement exists, so the release is never without a candidate. The branch
  * goes too: two release branches side by side is an invitation to publish the wrong one.
+ *
+ * @throws When the plan carries no candidate or no head for it. A redraft is only ever decided
+ * against a candidate, so this is a broken plan, not a state of the repository.
  */
 async function applySupersede(
   journal: Journal,
   gh: GithubAdapter,
   git: GitAdapter,
-  candidate: Candidate,
-  replacement: { pullNumber: number | null; branch: string }
+  plan: ReleasePlan,
+  replacementPullNumber: number | null
 ): Promise<void> {
+  const { candidate, candidateHeadSha } = plan;
+
+  if (candidate === null || candidateHeadSha === null) {
+    throw new Error(
+      `A ${plan.mode} needs the candidate it replaces and the head its branch was resolved at, ` +
+        'but the plan carries neither. Nothing was retired.'
+    );
+  }
+
+  const replacement = { pullNumber: replacementPullNumber, branch: plan.branch };
   const reference =
     replacement.pullNumber === null ? `\`${replacement.branch}\`` : `#${replacement.pullNumber}`;
 
@@ -758,9 +721,9 @@ async function applySupersede(
     {
       op: 'branch.delete',
       target: `refs/heads/${candidate.branch}`,
-      before: candidate.pullHeadSha,
+      before: candidateHeadSha,
       detail: `superseded by ${replacement.branch}`,
     },
-    async () => git.deleteBranch(candidate.branch)
+    async () => git.deleteBranch(candidate.branch, candidateHeadSha)
   );
 }

--- a/.github/actions/draft-release/lib/pipeline.ts
+++ b/.github/actions/draft-release/lib/pipeline.ts
@@ -14,12 +14,10 @@ import { compareStable, increment, parseStable } from './semver.ts';
 import type { RegistryRequest } from './npm.ts';
 import type {
   AttentionRecord,
-  AttributedPull,
   AttributionRecord,
   AttributionStatus,
   BumpClassification,
   BumpKind,
-  Candidate,
   CleanupItem,
   Clock,
   DraftReleaseInputs,
@@ -30,10 +28,11 @@ import type {
   JournalSnapshot,
   Logger,
   MilestonePlan,
-  PinnedRange,
+  MilestoneTarget,
   RealignItem,
   ReleaseMode,
   ReleasePayload,
+  ReleasePlan,
   VersionSource,
 } from './types.ts';
 
@@ -63,39 +62,6 @@ export type DraftReleaseDeps = {
   request: RegistryRequest;
   logger: Logger;
   clock?: Clock;
-};
-
-/**
- * Everything the run decided, before it wrote anything.
- *
- * Producing this is the only phase allowed to refuse. Once a plan exists, every remaining step is a
- * write, so a refusal can never leave the repository half-changed.
- */
-export type ReleasePlan = {
-  mode: ReleaseMode;
-  candidate: Candidate | null;
-  previousVersion: string;
-  version: string;
-  bumpKind: BumpKind;
-  classification: BumpClassification;
-  versionSource: VersionSource;
-  range: PinnedRange;
-  integrationCount: number;
-  pullRequests: AttributedPull[];
-  attention: AttentionRecord[];
-  warnings: string[];
-  milestones: MilestonePlan;
-  branch: string;
-  /** `false` when the branch already points at the pinned head, so nothing has to be pushed. */
-  branchAdvances: boolean;
-  /**
-   * The head git resolved for the candidate's branch during preflight, `null` without a candidate.
-   *
-   * A redraft deletes that branch under a lease on this value, so a commit pushed to it after the
-   * preflight fails the delete instead of being lost.
-   */
-  candidateHeadSha: string | null;
-  realignment: RealignItem[];
 };
 
 export type DraftReleaseResult = {
@@ -212,9 +178,11 @@ export async function preflightRelease(deps: DraftReleaseDeps): Promise<ReleaseP
 /**
  * Performs a plan.
  *
- * The order matters in one place: the milestone moves happen before the branch and the pull
- * request, so work in flight has somewhere to go as early as possible. `check-pr-status` fails any
- * pull request targeting `develop` without a milestone.
+ * The branch push and the pull request come first. They are the two writes most likely to fail on
+ * permissions, a missing ruleset bypass or an app scope, and a failure there leaves at most one
+ * write to undo. The milestone phase is dozens of writes, so failing after it would leave dozens of
+ * moves to undo by hand. Moving milestones first only gave work in flight a home a few seconds
+ * earlier, which never paid for that.
  */
 export async function applyRelease(
   plan: ReleasePlan,
@@ -223,37 +191,7 @@ export async function applyRelease(
   const { inputs, git, gh, journal, logger } = deps;
   const generatedAt = (deps.clock ?? ((): string => new Date().toISOString()))();
 
-  // 1. Milestones.
-  const shippingNumber = await applyShippingMilestone(journal, gh, plan.milestones.shipping);
-  const nextNumber = await applyNextMilestone(journal, gh, plan.milestones.next);
-
-  await applyRealignment(journal, gh, plan.realignment, shippingNumber);
-
-  const milestoneItems = shippingNumber === null ? [] : await gh.listMilestoneItems(shippingNumber);
-  const cleanup = planCleanup(milestoneItems, nextNumber);
-
-  await applyCleanup(journal, gh, cleanup, plan.milestones);
-
-  if (plan.milestones.shipping.close === true) {
-    await journal.write(
-      {
-        op: 'milestone.close',
-        target: `milestone/${shippingNumber ?? '<new>'}`,
-        before: 'open',
-        after: 'closed',
-        detail: plan.milestones.shipping.title,
-      },
-      async () => {
-        if (shippingNumber === null) {
-          return null;
-        }
-
-        return gh.updateMilestone(shippingNumber, { state: 'closed' });
-      }
-    );
-  }
-
-  // 2. Branch.
+  // 1. Branch.
   if (plan.branchAdvances === true) {
     await journal.write(
       {
@@ -271,60 +209,60 @@ export async function applyRelease(
     logger.info(`${plan.branch} already points at ${plan.range.toSha}, nothing to push.`);
   }
 
-  // 3. Pull request. A refresh keeps the one in flight, with its reviews and its comments.
+  // 2. Pull request. A refresh keeps the one in flight, with its reviews and its comments.
   const { pullNumber, pullUrl } = await applyPullRequest(journal, gh, plan);
 
   await journal.write(
     { op: 'pr.label', target: pullTarget(pullNumber), after: EXPERIMENTAL_LABEL },
     async () => {
-      if (pullNumber === null) {
-        return;
-      }
-
-      await gh.addLabels(pullNumber, [EXPERIMENTAL_LABEL]);
+      await gh.addLabels(applied(pullNumber, 'The pull request number'), [EXPERIMENTAL_LABEL]);
     }
   );
 
+  // 3. Milestones.
+  const shippingNumber = await applyMilestone(journal, gh, plan.milestones.shipping, 'shipping');
+  const nextNumber = await applyMilestone(journal, gh, plan.milestones.next, 'next');
+
+  await applyRealignment(journal, gh, plan.realignment, shippingNumber);
+
+  const milestoneItems = shippingNumber === null ? [] : await gh.listMilestoneItems(shippingNumber);
+  const cleanup = planCleanup(milestoneItems, nextNumber);
+
+  await applyCleanup(journal, gh, cleanup, plan.milestones);
+
+  if (plan.milestones.shipping.close === true) {
+    await journal.write(
+      {
+        op: 'milestone.close',
+        target: `milestone/${shippingNumber ?? '<new>'}`,
+        before: 'open',
+        after: 'closed',
+        detail: plan.milestones.shipping.title,
+      },
+      async () =>
+        gh.updateMilestone(applied(shippingNumber, 'The shipping milestone number'), {
+          state: 'closed',
+        })
+    );
+  }
+
   // 4. Report.
   const payload = buildPayload({
+    plan,
+    outcome: {
+      shippingNumber,
+      nextNumber,
+      pullNumber,
+      pullUrl,
+      // Read after the realignment, so an applied run reports the corrected state and a dry run
+      // reports the drift it would correct. The `inMilestoneNotInHistory` direction still earns its
+      // place either way: it catches a pull request someone filed under this release that never
+      // landed in the range.
+      reconciliation: reconcile(plan.pullRequests, milestoneItems),
+    },
     generatedAt,
     coords: gh.coords,
     dryRun: inputs.dryRun,
-    version: plan.version,
-    bump: plan.bumpKind,
-    previousVersion: plan.previousVersion,
-    versionSource: plan.versionSource,
-    mode: plan.mode,
-    range: plan.range,
-    integrationCount: plan.integrationCount,
-    branch: plan.branch,
-    branchAdvanced: plan.branchAdvances,
-    pullNumber,
-    pullUrl,
-    classification: plan.classification,
-    pullRequests: plan.pullRequests,
-    attention: plan.attention,
-    milestones: {
-      shipping: {
-        number: shippingNumber,
-        title: plan.milestones.shipping.title,
-        renamedFrom:
-          plan.milestones.shipping.action === 'rename'
-            ? plan.milestones.shipping.currentTitle
-            : null,
-        state: 'closed',
-      },
-      next: {
-        number: nextNumber,
-        title: plan.milestones.next.title,
-        created: plan.milestones.next.action === 'create',
-      },
-    },
-    // Read after the realignment, so an applied run reports the corrected state and a dry run
-    // reports the drift it would correct. The `inMilestoneNotInHistory` direction still earns its
-    // place either way: it catches a pull request someone filed under this release that never
-    // landed in the range.
-    reconciliation: reconcile(plan.pullRequests, milestoneItems),
   });
 
   const body = renderBody({
@@ -338,11 +276,7 @@ export async function applyRelease(
   await journal.write(
     { op: 'pr.body', target: pullTarget(pullNumber), after: `Release ${plan.version}` },
     async () => {
-      if (pullNumber === null) {
-        return;
-      }
-
-      await gh.updatePullBody(pullNumber, body);
+      await gh.updatePullBody(applied(pullNumber, 'The pull request number'), body);
     }
   );
 
@@ -361,11 +295,7 @@ export async function applyRelease(
   });
 
   await journal.write({ op: 'pr.comment', target: pullTarget(pullNumber) }, async () => {
-    if (pullNumber === null) {
-      return;
-    }
-
-    await gh.createComment(pullNumber, comment);
+    await gh.createComment(applied(pullNumber, 'The pull request number'), comment);
   });
 
   return {
@@ -390,6 +320,21 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
 
 function pullTarget(pullNumber: number | null): string {
   return pullNumber === null ? 'pulls/<new>' : `pulls/${pullNumber}`;
+}
+
+/**
+ * Narrows an id the run only lacks on a dry run, inside a write that a dry run never performs.
+ *
+ * `journal.write` records the intent and skips the callback when the journal is planning, so a
+ * `null` reaching one of these callbacks means the plan and the journal disagree about the mode.
+ * Throwing names that, where an early return would silently drop the write.
+ */
+function applied<T>(value: T | null, what: string): T {
+  if (value === null) {
+    throw new Error(`${what} is missing while applying, which only a dry run should produce.`);
+  }
+
+  return value;
 }
 
 /** A failed API call must never be reported as a commit pushed straight to the base branch. */
@@ -494,11 +439,18 @@ export async function resolveVersion(input: {
   };
 }
 
-/** @returns The shipping milestone number, or `null` on a dry run that would have created it. */
-async function applyShippingMilestone(
+/**
+ * Brings one milestone to the title the plan decided.
+ *
+ * @param role - Which of the two milestones this is, recorded in the journal so a reader of a
+ * partial run can tell the two renames apart.
+ * @returns The milestone number, or `null` on a dry run that would have created it.
+ */
+async function applyMilestone(
   journal: Journal,
   gh: GithubAdapter,
-  plan: MilestonePlan['shipping']
+  plan: MilestoneTarget,
+  role: 'shipping' | 'next'
 ): Promise<number | null> {
   if (plan.action === 'keep') {
     return plan.number;
@@ -511,61 +463,19 @@ async function applyShippingMilestone(
         target: `milestone/${plan.number ?? '<new>'}`,
         before: plan.currentTitle,
         after: plan.title,
-        detail: 'shipping',
+        detail: role,
       },
-      async () => {
-        if (plan.number === null) {
-          return null;
-        }
-
-        return gh.updateMilestone(plan.number, { title: plan.title });
-      }
+      async () =>
+        gh.updateMilestone(applied(plan.number, `The ${role} milestone number`), {
+          title: plan.title,
+        })
     );
 
     return plan.number;
   }
 
   const created = await journal.write(
-    { op: 'milestone.create', target: 'milestones', after: plan.title, detail: 'shipping' },
-    async () => gh.createMilestone(plan.title)
-  );
-
-  return created?.number ?? null;
-}
-
-/** @returns The next milestone number, or `null` on a dry run that would have created it. */
-async function applyNextMilestone(
-  journal: Journal,
-  gh: GithubAdapter,
-  plan: MilestonePlan['next']
-): Promise<number | null> {
-  if (plan.action === 'reuse') {
-    return plan.number;
-  }
-
-  if (plan.action === 'rename') {
-    await journal.write(
-      {
-        op: 'milestone.rename',
-        target: `milestone/${plan.number ?? '<new>'}`,
-        before: plan.currentTitle,
-        after: plan.title,
-        detail: 'next',
-      },
-      async () => {
-        if (plan.number === null) {
-          return null;
-        }
-
-        return gh.updateMilestone(plan.number, { title: plan.title });
-      }
-    );
-
-    return plan.number;
-  }
-
-  const created = await journal.write(
-    { op: 'milestone.create', target: 'milestones', after: plan.title, detail: 'next' },
+    { op: 'milestone.create', target: 'milestones', after: plan.title, detail: role },
     async () => gh.createMilestone(plan.title)
   );
 
@@ -594,11 +504,10 @@ async function applyRealignment(
         detail: 'Merged inside the release range.',
       },
       async () => {
-        if (shippingNumber === null) {
-          return;
-        }
-
-        await gh.setIssueMilestone(item.number, shippingNumber);
+        await gh.setIssueMilestone(
+          item.number,
+          applied(shippingNumber, 'The shipping milestone number')
+        );
       }
     );
   }

--- a/.github/actions/draft-release/lib/pipeline.ts
+++ b/.github/actions/draft-release/lib/pipeline.ts
@@ -4,7 +4,14 @@ import {
   resolveIntegrations,
 } from './attribution.ts';
 import { classifyIntegrations, decideBump } from './bump.ts';
-import { planCleanup, planMilestones, reconcile } from './milestones.ts';
+import {
+  assertBranchContained,
+  assertCandidateUnpublished,
+  crossCheckCandidate,
+  decideMode,
+  findCandidate,
+} from './candidate.ts';
+import { planCleanup, planMilestones, planRealignment, reconcile } from './milestones.ts';
 import { fetchPackument, resolveLatestVersion } from './npm.ts';
 import { pinRange } from './range.ts';
 import { buildPayload, renderBody, renderMilestoneComment, renderStepSummary } from './report.ts';
@@ -13,10 +20,12 @@ import { compareStable, increment, parseStable } from './semver.ts';
 import type { RegistryRequest } from './npm.ts';
 import type {
   AttentionRecord,
+  AttributedPull,
   AttributionRecord,
   AttributionStatus,
   BumpClassification,
   BumpKind,
+  Candidate,
   CleanupItem,
   Clock,
   DraftReleaseInputs,
@@ -27,10 +36,19 @@ import type {
   JournalSnapshot,
   Logger,
   MilestonePlan,
+  PinnedRange,
+  RealignItem,
+  ReleaseMode,
   ReleasePayload,
   VersionSource,
 } from './types.ts';
 
+/**
+ * The branch every release is cut from.
+ *
+ * Not an input. A release candidate always comes from the protected `develop` head, so nothing
+ * about the release content can be chosen at dispatch time.
+ */
 export const TARGET_BASE = 'develop';
 export const RELEASE_BASE = 'main';
 export const RELEASE_BRANCH_NAME = 'releases';
@@ -53,11 +71,38 @@ export type DraftReleaseDeps = {
   clock?: Clock;
 };
 
+/**
+ * Everything the run decided, before it wrote anything.
+ *
+ * Producing this is the only phase allowed to refuse. Once a plan exists, every remaining step is a
+ * write, so a refusal can never leave the repository half-changed.
+ */
+export type ReleasePlan = {
+  mode: ReleaseMode;
+  candidate: Candidate | null;
+  previousVersion: string;
+  version: string;
+  bumpKind: BumpKind;
+  classification: BumpClassification;
+  versionSource: VersionSource;
+  range: PinnedRange;
+  integrationCount: number;
+  pullRequests: AttributedPull[];
+  attention: AttentionRecord[];
+  warnings: string[];
+  milestones: MilestonePlan;
+  branch: string;
+  /** `false` when the branch already points at the pinned head, so nothing has to be pushed. */
+  branchAdvances: boolean;
+  realignment: RealignItem[];
+};
+
 export type DraftReleaseResult = {
   branch: string;
   bump: BumpKind;
   cleanup: CleanupItem[];
   journal: JournalSnapshot;
+  mode: ReleaseMode;
   payload: ReleasePayload;
   pullNumber: number | null;
   pullUrl: string | null;
@@ -67,41 +112,30 @@ export type DraftReleaseResult = {
 };
 
 /**
- * Orders the whole run.
+ * Reads the world and decides the release.
  *
- * The order matters in two places. The range is pinned before anything else, so a pull request
- * merged while the action runs falls outside the release however long the run takes. And the
- * milestone moves happen before the branch and the pull request, so work in flight has somewhere to
- * go as early as possible: `check-pr-status` fails any pull request targeting `develop` without a
- * milestone.
+ * The range is pinned before anything else, so a pull request merged while the action runs falls
+ * outside the release however long the run takes.
  */
-export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftReleaseResult> {
-  const { inputs, git, gh, journal, request, logger } = deps;
-  const generatedAt = (deps.clock ?? ((): string => new Date().toISOString()))();
+export async function preflightRelease(deps: DraftReleaseDeps): Promise<ReleasePlan> {
+  const { inputs, git, gh, request, logger } = deps;
 
-  // 0. Pin the range.
   assertSupportedMergeMethods(await gh.getRepository());
 
   const previousVersion = resolveLatestVersion(await fetchPackument(request));
   logger.info(`Published baseline: ${previousVersion}`);
 
-  const pinned = pinRange(git, {
-    baselineVersion: previousVersion,
-    sourceRef: inputs.sourceRef,
-  });
-  logger.info(`Range pinned: ${pinned.fromRef} (${pinned.fromSha}) → ${pinned.toSha}`);
+  const range = pinRange(git, { baselineVersion: previousVersion, sourceRef: TARGET_BASE });
+  logger.info(`Range pinned: ${range.fromRef} (${range.fromSha}) → ${range.toSha}`);
 
-  const integrations = git.listIntegrations(pinned.fromSha, pinned.toSha);
+  const integrations = git.listIntegrations(range.fromSha, range.toSha);
 
   if (integrations.length === 0) {
-    throw new Error(
-      `Nothing to release: ${pinned.fromRef} and ${pinned.toRef} are the same commit.`
-    );
+    throw new Error(`Nothing to release: ${range.fromRef} and ${range.toRef} are the same commit.`);
   }
 
   logger.info(`${integrations.length} integrations to attribute`);
 
-  // 1. Attribution.
   const records = await resolveIntegrations(
     integrations,
     { listPullsForCommit: gh.listPullsForCommit, getPull: gh.getPull },
@@ -110,10 +144,6 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
 
   assertNoFailedLookups(records);
 
-  const attention = toAttentionRecords(records);
-  const warnings = toWarnings(records);
-
-  // 2. Version.
   const { version, bumpKind, classification, versionSource } = await resolveVersion({
     inputs,
     previousVersion,
@@ -132,64 +162,167 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
     records.filter((record) => ignoredShas.has(record.sha) === false)
   );
 
-  // 3. Milestones.
-  const allMilestones = await gh.listMilestones('all');
-  const openMilestones = allMilestones.filter((milestone) => milestone.state === 'open');
-  const milestonePlan = planMilestones(openMilestones, version, allMilestones);
+  const candidate = findCandidate(await gh.listPulls({ state: 'open', base: RELEASE_BASE }));
 
-  const shippingNumber = await applyShippingMilestone(journal, gh, milestonePlan.shipping);
-  const nextNumber = await applyNextMilestone(journal, gh, milestonePlan.next);
-
-  const milestoneItems = shippingNumber === null ? [] : await gh.listMilestoneItems(shippingNumber);
-
-  await journal.write(
-    {
-      op: 'milestone.close',
-      target: `milestone/${shippingNumber ?? '<new>'}`,
-      before: 'open',
-      after: 'closed',
-      detail: milestonePlan.shipping.title,
-    },
-    async () => {
-      if (shippingNumber === null) {
-        return null;
-      }
-
-      return gh.updateMilestone(shippingNumber, { state: 'closed' });
-    }
-  );
-
-  // 4. Branch, pull request, experimental label.
-  const branch = `${RELEASE_BRANCH_NAME}/${version}`;
-
-  if (git.remoteBranchExists(branch) === true) {
-    throw new Error(`The branch ${branch} already exists. Delete it or pick another version.`);
+  if (candidate !== null) {
+    assertCandidateUnpublished(candidate, previousVersion);
   }
 
-  await journal.write(
-    {
-      op: 'branch.push',
-      target: `refs/heads/${branch}`,
-      after: pinned.toSha,
-      detail: `cut from ${pinned.toRef}`,
-    },
-    async () => git.pushBranch(pinned.toSha, branch)
+  const mode = decideMode(candidate, version);
+  const branch = `${RELEASE_BRANCH_NAME}/${version}`;
+
+  logger.info(
+    candidate === null
+      ? `No candidate in flight: ${mode}`
+      : `Candidate ${candidate.version} on #${candidate.pullNumber}: ${mode}`
   );
 
-  const title = `Release ${version}`;
-  const createdPull = await journal.write(
-    { op: 'pr.create', target: `${branch} → ${RELEASE_BASE}`, after: title },
-    async () =>
-      gh.createPull({
-        head: branch,
-        base: RELEASE_BASE,
-        title,
-        body: `Release \`${version}\`. The attribution report lands here once the run finishes.`,
-      })
-  );
+  const branchAdvances = planBranch({ git, mode, branch, candidate, range });
+  const milestones = planMilestones({
+    allMilestones: await gh.listMilestones('all'),
+    version,
+    candidateVersion: candidate?.version ?? null,
+  });
 
-  const pullNumber = createdPull?.number ?? null;
-  const pullUrl = createdPull?.html_url ?? null;
+  return {
+    mode,
+    candidate,
+    previousVersion,
+    version,
+    bumpKind,
+    classification,
+    versionSource,
+    range,
+    integrationCount: integrations.length,
+    pullRequests,
+    attention: toAttentionRecords(records),
+    warnings: [
+      ...toWarnings(records),
+      ...(candidate === null ? [] : crossCheckCandidate(candidate)),
+    ],
+    milestones,
+    branch,
+    branchAdvances,
+    realignment: planRealignment(pullRequests, milestones.shipping),
+  };
+}
+
+/**
+ * Decides what has to happen to the release branch, and refuses what must not.
+ *
+ * @returns `false` when the branch already points at the pinned head, which is the case where
+ * nothing landed since the last run. Pushing anyway would fire `synchronize` on the pull request
+ * and publish another identical experimental artifact for nothing.
+ */
+function planBranch(input: {
+  git: GitAdapter;
+  mode: ReleaseMode;
+  branch: string;
+  candidate: Candidate | null;
+  range: PinnedRange;
+}): boolean {
+  const { git, mode, branch, candidate, range } = input;
+
+  if (mode !== 'refresh' && git.remoteBranchExists(branch) === true) {
+    throw new Error(
+      `The branch ${branch} already exists but no open pull request is drafting it. ` +
+        'An earlier run left it behind. Delete it, or reopen its pull request, before drafting.'
+    );
+  }
+
+  if (candidate === null) {
+    return true;
+  }
+
+  if (git.remoteBranchExists(candidate.branch) === false) {
+    throw new Error(
+      `#${candidate.pullNumber} is open against ${candidate.branch}, but that branch is gone from ` +
+        'the remote. Close the pull request, or restore the branch, before drafting.'
+    );
+  }
+
+  // The branch a candidate lives on is only ever a pointer into `develop`. Whether this run
+  // advances it or replaces it, a commit pushed to it directly would be discarded, so both paths
+  // refuse before writing anything.
+  git.fetchBranch(candidate.branch);
+
+  const branchHeadSha = git.resolveSha(`origin/${candidate.branch}`);
+
+  assertBranchContained({
+    branch: candidate.branch,
+    branchHeadSha,
+    sourceRef: range.toRef,
+    sourceSha: range.toSha,
+    contained: git.isAncestor(branchHeadSha, range.toSha),
+  });
+
+  return mode === 'redraft' || branchHeadSha !== range.toSha;
+}
+
+/**
+ * Performs a plan.
+ *
+ * The order matters in one place: the milestone moves happen before the branch and the pull
+ * request, so work in flight has somewhere to go as early as possible. `check-pr-status` fails any
+ * pull request targeting `develop` without a milestone.
+ */
+export async function applyRelease(
+  plan: ReleasePlan,
+  deps: DraftReleaseDeps
+): Promise<DraftReleaseResult> {
+  const { inputs, git, gh, journal, logger } = deps;
+  const generatedAt = (deps.clock ?? ((): string => new Date().toISOString()))();
+
+  // 1. Milestones.
+  const shippingNumber = await applyShippingMilestone(journal, gh, plan.milestones.shipping);
+  const nextNumber = await applyNextMilestone(journal, gh, plan.milestones.next);
+
+  await applyRealignment(journal, gh, plan.realignment, shippingNumber);
+
+  const milestoneItems = shippingNumber === null ? [] : await gh.listMilestoneItems(shippingNumber);
+  const cleanup = planCleanup(milestoneItems, nextNumber);
+
+  await applyCleanup(journal, gh, cleanup, plan.milestones);
+
+  if (plan.milestones.shipping.close === true) {
+    await journal.write(
+      {
+        op: 'milestone.close',
+        target: `milestone/${shippingNumber ?? '<new>'}`,
+        before: 'open',
+        after: 'closed',
+        detail: plan.milestones.shipping.title,
+      },
+      async () => {
+        if (shippingNumber === null) {
+          return null;
+        }
+
+        return gh.updateMilestone(shippingNumber, { state: 'closed' });
+      }
+    );
+  }
+
+  // 2. Branch.
+  if (plan.branchAdvances === true) {
+    await journal.write(
+      {
+        op: 'branch.push',
+        target: `refs/heads/${plan.branch}`,
+        after: plan.range.toSha,
+        detail:
+          plan.mode === 'refresh'
+            ? `advanced to ${plan.range.toRef}`
+            : `cut from ${plan.range.toRef}`,
+      },
+      async () => git.pushBranch(plan.range.toSha, plan.branch)
+    );
+  } else {
+    logger.info(`${plan.branch} already points at ${plan.range.toSha}, nothing to push.`);
+  }
+
+  // 3. Pull request. A refresh keeps the one in flight, with its reviews and its comments.
+  const { pullNumber, pullUrl } = await applyPullRequest(journal, gh, plan);
 
   await journal.write(
     { op: 'pr.label', target: pullTarget(pullNumber), after: EXPERIMENTAL_LABEL },
@@ -202,58 +335,77 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
     }
   );
 
-  // 5. Report.
+  // 4. Report.
   const payload = buildPayload({
     generatedAt,
     coords: gh.coords,
     dryRun: inputs.dryRun,
-    version,
-    bump: bumpKind,
-    previousVersion,
-    versionSource,
-    range: pinned,
-    integrationCount: integrations.length,
-    branch,
+    version: plan.version,
+    bump: plan.bumpKind,
+    previousVersion: plan.previousVersion,
+    versionSource: plan.versionSource,
+    mode: plan.mode,
+    range: plan.range,
+    integrationCount: plan.integrationCount,
+    branch: plan.branch,
+    branchAdvanced: plan.branchAdvances,
     pullNumber,
     pullUrl,
-    classification,
-    pullRequests,
-    attention,
+    classification: plan.classification,
+    pullRequests: plan.pullRequests,
+    attention: plan.attention,
     milestones: {
       shipping: {
         number: shippingNumber,
-        title: milestonePlan.shipping.title,
+        title: plan.milestones.shipping.title,
         renamedFrom:
-          milestonePlan.shipping.action === 'rename' ? milestonePlan.shipping.currentTitle : null,
+          plan.milestones.shipping.action === 'rename'
+            ? plan.milestones.shipping.currentTitle
+            : null,
         state: 'closed',
       },
       next: {
         number: nextNumber,
-        title: milestonePlan.next.title,
-        created: milestonePlan.next.action === 'create',
+        title: plan.milestones.next.title,
+        created: plan.milestones.next.action === 'create',
       },
     },
-    reconciliation: reconcile(pullRequests, milestoneItems),
+    // Read after the realignment, so an applied run reports the corrected state and a dry run
+    // reports the drift it would correct. The `inMilestoneNotInHistory` direction still earns its
+    // place either way: it catches a pull request someone filed under this release that never
+    // landed in the range.
+    reconciliation: reconcile(plan.pullRequests, milestoneItems),
   });
 
-  const body = renderBody({ payload, pullRequests, attention, warnings });
+  const body = renderBody({
+    payload,
+    pullRequests: plan.pullRequests,
+    attention: plan.attention,
+    warnings: plan.warnings,
+    supersedes: plan.mode === 'redraft' ? plan.candidate : null,
+  });
 
-  await journal.write({ op: 'pr.body', target: pullTarget(pullNumber), after: title }, async () => {
-    if (pullNumber === null) {
-      return;
+  await journal.write(
+    { op: 'pr.body', target: pullTarget(pullNumber), after: `Release ${plan.version}` },
+    async () => {
+      if (pullNumber === null) {
+        return;
+      }
+
+      await gh.updatePullBody(pullNumber, body);
     }
+  );
 
-    await gh.updatePullBody(pullNumber, body);
-  });
+  // 5. Retire the candidate this run replaced, once its replacement exists.
+  if (plan.mode === 'redraft' && plan.candidate !== null) {
+    await applySupersede(journal, gh, git, plan.candidate, { pullNumber, branch: plan.branch });
+  }
 
-  // 6. Milestone cleanup and comment.
-  const cleanup = planCleanup(milestoneItems, nextNumber);
-
-  await applyCleanup(journal, gh, cleanup, milestonePlan);
-
+  // 6. The per-run record of what this run pulled in.
   const comment = renderMilestoneComment({
-    version,
-    nextTitle: milestonePlan.next.title,
+    version: plan.version,
+    nextTitle: plan.milestones.next.title,
+    mode: plan.mode,
     entries: journal.entries(),
     dryRun: inputs.dryRun,
   });
@@ -267,17 +419,23 @@ export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftRele
   });
 
   return {
-    branch,
-    bump: bumpKind,
+    branch: plan.branch,
+    bump: plan.bumpKind,
     cleanup,
     journal: journal.toJSON(),
+    mode: plan.mode,
     payload,
     pullNumber,
     pullUrl,
     summary: renderStepSummary({ payload, entries: journal.entries() }),
-    version,
-    warnings,
+    version: plan.version,
+    warnings: plan.warnings,
   };
+}
+
+/** Decides the whole release, then performs it. */
+export async function runDraftRelease(deps: DraftReleaseDeps): Promise<DraftReleaseResult> {
+  return applyRelease(await preflightRelease(deps), deps);
 }
 
 function pullTarget(pullNumber: number | null): string {
@@ -403,6 +561,7 @@ async function applyShippingMilestone(
         target: `milestone/${plan.number ?? '<new>'}`,
         before: plan.currentTitle,
         after: plan.title,
+        detail: 'shipping',
       },
       async () => {
         if (plan.number === null) {
@@ -434,12 +593,65 @@ async function applyNextMilestone(
     return plan.number;
   }
 
+  if (plan.action === 'rename') {
+    await journal.write(
+      {
+        op: 'milestone.rename',
+        target: `milestone/${plan.number ?? '<new>'}`,
+        before: plan.currentTitle,
+        after: plan.title,
+        detail: 'next',
+      },
+      async () => {
+        if (plan.number === null) {
+          return null;
+        }
+
+        return gh.updateMilestone(plan.number, { title: plan.title });
+      }
+    );
+
+    return plan.number;
+  }
+
   const created = await journal.write(
     { op: 'milestone.create', target: 'milestones', after: plan.title, detail: 'next' },
     async () => gh.createMilestone(plan.title)
   );
 
   return created?.number ?? null;
+}
+
+/**
+ * Corrects the milestone of every pull request that shipped.
+ *
+ * Sequential on purpose: a release milestone carries dozens of items and GitHub throttles parallel
+ * issue writes.
+ */
+async function applyRealignment(
+  journal: Journal,
+  gh: GithubAdapter,
+  realignment: readonly RealignItem[],
+  shippingNumber: number | null
+): Promise<void> {
+  for (const item of realignment) {
+    await journal.write(
+      {
+        op: 'issue.milestone.set',
+        target: `issues/${item.number}`,
+        before: item.from,
+        after: item.toTitle,
+        detail: 'Merged inside the release range.',
+      },
+      async () => {
+        if (shippingNumber === null) {
+          return;
+        }
+
+        await gh.setIssueMilestone(item.number, shippingNumber);
+      }
+    );
+  }
 }
 
 async function applyCleanup(
@@ -470,4 +682,85 @@ async function applyCleanup(
       }
     );
   }
+}
+
+/**
+ * @returns The pull request the report lands on. A refresh reuses the candidate's, so its reviews,
+ * its comments and its `publish-experimental` label all survive.
+ */
+async function applyPullRequest(
+  journal: Journal,
+  gh: GithubAdapter,
+  plan: ReleasePlan
+): Promise<{ pullNumber: number | null; pullUrl: string | null }> {
+  if (plan.mode === 'refresh' && plan.candidate !== null) {
+    return { pullNumber: plan.candidate.pullNumber, pullUrl: plan.candidate.pullUrl };
+  }
+
+  const title = `Release ${plan.version}`;
+  const created = await journal.write(
+    { op: 'pr.create', target: `${plan.branch} → ${RELEASE_BASE}`, after: title },
+    async () =>
+      gh.createPull({
+        head: plan.branch,
+        base: RELEASE_BASE,
+        title,
+        body: `Release \`${plan.version}\`. The attribution report lands here once the run finishes.`,
+      })
+  );
+
+  return { pullNumber: created?.number ?? null, pullUrl: created?.html_url ?? null };
+}
+
+/**
+ * Retires the candidate a redraft replaced.
+ *
+ * Only reached once the replacement exists, so the release is never without a candidate. The branch
+ * goes too: two release branches side by side is an invitation to publish the wrong one.
+ */
+async function applySupersede(
+  journal: Journal,
+  gh: GithubAdapter,
+  git: GitAdapter,
+  candidate: Candidate,
+  replacement: { pullNumber: number | null; branch: string }
+): Promise<void> {
+  const reference =
+    replacement.pullNumber === null ? `\`${replacement.branch}\`` : `#${replacement.pullNumber}`;
+
+  await journal.write(
+    {
+      op: 'pr.comment',
+      target: `pulls/${candidate.pullNumber}`,
+      detail: `superseded by ${reference}`,
+    },
+    async () =>
+      gh.createComment(
+        candidate.pullNumber,
+        `Superseded by ${reference}. The commits that landed since this candidate was drafted ` +
+          `changed the release version, so \`${candidate.branch}\` is replaced by ` +
+          `\`${replacement.branch}\`.`
+      )
+  );
+
+  await journal.write(
+    {
+      op: 'pr.close',
+      target: `pulls/${candidate.pullNumber}`,
+      before: 'open',
+      after: 'closed',
+      detail: `superseded by ${reference}`,
+    },
+    async () => gh.closePull(candidate.pullNumber)
+  );
+
+  await journal.write(
+    {
+      op: 'branch.delete',
+      target: `refs/heads/${candidate.branch}`,
+      before: candidate.pullHeadSha,
+      detail: `superseded by ${replacement.branch}`,
+    },
+    async () => git.deleteBranch(candidate.branch)
+  );
 }

--- a/.github/actions/draft-release/lib/range.ts
+++ b/.github/actions/draft-release/lib/range.ts
@@ -127,8 +127,18 @@ export function createGitAdapter(exec: GitExec): GitAdapter {
       run(['push', 'origin', `${sha}:refs/heads/${branch}`]);
     },
 
-    deleteBranch(branch) {
-      run(['push', 'origin', '--delete', `refs/heads/${branch}`]);
+    /**
+     * Compare-and-swap, not a plain delete. The lease names the head the preflight resolved, so a
+     * commit pushed to the branch between preflight and this write makes git refuse rather than
+     * drop it.
+     */
+    deleteBranch(branch, expectedSha) {
+      run([
+        'push',
+        `--force-with-lease=refs/heads/${branch}:${expectedSha}`,
+        'origin',
+        `:refs/heads/${branch}`,
+      ]);
     },
 
     /**

--- a/.github/actions/draft-release/lib/range.ts
+++ b/.github/actions/draft-release/lib/range.ts
@@ -74,11 +74,18 @@ export function createGitExec(cwd: string = process.cwd()): GitExec {
 
 /** Wraps a process surface into the Git operations this action performs. */
 export function createGitAdapter(exec: GitExec): GitAdapter {
+  /**
+   * The exit code travels on the error, which is what tells the write journal that git reached a
+   * verdict. Git updates a ref atomically, so a push that exits non-zero left the ref untouched.
+   * See `classifyFailure` in [`journal.ts`](journal.ts).
+   */
   function run(args: string[]): string {
     const result = exec(args);
 
     if (result.status !== 0) {
-      throw new Error(`git ${args.join(' ')} failed: ${result.stderr.trim()}`);
+      throw Object.assign(new Error(`git ${args.join(' ')} failed: ${result.stderr.trim()}`), {
+        status: result.status,
+      });
     }
 
     return result.stdout;
@@ -118,6 +125,20 @@ export function createGitAdapter(exec: GitExec): GitAdapter {
 
     pushBranch(sha, branch) {
       run(['push', 'origin', `${sha}:refs/heads/${branch}`]);
+    },
+
+    deleteBranch(branch) {
+      run(['push', 'origin', '--delete', `refs/heads/${branch}`]);
+    },
+
+    /**
+     * Brings one remote branch into `refs/remotes/origin`.
+     *
+     * Forced on purpose: the local remote-tracking ref is a read cache with no history to protect,
+     * and a release branch that was rewritten would otherwise refuse to update.
+     */
+    fetchBranch(branch) {
+      run(['fetch', '--force', 'origin', `refs/heads/${branch}:refs/remotes/origin/${branch}`]);
     },
 
     remoteBranchExists(branch) {

--- a/.github/actions/draft-release/lib/report.ts
+++ b/.github/actions/draft-release/lib/report.ts
@@ -81,7 +81,7 @@ export function renderAuthor(author: Author): string {
  * The time of day is kept in the payload for anything that needs to order two merges.
  */
 export function renderMergeDate(mergedAt: string): string {
-  return /^(\d{4}-\d{2}-\d{2})/u.exec(mergedAt ?? '')?.[1] ?? '—';
+  return /^(\d{4}-\d{2}-\d{2})/u.exec(mergedAt)?.[1] ?? '—';
 }
 
 /**

--- a/.github/actions/draft-release/lib/report.ts
+++ b/.github/actions/draft-release/lib/report.ts
@@ -8,11 +8,12 @@ import type {
   PinnedRange,
   ReleasePayload,
   Reconciliation,
+  ReleaseMode,
   RepositoryCoords,
   VersionSource,
 } from './types.ts';
 
-export const SCHEMA_VERSION = 4;
+export const SCHEMA_VERSION = 5;
 export const BLOCK_START = '<!-- STRAPI_RELEASE_CANDIDATE_START -->';
 export const BLOCK_END = '<!-- STRAPI_RELEASE_CANDIDATE_END -->';
 
@@ -76,18 +77,35 @@ export function renderAuthor(author: Author): string {
   return author.name === null ? login : `${cell(author.name)} (${login})`;
 }
 
-/** The shipping table, one row per attributed pull request. */
+/**
+ * The calendar day a pull request landed, from its ISO `merged_at`.
+ *
+ * The day is the whole point of the column: it answers which release window the work landed in.
+ * The time of day is kept in the payload for anything that needs to order two merges.
+ */
+export function renderMergeDate(mergedAt: string): string {
+  return /^(\d{4}-\d{2}-\d{2})/u.exec(mergedAt ?? '')?.[1] ?? '—';
+}
+
+/**
+ * The shipping table, one row per attributed pull request.
+ *
+ * The milestone column is the one the author picked, read when the range was attributed. The run
+ * then corrects it to the shipping milestone, so a value that disagrees with the release is the
+ * interesting case rather than a mistake in the report.
+ */
 export function renderPullRequestTable(pullRequests: readonly AttributedPull[]): string {
   if (pullRequests.length === 0) {
     return '_No pull request resolved in this range._';
   }
 
   return table(
-    ['PR', 'Title', 'Author', 'Milestone', 'Basis'],
+    ['PR', 'Title', 'Author', 'Merged', 'Milestone at merge', 'Basis'],
     pullRequests.map(
       (pull) =>
         `| [#${pull.number}](${pull.url}) | ${cell(pull.title)} | ${renderAuthor(pull.author)} | ` +
-        `${cell(pull.milestone ?? '—')} | ${cell(pull.basis)} |`
+        `${renderMergeDate(pull.mergedAt)} | ${cell(pull.milestone ?? '—')} | ` +
+        `${cell(pull.basis)} |`
     )
   );
 }
@@ -112,17 +130,22 @@ export function renderAttentionTable(records: readonly AttentionRecord[]): strin
   ].join('\n');
 }
 
-/** Every mutation, planned or applied, as a table. */
+/**
+ * Every mutation, with how far it got.
+ *
+ * The state column is the point of the table. Only an `applied` entry is worth undoing, and an
+ * `indeterminate` one is the entry somebody has to go and look at before touching anything.
+ */
 export function renderJournalTable(entries: readonly JournalEntry[]): string {
   if (entries.length === 0) {
     return '_No write recorded._';
   }
 
   return table(
-    ['Operation', 'Target', 'Before', 'After'],
+    ['State', 'Operation', 'Target', 'Before', 'After'],
     entries.map(
       (entry) =>
-        `| ${entry.op} | ${cell(entry.target)} | ${cell(entry.before ?? '—')} | ` +
+        `| ${entry.state} | ${entry.op} | ${cell(entry.target)} | ${cell(entry.before ?? '—')} | ` +
         `${cell(entry.after ?? '—')} |`
     )
   );
@@ -136,9 +159,11 @@ export type PayloadInput = {
   bump: BumpKind;
   previousVersion: string;
   versionSource: VersionSource;
+  mode: ReleaseMode;
   range: PinnedRange;
   integrationCount: number;
   branch: string;
+  branchAdvanced: boolean;
   pullNumber: number | null;
   pullUrl: string | null;
   classification: BumpClassification;
@@ -160,12 +185,14 @@ export function buildPayload(input: PayloadInput): ReleasePayload {
       bump: input.bump,
       previousVersion: input.previousVersion,
       source: input.versionSource,
+      mode: input.mode,
     },
     range: { ...input.range, integrationCount: input.integrationCount },
     candidate: {
       branch: input.branch,
       headSha: input.range.toSha,
       expectedExperimentalVersion: experimentalVersion(input.range.toSha),
+      branchAdvanced: input.branchAdvanced,
       pullRequestNumber: input.pullNumber,
       pullRequestUrl: input.pullUrl,
     },
@@ -216,6 +243,22 @@ export function extractJsonBlock(body: string): unknown {
   }
 }
 
+/**
+ * What the run did to the candidate, in one sentence.
+ *
+ * A reader who opens the pull request a second time needs to know whether they are looking at a
+ * fresh draft or at the same candidate carrying more work than it did an hour ago.
+ */
+const MODE_LINES: Record<ReleaseMode, string> = {
+  draft: 'Drafted from `develop`.',
+  refresh:
+    'Refreshed. This candidate was already open, and it now covers everything that landed on ' +
+    '`develop` since it was drafted.',
+  redraft:
+    'Redrafted. The commits that landed since changed the version, so this candidate replaces the ' +
+    'one drafted before it.',
+};
+
 function formatNumbers(numbers: readonly number[]): string {
   return numbers.length === 0 ? '_none_' : numbers.map((number) => `#${number}`).join(', ');
 }
@@ -225,6 +268,8 @@ export type BodyInput = {
   pullRequests: readonly AttributedPull[];
   attention: readonly AttentionRecord[];
   warnings?: readonly string[];
+  /** The candidate a redraft replaced, `null` on every other run. */
+  supersedes?: { pullNumber: number; branch: string } | null;
 };
 
 /** The pull request body: a human summary, the shipping table, then the machine-readable block. */
@@ -240,6 +285,15 @@ export function renderBody(input: BodyInput): string {
     `\`${payload.release.previousVersion}\` → \`${payload.release.version}\` ` +
       `(**${payload.release.bump}**, decided from ${decidedBy}).`,
     '',
+    MODE_LINES[payload.release.mode],
+    ...(input.supersedes === null || input.supersedes === undefined
+      ? []
+      : [
+          '',
+          `Supersedes #${input.supersedes.pullNumber}, which was drafted as ` +
+            `\`${input.supersedes.branch}\`.`,
+        ]),
+    '',
     table(
       ['', ''],
       [
@@ -248,6 +302,8 @@ export function renderBody(input: BodyInput): string {
         `| **To** | \`${payload.range.toSha}\` |`,
         `| **Integrations** | ${payload.range.integrationCount} |`,
         `| **Pull requests** | ${pullRequests.length} |`,
+        `| **Branch** | \`${payload.candidate.branch}\`, ` +
+          `${payload.candidate.branchAdvanced === true ? 'advanced to the pinned head' : 'already at the pinned head'} |`,
         `| **Milestone** | ${payload.milestones.shipping.title} (closed) → ` +
           `${payload.milestones.next.title} |`,
       ]
@@ -302,10 +358,16 @@ export function renderBody(input: BodyInput): string {
   ].join('\n');
 }
 
-/** The single comment posted on the release pull request after the milestone work. */
+/**
+ * The comment posted on the release pull request after the milestone work.
+ *
+ * One comment per run, never rewritten. The body of the pull request is the current truth and gets
+ * replaced wholesale; these comments are the only record of which run pulled which work in.
+ */
 export function renderMilestoneComment(input: {
   version: string;
   nextTitle: string;
+  mode: ReleaseMode;
   entries: readonly JournalEntry[];
   dryRun: boolean;
 }): string {
@@ -313,12 +375,22 @@ export function renderMilestoneComment(input: {
     (entry) => entry.op.startsWith('milestone.') === true || entry.op.startsWith('issue.') === true
   );
 
+  const applied = {
+    draft: `\`${input.version}\` is closed. Work now collects in \`${input.nextTitle}\`.`,
+    refresh:
+      `\`${input.version}\` stays closed and now carries everything that landed since the last ` +
+      `run. Work continues to collect in \`${input.nextTitle}\`.`,
+    redraft:
+      `The candidate is now \`${input.version}\`, and its milestone is closed. Work collects in ` +
+      `\`${input.nextTitle}\`.`,
+  }[input.mode];
+
   return [
     `## Milestone reconciliation for ${input.version}`,
     '',
     input.dryRun === true
       ? `Dry run. Nothing below was applied. Work now collects in \`${input.nextTitle}\`.`
-      : `\`${input.version}\` is closed. Work now collects in \`${input.nextTitle}\`.`,
+      : applied,
     '',
     renderJournalTable(milestoneEntries),
   ].join('\n');
@@ -334,7 +406,7 @@ export function renderStepSummary(input: {
   const heading = payload.dryRun === true ? 'Planned' : 'Applied';
 
   return [
-    `# draft-release — ${payload.release.version} (${payload.release.bump})`,
+    `# draft-release — ${payload.release.version} (${payload.release.bump}, ${payload.release.mode})`,
     '',
     `${mode}. Baseline \`${payload.release.previousVersion}\`, range \`${payload.range.fromRef}\` → ` +
       `\`${short(payload.range.toSha)}\`, ${payload.range.integrationCount} integrations, ` +

--- a/.github/actions/draft-release/lib/report.ts
+++ b/.github/actions/draft-release/lib/report.ts
@@ -2,15 +2,12 @@ import type {
   AttentionRecord,
   AttributedPull,
   Author,
-  BumpClassification,
-  BumpKind,
   JournalEntry,
-  PinnedRange,
-  ReleasePayload,
-  Reconciliation,
   ReleaseMode,
+  ReleaseOutcome,
+  ReleasePayload,
+  ReleasePlan,
   RepositoryCoords,
-  VersionSource,
 } from './types.ts';
 
 export const SCHEMA_VERSION = 5;
@@ -151,61 +148,65 @@ export function renderJournalTable(entries: readonly JournalEntry[]): string {
   );
 }
 
-export type PayloadInput = {
+/**
+ * Builds the machine-readable payload embedded in the pull request body.
+ *
+ * Everything the plan decided is read from the plan; the outcome only adds what the writes
+ * produced. Deriving the milestone section here keeps the payload shape the concern of one module.
+ */
+export function buildPayload(input: {
+  plan: ReleasePlan;
+  outcome: ReleaseOutcome;
   generatedAt: string;
   coords: RepositoryCoords;
   dryRun: boolean;
-  version: string;
-  bump: BumpKind;
-  previousVersion: string;
-  versionSource: VersionSource;
-  mode: ReleaseMode;
-  range: PinnedRange;
-  integrationCount: number;
-  branch: string;
-  branchAdvanced: boolean;
-  pullNumber: number | null;
-  pullUrl: string | null;
-  classification: BumpClassification;
-  pullRequests: AttributedPull[];
-  attention: AttentionRecord[];
-  milestones: ReleasePayload['milestones'];
-  reconciliation: Reconciliation;
-};
+}): ReleasePayload {
+  const { plan, outcome } = input;
+  const { shipping, next } = plan.milestones;
 
-/** Builds the machine-readable payload embedded in the pull request body. */
-export function buildPayload(input: PayloadInput): ReleasePayload {
   return {
     schemaVersion: SCHEMA_VERSION,
     generatedAt: input.generatedAt,
     repository: `${input.coords.owner}/${input.coords.repo}`,
     dryRun: input.dryRun,
     release: {
-      version: input.version,
-      bump: input.bump,
-      previousVersion: input.previousVersion,
-      source: input.versionSource,
-      mode: input.mode,
+      version: plan.version,
+      bump: plan.bumpKind,
+      previousVersion: plan.previousVersion,
+      source: plan.versionSource,
+      mode: plan.mode,
     },
-    range: { ...input.range, integrationCount: input.integrationCount },
+    range: { ...plan.range, integrationCount: plan.integrationCount },
     candidate: {
-      branch: input.branch,
-      headSha: input.range.toSha,
-      expectedExperimentalVersion: experimentalVersion(input.range.toSha),
-      branchAdvanced: input.branchAdvanced,
-      pullRequestNumber: input.pullNumber,
-      pullRequestUrl: input.pullUrl,
+      branch: plan.branch,
+      headSha: plan.range.toSha,
+      expectedExperimentalVersion: experimentalVersion(plan.range.toSha),
+      branchAdvanced: plan.branchAdvances,
+      pullRequestNumber: outcome.pullNumber,
+      pullRequestUrl: outcome.pullUrl,
     },
     bumpEvidence: {
-      featureIntegrations: input.classification.features,
-      breakingIntegrations: input.classification.breaking,
-      ignored: input.classification.ignored,
-      unparsed: input.classification.unparsed,
+      featureIntegrations: plan.classification.features,
+      breakingIntegrations: plan.classification.breaking,
+      ignored: plan.classification.ignored,
+      unparsed: plan.classification.unparsed,
     },
-    pullRequests: input.pullRequests,
-    attention: input.attention,
-    milestones: input.milestones,
-    reconciliation: input.reconciliation,
+    pullRequests: plan.pullRequests,
+    attention: plan.attention,
+    milestones: {
+      shipping: {
+        number: outcome.shippingNumber,
+        title: shipping.title,
+        renamedFrom: shipping.action === 'rename' ? shipping.currentTitle : null,
+        state: 'closed',
+      },
+      next: {
+        number: outcome.nextNumber,
+        title: next.title,
+        created: next.action === 'create',
+      },
+    },
+    reconciliation: outcome.reconciliation,
   };
 }
 

--- a/.github/actions/draft-release/lib/types.ts
+++ b/.github/actions/draft-release/lib/types.ts
@@ -141,7 +141,12 @@ export type PullPayload = {
   merged_at?: string | null;
   merge_commit_sha?: string | null;
   base?: { ref?: string | null } | null;
-  head?: { ref?: string | null; sha?: string | null } | null;
+  head?: {
+    ref?: string | null;
+    sha?: string | null;
+    /** `null` when the head repository was deleted, which only a fork can be. */
+    repo?: { full_name?: string | null } | null;
+  } | null;
   user?: { login?: string | null } | null;
   milestone?: { title?: string | null } | null;
 };
@@ -333,20 +338,19 @@ export type PinnedRange = {
 /**
  * A release candidate already in flight, discovered from its open pull request.
  *
- * The pull request is the only artifact whose lifecycle matches the candidate's. A release branch
+ * The pull request is the only artifact whose lifecycle matches the candidate's, and only one whose
+ * head lives in this repository qualifies. A release branch
  * outlives it, because the ruleset that protects release branches forbids deleting them without a
  * bypass, and a milestone is renamed by this very action.
  */
 export type Candidate = {
-  /** The version the candidate was cut under, parsed out of its branch name. */
+  /** The version the candidate was cut under, as its branch name spells it. */
   version: string;
+  /** The same version parsed once, because the branch pattern already proved it is `x.y.z`. */
+  parsedVersion: StableVersion;
   branch: string;
   pullNumber: number;
   pullUrl: string;
-  /** The head the pull request payload reports, used only to cross-check the git ref. */
-  pullHeadSha: string;
-  /** The payload the last run embedded in the body, `null` when it is absent or unreadable. */
-  payload: unknown;
 };
 
 /** The machine-readable payload embedded in the release pull request body. */
@@ -438,7 +442,8 @@ export type GitAdapter = {
   isAncestor: (ancestor: string, descendant: string) => boolean;
   listIntegrations: (fromSha: string, toSha: string) => Integration[];
   pushBranch: (sha: string, branch: string) => void;
-  deleteBranch: (branch: string) => void;
+  /** Deletes under a lease: the push fails unless the remote head is still `expectedSha`. */
+  deleteBranch: (branch: string, expectedSha: string) => void;
   remoteBranchExists: (branch: string) => boolean;
   /** Brings a remote branch into `refs/remotes/origin`, so a guard never rests on how the
    * workflow's checkout was configured. */

--- a/.github/actions/draft-release/lib/types.ts
+++ b/.github/actions/draft-release/lib/types.ts
@@ -237,12 +237,21 @@ export type Milestone = {
   state?: string;
 };
 
+/**
+ * One milestone the run has to end up with, and how it gets there.
+ *
+ * `number` and `currentTitle` are `null` only with `create`, where the milestone does not exist
+ * until the run applies.
+ */
+export type MilestoneTarget = {
+  action: 'create' | 'keep' | 'rename';
+  number: number | null;
+  currentTitle: string | null;
+  title: string;
+};
+
 export type MilestonePlan = {
-  shipping: {
-    action: 'create' | 'rename' | 'keep';
-    number: number | null;
-    currentTitle: string | null;
-    title: string;
+  shipping: MilestoneTarget & {
     /**
      * Whether the run still has to close it.
      *
@@ -252,12 +261,7 @@ export type MilestonePlan = {
      */
     close: boolean;
   };
-  next: {
-    action: 'create' | 'reuse' | 'rename';
-    number: number | null;
-    currentTitle: string | null;
-    title: string;
-  };
+  next: MilestoneTarget;
 };
 
 /**
@@ -351,6 +355,53 @@ export type Candidate = {
   branch: string;
   pullNumber: number;
   pullUrl: string;
+};
+
+/**
+ * Everything the run decided, before it wrote anything.
+ *
+ * Producing this is the only phase allowed to refuse. Once a plan exists, every remaining step is a
+ * write, so a refusal can never leave the repository half-changed.
+ */
+export type ReleasePlan = {
+  mode: ReleaseMode;
+  candidate: Candidate | null;
+  previousVersion: string;
+  version: string;
+  bumpKind: BumpKind;
+  classification: BumpClassification;
+  versionSource: VersionSource;
+  range: PinnedRange;
+  integrationCount: number;
+  pullRequests: AttributedPull[];
+  attention: AttentionRecord[];
+  warnings: string[];
+  milestones: MilestonePlan;
+  branch: string;
+  /** `false` when the branch already points at the pinned head, so nothing has to be pushed. */
+  branchAdvances: boolean;
+  /**
+   * The head git resolved for the candidate's branch during preflight, `null` without a candidate.
+   *
+   * A redraft deletes that branch under a lease on this value, so a commit pushed to it after the
+   * preflight fails the delete instead of being lost.
+   */
+  candidateHeadSha: string | null;
+  realignment: RealignItem[];
+};
+
+/**
+ * What the writes produced that the plan could not know.
+ *
+ * The numbers GitHub assigned to whatever this run created, and the milestone drift read once the
+ * realignment had run. Every field is `null` on a dry run that would have created the thing.
+ */
+export type ReleaseOutcome = {
+  shippingNumber: number | null;
+  nextNumber: number | null;
+  pullNumber: number | null;
+  pullUrl: string | null;
+  reconciliation: Reconciliation;
 };
 
 /** The machine-readable payload embedded in the release pull request body. */

--- a/.github/actions/draft-release/lib/types.ts
+++ b/.github/actions/draft-release/lib/types.ts
@@ -46,6 +46,7 @@ export type IgnoreReason = (typeof IGNORE_REASONS)[number];
 
 /** Every mutation the action can perform, as recorded in the write journal. */
 export const JOURNAL_OPS = [
+  'branch.delete',
   'branch.push',
   'issue.milestone.clear',
   'issue.milestone.set',
@@ -53,12 +54,40 @@ export const JOURNAL_OPS = [
   'milestone.create',
   'milestone.rename',
   'pr.body',
+  'pr.close',
   'pr.comment',
   'pr.create',
   'pr.label',
 ] as const;
 
 export type JournalOp = (typeof JOURNAL_OPS)[number];
+
+/**
+ * How far a recorded mutation got.
+ *
+ * `failed` and `indeterminate` are deliberately separate. A run that dies halfway is finished by
+ * hand, and the person doing it needs to know the difference between a write the server refused and
+ * a write whose outcome nobody can vouch for.
+ */
+export const JOURNAL_ENTRY_STATES = [
+  'planned',
+  'attempted',
+  'applied',
+  'failed',
+  'indeterminate',
+] as const;
+
+export type JournalEntryState = (typeof JOURNAL_ENTRY_STATES)[number];
+
+/**
+ * What a run does with the release candidate.
+ *
+ * `draft` opens one, `refresh` advances the one in flight, and `redraft` replaces it because the
+ * version it was cut under no longer matches what landed.
+ */
+export const RELEASE_MODES = ['draft', 'refresh', 'redraft'] as const;
+
+export type ReleaseMode = (typeof RELEASE_MODES)[number];
 
 export const CLEANUP_ACTIONS = ['keep', 'move', 'clear'] as const;
 
@@ -108,6 +137,7 @@ export type PullPayload = {
   number: number;
   title?: string | null;
   html_url?: string | null;
+  body?: string | null;
   merged_at?: string | null;
   merge_commit_sha?: string | null;
   base?: { ref?: string | null } | null;
@@ -125,6 +155,13 @@ export type PullSummary = {
   baseRef: string;
   headRef: string;
   milestone: string | null;
+  /**
+   * When the pull request landed, ISO 8601, from `merged_at`.
+   *
+   * Never empty on a summary that reaches the report: attribution refuses any pull request without
+   * a `merged_at`, so a summary can only exist for one that merged.
+   */
+  mergedAt: string;
 };
 
 /** One integration, decided. Always carries the rule that decided it. */
@@ -201,12 +238,33 @@ export type MilestonePlan = {
     number: number | null;
     currentTitle: string | null;
     title: string;
+    /**
+     * Whether the run still has to close it.
+     *
+     * `false` on a refresh, where the milestone was already closed by the run that drafted the
+     * candidate. A closed milestone still accepts item assignments through the REST API, which is
+     * what lets a refresh keep filling it without reopening it first.
+     */
+    close: boolean;
   };
   next: {
-    action: 'create' | 'reuse';
+    action: 'create' | 'reuse' | 'rename';
     number: number | null;
+    currentTitle: string | null;
     title: string;
   };
+};
+
+/**
+ * A pull request whose milestone disagrees with what history says.
+ *
+ * History is the authority: a pull request merged inside the range ships in this release whatever
+ * milestone its author picked, so the milestone is corrected rather than obeyed.
+ */
+export type RealignItem = {
+  number: number;
+  from: string | null;
+  toTitle: string;
 };
 
 /** An issue or pull request carrying a milestone, as returned by the issues endpoint. */
@@ -247,7 +305,9 @@ export type JournalEntry = {
   after: string | null;
   detail: string | null;
   at: string;
-  applied: boolean;
+  state: JournalEntryState;
+  /** The failure that stopped this write, `null` while it has not failed. */
+  error: string | null;
 };
 
 export type JournalSnapshot = {
@@ -270,6 +330,25 @@ export type PinnedRange = {
   toSha: string;
 };
 
+/**
+ * A release candidate already in flight, discovered from its open pull request.
+ *
+ * The pull request is the only artifact whose lifecycle matches the candidate's. A release branch
+ * outlives it, because the ruleset that protects release branches forbids deleting them without a
+ * bypass, and a milestone is renamed by this very action.
+ */
+export type Candidate = {
+  /** The version the candidate was cut under, parsed out of its branch name. */
+  version: string;
+  branch: string;
+  pullNumber: number;
+  pullUrl: string;
+  /** The head the pull request payload reports, used only to cross-check the git ref. */
+  pullHeadSha: string;
+  /** The payload the last run embedded in the body, `null` when it is absent or unreadable. */
+  payload: unknown;
+};
+
 /** The machine-readable payload embedded in the release pull request body. */
 export type ReleasePayload = {
   schemaVersion: number;
@@ -281,6 +360,8 @@ export type ReleasePayload = {
     bump: BumpKind;
     previousVersion: string;
     source: VersionSource;
+    /** Whether this run opened the candidate, advanced it, or replaced it. */
+    mode: ReleaseMode;
   };
   range: PinnedRange & { integrationCount: number };
   /** What later automation needs to find this candidate again, without re-deriving any of it. */
@@ -291,6 +372,13 @@ export type ReleasePayload = {
     headSha: string;
     /** The artifact `publish-pr-experimental.yml` publishes from `headSha`. */
     expectedExperimentalVersion: string;
+    /**
+     * Whether this run moved the branch.
+     *
+     * `false` when the branch already pointed at the pinned head, which means the experimental
+     * artifact a reader may already have tested is still the current one.
+     */
+    branchAdvanced: boolean;
     /** The release pull request, `null` on a dry run where no pull request is created. */
     pullRequestNumber: number | null;
     pullRequestUrl: string | null;
@@ -350,7 +438,11 @@ export type GitAdapter = {
   isAncestor: (ancestor: string, descendant: string) => boolean;
   listIntegrations: (fromSha: string, toSha: string) => Integration[];
   pushBranch: (sha: string, branch: string) => void;
+  deleteBranch: (branch: string) => void;
   remoteBranchExists: (branch: string) => boolean;
+  /** Brings a remote branch into `refs/remotes/origin`, so a guard never rests on how the
+   * workflow's checkout was configured. */
+  fetchBranch: (branch: string) => void;
 };
 
 export type GithubAdapter = {
@@ -358,6 +450,7 @@ export type GithubAdapter = {
   getRepository: () => Promise<RepositoryMergeSettings>;
   listPullsForCommit: (sha: string) => Promise<PullPayload[]>;
   getPull: (pullNumber: number) => Promise<PullPayload>;
+  listPulls: (input: { state: 'open' | 'closed' | 'all'; base: string }) => Promise<PullPayload[]>;
   listPullCommits: (pullNumber: number) => Promise<PullCommit[]>;
   listMilestones: (state: 'open' | 'closed' | 'all') => Promise<Milestone[]>;
   createMilestone: (title: string) => Promise<Milestone>;
@@ -374,6 +467,7 @@ export type GithubAdapter = {
     body: string;
   }) => Promise<{ number: number; html_url?: string | null }>;
   updatePullBody: (pullNumber: number, body: string) => Promise<void>;
+  closePull: (pullNumber: number) => Promise<void>;
   addLabels: (issueNumber: number, labels: string[]) => Promise<void>;
   createComment: (issueNumber: number, body: string) => Promise<void>;
 };
@@ -390,5 +484,4 @@ export type Clock = () => string;
 export type DraftReleaseInputs = {
   version: string;
   dryRun: boolean;
-  sourceRef: string;
 };

--- a/.github/actions/draft-release/lib/types.ts
+++ b/.github/actions/draft-release/lib/types.ts
@@ -151,6 +151,9 @@ export type PullPayload = {
   milestone?: { title?: string | null } | null;
 };
 
+/** A pull request the API reports as merged, produced only by the `isMerged` guard. */
+export type MergedPull = PullPayload & { merged_at: string };
+
 /** The projection of a pull request that reaches the report. */
 export type PullSummary = {
   number: number;
@@ -163,8 +166,8 @@ export type PullSummary = {
   /**
    * When the pull request landed, ISO 8601, from `merged_at`.
    *
-   * Never empty on a summary that reaches the report: attribution refuses any pull request without
-   * a `merged_at`, so a summary can only exist for one that merged.
+   * Always a real timestamp: a summary is only ever projected from a {@link MergedPull}, which is
+   * the type the `isMerged` guard produces, so the payload cannot have arrived without one.
    */
   mergedAt: string;
 };

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -4,6 +4,11 @@ name: 'Draft release'
 # version from the commits that landed, cuts `releases/x.y.z`, opens the draft PR against `main`,
 # attributes every shipping PR, and reconciles milestones.
 #
+# Runs as many times as a release window needs. A second run folds whatever landed on `develop`
+# since into the same candidate: it advances the release branch, refills the shipping milestone, and
+# rewrites the report on the pull request already open. When the new commits change the version, it
+# redrafts the candidate under the version they decided.
+#
 # Defaults to a dry run. A dry run performs no write at all and reports the exact list of writes the
 # real run would perform.
 
@@ -19,13 +24,15 @@ on:
         description: 'Explicit x.y.z version. Default: auto-computed.'
         required: false
         default: ''
-      source_ref:
-        description: 'Branch to cut the release from.'
-        required: false
-        default: 'develop'
 
 permissions:
   contents: read
+
+# Never two at once. Both runs would compute the same release and race each other's writes, and the
+# journal exists to survive a run that stops, not two that interleave.
+concurrency:
+  group: draft-release
+  cancel-in-progress: false
 
 jobs:
   draft:
@@ -57,7 +64,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           version: ${{ inputs.version }}
           dry_run: ${{ inputs.dry_run }}
-          source_ref: ${{ inputs.source_ref }}
 
       - name: Upload the write journal
         if: always() && steps.draft.outputs.journal_path != ''

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -10,15 +10,15 @@ name: 'Draft release'
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Explicit x.y.z version. Leave empty to decide it from the commits.'
-        required: false
-        default: ''
       dry_run:
-        description: 'Rehearse without writing anything.'
+        description: 'Dry run? Default: true.'
         type: boolean
         required: false
         default: true
+      version:
+        description: 'Explicit x.y.z version. Default: auto-computed.'
+        required: false
+        default: ''
       source_ref:
         description: 'Branch to cut the release from.'
         required: false
@@ -36,8 +36,8 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_SECRET }}
+          app-id: ${{ secrets.DRAFT_RELEASE_APP_ID }}
+          private-key: ${{ secrets.DRAFT_RELEASE_APP_SECRET }}
 
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### What does it do?

Makes `draft-release` runnable more than once for the same release, and fixes the ordering that made a second run destructive.

`develop` keeps moving while a release candidate is open. The action now folds whatever landed since into the same release instead of assuming a fresh repository. The open pull request against `main` whose head is `releases/x.y.z` identifies the candidate. A leftover branch cannot: the ruleset over `releases/*` forbids deleting one, so a branch outlives the candidate it carried.

Three outcomes:

| Mode      | When                                                     | What it does                                                                                                                             |
| --------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
| `draft`   | No candidate is open.                                    | Cuts the branch, opens the pull request, closes the shipping milestone.                                                                  |
| `refresh` | A candidate is open and the version still agrees.        | Fast-forwards the branch, pulls every shipping pull request onto the closed shipping milestone, rewrites the body. The pull request keeps its number, its reviews and its label. |
| `redraft` | A candidate is open and the commits changed the version. | Renames both milestones, opens a replacement, then comments on, closes and deletes what it replaced.                                     |

Closing the shipping milestone stays the behaviour, because that is what makes GitHub offer the next milestone to anyone opening a pull request. A later run fills the closed milestone through the REST API rather than reopening it.

Other changes in this pull request:

- **`preflightRelease` / `applyRelease`.** The pipeline splits into a phase that decides and is the only one allowed to refuse, and a phase that writes. Milestones used to be written in step 3 while the branch was validated in step 4, so a second run renamed milestones and then died on a branch that already existed. All 17 stops now fire before the first write.
- **Journal states.** `applied: boolean` was set before the call was made, so a write that threw was recorded as done. Entries now carry `planned`, `attempted`, `applied`, `failed` or `indeterminate`. A GitHub response status and a git exit code both prove the operation reached a verdict; an error carrying neither is `indeterminate` rather than assumed harmless.
- **Milestone realignment.** A pull request merged during the release window carries the next release's milestone, because that is the only one GitHub offers. It ships regardless, so history wins and the milestone is corrected.
- **`source_ref` removed.** A candidate always comes from the protected `develop` head, so nothing about the release content can be chosen at dispatch time.
- **`concurrency` on the workflow.** Two runs would compute the same release and race each other's writes.
- **Merge date** per pull request, in the shipping table and in the payload. No extra API call: attribution already refuses any pull request without a `merged_at`.

### Why is it needed?

A release window is not a single moment. Pull requests keep merging to `develop` after a candidate is drafted, and until now the only way to account for them was to undo the first run by hand and start again.

The first run also left the repository in a state the second run could not read. It closes the shipping milestone and opens the next one, so a re-run found the next milestone open, tried to rename it to the shipping version, and hit a duplicate title. The milestone writes happened before the branch was checked, so that damage landed before the run stopped.

### How to test it?

run "Draft release" action.

### Related issue(s)/PR(s)

- Follows #27562, which added the action. Also absorbs the parts of an internal review of that pull request that touch the same code: the preflight, the milestone plan validation, the journal states, and the `source_ref` removal.

---

_AI assisted_
