### PR TITLE
fix(content-manager): prevent mobile actions drawer from covering fields

### DIFF
--- a/packages/core/content-manager/admin/src/components/ActionsDrawer.tsx
+++ b/packages/core/content-manager/admin/src/components/ActionsDrawer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { WIDTH_SIDE_NAVIGATION, createContext } from '@strapi/admin/strapi-admin';
-import { Portal, Flex, Box, ScrollArea, IconButton } from '@strapi/design-system';
+import { Portal, Flex, Box, ScrollArea, IconButton, useMeasure } from '@strapi/design-system';
 import { CaretDown, CaretUp } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
@@ -25,6 +25,7 @@ interface ActionsDrawerContextValue {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   hasContent: boolean;
   hasSideNav: boolean;
+  headerRef: (element: HTMLDivElement) => void;
 }
 
 const [ActionsDrawerProvider, useActionsDrawer] = createContext<ActionsDrawerContextValue | null>(
@@ -114,6 +115,7 @@ interface RootProps {
 
 const Root = ({ children, hasContent = false, hasSideNav = false }: RootProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const [headerRef, { height: headerHeight }] = useMeasure<HTMLDivElement>();
 
   // Close drawer when there's no content
   React.useEffect(() => {
@@ -128,7 +130,9 @@ const Root = ({ children, hasContent = false, hasSideNav = false }: RootProps) =
       setIsOpen={setIsOpen}
       hasContent={hasContent}
       hasSideNav={hasSideNav}
+      headerRef={headerRef}
     >
+      <Box height={`${headerHeight}px`} shrink={0} data-testid="actions-drawer-spacer" />
       <DrawerContainer $hasSideNav={hasSideNav} $isOpen={isOpen}>
         {children}
       </DrawerContainer>
@@ -174,6 +178,7 @@ const Header = ({ children }: HeaderProps) => {
   const isOpen = ctx?.isOpen ?? false;
   const hasContent = ctx?.hasContent ?? false;
   const setIsOpen = ctx?.setIsOpen;
+  const headerRef = ctx?.headerRef;
   const { formatMessage } = useIntl();
 
   const toggleOpen = () => {
@@ -181,7 +186,7 @@ const Header = ({ children }: HeaderProps) => {
   };
 
   return (
-    <DrawerContent background="neutral0">
+    <DrawerContent ref={headerRef} background="neutral0">
       <Flex
         paddingTop={3}
         paddingBottom={3}

--- a/packages/core/content-manager/admin/src/components/tests/ActionsDrawer.test.tsx
+++ b/packages/core/content-manager/admin/src/components/tests/ActionsDrawer.test.tsx
@@ -2,6 +2,13 @@ import { render, screen, waitFor } from '@tests/utils';
 
 import { ActionsDrawer } from '../ActionsDrawer';
 
+const mockUseMeasure = jest.fn(() => [jest.fn(), { height: 0 }]);
+
+jest.mock('@strapi/design-system', () => ({
+  ...jest.requireActual('@strapi/design-system'),
+  useMeasure: () => mockUseMeasure(),
+}));
+
 describe('ActionsDrawer', () => {
   const defaultHeaderContent = <div>Header Content</div>;
   const defaultDrawerContent = <div>Drawer Children</div>;
@@ -15,6 +22,18 @@ describe('ActionsDrawer', () => {
       );
 
       expect(screen.getByText('Header Content')).toBeInTheDocument();
+    });
+
+    it('should reserve the full height of the fixed header', () => {
+      mockUseMeasure.mockReturnValueOnce([jest.fn(), { height: 180 }]);
+
+      render(
+        <ActionsDrawer.Root hasContent={false}>
+          <ActionsDrawer.Header>{defaultHeaderContent}</ActionsDrawer.Header>
+        </ActionsDrawer.Root>
+      );
+
+      expect(screen.getByTestId('actions-drawer-spacer')).toHaveStyle({ height: '180px' });
     });
 
     it('should render drawer content when provided', () => {

--- a/packages/core/content-manager/admin/src/history/components/VersionsList.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionsList.tsx
@@ -274,10 +274,6 @@ const VersionsList = () => {
           <VersionsListItems />
         </ActionsDrawer.Content>
       </ActionsDrawer.Root>
-      {/* Adding a fixed height to the bottom of the page to prevent 
-      the actions drawer from covering the content
-      (32px + 12px * 2 padding + 1px border) */}
-      <Box width="100%" height="5.7rem" />
     </>
   );
 };

--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -262,10 +262,6 @@ const EditViewPage = () => {
                     <Panels withActions={false} />
                   </ActionsDrawer.Content>
                 </ActionsDrawer.Root>
-                {/* Adding a fixed height to the bottom of the page to prevent 
-                the actions drawer from covering the content
-                (40px button + 12px * 2 padding + 1px border) */}
-                <Box height="6.5rem" />
               </>
             )}
           </Layouts.Content>


### PR DESCRIPTION
### What does it do?

updates mobile content manager actions drawer to reserve space based on its measured header height instead of fixed spacer values

### Why is it needed?

Custom injected components (e.g. via plugins see videos below) can increase the height of the fixed mobile actions drawer. previously the page reserved a fixed amount of space, causing the drawer to cover fields at the bottom of the entry form and preventing users from scrolling far enough to access them

Without any elements added:

https://github.com/user-attachments/assets/ec00fa69-61b5-4657-b43f-4af05bc329e0

With elements injected using custom plugin:

https://github.com/user-attachments/assets/7bfeecde-8997-4ed0-ad26-457ce57e434b

After this PR:

https://github.com/user-attachments/assets/e60e9b5d-0b0b-4d6c-834a-434a9fc5ec16



### How to test it?

Inject components to the content manager (editView, right-links), open create/edit view of an entry, verify you can scroll all the way down and see all fields on mobile (i did not test the enterprise edition)

### Related issue(s)/PR(s)

none
