### PR TITLE
chore(deps): bump ai sdk in content-type-builder to v6

### DIFF
--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -66,7 +66,7 @@
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
-    "@ai-sdk/react": "2.0.212",
+    "@ai-sdk/react": "3.0.280",
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/modifiers": "9.0.0",
     "@dnd-kit/sortable": "10.0.0",
@@ -77,7 +77,7 @@
     "@strapi/generators": "5.52.3",
     "@strapi/icons": "2.2.4",
     "@strapi/utils": "5.52.3",
-    "ai": "5.0.210",
+    "ai": "6.0.277",
     "date-fns": "2.30.0",
     "fs-extra": "11.3.4",
     "immer": "9.0.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,56 +82,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/gateway@npm:2.0.109":
-  version: 2.0.109
-  resolution: "@ai-sdk/gateway@npm:2.0.109"
+"@ai-sdk/gateway@npm:3.0.189":
+  version: 3.0.189
+  resolution: "@ai-sdk/gateway@npm:3.0.189"
   dependencies:
-    "@ai-sdk/provider": "npm:2.0.3"
-    "@ai-sdk/provider-utils": "npm:3.0.28"
-    "@vercel/oidc": "npm:3.1.0"
+    "@ai-sdk/provider": "npm:3.0.15"
+    "@ai-sdk/provider-utils": "npm:4.0.50"
+    "@vercel/oidc": "npm:3.2.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/dedfb6727e08b869785da3bcf96dcacca2c63a3809c1786f2774cd1a1b217f6ed39f731e83ac0ed7f988c534cd8359e9d90c344ad8e4abc482e5e67d5f991a9f
+  checksum: 10c0/32891841903f42581b3b80ca1e74bb7d413bcbdf674a9b7a91ea616b6b6d804c46750dbc3e0b078bdf7c92a73bafaadec07bdac643b5b8e0d09a8eac5fff4530
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider-utils@npm:3.0.28":
-  version: 3.0.28
-  resolution: "@ai-sdk/provider-utils@npm:3.0.28"
+"@ai-sdk/provider-utils@npm:4.0.50":
+  version: 4.0.50
+  resolution: "@ai-sdk/provider-utils@npm:4.0.50"
   dependencies:
-    "@ai-sdk/provider": "npm:2.0.3"
-    "@standard-schema/spec": "npm:^1.0.0"
-    eventsource-parser: "npm:^3.0.6"
+    "@ai-sdk/provider": "npm:3.0.15"
+    "@standard-schema/spec": "npm:^1.1.0"
+    eventsource-parser: "npm:^3.0.8"
+    undici: "npm:^6.28.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/fcbcead985ebaa22fef548acce600ca65c343b13a92de808da5e5bd01a61c0f7856a19840bb3eeeb6b6ac808c4f6ca031524192085d21560cf78fa7d9833dda0
+  checksum: 10c0/c80ea0a8489da063aa704a431354c4d9136880ab30c6e54324d9458cfb02ea30858bac24e8d559a21de3b984fec16b6aedee6e2ce85687f11d8a65a06311ed86
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@ai-sdk/provider@npm:2.0.3"
+"@ai-sdk/provider@npm:3.0.15":
+  version: 3.0.15
+  resolution: "@ai-sdk/provider@npm:3.0.15"
   dependencies:
     json-schema: "npm:^0.4.0"
-  checksum: 10c0/f0f663a2d2226d3cb447a3bcc13c70333c1957953237c5583681f26b0d4109f7136ce234499ba730c63bba97243e127b7763d8d962571377d1d9b5193506232c
+  checksum: 10c0/0a17eca818c6d821e9488188cf02789502e426eff125d9c9572c2308baead3ed2e93ad53856887b207f287e6907441da81860e31350b12a11c91a6dfd1c6f344
   languageName: node
   linkType: hard
 
-"@ai-sdk/react@npm:2.0.212":
-  version: 2.0.212
-  resolution: "@ai-sdk/react@npm:2.0.212"
+"@ai-sdk/react@npm:3.0.280":
+  version: 3.0.280
+  resolution: "@ai-sdk/react@npm:3.0.280"
   dependencies:
-    "@ai-sdk/provider-utils": "npm:3.0.28"
-    ai: "npm:5.0.210"
+    "@ai-sdk/provider-utils": "npm:4.0.50"
+    ai: "npm:6.0.277"
     swr: "npm:^2.2.5"
     throttleit: "npm:2.1.0"
   peerDependencies:
     react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
-    zod: ^3.25.76 || ^4.1.8
-  peerDependenciesMeta:
-    zod:
-      optional: true
-  checksum: 10c0/cca6968a375572f57648a294b05be11708bd41f11b93fd1b37c187c5900145cf98df7fb9d7160f7711bb57d9e3111f04b2c06032994cd17c8279c0209ff1c2e0
+  checksum: 10c0/12c56e6710cf93edf8df86918ac826b7a6812f3f134527649377dd6dc866adc585c0eb023c1e9fe2aa58d702081630d0aece9fbc5b42975cccd29e9a88d3c9ed
   languageName: node
   linkType: hard
 
@@ -5892,10 +5889,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@opentelemetry/api@npm:1.9.0"
-  checksum: 10c0/9aae2fe6e8a3a3eeb6c1fdef78e1939cf05a0f37f8a4fae4d6bf2e09eb1e06f966ece85805626e01ba5fab48072b94f19b835449e58b6d26720ee19a58298add
+"@opentelemetry/api@npm:^1.9.0":
+  version: 1.9.1
+  resolution: "@opentelemetry/api@npm:1.9.1"
+  checksum: 10c0/c608485fc8b5a91e1f7e05e843b45b509307456b31cd2ad365933d90813e40ebfedf179f1451c762037e82d7c76aa8500e95d2da3609f640a1206cde5322cd14
   languageName: node
   linkType: hard
 
@@ -9135,7 +9132,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/content-type-builder@workspace:packages/core/content-type-builder"
   dependencies:
-    "@ai-sdk/react": "npm:2.0.212"
+    "@ai-sdk/react": "npm:3.0.280"
     "@dnd-kit/core": "npm:6.3.1"
     "@dnd-kit/modifiers": "npm:9.0.0"
     "@dnd-kit/sortable": "npm:10.0.0"
@@ -9158,7 +9155,7 @@ __metadata:
     "@types/node": "npm:20.19.41"
     "@types/pluralize": "npm:0.0.32"
     "@types/react": "npm:18.3.2"
-    ai: "npm:5.0.210"
+    ai: "npm:6.0.277"
     date-fns: "npm:2.30.0"
     fs-extra: "npm:11.3.4"
     immer: "npm:9.0.21"
@@ -12412,10 +12409,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/oidc@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@vercel/oidc@npm:3.1.0"
-  checksum: 10c0/f57278ed4b4c022c7ca85e8baa5f9bdb2623397abfa0e5dbfd75de283c8e5dc534d64dac1364b5ad8c96d00eb2d469886e6f7b640f6f195def5766950ad8ce71
+"@vercel/oidc@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@vercel/oidc@npm:3.2.0"
+  checksum: 10c0/98318d3236f58c296616c8c2e1655b268c7bf58525bcd985adac7af6d900e05fc610f6f03ce2ff4bdcd3df7885a40c0ca44fdc761f122dcfe15a78c2756b0243
   languageName: node
   linkType: hard
 
@@ -13040,17 +13037,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ai@npm:5.0.210":
-  version: 5.0.210
-  resolution: "ai@npm:5.0.210"
+"ai@npm:6.0.277":
+  version: 6.0.277
+  resolution: "ai@npm:6.0.277"
   dependencies:
-    "@ai-sdk/gateway": "npm:2.0.109"
-    "@ai-sdk/provider": "npm:2.0.3"
-    "@ai-sdk/provider-utils": "npm:3.0.28"
-    "@opentelemetry/api": "npm:1.9.0"
+    "@ai-sdk/gateway": "npm:3.0.189"
+    "@ai-sdk/provider": "npm:3.0.15"
+    "@ai-sdk/provider-utils": "npm:4.0.50"
+    "@opentelemetry/api": "npm:^1.9.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/c47ed1255ec1d1a3d64f8b5db00dae97380344c3b614a005cd5699f0f79dc5dc7efc2f41acd210d3837aec2bccc6cca03c6e94d676beab24ac84ef572641f819
+  checksum: 10c0/43a2fdce23a40093f16b68c957c98c9b768087d15d4ad69403e44d545042e54f625794920bac30ca57f798bc539a8d2f8378edc2fa37c69898a5ee536b255b24
   languageName: node
   linkType: hard
 
@@ -17525,17 +17522,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1":
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1, eventsource-parser@npm:^3.0.8":
   version: 3.1.1
   resolution: "eventsource-parser@npm:3.1.1"
   checksum: 10c0/dd3236c61140587253dcaaf947de528ac0e7371caffdc53c77afaeee36a17661f00e251a6ea16af56c99be5ac138303e67b5d750630e7c41b02e3564e8ad8c44
-  languageName: node
-  linkType: hard
-
-"eventsource-parser@npm:^3.0.6":
-  version: 3.0.6
-  resolution: "eventsource-parser@npm:3.0.6"
-  checksum: 10c0/70b8ccec7dac767ef2eca43f355e0979e70415701691382a042a2df8d6a68da6c2fca35363669821f3da876d29c02abe9b232964637c1b6635c940df05ada78a
   languageName: node
   linkType: hard
 
@@ -29428,7 +29418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:6.28.1":
+"undici@npm:6.28.1, undici@npm:^6.28.0":
   version: 6.28.1
   resolution: "undici@npm:6.28.1"
   checksum: 10c0/9c7c277da83972f4f506d564b1d627e3e78aadf866915eab768d96fc70daeae8ff7d87d0cdb32403ae1afdf3aef0f11715e0847d66910fda62822c33c5a7e674


### PR DESCRIPTION
### What does it do?

Bumps the AI SDK used by the Content-Type Builder AI chat to the v6 line:

| Package | Before | After |
| --- | --- | --- |
| `ai` | 5.0.210 | 6.0.277 |
| `@ai-sdk/react` | 2.0.212 | 3.0.280 |
| `@ai-sdk/provider-utils` (transitive) | 3.0.28 | 4.0.50 |

Two lines in `packages/core/content-type-builder/package.json` plus the lockfile. No source changes.

### Why is it needed?

`@ai-sdk/provider-utils` 3.x is flagged by [GHSA-866g-f22w-33x8](https://github.com/advisories/GHSA-866g-f22w-33x8) (low severity) and shows up in consumers' `npm audit`. No 3.x release fixes it, so the only way out is the next `ai` major.

The vulnerable code is a server-side response handler that the admin never calls, so this is audit hygiene rather than a real exposure.

❗ v6 was chosen over v7 on purpose: v7 is ESM-only and requires Node 22, which conflicts with Strapi's Node 20 support.

### How to test it?

Automated:

```bash
yarn install
yarn npm audit -R -A        # no @ai-sdk/provider-utils entry anymore
cd packages/core/content-type-builder
yarn test:ts:front && yarn lint && yarn build && yarn test:front
```

Manual, in an EE project with a licence that has the `cms-ai` feature:

1. Open the Content-Type Builder and the AI chat.
2. Ask it to create a collection type. The answer streams, the "Updated N schemas" marker appears, and the new type shows up in the sidebar.
3. Attach an image (drag & drop or paste) and send. The attachment uploads and is sent with the message.
4. Stop a response mid-stream. The chat goes back to ready without an error.

All of the above was verified against the production AI server. The `useChat` API, message part shapes and the stream protocol are unchanged between v5 and v6 for the parts the chat uses.

### Related issue(s)/PR(s)

- Linear: [EE-174](https://linear.app/strapi/issue/EE-174/migrate-ai-sdk-in-content-type-builder-past-vulnerable-provider-utils)
- Parent: [CMS-461](https://linear.app/strapi/issue/CMS-461/resolve-deprecation-warnings-on-install-of-new-project)