### PR TITLE
docs: fix three dead relative links

### DIFF
--- a/docs/docs/docs/01-core/configuration/01-security-defaults.md
+++ b/docs/docs/docs/01-core/configuration/01-security-defaults.md
@@ -137,7 +137,7 @@ module.exports = () => ({
 });
 ```
 
-See [MIME type validation](/upload/mime-validation) for how allow/deny lists are evaluated.
+See [MIME type validation](/docs/core/upload/backend/mime-validation) for how allow/deny lists are evaluated.
 
 ### SVG uploads and existing projects
 

--- a/docs/docs/docs/01-core/content-releases/00-intro.md
+++ b/docs/docs/docs/01-core/content-releases/00-intro.md
@@ -10,7 +10,7 @@ A release contains various content entries, each capable of being assigned a spe
 
 ### Architecture
 
-As opposed to other EE features built in the [EE folder](docs/docs/01-core/admin/01-ee/00-intro.md), Releases is built as a plugin. The plugin can be found in:
+As opposed to other EE features built in the [EE folder](../admin/01-ee/00-intro.md), Releases is built as a plugin. The plugin can be found in:
 
 ```
 packages/core/content-releases

--- a/packages/core/strapi/README.md
+++ b/packages/core/strapi/README.md
@@ -136,7 +136,7 @@ You can unlock additional features such as SSO, Audit Logs, Review Workflows in 
 
 ## Contributing
 
-Please read our [Contributing Guide](./CONTRIBUTING.md) before submitting a Pull Request to the project.
+Please read our [Contributing Guide](https://github.com/strapi/strapi/blob/develop/CONTRIBUTING.md) before submitting a Pull Request to the project.
 
 ## Community support
 


### PR DESCRIPTION
Three dead links:

- `01-core/content-releases/00-intro.md`: the EE-folder link doubled the `docs/docs` segment (resolves to a nonexistent nested path)
- `01-core/configuration/01-security-defaults.md`: linked `/upload/mime-validation` — no such route; the page lives at `/docs/core/upload/backend/mime-validation`
- `packages/core/strapi/README.md`: linked a package-local `CONTRIBUTING.md` that doesn't exist → absolute link to the repo-root guide

Docs-only. (CLA note: will sign at cla.strapi.io if this moves toward merge.)