### PR TITLE
feat(upload): add the media_update_asset MCP tool

### DIFF
--- a/packages/core/upload/server/src/controllers/utils/__tests__/find-entity-and-check-permissions.test.ts
+++ b/packages/core/upload/server/src/controllers/utils/__tests__/find-entity-and-check-permissions.test.ts
@@ -1,0 +1,48 @@
+import type { Core } from '@strapi/types';
+
+import { ACTIONS, FILE_MODEL_UID } from '../../../constants';
+import { findEntityAndCheckPermissions } from '../find-entity-and-check-permissions';
+
+describe('findEntityAndCheckPermissions', () => {
+  test('resolves the entity and permissions from the injected Strapi instance', async () => {
+    const file = { id: 1, createdBy: { id: 9 } };
+    const findOne = jest.fn().mockResolvedValue(file);
+    const findUser = jest.fn().mockResolvedValue({ id: 9, roles: [{ id: 2 }] });
+    const cannot = jest.fn().mockReturnValue(false);
+    const toSubject = jest.fn((entity: unknown) => entity);
+    const permissionsManager = {
+      action: ACTIONS.update,
+      ability: { cannot },
+      toSubject,
+    };
+    const createPermissionsManager = jest.fn().mockReturnValue(permissionsManager);
+    const uploadPlugin = {
+      service: jest.fn().mockReturnValue({ findOne }),
+    };
+    const strapi = {
+      plugin: jest.fn().mockReturnValue(uploadPlugin),
+      service: jest.fn((uid: string) => {
+        if (uid === 'admin::permission') return { createPermissionsManager };
+        if (uid === 'admin::user') return { findOne: findUser };
+        throw new Error(`Unexpected service: ${uid}`);
+      }),
+    } as unknown as Core.Strapi;
+
+    await findEntityAndCheckPermissions({}, ACTIONS.update, FILE_MODEL_UID, 1, strapi);
+
+    expect(strapi.plugin).toHaveBeenCalledWith('upload');
+    expect(findOne).toHaveBeenCalledWith(1, ['createdBy', 'folder']);
+    expect(strapi.service).toHaveBeenCalledWith('admin::permission');
+    expect(strapi.service).toHaveBeenCalledWith('admin::user');
+    expect(createPermissionsManager).toHaveBeenCalledWith({
+      ability: {},
+      action: ACTIONS.update,
+      model: FILE_MODEL_UID,
+    });
+    expect(findUser).toHaveBeenCalledWith(9, ['roles']);
+    expect(cannot).toHaveBeenCalledWith(
+      ACTIONS.update,
+      expect.objectContaining({ createdBy: { id: 9, roles: [{ id: 2 }] } })
+    );
+  });
+});

--- a/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
@@ -16,6 +16,8 @@ const makeStrapi = (options: { isEnabled?: boolean; withAi?: boolean } = {}) => 
   return { strapi, registerTool };
 };
 
+const READ_TOOLS = ['media_list_assets', 'media_get_asset', 'media_list_folders'];
+
 describe('upload MCP tool registration', () => {
   describe('registration', () => {
     test('registers every read tool', () => {
@@ -23,11 +25,12 @@ describe('upload MCP tool registration', () => {
 
       registerUploadMcpTools({ strapi });
 
-      expect(registerTool).toHaveBeenCalledTimes(3);
+      expect(registerTool).toHaveBeenCalledTimes(4);
       expect(registerTool.mock.calls.map(([tool]) => tool.name)).toEqual([
         'media_list_assets',
         'media_get_asset',
         'media_list_folders',
+        'update_media',
       ]);
     });
 
@@ -53,7 +56,7 @@ describe('upload MCP tool registration', () => {
 
       registerUploadMcpTools({ strapi });
 
-      expect(registerTool).toHaveBeenCalledTimes(3);
+      expect(registerTool).toHaveBeenCalledTimes(4);
     });
 
     test('does not throw when strapi.ai is unavailable', () => {
@@ -71,9 +74,14 @@ describe('upload MCP tool registration', () => {
     test('gates every read tool on plugin::upload.read', () => {
       // `plugin::upload.read` is registered without a subject, so the policy carries an action
       // only. The per-model check lives in the handlers, via the permissions manager.
-      for (const tool of tools) {
-        expect(tool.auth.policies).toEqual([{ action: ACTIONS.read }]);
+      for (const name of READ_TOOLS) {
+        expect(byName[name].auth.policies).toEqual([{ action: ACTIONS.read }]);
       }
+    });
+
+    test('gates update_media on plugin::upload.assets.update, not on read', () => {
+      // A read-only token must never reach a write tool, so the write action is the gate.
+      expect(byName.update_media.auth.policies).toEqual([{ action: ACTIONS.update }]);
     });
 
     test('does not pin a policy to a subject the action was never registered with', () => {
@@ -85,9 +93,17 @@ describe('upload MCP tool registration', () => {
     });
 
     test('never gates a read tool on a write action', () => {
-      const actions = tools.flatMap((tool) => tool.auth.policies.map((policy) => policy.action));
+      const actions = READ_TOOLS.flatMap((name) =>
+        byName[name].auth.policies.map((policy) => policy.action)
+      );
 
       expect(actions).not.toContain(ACTIONS.update);
+      expect(actions).not.toContain(ACTIONS.create);
+    });
+
+    test('never gates a tool on the create action — uploading is out of scope', () => {
+      const actions = tools.flatMap((tool) => tool.auth.policies.map((policy) => policy.action));
+
       expect(actions).not.toContain(ACTIONS.create);
     });
 
@@ -106,7 +122,30 @@ describe('upload MCP tool registration', () => {
     test('exposes an input schema for the tools that take arguments, and none for the folder tree', () => {
       expect(byName.media_list_assets.resolveInputSchema).toBeDefined();
       expect(byName.media_get_asset.resolveInputSchema).toBeDefined();
+      expect(byName.update_media.resolveInputSchema).toBeDefined();
       expect(byName.media_list_folders.resolveInputSchema).toBeUndefined();
+    });
+
+    test('points update_media at the right tool for a folder change', () => {
+      // An agent that wants to move an asset must be steered from the tool description alone.
+      expect(byName.update_media.description).toMatch(/move_media/);
+      expect(byName.update_media.description).toMatch(/numeric id/i);
+    });
+
+    test('publishes update_media as a plain object schema the registry can expose', () => {
+      // A `.refine()` would make this a ZodEffects, which the tool registry cannot convert to
+      // an input JSON Schema — the "at least one field" rule lives in the handler instead.
+      const schema = byName.update_media.resolveInputSchema?.(
+        {} as Parameters<NonNullable<typeof byName.update_media.resolveInputSchema>>[0]
+      );
+
+      expect(schema?.shape).toBeDefined();
+      expect(Object.keys(schema?.shape ?? {}).sort()).toEqual([
+        'alternativeText',
+        'caption',
+        'id',
+        'name',
+      ]);
     });
   });
 });

--- a/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/register-upload-mcp-tools.test.ts
@@ -30,7 +30,7 @@ describe('upload MCP tool registration', () => {
         'media_list_assets',
         'media_get_asset',
         'media_list_folders',
-        'update_media',
+        'media_update_asset',
       ]);
     });
 
@@ -79,9 +79,9 @@ describe('upload MCP tool registration', () => {
       }
     });
 
-    test('gates update_media on plugin::upload.assets.update, not on read', () => {
+    test('gates media_update_asset on plugin::upload.assets.update, not on read', () => {
       // A read-only token must never reach a write tool, so the write action is the gate.
-      expect(byName.update_media.auth.policies).toEqual([{ action: ACTIONS.update }]);
+      expect(byName.media_update_asset.auth.policies).toEqual([{ action: ACTIONS.update }]);
     });
 
     test('does not pin a policy to a subject the action was never registered with', () => {
@@ -122,21 +122,21 @@ describe('upload MCP tool registration', () => {
     test('exposes an input schema for the tools that take arguments, and none for the folder tree', () => {
       expect(byName.media_list_assets.resolveInputSchema).toBeDefined();
       expect(byName.media_get_asset.resolveInputSchema).toBeDefined();
-      expect(byName.update_media.resolveInputSchema).toBeDefined();
+      expect(byName.media_update_asset.resolveInputSchema).toBeDefined();
       expect(byName.media_list_folders.resolveInputSchema).toBeUndefined();
     });
 
-    test('points update_media at the right tool for a folder change', () => {
+    test('points media_update_asset at the right tool for a folder change', () => {
       // An agent that wants to move an asset must be steered from the tool description alone.
-      expect(byName.update_media.description).toMatch(/move_media/);
-      expect(byName.update_media.description).toMatch(/numeric id/i);
+      expect(byName.media_update_asset.description).toMatch(/media_move_assets/);
+      expect(byName.media_update_asset.description).toMatch(/numeric id/i);
     });
 
-    test('publishes update_media as a plain object schema the registry can expose', () => {
+    test('publishes media_update_asset as a plain object schema the registry can expose', () => {
       // A `.refine()` would make this a ZodEffects, which the tool registry cannot convert to
       // an input JSON Schema — the "at least one field" rule lives in the handler instead.
-      const schema = byName.update_media.resolveInputSchema?.(
-        {} as Parameters<NonNullable<typeof byName.update_media.resolveInputSchema>>[0]
+      const schema = byName.media_update_asset.resolveInputSchema?.(
+        {} as Parameters<NonNullable<typeof byName.media_update_asset.resolveInputSchema>>[0]
       );
 
       expect(schema?.shape).toBeDefined();

--- a/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
@@ -4,8 +4,8 @@ import {
   mediaListAssetsOutputSchema,
   mediaGetAssetOutputSchema,
   mediaListFoldersOutputSchema,
-  updateMediaInputSchema,
-  updateMediaOutputSchema,
+  mediaUpdateAssetInputSchema,
+  mediaUpdateAssetOutputSchema,
 } from '../schemas';
 import { ALLOWED_SORT_STRINGS } from '../../constants';
 
@@ -72,9 +72,9 @@ describe('upload MCP schemas', () => {
     });
   });
 
-  describe('update_media input', () => {
+  describe('media_update_asset input', () => {
     test('accepts the three writable metadata fields', () => {
-      const parsed = updateMediaInputSchema.safeParse({
+      const parsed = mediaUpdateAssetInputSchema.safeParse({
         id: 1,
         name: 'renamed.jpg',
         alternativeText: 'alt',
@@ -85,24 +85,27 @@ describe('upload MCP schemas', () => {
     });
 
     test('accepts a partial patch', () => {
-      expect(updateMediaInputSchema.safeParse({ id: 1, caption: 'only this' }).success).toBe(true);
+      expect(mediaUpdateAssetInputSchema.safeParse({ id: 1, caption: 'only this' }).success).toBe(
+        true
+      );
     });
 
     test('accepts null on the nullable text fields, to clear them', () => {
       expect(
-        updateMediaInputSchema.safeParse({ id: 1, alternativeText: null, caption: null }).success
+        mediaUpdateAssetInputSchema.safeParse({ id: 1, alternativeText: null, caption: null })
+          .success
       ).toBe(true);
     });
 
     test('rejects a null name — an asset cannot be left unnamed', () => {
-      expect(updateMediaInputSchema.safeParse({ id: 1, name: null }).success).toBe(false);
-      expect(updateMediaInputSchema.safeParse({ id: 1, name: '' }).success).toBe(false);
+      expect(mediaUpdateAssetInputSchema.safeParse({ id: 1, name: null }).success).toBe(false);
+      expect(mediaUpdateAssetInputSchema.safeParse({ id: 1, name: '' }).success).toBe(false);
     });
 
     test('requires the numeric id', () => {
-      expect(updateMediaInputSchema.safeParse({ name: 'renamed.jpg' }).success).toBe(false);
+      expect(mediaUpdateAssetInputSchema.safeParse({ name: 'renamed.jpg' }).success).toBe(false);
       expect(
-        updateMediaInputSchema.safeParse({ id: 'z7v8zma53x01r6oceimv922b', name: 'x' }).success
+        mediaUpdateAssetInputSchema.safeParse({ id: 'z7v8zma53x01r6oceimv922b', name: 'x' }).success
       ).toBe(false);
     });
 
@@ -110,11 +113,11 @@ describe('upload MCP schemas', () => {
       ['folder', 3],
       ['folderId', 3],
       ['folderPath', '/1/2'],
-    ])('rejects %s and directs the caller to move_media', (field, value) => {
-      const parsed = updateMediaInputSchema.safeParse({ id: 1, [field]: value });
+    ])('rejects %s and directs the caller to media_move_assets', (field, value) => {
+      const parsed = mediaUpdateAssetInputSchema.safeParse({ id: 1, [field]: value });
 
       expect(parsed.success).toBe(false);
-      expect(JSON.stringify(parsed.error?.issues)).toMatch(/move_media/);
+      expect(JSON.stringify(parsed.error?.issues)).toMatch(/media_move_assets/);
     });
 
     test.each([
@@ -130,7 +133,8 @@ describe('upload MCP schemas', () => {
       ['formats', { thumbnail: {} }],
     ])('rejects the provider-owned field %s', (field, value) => {
       expect(
-        updateMediaInputSchema.safeParse({ id: 1, name: 'renamed.jpg', [field]: value }).success
+        mediaUpdateAssetInputSchema.safeParse({ id: 1, name: 'renamed.jpg', [field]: value })
+          .success
       ).toBe(false);
     });
 
@@ -139,22 +143,23 @@ describe('upload MCP schemas', () => {
       (field) => {
         // File content is out of MCP scope entirely — MCP is text-only.
         expect(
-          updateMediaInputSchema.safeParse({ id: 1, name: 'renamed.jpg', [field]: 'x' }).success
+          mediaUpdateAssetInputSchema.safeParse({ id: 1, name: 'renamed.jpg', [field]: 'x' })
+            .success
         ).toBe(false);
       }
     );
 
     test('reports the unrecognised key by name, so an agent can correct itself', () => {
-      const parsed = updateMediaInputSchema.safeParse({ id: 1, name: 'x', folder: 3 });
+      const parsed = mediaUpdateAssetInputSchema.safeParse({ id: 1, name: 'x', folder: 3 });
 
       expect(parsed.success).toBe(false);
       expect(JSON.stringify(parsed.error?.issues)).toMatch(/folder/);
     });
   });
 
-  describe('update_media output', () => {
+  describe('media_update_asset output', () => {
     test('returns the asset in the same shape as the read tools', () => {
-      const parsed = updateMediaOutputSchema.safeParse({
+      const parsed = mediaUpdateAssetOutputSchema.safeParse({
         data: {
           id: 1,
           name: 'renamed.jpg',
@@ -171,8 +176,8 @@ describe('upload MCP schemas', () => {
     });
 
     test('requires data — a successful write always returns the updated asset', () => {
-      expect(updateMediaOutputSchema.safeParse({ data: null }).success).toBe(false);
-      expect(updateMediaOutputSchema.safeParse({}).success).toBe(false);
+      expect(mediaUpdateAssetOutputSchema.safeParse({ data: null }).success).toBe(false);
+      expect(mediaUpdateAssetOutputSchema.safeParse({}).success).toBe(false);
     });
   });
 

--- a/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
@@ -106,10 +106,15 @@ describe('upload MCP schemas', () => {
       ).toBe(false);
     });
 
-    test('rejects folder — moving an asset belongs to move_media', () => {
-      expect(updateMediaInputSchema.safeParse({ id: 1, folder: 3 }).success).toBe(false);
-      expect(updateMediaInputSchema.safeParse({ id: 1, folderId: 3 }).success).toBe(false);
-      expect(updateMediaInputSchema.safeParse({ id: 1, folderPath: '/1/2' }).success).toBe(false);
+    test.each([
+      ['folder', 3],
+      ['folderId', 3],
+      ['folderPath', '/1/2'],
+    ])('rejects %s and directs the caller to move_media', (field, value) => {
+      const parsed = updateMediaInputSchema.safeParse({ id: 1, [field]: value });
+
+      expect(parsed.success).toBe(false);
+      expect(JSON.stringify(parsed.error?.issues)).toMatch(/move_media/);
     });
 
     test.each([

--- a/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/schemas.test.ts
@@ -4,6 +4,8 @@ import {
   mediaListAssetsOutputSchema,
   mediaGetAssetOutputSchema,
   mediaListFoldersOutputSchema,
+  updateMediaInputSchema,
+  updateMediaOutputSchema,
 } from '../schemas';
 import { ALLOWED_SORT_STRINGS } from '../../constants';
 
@@ -67,6 +69,105 @@ describe('upload MCP schemas', () => {
 
     test('requires the id', () => {
       expect(mediaGetAssetInputSchema.safeParse({}).success).toBe(false);
+    });
+  });
+
+  describe('update_media input', () => {
+    test('accepts the three writable metadata fields', () => {
+      const parsed = updateMediaInputSchema.safeParse({
+        id: 1,
+        name: 'renamed.jpg',
+        alternativeText: 'alt',
+        caption: 'caption',
+      });
+
+      expect(parsed.success).toBe(true);
+    });
+
+    test('accepts a partial patch', () => {
+      expect(updateMediaInputSchema.safeParse({ id: 1, caption: 'only this' }).success).toBe(true);
+    });
+
+    test('accepts null on the nullable text fields, to clear them', () => {
+      expect(
+        updateMediaInputSchema.safeParse({ id: 1, alternativeText: null, caption: null }).success
+      ).toBe(true);
+    });
+
+    test('rejects a null name — an asset cannot be left unnamed', () => {
+      expect(updateMediaInputSchema.safeParse({ id: 1, name: null }).success).toBe(false);
+      expect(updateMediaInputSchema.safeParse({ id: 1, name: '' }).success).toBe(false);
+    });
+
+    test('requires the numeric id', () => {
+      expect(updateMediaInputSchema.safeParse({ name: 'renamed.jpg' }).success).toBe(false);
+      expect(
+        updateMediaInputSchema.safeParse({ id: 'z7v8zma53x01r6oceimv922b', name: 'x' }).success
+      ).toBe(false);
+    });
+
+    test('rejects folder — moving an asset belongs to move_media', () => {
+      expect(updateMediaInputSchema.safeParse({ id: 1, folder: 3 }).success).toBe(false);
+      expect(updateMediaInputSchema.safeParse({ id: 1, folderId: 3 }).success).toBe(false);
+      expect(updateMediaInputSchema.safeParse({ id: 1, folderPath: '/1/2' }).success).toBe(false);
+    });
+
+    test.each([
+      ['url', '/uploads/evil.jpg'],
+      ['provider', 'aws-s3'],
+      ['provider_metadata', { secretKey: 'leak' }],
+      ['hash', 'forced_hash'],
+      ['mime', 'text/html'],
+      ['size', 1],
+      ['width', 10],
+      ['height', 10],
+      ['ext', '.png'],
+      ['formats', { thumbnail: {} }],
+    ])('rejects the provider-owned field %s', (field, value) => {
+      expect(
+        updateMediaInputSchema.safeParse({ id: 1, name: 'renamed.jpg', [field]: value }).success
+      ).toBe(false);
+    });
+
+    test.each(['file', 'files', 'data', 'buffer', 'filepath', 'focalPoint'])(
+      'rejects the out-of-scope field %s',
+      (field) => {
+        // File content is out of MCP scope entirely — MCP is text-only.
+        expect(
+          updateMediaInputSchema.safeParse({ id: 1, name: 'renamed.jpg', [field]: 'x' }).success
+        ).toBe(false);
+      }
+    );
+
+    test('reports the unrecognised key by name, so an agent can correct itself', () => {
+      const parsed = updateMediaInputSchema.safeParse({ id: 1, name: 'x', folder: 3 });
+
+      expect(parsed.success).toBe(false);
+      expect(JSON.stringify(parsed.error?.issues)).toMatch(/folder/);
+    });
+  });
+
+  describe('update_media output', () => {
+    test('returns the asset in the same shape as the read tools', () => {
+      const parsed = updateMediaOutputSchema.safeParse({
+        data: {
+          id: 1,
+          name: 'renamed.jpg',
+          alternativeText: 'alt',
+          caption: null,
+          url: '/uploads/photo.jpg',
+          mime: 'image/jpeg',
+          size: 12.5,
+          folder: null,
+        },
+      });
+
+      expect(parsed.success).toBe(true);
+    });
+
+    test('requires data — a successful write always returns the updated asset', () => {
+      expect(updateMediaOutputSchema.safeParse({ data: null }).success).toBe(false);
+      expect(updateMediaOutputSchema.safeParse({}).success).toBe(false);
     });
   });
 

--- a/packages/core/upload/server/src/mcp/__tests__/write-handlers.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/write-handlers.test.ts
@@ -54,7 +54,6 @@ const setupStrapi = (options: MockOptions = {}) => {
 
   // Shaped for `tests/setup/unit.setup.js`, whose global `strapi` setter derives
   // `strapi.plugin()` from `plugins` and `strapi.service('admin::x')` from `admin.services`.
-  // `permissions.ts` and `getService()` both go through that global.
   const strapi = {
     plugins: {
       upload: { services: { upload: { findOne, updateFileInfo } } },
@@ -74,9 +73,7 @@ const setupStrapi = (options: MockOptions = {}) => {
 
 const context = { userAbility: {}, user: SESSION_USER } as unknown as Modules.MCP.McpHandlerContext;
 
-// The handler resolves services off the instance it is given, not the global, so the fake built
-// by `setupStrapi()` is passed in explicitly. The global is still assigned there, because
-// `findEntityAndCheckPermissions` is shared with the admin controllers and reads it.
+// Pass the fully shaped instance produced by the unit-test setter to the handler explicitly.
 const invoke = (args: Record<string, unknown>) =>
   createUpdateMediaHandler(
     (global as unknown as { strapi: Core.Strapi }).strapi,

--- a/packages/core/upload/server/src/mcp/__tests__/write-handlers.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/write-handlers.test.ts
@@ -1,0 +1,261 @@
+import { errors } from '@strapi/utils';
+import type { Core, Modules } from '@strapi/types';
+
+import { createUpdateMediaHandler } from '../handlers/write-handlers';
+import { MCP_NOT_FOUND_ASSET, MCP_UPDATE_ASSET_NO_FIELDS } from '../handlers/constants';
+import { ACTIONS, FILE_MODEL_UID } from '../../constants';
+
+type MockOptions = {
+  /** Model-level grant: what `pm.isAllowed` reports. */
+  isAllowed?: boolean;
+  /** Row-level grant: what a permission *condition* reports for this asset. */
+  canOnEntity?: boolean;
+  /** The stored row `upload.findOne()` resolves to; null for a missing asset. */
+  asset?: Record<string, unknown> | null;
+};
+
+const SESSION_USER = { id: 7 };
+
+const STORED_ASSET = {
+  id: 1,
+  name: 'photo.jpg',
+  alternativeText: 'old alt',
+  caption: 'old caption',
+  url: '/uploads/photo.jpg',
+  mime: 'image/jpeg',
+  size: 12.5,
+  provider: 'local',
+  provider_metadata: { secretKey: 'super-secret' },
+  hash: 'photo_abc123',
+  folderPath: '/1',
+  folder: { id: 2, name: 'Photos' },
+};
+
+const setupStrapi = (options: MockOptions = {}) => {
+  const { isAllowed = true, canOnEntity = true, asset = STORED_ASSET } = options;
+
+  const findOne = jest.fn().mockResolvedValue(asset);
+  const updateFileInfo = jest
+    .fn()
+    .mockImplementation(async (id: number, fileInfo: Record<string, unknown>) => ({
+      ...STORED_ASSET,
+      ...fileInfo,
+      id,
+    }));
+
+  const createPermissionsManager = jest.fn(() => ({
+    isAllowed,
+    action: ACTIONS.update,
+    ability: { cannot: jest.fn(() => canOnEntity === false) },
+    toSubject: jest.fn((entity: unknown) => entity),
+  }));
+
+  const adminUserFindOne = jest.fn().mockResolvedValue({ id: 9, roles: [{ id: 1 }] });
+
+  // Shaped for `tests/setup/unit.setup.js`, whose global `strapi` setter derives
+  // `strapi.plugin()` from `plugins` and `strapi.service('admin::x')` from `admin.services`.
+  // `permissions.ts` and `getService()` both go through that global.
+  const strapi = {
+    plugins: {
+      upload: { services: { upload: { findOne, updateFileInfo } } },
+    },
+    admin: {
+      services: {
+        permission: { createPermissionsManager },
+        user: { findOne: adminUserFindOne },
+      },
+    },
+  };
+
+  (global as unknown as { strapi: unknown }).strapi = strapi;
+
+  return { strapi, findOne, updateFileInfo, createPermissionsManager, adminUserFindOne };
+};
+
+const context = { userAbility: {}, user: SESSION_USER } as unknown as Modules.MCP.McpHandlerContext;
+
+// The handler resolves services off the instance it is given, not the global, so the fake built
+// by `setupStrapi()` is passed in explicitly. The global is still assigned there, because
+// `findEntityAndCheckPermissions` is shared with the admin controllers and reads it.
+const invoke = (args: Record<string, unknown>) =>
+  createUpdateMediaHandler(
+    (global as unknown as { strapi: Core.Strapi }).strapi,
+    context
+  )({ args });
+
+describe('update_media handler', () => {
+  afterEach(() => {
+    // `tests/setup/unit.setup.js` defines the global `strapi` as an accessor, so it is
+    // reassigned per test rather than deleted.
+    jest.clearAllMocks();
+  });
+
+  describe('metadata update', () => {
+    test('writes the writable fields through updateFileInfo and attributes the session user', async () => {
+      const { updateFileInfo } = setupStrapi();
+
+      const result = await invoke({
+        id: 1,
+        name: 'renamed.jpg',
+        alternativeText: 'new alt',
+        caption: 'new caption',
+      });
+
+      expect(updateFileInfo).toHaveBeenCalledWith(
+        1,
+        { name: 'renamed.jpg', alternativeText: 'new alt', caption: 'new caption' },
+        { user: SESSION_USER }
+      );
+
+      expect(result.structuredContent).toEqual({
+        data: expect.objectContaining({
+          id: 1,
+          name: 'renamed.jpg',
+          alternativeText: 'new alt',
+          caption: 'new caption',
+        }),
+      });
+    });
+
+    test('forwards only the fields the caller sent, leaving the others untouched', async () => {
+      const { updateFileInfo } = setupStrapi();
+
+      await invoke({ id: 1, caption: 'just the caption' });
+
+      // Omitted keys must not be forwarded: `updateFileInfo` reads nil as "keep the stored
+      // value", so sending them as undefined would be equivalent but noisier — and sending
+      // them as null would wrongly read as unchanged rather than cleared.
+      expect(updateFileInfo).toHaveBeenCalledWith(
+        1,
+        { caption: 'just the caption' },
+        { user: SESSION_USER }
+      );
+    });
+
+    test('clears a field passed as null by writing an empty string', async () => {
+      const { updateFileInfo } = setupStrapi();
+
+      await invoke({ id: 1, alternativeText: null, caption: null });
+
+      // `updateFileInfo` treats nil as "keep the stored value" (`_.isNil`), so a literal null
+      // would be a silent no-op. Empty string is what the admin panel writes when a user
+      // empties the field.
+      expect(updateFileInfo).toHaveBeenCalledWith(
+        1,
+        { alternativeText: '', caption: '' },
+        { user: SESSION_USER }
+      );
+    });
+
+    test('returns the asset through the read sanitizer, without provider fields', async () => {
+      setupStrapi();
+
+      const result = await invoke({ id: 1, name: 'renamed.jpg' });
+      const data = result.structuredContent?.data as Record<string, unknown>;
+
+      for (const field of ['provider', 'provider_metadata', 'hash', 'folderPath', 'formats']) {
+        expect(data).not.toHaveProperty(field);
+      }
+
+      expect(data).toMatchObject({ folder: { id: 2, name: 'Photos' } });
+    });
+  });
+
+  describe('out-of-scope fields', () => {
+    test('rejects a patch that carries no writable field', async () => {
+      setupStrapi();
+
+      await expect(invoke({ id: 1 })).rejects.toThrow(errors.ValidationError);
+      await expect(invoke({ id: 1 })).rejects.toThrow(MCP_UPDATE_ASSET_NO_FIELDS);
+    });
+
+    test('names the right tool when the caller sends nothing writable', async () => {
+      setupStrapi();
+
+      // The error is the agent's only recovery hint, so it must point at move_media
+      // rather than just restating that the patch was empty.
+      await expect(invoke({ id: 1 })).rejects.toThrow(/move_media/);
+    });
+
+    test('never forwards a field outside the allowlist to the upload service', async () => {
+      const { updateFileInfo } = setupStrapi();
+
+      // Defence in depth: the strict Zod schema rejects these before the handler runs, but the
+      // handler must not forward them if it is ever called from another entry point.
+      await invoke({
+        id: 1,
+        name: 'renamed.jpg',
+        folder: 5,
+        url: '/uploads/evil.jpg',
+        provider: 'aws-s3',
+        provider_metadata: { secretKey: 'leak' },
+        hash: 'forced',
+        mime: 'text/html',
+        focalPoint: { x: 10, y: 10 },
+      } as Record<string, unknown>);
+
+      expect(updateFileInfo).toHaveBeenCalledWith(
+        1,
+        { name: 'renamed.jpg' },
+        { user: SESSION_USER }
+      );
+    });
+  });
+
+  describe('permissions', () => {
+    test('binds the permissions manager to the update action on the file model', async () => {
+      const { createPermissionsManager } = setupStrapi();
+
+      await invoke({ id: 1, name: 'renamed.jpg' });
+
+      expect(createPermissionsManager).toHaveBeenCalledWith({
+        ability: context.userAbility,
+        action: ACTIONS.update,
+        model: FILE_MODEL_UID,
+      });
+    });
+
+    test('denies the write without plugin::upload.assets.update', async () => {
+      const { updateFileInfo } = setupStrapi({ isAllowed: false });
+
+      await expect(invoke({ id: 1, name: 'renamed.jpg' })).rejects.toThrow(errors.ForbiddenError);
+      expect(updateFileInfo).not.toHaveBeenCalled();
+    });
+
+    test('denies the write when a permission condition excludes this asset', async () => {
+      const { updateFileInfo } = setupStrapi({ canOnEntity: false });
+
+      await expect(invoke({ id: 1, name: 'renamed.jpg' })).rejects.toThrow(errors.ForbiddenError);
+      expect(updateFileInfo).not.toHaveBeenCalled();
+    });
+
+    test('resolves the creator with roles so owner conditions can be evaluated', async () => {
+      const { adminUserFindOne, findOne } = setupStrapi({
+        asset: { ...STORED_ASSET, createdBy: { id: 9 } },
+      });
+
+      await invoke({ id: 1, name: 'renamed.jpg' });
+
+      expect(findOne).toHaveBeenCalledWith(1, ['createdBy', 'folder']);
+      expect(adminUserFindOne).toHaveBeenCalledWith(9, ['roles']);
+    });
+
+    test('does not look up a creator for an asset that has none', async () => {
+      const { adminUserFindOne } = setupStrapi();
+
+      await invoke({ id: 1, name: 'renamed.jpg' });
+
+      expect(adminUserFindOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('missing asset', () => {
+    test('throws NotFound for an unknown id', async () => {
+      const { updateFileInfo } = setupStrapi({ asset: null });
+
+      await expect(invoke({ id: 999, name: 'renamed.jpg' })).rejects.toThrow(errors.NotFoundError);
+      await expect(invoke({ id: 999, name: 'renamed.jpg' })).rejects.toThrow(MCP_NOT_FOUND_ASSET);
+      expect(updateFileInfo).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/upload/server/src/mcp/__tests__/write-handlers.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/write-handlers.test.ts
@@ -1,7 +1,7 @@
 import { errors } from '@strapi/utils';
 import type { Core, Modules } from '@strapi/types';
 
-import { createUpdateMediaHandler } from '../handlers/write-handlers';
+import { createMediaUpdateAssetHandler } from '../handlers/write-handlers';
 import { MCP_NOT_FOUND_ASSET, MCP_UPDATE_ASSET_NO_FIELDS } from '../handlers/constants';
 import { ACTIONS, FILE_MODEL_UID } from '../../constants';
 
@@ -75,12 +75,12 @@ const context = { userAbility: {}, user: SESSION_USER } as unknown as Modules.MC
 
 // Pass the fully shaped instance produced by the unit-test setter to the handler explicitly.
 const invoke = (args: Record<string, unknown>) =>
-  createUpdateMediaHandler(
+  createMediaUpdateAssetHandler(
     (global as unknown as { strapi: Core.Strapi }).strapi,
     context
   )({ args });
 
-describe('update_media handler', () => {
+describe('media_update_asset handler', () => {
   afterEach(() => {
     // `tests/setup/unit.setup.js` defines the global `strapi` as an accessor, so it is
     // reassigned per test rather than deleted.
@@ -169,9 +169,9 @@ describe('update_media handler', () => {
     test('names the right tool when the caller sends nothing writable', async () => {
       setupStrapi();
 
-      // The error is the agent's only recovery hint, so it must point at move_media
+      // The error is the agent's only recovery hint, so it must point at media_move_assets
       // rather than just restating that the patch was empty.
-      await expect(invoke({ id: 1 })).rejects.toThrow(/move_media/);
+      await expect(invoke({ id: 1 })).rejects.toThrow(/media_move_assets/);
     });
 
     test('never forwards a field outside the allowlist to the upload service', async () => {

--- a/packages/core/upload/server/src/mcp/handlers/constants.ts
+++ b/packages/core/upload/server/src/mcp/handlers/constants.ts
@@ -1,1 +1,4 @@
 export const MCP_NOT_FOUND_ASSET = 'Media asset not found.';
+
+export const MCP_UPDATE_ASSET_NO_FIELDS =
+  'Provide at least one field to update: name, alternativeText or caption. To move an asset between folders use move_media; url, mime, size and the file contents are owned by the upload provider and cannot be edited over MCP.';

--- a/packages/core/upload/server/src/mcp/handlers/constants.ts
+++ b/packages/core/upload/server/src/mcp/handlers/constants.ts
@@ -1,4 +1,4 @@
 export const MCP_NOT_FOUND_ASSET = 'Media asset not found.';
 
 export const MCP_UPDATE_ASSET_NO_FIELDS =
-  'Provide at least one field to update: name, alternativeText or caption. To move an asset between folders use move_media; url, mime, size and the file contents are owned by the upload provider and cannot be edited over MCP.';
+  'Provide at least one field to update: name, alternativeText or caption. To move an asset between folders use media_move_assets; url, mime, size and the file contents are owned by the upload provider and cannot be edited over MCP.';

--- a/packages/core/upload/server/src/mcp/handlers/index.ts
+++ b/packages/core/upload/server/src/mcp/handlers/index.ts
@@ -3,5 +3,5 @@ export {
   createMediaGetAssetHandler,
   createMediaListFoldersHandler,
 } from './read-handlers';
-export { createUpdateMediaHandler } from './write-handlers';
+export { createMediaUpdateAssetHandler } from './write-handlers';
 export { MCP_NOT_FOUND_ASSET, MCP_UPDATE_ASSET_NO_FIELDS } from './constants';

--- a/packages/core/upload/server/src/mcp/handlers/index.ts
+++ b/packages/core/upload/server/src/mcp/handlers/index.ts
@@ -3,4 +3,5 @@ export {
   createMediaGetAssetHandler,
   createMediaListFoldersHandler,
 } from './read-handlers';
-export { MCP_NOT_FOUND_ASSET } from './constants';
+export { createUpdateMediaHandler } from './write-handlers';
+export { MCP_NOT_FOUND_ASSET, MCP_UPDATE_ASSET_NO_FIELDS } from './constants';

--- a/packages/core/upload/server/src/mcp/handlers/write-handlers.ts
+++ b/packages/core/upload/server/src/mcp/handlers/write-handlers.ts
@@ -1,0 +1,98 @@
+import { errors } from '@strapi/utils';
+import type { Core, Modules } from '@strapi/types';
+
+import { getService } from '../../utils';
+import { ACTIONS, FILE_MODEL_UID } from '../../constants';
+import { findEntityAndCheckPermissions } from '../../controllers/utils/find-entity-and-check-permissions';
+import { assertMediaPermission } from '../permissions';
+import { sanitizeMediaAsset } from '../sanitizers/sanitize-media';
+import { MCP_NOT_FOUND_ASSET, MCP_UPDATE_ASSET_NO_FIELDS } from './constants';
+import { ok } from '../utils';
+
+// Type-level only: the MCP SDK validates `args` against the tool's strict Zod input schema
+// before the handler runs, so unknown keys never reach here.
+type UpdateMediaArgs = {
+  id: number;
+  name?: string;
+  alternativeText?: string | null;
+  caption?: string | null;
+};
+
+/** The metadata keys `update_media` may write. Everything else is rejected by the schema. */
+const WRITABLE_FIELDS = ['name', 'alternativeText', 'caption'] as const;
+
+/**
+ * Picks the metadata the caller actually sent.
+ *
+ * `updateFileInfo` treats nil as "keep the stored value" (`_.isNil`), so an explicit
+ * `alternativeText: null` cannot be forwarded as null — it would be read as "unchanged"
+ * instead of "clear it". Clearing is expressed as an empty string, which is what the admin
+ * panel writes when the field is emptied.
+ */
+const buildFileInfo = (args: UpdateMediaArgs): Record<string, string> => {
+  const fileInfo: Record<string, string> = {};
+
+  for (const field of WRITABLE_FIELDS) {
+    const value = args[field];
+
+    if (value !== undefined) {
+      fileInfo[field] = value === null ? '' : value;
+    }
+  }
+
+  return fileInfo;
+};
+
+/**
+ * `update_media` — edits the writable metadata of one asset.
+ *
+ * Gated on `plugin::upload.assets.update` and mirrors `PUT /upload/files/:id`: the same
+ * `findEntityAndCheckPermissions` row-level check, the same `updateFileInfo` service call, and
+ * the same `updatedBy` attribution from the session user.
+ *
+ * The response carries the updated asset through the read sanitizer, so a client can confirm
+ * the write without a second `media_get_asset` round-trip — and so provider fields stay
+ * invisible on the write path too.
+ */
+export const createUpdateMediaHandler =
+  (strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
+  async ({
+    args,
+  }: {
+    args: Record<string, unknown>;
+  }): Promise<Modules.MCP.McpToolHandlerReturn> => {
+    const { id, ...metadata } = args as UpdateMediaArgs;
+    const fileInfo = buildFileInfo(metadata as UpdateMediaArgs);
+
+    // A patch with no writable field is a caller error, not a no-op success: the schema cannot
+    // express "at least one of" without becoming a ZodEffects the registry can't publish.
+    if (Object.keys(fileInfo).length === 0) {
+      throw new errors.ValidationError(MCP_UPDATE_ASSET_NO_FIELDS);
+    }
+
+    // Model-level gate first, so a token without the action is refused before any DB read.
+    // `findEntityAndCheckPermissions` only covers the row-level check.
+    assertMediaPermission(strapi, context, ACTIONS.update, FILE_MODEL_UID);
+
+    // Row-level check, shared with the admin controller: resolves the creator's roles so an
+    // owner-scoped permission condition is evaluated against the same subject the REST API
+    // would build, and throws Forbidden when a condition excludes this asset.
+    //
+    // Its NotFoundError carries no message, which would reach the agent as a bare "Not Found";
+    // rethrowing adds the same wording the read tools use.
+    try {
+      await findEntityAndCheckPermissions(context.userAbility, ACTIONS.update, FILE_MODEL_UID, id);
+    } catch (error) {
+      if (error instanceof errors.NotFoundError) {
+        throw new errors.NotFoundError(MCP_NOT_FOUND_ASSET);
+      }
+
+      throw error;
+    }
+
+    const updated = await getService('upload', strapi).updateFileInfo(id, fileInfo, {
+      user: context.user,
+    });
+
+    return ok({ data: sanitizeMediaAsset(updated) });
+  };

--- a/packages/core/upload/server/src/mcp/handlers/write-handlers.ts
+++ b/packages/core/upload/server/src/mcp/handlers/write-handlers.ts
@@ -11,14 +11,14 @@ import { ok } from '../utils';
 
 // Type-level only: the MCP SDK validates `args` against the tool's strict Zod input schema
 // before the handler runs, so unknown keys never reach here.
-type UpdateMediaArgs = {
+type MediaUpdateAssetArgs = {
   id: number;
   name?: string;
   alternativeText?: string | null;
   caption?: string | null;
 };
 
-/** The metadata keys `update_media` may write. Everything else is rejected by the schema. */
+/** The metadata keys `media_update_asset` may write. Everything else is rejected by the schema. */
 const WRITABLE_FIELDS = ['name', 'alternativeText', 'caption'] as const;
 
 /**
@@ -29,7 +29,7 @@ const WRITABLE_FIELDS = ['name', 'alternativeText', 'caption'] as const;
  * instead of "clear it". Clearing is expressed as an empty string, which is what the admin
  * panel writes when the field is emptied.
  */
-const buildFileInfo = (args: UpdateMediaArgs): Record<string, string> => {
+const buildFileInfo = (args: MediaUpdateAssetArgs): Record<string, string> => {
   const fileInfo: Record<string, string> = {};
 
   for (const field of WRITABLE_FIELDS) {
@@ -44,7 +44,7 @@ const buildFileInfo = (args: UpdateMediaArgs): Record<string, string> => {
 };
 
 /**
- * `update_media` — edits the writable metadata of one asset.
+ * `media_update_asset` — edits the writable metadata of one asset.
  *
  * Gated on `plugin::upload.assets.update` and mirrors `PUT /upload/files/:id`: the same
  * `findEntityAndCheckPermissions` row-level check, the same `updateFileInfo` service call, and
@@ -54,15 +54,15 @@ const buildFileInfo = (args: UpdateMediaArgs): Record<string, string> => {
  * the write without a second `media_get_asset` round-trip — and so provider fields stay
  * invisible on the write path too.
  */
-export const createUpdateMediaHandler =
+export const createMediaUpdateAssetHandler =
   (strapi: Core.Strapi, context: Modules.MCP.McpHandlerContext) =>
   async ({
     args,
   }: {
     args: Record<string, unknown>;
   }): Promise<Modules.MCP.McpToolHandlerReturn> => {
-    const { id, ...metadata } = args as UpdateMediaArgs;
-    const fileInfo = buildFileInfo(metadata as UpdateMediaArgs);
+    const { id, ...metadata } = args as MediaUpdateAssetArgs;
+    const fileInfo = buildFileInfo(metadata as MediaUpdateAssetArgs);
 
     // A patch with no writable field is a caller error, not a no-op success: the schema cannot
     // express "at least one of" without becoming a ZodEffects the registry can't publish.

--- a/packages/core/upload/server/src/mcp/handlers/write-handlers.ts
+++ b/packages/core/upload/server/src/mcp/handlers/write-handlers.ts
@@ -81,7 +81,13 @@ export const createUpdateMediaHandler =
     // Its NotFoundError carries no message, which would reach the agent as a bare "Not Found";
     // rethrowing adds the same wording the read tools use.
     try {
-      await findEntityAndCheckPermissions(context.userAbility, ACTIONS.update, FILE_MODEL_UID, id);
+      await findEntityAndCheckPermissions(
+        context.userAbility,
+        ACTIONS.update,
+        FILE_MODEL_UID,
+        id,
+        strapi
+      );
     } catch (error) {
       if (error instanceof errors.NotFoundError) {
         throw new errors.NotFoundError(MCP_NOT_FOUND_ASSET);

--- a/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
+++ b/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
@@ -8,11 +8,14 @@ import {
   mediaListAssetsOutputSchema,
   mediaGetAssetOutputSchema,
   mediaListFoldersOutputSchema,
+  updateMediaInputSchema,
+  updateMediaOutputSchema,
 } from './schemas';
 import {
   createMediaListAssetsHandler,
   createMediaGetAssetHandler,
   createMediaListFoldersHandler,
+  createUpdateMediaHandler,
 } from './handlers';
 
 /**
@@ -50,6 +53,17 @@ export const buildUploadMcpToolDefinitions = (): UploadMcpTool[] => [
     auth: { policies: [{ action: ACTIONS.read }] },
     resolveOutputSchema: () => mediaListFoldersOutputSchema,
     createHandler: createMediaListFoldersHandler,
+  },
+  {
+    name: 'update_media',
+    title: 'Media: update asset metadata',
+    description:
+      "Update the editable metadata of a Media Library asset, identified by its numeric id. Only name, alternativeText and caption can be written: use move_media to change an asset's folder, and note that url, mime, size and the file contents are owned by the upload provider and cannot be edited over MCP.",
+    telemetry: { source: 'upload', name: 'update' },
+    auth: { policies: [{ action: ACTIONS.update }] },
+    resolveInputSchema: () => updateMediaInputSchema,
+    resolveOutputSchema: () => updateMediaOutputSchema,
+    createHandler: createUpdateMediaHandler,
   },
 ];
 

--- a/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
+++ b/packages/core/upload/server/src/mcp/register-upload-mcp-tools.ts
@@ -8,14 +8,14 @@ import {
   mediaListAssetsOutputSchema,
   mediaGetAssetOutputSchema,
   mediaListFoldersOutputSchema,
-  updateMediaInputSchema,
-  updateMediaOutputSchema,
+  mediaUpdateAssetInputSchema,
+  mediaUpdateAssetOutputSchema,
 } from './schemas';
 import {
   createMediaListAssetsHandler,
   createMediaGetAssetHandler,
   createMediaListFoldersHandler,
-  createUpdateMediaHandler,
+  createMediaUpdateAssetHandler,
 } from './handlers';
 
 /**
@@ -55,15 +55,15 @@ export const buildUploadMcpToolDefinitions = (): UploadMcpTool[] => [
     createHandler: createMediaListFoldersHandler,
   },
   {
-    name: 'update_media',
+    name: 'media_update_asset',
     title: 'Media: update asset metadata',
     description:
-      "Update the editable metadata of a Media Library asset, identified by its numeric id. Only name, alternativeText and caption can be written: use move_media to change an asset's folder, and note that url, mime, size and the file contents are owned by the upload provider and cannot be edited over MCP.",
+      "Update the editable metadata of a Media Library asset, identified by its numeric id. Only name, alternativeText and caption can be written: use media_move_assets to change an asset's folder, and note that url, mime, size and the file contents are owned by the upload provider and cannot be edited over MCP.",
     telemetry: { source: 'upload', name: 'update' },
     auth: { policies: [{ action: ACTIONS.update }] },
-    resolveInputSchema: () => updateMediaInputSchema,
-    resolveOutputSchema: () => updateMediaOutputSchema,
-    createHandler: createUpdateMediaHandler,
+    resolveInputSchema: () => mediaUpdateAssetInputSchema,
+    resolveOutputSchema: () => mediaUpdateAssetOutputSchema,
+    createHandler: createMediaUpdateAssetHandler,
   },
 ];
 

--- a/packages/core/upload/server/src/mcp/schemas/index.ts
+++ b/packages/core/upload/server/src/mcp/schemas/index.ts
@@ -7,7 +7,7 @@ export {
   mediaListAssetsInputSchema,
   mediaGetAssetInputSchema,
   mediaListFoldersInputSchema,
-  updateMediaInputSchema,
+  mediaUpdateAssetInputSchema,
 } from './input-schemas';
 export {
   mediaAssetOutputSchema,
@@ -15,6 +15,6 @@ export {
   mediaListAssetsOutputSchema,
   mediaFolderNodeSchema,
   mediaListFoldersOutputSchema,
-  updateMediaOutputSchema,
+  mediaUpdateAssetOutputSchema,
   type MediaFolderNode,
 } from './output-schemas';

--- a/packages/core/upload/server/src/mcp/schemas/index.ts
+++ b/packages/core/upload/server/src/mcp/schemas/index.ts
@@ -7,6 +7,7 @@ export {
   mediaListAssetsInputSchema,
   mediaGetAssetInputSchema,
   mediaListFoldersInputSchema,
+  updateMediaInputSchema,
 } from './input-schemas';
 export {
   mediaAssetOutputSchema,
@@ -14,5 +15,6 @@ export {
   mediaListAssetsOutputSchema,
   mediaFolderNodeSchema,
   mediaListFoldersOutputSchema,
+  updateMediaOutputSchema,
   type MediaFolderNode,
 } from './output-schemas';

--- a/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
@@ -77,37 +77,51 @@ export const mediaGetAssetInputSchema = z.object({
 
 export const mediaListFoldersInputSchema = z.object({});
 
+const FOLDER_INPUT_KEYS = ['folder', 'folderId', 'folderPath'] as const;
+
 /**
  * `update_media` input — the only writable asset metadata.
  *
- * `.strict()` is what turns an out-of-scope field into an actionable error rather than a silent
- * no-op: an agent that guesses `folder` or `url` is told the key is unrecognised instead of
- * getting a success response with nothing changed. The descriptions name the alternative
- * (`move_media`) or the reason a field is not writable, so the agent can recover without
- * a round-trip.
+ * `.strict()` turns an out-of-scope field into an error rather than a silent no-op. The custom
+ * object error directs folder-shaped inputs to `move_media`; other unknown keys are named by
+ * Zod's default error, so the agent can correct the call without a round-trip.
  *
  * The "at least one field" rule is enforced in the handler, not here: a `.refine()` would turn
  * this into a `ZodEffects`, which the MCP tool registry cannot expose as an input schema.
  */
 export const updateMediaInputSchema = z
-  .object({
-    id: mediaIdSchema,
-    name: z
-      .string()
-      .min(1)
-      .optional()
-      .describe(
-        'New asset name as shown in the Media Library. Renames the entry only — the stored file and its URL are unchanged.'
-      ),
-    alternativeText: z
-      .string()
-      .nullable()
-      .optional()
-      .describe('Alt text used by the frontend for accessibility. Pass null to clear it.'),
-    caption: z
-      .string()
-      .nullable()
-      .optional()
-      .describe('Caption shown alongside the asset. Pass null to clear it.'),
-  })
+  .object(
+    {
+      id: mediaIdSchema,
+      name: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          'New asset name as shown in the Media Library. Renames the entry only — the stored file and its URL are unchanged.'
+        ),
+      alternativeText: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Alt text used by the frontend for accessibility. Pass null to clear it.'),
+      caption: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Caption shown alongside the asset. Pass null to clear it.'),
+    },
+    {
+      error(issue) {
+        if (
+          issue.code === 'unrecognized_keys' &&
+          FOLDER_INPUT_KEYS.some((key) => issue.keys.includes(key))
+        ) {
+          return 'Folder changes are not supported by update_media. Use move_media to move an asset between folders.';
+        }
+
+        return undefined;
+      },
+    }
+  )
   .strict();

--- a/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
@@ -76,3 +76,38 @@ export const mediaGetAssetInputSchema = z.object({
 });
 
 export const mediaListFoldersInputSchema = z.object({});
+
+/**
+ * `update_media` input — the only writable asset metadata.
+ *
+ * `.strict()` is what turns an out-of-scope field into an actionable error rather than a silent
+ * no-op: an agent that guesses `folder` or `url` is told the key is unrecognised instead of
+ * getting a success response with nothing changed. The descriptions name the alternative
+ * (`move_media`) or the reason a field is not writable, so the agent can recover without
+ * a round-trip.
+ *
+ * The "at least one field" rule is enforced in the handler, not here: a `.refine()` would turn
+ * this into a `ZodEffects`, which the MCP tool registry cannot expose as an input schema.
+ */
+export const updateMediaInputSchema = z
+  .object({
+    id: mediaIdSchema,
+    name: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        'New asset name as shown in the Media Library. Renames the entry only — the stored file and its URL are unchanged.'
+      ),
+    alternativeText: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Alt text used by the frontend for accessibility. Pass null to clear it.'),
+    caption: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Caption shown alongside the asset. Pass null to clear it.'),
+  })
+  .strict();

--- a/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
@@ -80,16 +80,16 @@ export const mediaListFoldersInputSchema = z.object({});
 const FOLDER_INPUT_KEYS = ['folder', 'folderId', 'folderPath'] as const;
 
 /**
- * `update_media` input — the only writable asset metadata.
+ * `media_update_asset` input — the only writable asset metadata.
  *
  * `.strict()` turns an out-of-scope field into an error rather than a silent no-op. The custom
- * object error directs folder-shaped inputs to `move_media`; other unknown keys are named by
+ * object error directs folder-shaped inputs to `media_move_assets`; other unknown keys are named by
  * Zod's default error, so the agent can correct the call without a round-trip.
  *
  * The "at least one field" rule is enforced in the handler, not here: a `.refine()` would turn
  * this into a `ZodEffects`, which the MCP tool registry cannot expose as an input schema.
  */
-export const updateMediaInputSchema = z
+export const mediaUpdateAssetInputSchema = z
   .object(
     {
       id: mediaIdSchema,
@@ -121,7 +121,7 @@ export const updateMediaInputSchema = z
           issue.code === 'unrecognized_keys' &&
           FOLDER_INPUT_KEYS.some((key) => issue.keys.includes(key))
         ) {
-          return 'Folder changes are not supported by update_media. Use move_media to move an asset between folders.';
+          return 'Folder changes are not supported by media_update_asset. Use media_move_assets to move an asset between folders.';
         }
 
         return undefined;

--- a/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/input-schemas.ts
@@ -104,12 +104,16 @@ export const updateMediaInputSchema = z
         .string()
         .nullable()
         .optional()
-        .describe('Alt text used by the frontend for accessibility. Pass null to clear it.'),
+        .describe(
+          'Alt text used by the frontend for accessibility. Pass null to clear it; the field then reads back as an empty string.'
+        ),
       caption: z
         .string()
         .nullable()
         .optional()
-        .describe('Caption shown alongside the asset. Pass null to clear it.'),
+        .describe(
+          'Caption shown alongside the asset. Pass null to clear it; the field then reads back as an empty string.'
+        ),
     },
     {
       error(issue) {

--- a/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
@@ -64,9 +64,9 @@ export const mediaListFoldersOutputSchema = z.object({
 });
 
 /**
- * `update_media` output — the updated asset in the same shape the read tools return,
+ * `media_update_asset` output — the updated asset in the same shape the read tools return,
  * so an agent can confirm the write without a follow-up `media_get_asset` call.
  */
-export const updateMediaOutputSchema = z.object({
+export const mediaUpdateAssetOutputSchema = z.object({
   data: mediaAssetOutputSchema,
 });

--- a/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
+++ b/packages/core/upload/server/src/mcp/schemas/output-schemas.ts
@@ -62,3 +62,11 @@ export const mediaFolderNodeSchema: z.ZodType<MediaFolderNode> = z.lazy(() =>
 export const mediaListFoldersOutputSchema = z.object({
   data: z.array(mediaFolderNodeSchema).describe('Nested folder structure, roots first.'),
 });
+
+/**
+ * `update_media` output — the updated asset in the same shape the read tools return,
+ * so an agent can confirm the write without a follow-up `media_get_asset` call.
+ */
+export const updateMediaOutputSchema = z.object({
+  data: mediaAssetOutputSchema,
+});

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -8,6 +8,7 @@ import { createMediaSeeder } from './utils/media-seed';
 const UPLOAD_ACTIONS = {
   read: 'plugin::upload.read',
   settingsRead: 'plugin::upload.settings.read',
+  assetsUpdate: 'plugin::upload.assets.update',
 } as const;
 
 const READ_TOOLS = ['media_list_assets', 'media_get_asset', 'media_list_folders'] as const;
@@ -23,7 +24,7 @@ const FORBIDDEN_ASSET_FIELDS = [
   'related',
 ] as const;
 
-describe('MCP upload read tools RBAC (api)', () => {
+describe('MCP upload tools RBAC (api)', () => {
   let strapi: Core.Strapi;
   let rq: Awaited<ReturnType<typeof createAuthRequest>>;
   let mcp: ReturnType<typeof createMcpClient>;
@@ -93,6 +94,16 @@ describe('MCP upload read tools RBAC (api)', () => {
     return token;
   };
 
+  /** A session that can both write metadata and read it back for verification. */
+  const createUpdateTokenSession = async (): Promise<AdminToken> => {
+    const token = await createAdminToken([
+      permission(UPLOAD_ACTIONS.read),
+      permission(UPLOAD_ACTIONS.assetsUpdate),
+    ]);
+    await mcp.initializeSession(token.accessKey);
+    return token;
+  };
+
   // ---------------------------------------------------------------------------
   // Tool exposure
   // ---------------------------------------------------------------------------
@@ -138,6 +149,13 @@ describe('MCP upload read tools RBAC (api)', () => {
       expect(toolNames.filter((name) => /^media_/.test(name)).sort()).toEqual(
         [...READ_TOOLS].sort()
       );
+      expect(toolNames).not.toContain('update_media');
+    });
+
+    test('a token with plugin::upload.assets.update sees the metadata tool', async () => {
+      const token = await createUpdateTokenSession();
+
+      expect(await mcp.listToolNames(token.accessKey)).toContain('update_media');
     });
   });
 
@@ -441,6 +459,225 @@ describe('MCP upload read tools RBAC (api)', () => {
       const response = await mcp.callTool(token.accessKey, 'media_list_folders', {});
 
       expect(response.result?.structuredContent?.data).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // update_media
+  // ---------------------------------------------------------------------------
+
+  describe('update_media', () => {
+    const structured = (response: Awaited<ReturnType<typeof mcp.callTool>>) =>
+      response.result?.structuredContent?.data as Record<string, unknown>;
+
+    const readBack = async (accessKey: string, id: number) => {
+      const response = await mcp.callTool(accessKey, 'media_get_asset', { id });
+      expect(response.error).toBeUndefined();
+      return response.result?.structuredContent?.data as Record<string, unknown>;
+    };
+
+    test('round-trips a metadata update, confirmed by media_get_asset', async () => {
+      const seeded = await seeder.seedAsset({ name: 'before.jpg', alternativeText: 'old alt' });
+      const token = await createUpdateTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'update_media', {
+        id: seeded.id,
+        name: 'after.jpg',
+        alternativeText: 'new alt',
+        caption: 'new caption',
+      });
+
+      expect(response.error).toBeUndefined();
+      expect(response.result?.isError).not.toBe(true);
+
+      // The write response is authoritative on its own — no follow-up read required.
+      expect(structured(response)).toMatchObject({
+        id: seeded.id,
+        name: 'after.jpg',
+        alternativeText: 'new alt',
+        caption: 'new caption',
+      });
+
+      // ...and the change is actually persisted, not just echoed back.
+      expect(await readBack(token.accessKey, seeded.id)).toMatchObject({
+        name: 'after.jpg',
+        alternativeText: 'new alt',
+        caption: 'new caption',
+      });
+    });
+
+    test('leaves the fields the caller omitted untouched', async () => {
+      const seeded = await seeder.seedAsset({
+        name: 'keep.jpg',
+        alternativeText: 'keep alt',
+        caption: 'keep caption',
+      });
+      const token = await createUpdateTokenSession();
+
+      await mcp.callTool(token.accessKey, 'update_media', {
+        id: seeded.id,
+        caption: 'only the caption changed',
+      });
+
+      expect(await readBack(token.accessKey, seeded.id)).toMatchObject({
+        name: 'keep.jpg',
+        alternativeText: 'keep alt',
+        caption: 'only the caption changed',
+      });
+    });
+
+    test('clears a text field passed as null', async () => {
+      const seeded = await seeder.seedAsset({
+        name: 'clear.jpg',
+        alternativeText: 'to be cleared',
+      });
+      const token = await createUpdateTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'update_media', {
+        id: seeded.id,
+        alternativeText: null,
+      });
+
+      expect(response.error ?? response.result?.isError).toBeFalsy();
+      expect(await readBack(token.accessKey, seeded.id)).toMatchObject({ alternativeText: '' });
+    });
+
+    test('does not move the asset or change its url when renaming', async () => {
+      const folder = await seeder.seedFolder('Stays');
+      const seeded = await seeder.seedAsset({ name: 'renamed.jpg', folderId: folder.id });
+      const token = await createUpdateTokenSession();
+
+      const before = await readBack(token.accessKey, seeded.id);
+
+      await mcp.callTool(token.accessKey, 'update_media', {
+        id: seeded.id,
+        name: 'new-label.jpg',
+      });
+
+      const after = await readBack(token.accessKey, seeded.id);
+      expect(after).toMatchObject({
+        name: 'new-label.jpg',
+        url: before.url,
+        mime: before.mime,
+        folder: { id: folder.id, name: 'Stays' },
+      });
+    });
+
+    test('returns the sanitized shape, with no provider secrets on the write path either', async () => {
+      const seeded = await seeder.seedAsset({ name: 'sanitized.jpg' });
+      const token = await createUpdateTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'update_media', {
+        id: seeded.id,
+        caption: 'a caption',
+      });
+
+      const asset = structured(response);
+      for (const field of FORBIDDEN_ASSET_FIELDS) {
+        expect(asset).not.toHaveProperty(field);
+      }
+    });
+
+    test.each([
+      ['url', '/uploads/evil.jpg'],
+      ['folder', 1],
+      ['folderId', 1],
+      ['folderPath', '/1/2'],
+      ['provider', 'aws-s3'],
+      ['provider_metadata', { secretKey: 'leak' }],
+      ['hash', 'forced_hash'],
+      ['mime', 'text/html'],
+      ['size', 1],
+      ['formats', { thumbnail: {} }],
+      ['file', 'new binary content'],
+      ['files', ['new binary content']],
+      ['focalPoint', { x: 10, y: 10 }],
+    ])('rejects the out-of-scope field %s at the schema level', async (field, value) => {
+      const seeded = await seeder.seedAsset({ name: 'guarded.jpg', alternativeText: 'untouched' });
+      const token = await createUpdateTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'update_media', {
+        id: seeded.id,
+        name: 'attempted.jpg',
+        [field]: value,
+      });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
+
+      // A rejected call must not partially apply: the legitimate `name` in the same payload
+      // is discarded along with the unrecognised key.
+      expect(await readBack(token.accessKey, seeded.id)).toMatchObject({
+        name: 'guarded.jpg',
+        alternativeText: 'untouched',
+      });
+    });
+
+    test('rejects a patch with no writable field, naming the tool that does move assets', async () => {
+      const seeded = await seeder.seedAsset({ name: 'nothing.jpg' });
+      const token = await createUpdateTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'update_media', {
+        id: seeded.id,
+      });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
+      expect(JSON.stringify(response)).toMatch(/move_media/);
+    });
+
+    test('rejects a documentId in place of a numeric id', async () => {
+      const token = await createUpdateTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'update_media', {
+        id: 'z7v8zma53x01r6oceimv922b',
+        name: 'x.jpg',
+      });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
+    });
+
+    test('errors for an unknown id', async () => {
+      const token = await createUpdateTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'update_media', {
+        id: 999999,
+        name: 'ghost.jpg',
+      });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
+    });
+
+    test('denies the write to a token without plugin::upload.assets.update', async () => {
+      const seeded = await seeder.seedAsset({ name: 'readonly.jpg', alternativeText: 'untouched' });
+
+      // A read-granted token: it can see the asset but must not be able to edit it.
+      const token = await createReadTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'update_media', {
+        id: seeded.id,
+        name: 'hijacked.jpg',
+      });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
+      expect(await readBack(token.accessKey, seeded.id)).toMatchObject({
+        name: 'readonly.jpg',
+        alternativeText: 'untouched',
+      });
+    });
+
+    test('denies the write to a token holding an unrelated upload permission', async () => {
+      const seeded = await seeder.seedAsset({ name: 'unrelated.jpg' });
+
+      const token = await createAdminToken([permission(UPLOAD_ACTIONS.settingsRead)]);
+      await mcp.initializeSession(token.accessKey);
+
+      expect(await mcp.listToolNames(token.accessKey)).not.toContain('update_media');
+
+      const response = await mcp.callTool(token.accessKey, 'update_media', {
+        id: seeded.id,
+        name: 'hijacked.jpg',
+      });
+
+      expect(response.error ?? response.result?.isError).toBeTruthy();
     });
   });
 });

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -604,6 +604,10 @@ describe('MCP upload tools RBAC (api)', () => {
 
       expect(response.error ?? response.result?.isError).toBeTruthy();
 
+      if (field === 'folder' || field === 'folderId' || field === 'folderPath') {
+        expect(JSON.stringify(response)).toMatch(/move_media/);
+      }
+
       // A rejected call must not partially apply: the legitimate `name` in the same payload
       // is discarded along with the unrecognised key.
       expect(await readBack(token.accessKey, seeded.id)).toMatchObject({

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -149,13 +149,13 @@ describe('MCP upload tools RBAC (api)', () => {
       expect(toolNames.filter((name) => /^media_/.test(name)).sort()).toEqual(
         [...READ_TOOLS].sort()
       );
-      expect(toolNames).not.toContain('update_media');
+      expect(toolNames).not.toContain('media_update_asset');
     });
 
     test('a token with plugin::upload.assets.update sees the metadata tool', async () => {
       const token = await createUpdateTokenSession();
 
-      expect(await mcp.listToolNames(token.accessKey)).toContain('update_media');
+      expect(await mcp.listToolNames(token.accessKey)).toContain('media_update_asset');
     });
   });
 
@@ -463,10 +463,10 @@ describe('MCP upload tools RBAC (api)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // update_media
+  // media_update_asset
   // ---------------------------------------------------------------------------
 
-  describe('update_media', () => {
+  describe('media_update_asset', () => {
     const structured = (response: Awaited<ReturnType<typeof mcp.callTool>>) =>
       response.result?.structuredContent?.data as Record<string, unknown>;
 
@@ -480,7 +480,7 @@ describe('MCP upload tools RBAC (api)', () => {
       const seeded = await seeder.seedAsset({ name: 'before.jpg', alternativeText: 'old alt' });
       const token = await createUpdateTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'update_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: seeded.id,
         name: 'after.jpg',
         alternativeText: 'new alt',
@@ -529,7 +529,7 @@ describe('MCP upload tools RBAC (api)', () => {
       });
       const token = await createUpdateTokenSession();
 
-      await mcp.callTool(token.accessKey, 'update_media', {
+      await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: seeded.id,
         caption: 'only the caption changed',
       });
@@ -548,7 +548,7 @@ describe('MCP upload tools RBAC (api)', () => {
       });
       const token = await createUpdateTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'update_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: seeded.id,
         alternativeText: null,
       });
@@ -564,7 +564,7 @@ describe('MCP upload tools RBAC (api)', () => {
 
       const before = await readBack(token.accessKey, seeded.id);
 
-      await mcp.callTool(token.accessKey, 'update_media', {
+      await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: seeded.id,
         name: 'new-label.jpg',
       });
@@ -582,7 +582,7 @@ describe('MCP upload tools RBAC (api)', () => {
       const seeded = await seeder.seedAsset({ name: 'sanitized.jpg' });
       const token = await createUpdateTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'update_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: seeded.id,
         caption: 'a caption',
       });
@@ -611,7 +611,7 @@ describe('MCP upload tools RBAC (api)', () => {
       const seeded = await seeder.seedAsset({ name: 'guarded.jpg', alternativeText: 'untouched' });
       const token = await createUpdateTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'update_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: seeded.id,
         name: 'attempted.jpg',
         [field]: value,
@@ -620,7 +620,7 @@ describe('MCP upload tools RBAC (api)', () => {
       expect(response.error ?? response.result?.isError).toBeTruthy();
 
       if (field === 'folder' || field === 'folderId' || field === 'folderPath') {
-        expect(JSON.stringify(response)).toMatch(/move_media/);
+        expect(JSON.stringify(response)).toMatch(/media_move_assets/);
       }
 
       // A rejected call must not partially apply: the legitimate `name` in the same payload
@@ -635,18 +635,18 @@ describe('MCP upload tools RBAC (api)', () => {
       const seeded = await seeder.seedAsset({ name: 'nothing.jpg' });
       const token = await createUpdateTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'update_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: seeded.id,
       });
 
       expect(response.error ?? response.result?.isError).toBeTruthy();
-      expect(JSON.stringify(response)).toMatch(/move_media/);
+      expect(JSON.stringify(response)).toMatch(/media_move_assets/);
     });
 
     test('rejects a documentId in place of a numeric id', async () => {
       const token = await createUpdateTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'update_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: 'z7v8zma53x01r6oceimv922b',
         name: 'x.jpg',
       });
@@ -657,7 +657,7 @@ describe('MCP upload tools RBAC (api)', () => {
     test('errors for an unknown id', async () => {
       const token = await createUpdateTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'update_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: 999999,
         name: 'ghost.jpg',
       });
@@ -671,7 +671,7 @@ describe('MCP upload tools RBAC (api)', () => {
       // A read-granted token: it can see the asset but must not be able to edit it.
       const token = await createReadTokenSession();
 
-      const response = await mcp.callTool(token.accessKey, 'update_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: seeded.id,
         name: 'hijacked.jpg',
       });
@@ -689,9 +689,9 @@ describe('MCP upload tools RBAC (api)', () => {
       const token = await createAdminToken([permission(UPLOAD_ACTIONS.settingsRead)]);
       await mcp.initializeSession(token.accessKey);
 
-      expect(await mcp.listToolNames(token.accessKey)).not.toContain('update_media');
+      expect(await mcp.listToolNames(token.accessKey)).not.toContain('media_update_asset');
 
-      const response = await mcp.callTool(token.accessKey, 'update_media', {
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
         id: seeded.id,
         name: 'hijacked.jpg',
       });

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -504,6 +504,21 @@ describe('MCP upload tools RBAC (api)', () => {
         alternativeText: 'new alt',
         caption: 'new caption',
       });
+
+      // Read the row directly, outside MCP: a symmetric bug across the read and write pair
+      // would round-trip cleanly above while the stored row was wrong. This also pins the
+      // `updatedBy` attribution, which the MCP-only assertions never observe.
+      const row = await strapi.db.query('plugin::upload.file').findOne({
+        where: { id: seeded.id },
+        populate: { updatedBy: true },
+      });
+
+      expect(row).toMatchObject({
+        name: 'after.jpg',
+        alternativeText: 'new alt',
+        caption: 'new caption',
+      });
+      expect(row?.updatedBy).toBeTruthy();
     });
 
     test('leaves the fields the caller omitted untouched', async () => {


### PR DESCRIPTION
### What does it do?

Adds `media_update_asset`, the first write tool on the Media Library MCP surface. It edits the editable metadata of one asset — `name`, `alternativeText` and `caption` — mirroring `PUT /upload/files/:id`: the same `findEntityAndCheckPermissions` row-level check, the same `updateFileInfo` service call, and the same `updatedBy` attribution from the session user.

- Gated on `plugin::upload.assets.update`, not the read action, so a read-only token never gains an editing tool.
- Provider-owned fields (`url`, `mime`, `size`, file contents) are not writable. The input schema is `.strict()`, so an out-of-scope field is an error rather than a silent no-op, and a folder-shaped key (`folder`, `folderId`, `folderPath`) is answered with a message pointing at `media_move_assets`.
- Passing `null` for `alternativeText` or `caption` clears the field, storing `''` rather than `null`. `updateFileInfo` gates each field through `_.isNil`, which is true for `null` as well as `undefined`, so forwarding a literal `null` would be read as "keep the stored value" and the clear would silently no-op. The empty string is also what the admin panel writes when you empty the input, so both surfaces converge on the same stored value. An asset whose alt text was never set still holds `null`; both are falsy and both render as an empty field, but they are not strictly equal.
- A patch with no writable field is rejected as a validation error naming the fields that are writable. The "at least one of" rule lives in the handler because a `.refine()` would make the schema a `ZodEffects`, which the tool registry cannot publish as an input JSON Schema.
- The response returns the updated asset through the read sanitizer, so a client can confirm the write without a second `media_get_asset` round-trip, and provider secrets stay invisible on the write path too.

Tool names carry a `media_` prefix as of 2026-09-08 — see CMS-37 divergence 4. The card's names collide with the content-manager's derived tools and would break boot for a project with a content type named `media`.

### Why is it needed?

The Media Library MCP surface was read-only. An agent could find an asset but not correct its name or fill in missing alt text, so any metadata fix meant leaving the conversation for the admin panel. Metadata is also the part of an asset that is safe to write: it does not touch the stored file or its URL.

### How to test it?

**Manual**

1. `cd examples/getstarted && yarn develop` and upload an image in the Media Library.
2. In the admin panel, create an API token with the **plugin::upload.assets.update** permission, then point an MCP client at the app's MCP endpoint with that token.
3. Confirm `media_update_asset` appears in the tool list. Create a second token with **read only** and confirm the tool is absent for it.
4. Call `media_update_asset` with the asset's numeric `id` and a new `name` plus an `alternativeText`. The response should return the updated asset; reload the Media Library and check the new values are shown.
5. Confirm the file itself is untouched — the asset's URL still resolves to the same image after the rename.
6. Call it again with `alternativeText: null` and confirm the alt text is cleared in the panel, and that a field you omitted (e.g. `caption`) keeps its previous value. The cleared field reads back as `''`, not `null` — check via `media_get_asset` or the API if you want to see the stored value.
7. Error paths: call with only an `id` (expect a validation error listing the writable fields), with `folderId` (expect a message pointing at `media_move_assets`), with a `documentId` string instead of a numeric id, and with an id that does not exist (expect "Media asset not found.").
8. With the read-only token, attempt the write directly and confirm it is denied.

**Automated**

```bash
yarn nx run @strapi/upload:test:unit
yarn test:api --file tests/api/core/mcp/mcp-upload-rbac.test.api.ts
```

### Related issue(s)/PR(s)

fix CMS-40

Stacked on #27523 — please merge that first; this PR targets its branch, and the base will need retargeting to `develop` once it lands.
