### PR TITLE
fix(database): guard internal migrations against concurrent boot

### DIFF
--- a/packages/core/database/src/migrations/__tests__/internal-upgrade-simulation.test.ts
+++ b/packages/core/database/src/migrations/__tests__/internal-upgrade-simulation.test.ts
@@ -1,5 +1,6 @@
 import knex from 'knex';
 
+import { createMigrationRunner } from '../runner';
 import { createInternalMigrationProvider } from '../internal';
 import { internalMigrations } from '../internal-migrations';
 import { createStorage } from '../storage';
@@ -138,4 +139,50 @@ describe('internal migration upgrade simulation', () => {
 
     await sqlite.destroy();
   });
+
+  it('runs each pending internal migration only once when two runners start concurrently', async () => {
+    const { db, sqlite } = createTestDatabase();
+    const migrationName = 'core::concurrent-test-migration';
+    let resolveUpStarted: (() => void) | undefined;
+    const upStarted = new Promise<void>((resolve) => {
+      resolveUpStarted = resolve;
+    });
+
+    const migration = {
+      name: migrationName,
+      up: jest.fn().mockImplementation(async () => {
+        resolveUpStarted?.();
+        await new Promise((resolve) => {
+          setTimeout(resolve, 100);
+        });
+      }),
+      down: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const storage = createStorage({ db, tableName: 'strapi_migrations_internal' });
+    await storage.executed();
+
+    const createRunner = () =>
+      createMigrationRunner({
+        storage,
+        logger: { info: jest.fn() },
+        getMigrations: jest.fn().mockResolvedValue([migration]),
+      });
+
+    const firstRunner = createRunner();
+    const secondRunner = createRunner();
+
+    const firstRun = firstRunner.up();
+    await upStarted;
+    const secondRun = secondRunner.up();
+
+    await Promise.all([firstRun, secondRun]);
+
+    expect(migration.up).toHaveBeenCalledTimes(1);
+    expect(await sqlite('strapi_migrations_internal').where({ name: migrationName })).toHaveLength(
+      1
+    );
+
+    await sqlite.destroy();
+  }, 10000);
 });

--- a/packages/core/database/src/migrations/__tests__/runner.test.ts
+++ b/packages/core/database/src/migrations/__tests__/runner.test.ts
@@ -6,6 +6,7 @@ describe('createMigrationRunner', () => {
   const createMocks = (migrations: RunnableMigration[], executed: string[] = []) => {
     const storage = {
       executed: jest.fn().mockResolvedValue([...executed]),
+      tryClaimMigration: jest.fn().mockResolvedValue(true),
       logMigration: jest.fn().mockResolvedValue(undefined),
       unlogMigration: jest.fn().mockResolvedValue(undefined),
     };
@@ -71,9 +72,9 @@ describe('createMigrationRunner', () => {
       expect(migrations[0].up).toHaveBeenCalledTimes(1);
       expect(migrations[1].up).toHaveBeenCalledTimes(1);
       expect(migrations[2].up).toHaveBeenCalledTimes(1);
-      expect(storage.logMigration).toHaveBeenNthCalledWith(1, { name: '001-first.js' });
-      expect(storage.logMigration).toHaveBeenNthCalledWith(2, { name: '002-second.js' });
-      expect(storage.logMigration).toHaveBeenNthCalledWith(3, { name: '003-third.js' });
+      expect(storage.tryClaimMigration).toHaveBeenNthCalledWith(1, { name: '001-first.js' });
+      expect(storage.tryClaimMigration).toHaveBeenNthCalledWith(2, { name: '002-second.js' });
+      expect(storage.tryClaimMigration).toHaveBeenNthCalledWith(3, { name: '003-third.js' });
       expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({ event: 'migrating', name: '001-first.js' })
       );
@@ -112,17 +113,40 @@ describe('createMigrationRunner', () => {
       expect(failingMigrations[0].up).toHaveBeenCalledTimes(1);
       expect(failingMigrations[1].up).toHaveBeenCalledTimes(1);
       expect(failingMigrations[2].up).not.toHaveBeenCalled();
-      expect(storage.logMigration).toHaveBeenCalledTimes(1);
-      expect(storage.logMigration).toHaveBeenCalledWith({ name: '001-first.js' });
+      expect(storage.tryClaimMigration).toHaveBeenCalledTimes(2);
+      expect(storage.unlogMigration).toHaveBeenCalledWith({ name: '002-second.js' });
+    });
+
+    it('skips migrations that were already claimed by another runner', async () => {
+      const { runner, storage } = createMocks(migrations);
+      storage.tryClaimMigration.mockImplementation(async ({ name }: { name: string }) => {
+        return name !== '002-second.js';
+      });
+
+      const applied = await runner.up();
+
+      expect(migrations[0].up).toHaveBeenCalledTimes(1);
+      expect(migrations[1].up).not.toHaveBeenCalled();
+      expect(migrations[2].up).toHaveBeenCalledTimes(1);
+      expect(applied).toEqual([
+        { name: '001-first.js', path: undefined },
+        { name: '003-third.js', path: undefined },
+      ]);
     });
 
     it('is idempotent when re-run after successful up', async () => {
       const executed: string[] = [];
       const storage = {
         executed: jest.fn().mockImplementation(async () => [...executed]),
-        logMigration: jest.fn().mockImplementation(async ({ name }: { name: string }) => {
+        tryClaimMigration: jest.fn().mockImplementation(async ({ name }: { name: string }) => {
+          if (executed.includes(name)) {
+            return false;
+          }
+
           executed.push(name);
+          return true;
         }),
+        logMigration: jest.fn(),
         unlogMigration: jest.fn(),
       };
 

--- a/packages/core/database/src/migrations/__tests__/storage.test.ts
+++ b/packages/core/database/src/migrations/__tests__/storage.test.ts
@@ -12,6 +12,7 @@ describe('createStorage', () => {
       getSchemaConnection: jest.fn().mockReturnValue({
         hasTable: jest.fn().mockResolvedValue(false),
         createTable: jest.fn().mockResolvedValue(undefined),
+        alterTable: jest.fn().mockResolvedValue(undefined),
       }),
       getConnection: jest.fn().mockReturnValue({
         insert: jest.fn().mockReturnValue({
@@ -30,6 +31,29 @@ describe('createStorage', () => {
 
     tableName = 'migrations';
     storage = createStorage({ db, tableName });
+  });
+
+  describe('tryClaimMigration', () => {
+    it('returns true when the migration name can be inserted', async () => {
+      const name = '20220101120000_create_users_table';
+
+      await expect(storage.tryClaimMigration({ name })).resolves.toBe(true);
+
+      expect(db.getConnection().insert).toHaveBeenCalledWith(
+        expect.objectContaining({ name, time: expect.any(Date) })
+      );
+    });
+
+    it('returns false when the migration name is already claimed', async () => {
+      const name = '20220101120000_create_users_table';
+      const duplicateError = Object.assign(new Error('UNIQUE constraint failed'), {
+        code: 'SQLITE_CONSTRAINT_UNIQUE',
+      });
+
+      (db.getConnection().insert({}).into as jest.Mock).mockRejectedValueOnce(duplicateError);
+
+      await expect(storage.tryClaimMigration({ name })).resolves.toBe(false);
+    });
   });
 
   describe('logMigration', () => {

--- a/packages/core/database/src/migrations/runner.ts
+++ b/packages/core/database/src/migrations/runner.ts
@@ -68,25 +68,32 @@ export const createMigrationRunner = (opts: MigrationRunnerOptions) => {
 
     async up(): Promise<MigrationMeta[]> {
       const toBeApplied = await getPendingMigrations();
+      const applied: MigrationMeta[] = [];
 
       for (const migration of toBeApplied) {
         const start = Date.now();
 
         logEvent(opts.logger, 'migrating', migration.name);
 
+        const claimed = await opts.storage.tryClaimMigration({ name: migration.name });
+        if (!claimed) {
+          logEvent(opts.logger, 'skipped', migration.name, { reason: 'already_claimed' });
+          continue;
+        }
+
         try {
           await migration.up();
         } catch (error) {
+          await opts.storage.unlogMigration({ name: migration.name });
           throw wrapMigrationError(migration.name, 'up', error);
         }
 
-        await opts.storage.logMigration({ name: migration.name });
-
         const durationSeconds = (Date.now() - start) / 1000;
         logEvent(opts.logger, 'migrated', migration.name, { durationSeconds });
+        applied.push({ name: migration.name, path: migration.path });
       }
 
-      return toBeApplied.map(({ name, path }) => ({ name, path }));
+      return applied;
     },
 
     async down(): Promise<MigrationMeta[]> {

--- a/packages/core/database/src/migrations/storage.ts
+++ b/packages/core/database/src/migrations/storage.ts
@@ -5,17 +5,59 @@ export interface Options {
   tableName: string;
 }
 
+const DUPLICATE_ENTRY_ERROR_CODES = new Set(['23505', 'ER_DUP_ENTRY', 'SQLITE_CONSTRAINT_UNIQUE']);
+
+const isDuplicateEntryError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const err = error as { code?: string; message?: string };
+  if (err.code && DUPLICATE_ENTRY_ERROR_CODES.has(err.code)) {
+    return true;
+  }
+
+  const message = err.message?.toLowerCase() ?? '';
+  return message.includes('duplicate key') || message.includes('unique constraint failed');
+};
+
+const isExistingIndexError = (error: unknown): boolean => {
+  const message = (error as { message?: string }).message?.toLowerCase() ?? '';
+  return (
+    message.includes('already exists') ||
+    message.includes('duplicate key name') ||
+    message.includes('duplicate index')
+  );
+};
+
+const getNameUniqueIndex = (tableName: string) => `${tableName}_name_unique`;
+
 export const createStorage = (opts: Options) => {
   const { db, tableName } = opts;
+  const nameUniqueIndex = getNameUniqueIndex(tableName);
 
   const hasMigrationTable = () => db.getSchemaConnection().hasTable(tableName);
 
   const createMigrationTable = () => {
     return db.getSchemaConnection().createTable(tableName, (table) => {
       table.increments('id');
-      table.string('name');
+      table.string('name').notNullable().unique({ indexName: nameUniqueIndex });
       table.datetime('time', { useTz: false });
     });
+  };
+
+  const ensureNameUniqueIndex = async () => {
+    try {
+      await db.getSchemaConnection().alterTable(tableName, (table) => {
+        table.unique(['name'], { indexName: nameUniqueIndex });
+      });
+    } catch (error) {
+      if (isExistingIndexError(error)) {
+        return;
+      }
+
+      throw error;
+    }
   };
 
   return {
@@ -29,6 +71,25 @@ export const createStorage = (opts: Options) => {
         .into(tableName);
     },
 
+    async tryClaimMigration({ name }: { name: string }) {
+      try {
+        await db
+          .getConnection()
+          .insert({
+            name,
+            time: new Date(),
+          })
+          .into(tableName);
+        return true;
+      } catch (error) {
+        if (isDuplicateEntryError(error)) {
+          return false;
+        }
+
+        throw error;
+      }
+    },
+
     async unlogMigration({ name }: { name: string }) {
       await db.getConnection(tableName).del().where({ name });
     },
@@ -38,6 +99,8 @@ export const createStorage = (opts: Options) => {
         await createMigrationTable();
         return [];
       }
+
+      await ensureNameUniqueIndex();
 
       const logs = await db.getConnection(tableName).select().from(tableName).orderBy('time');
 


### PR DESCRIPTION
## Summary
- Claim each pending migration by inserting its name into the tracking table **before** running the migration body, instead of logging after success.
- Add a unique index on migration `name` (new tables and existing tables via `alterTable`) so concurrent claims fail fast with a duplicate-key error.
- On migration failure, remove the claim so a retry can proceed. A concurrent runner that loses the claim skips that migration.

This prevents two instances booting in parallel from both executing migrations such as `core::5.0.0-discard-drafts`.

## Test plan
- [x] `yarn test:unit --testPathPattern="migrations/__tests__/(runner|storage|internal-upgrade)"` in `packages/core/database`
- [x] Added concurrent-runner regression test in `internal-upgrade-simulation.test.ts`

Fixes #27567
