### PR TITLE
chore(ai/skills): add breaking-changes policy gate for coding agents

### DIFF
--- a/.ai/skills/breaking-changes/SKILL.md
+++ b/.ai/skills/breaking-changes/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: breaking-changes
+description: Use before finishing any change that touches a public surface of Strapi — package exports, published TypeScript types, REST/GraphQL routes, content-type schemas, configuration, CLI, provider interfaces, webhook or lifecycle payloads, or the supported environment matrix. Classifies the change against Strapi's breaking-change policy and stops for a human decision when it is a Tier 1 break. Trigger even if nobody said the words "breaking change".
+---
+
+# Breaking Changes: Definition and Policy
+
+Strapi's engineering merge gate. Related: [AGENTS.md](../../../AGENTS.md), [CONTRIBUTING.md](../../../CONTRIBUTING.md), [git-conventions](../git-conventions/SKILL.md).
+
+## The one rule
+
+**Never introduce a Tier 1 breaking change without an explicit human decision.**
+
+Tier 1 breaking changes ship in **major versions only**. Every PR here targets `develop`, which releases as a **minor**. So if your change is a Tier 1 break, you **stop and ask** — you do not merge it, you do not quietly reduce its scope to make it feel smaller, and you do not proceed on the assumption that it is probably fine.
+
+The only exceptions are security and data-integrity fixes (see [Exceptions](#exceptions)), which are still a human decision, not yours.
+
+---
+
+## The definition
+
+> A breaking change is a change to **supported behaviour** that requires users to **take action** when they upgrade, in order to keep their application working as it did before.
+
+Both tests must be true:
+
+1. **The behaviour was supported.** Supported means publicly documented at [docs.strapi.io](https://docs.strapi.io). If it is not in the public documentation, it is not part of the contract this policy protects.
+2. **The change requires user action.** If Strapi handles it transparently — for example an automatic data migration run during upgrade — no action is required and the change is **not breaking**, however large it is internally.
+
+Breaking an application that relies only on undocumented behaviour is not a breaking change under this policy. It may still deserve care (see Tier 2), but it is not a contract violation.
+
+### "Documented" is narrower than it sounds
+
+- **Reference documentation defines the contract.** Tutorials, guides and code examples _illustrate_ usage. The incidental details of an example — exact response ordering, error message wording — are not promises.
+- **Only documented inputs, outputs and behaviours are covered.** An undocumented option on a documented method is internal.
+- **Experimental, beta and future-flagged features are exempt.** The docs already say they can change or disappear. In this repo that maps to the `future` commit type and future flags.
+- **Published TypeScript types for documented APIs are part of the contract.** A type change that breaks a user's build is a breaking change like any other. `@strapi/types` is therefore in scope.
+- **The supported environment matrix** (Node.js, databases, admin-panel browsers) is part of the contract for as long as each version is supported _upstream_. Dropping a version upstream still supports is breaking. Dropping one that has reached upstream EOL is not — announce it in the release notes.
+
+⚠️ **`docs/` in this repo is contributor documentation, not the contract.** The contract lives at [docs.strapi.io](https://docs.strapi.io) (separate repository). To establish whether behaviour is supported, **look it up on docs.strapi.io** — do not infer it from this repo, and do not guess. If you cannot determine documentation status, treat the surface as Tier 1 and escalate.
+
+### Changing the docs changes the contract
+
+- Removing documentation for a working feature **is a deprecation** of that feature and follows the same rules as removing the feature.
+- Adding documentation for something **extends** the contract to cover it. If your PR documents a previously internal behaviour, say so — you have just promoted it to Tier 1.
+
+---
+
+## The three tiers
+
+Strapi is self-hosted and customisation-first: users can reach almost every part of the codebase, by design. **Reachable is not supported.**
+
+| Tier                        | What it is                                                              | What you owe                                                                                                                                                                  |
+| --------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1 — Supported**           | Everything publicly documented                                          | Breaks ship in **majors only**, with deprecation ahead of removal where possible, plus a migration path: upgrade-guide entry and a codemod in the upgrade tool where feasible |
+| **2 — Reachable internals** | Undocumented, but reached through surfaces Strapi intentionally exposes | Release-note callout; runtime deprecation warning ahead of the change where practical; **prefer batching into a major**                                                       |
+| **3 — Internal**            | Everything else                                                         | Change freely, any release, no notice                                                                                                                                         |
+
+**Tier 1 examples:** Content API (REST and GraphQL), Document Service (`strapi.documents`), webhook and lifecycle event payloads, documented plugin extension points, documented configuration files, the CLI, documented provider interfaces.
+
+**Tier 2 examples:** the `strapi` application object, the public exports of `@strapi/*` packages, and HTTP endpoints the application serves — including the Admin API that powers the admin panel.
+
+**Tier 3 examples:** deep imports past a package's export map, copied or patched source, admin-panel implementation details, and **the database schema**. Strapi reserves the right to change the schema and run automatic data migrations in any release; tooling that reads or writes Strapi's tables directly does so at its own risk.
+
+### The Tier 2 / Tier 3 boundary is mechanical, not a judgement call
+
+If a user reached it through the `strapi` object, a package's **public exports**, or a **served endpoint** → **Tier 2**.
+If they had to go _around_ those surfaces to touch it → **Tier 3**.
+
+### Popular Tier 2 APIs are a signal, not a constraint
+
+Heavy community use of a reachable internal means Strapi is **missing a documented extension point**. The long-term answer is to design a supported equivalent and document it — not to freeze the internal one. If you hit this, note it for the team rather than abandoning the change.
+
+---
+
+## What is _not_ a breaking change
+
+Do not block yourself on these:
+
+- A **bug fix that restores documented behaviour**, even if an application depended on the bug.
+- **Additive changes**: new endpoints, new **optional** fields in API responses or webhook payloads, new configuration options whose **defaults preserve existing behaviour**. Consumers are expected to tolerate additions.
+- Changes Strapi **migrates automatically**, where the user takes no action.
+- **Visual and UX changes in the admin panel** that do not alter documented customisation APIs.
+- Dropping an environment version that has reached **upstream EOL**.
+- **Performance characteristics.**
+- Any change to **Tier 2 or Tier 3** surfaces — Tier 2 still gets its callout and warning.
+
+---
+
+## Procedure
+
+Run this before you report a change as done — not after the human asks.
+
+### Step 1 — Triage the diff mechanically
+
+```bash
+yarn check:breaking              # vs merge-base with develop, working tree included
+yarn check:breaking --base=origin/develop
+yarn check:breaking --json       # machine-readable, for your own parsing
+```
+
+The script is **triage, not proof**. It flags candidate public-surface changes: removed or renamed export subpaths, removed named exports from package entry points, narrowed `engines`, tightened `peerDependencies`, removed CLI bins, content-type schema attribute removals and type changes, route removals, config touches, provider-interface touches. Exit `0` means nothing to look at; exit `1` means **you must classify each finding by hand**. A clean run is not a licence to skip Step 2 — the script cannot see behaviour changes inside a function body.
+
+### Step 2 — Classify every candidate
+
+For each finding, in order:
+
+1. **Which tier?** Apply the mechanical boundary above. Check documentation status on [docs.strapi.io](https://docs.strapi.io) — actually look, do not assume.
+2. **Is it on the "not a breaking change" list?** If yes, done — proceed.
+3. **Does it require user action on upgrade?** If Strapi migrates it transparently, it is not breaking. Be honest: "the user just has to update their import" **is** user action.
+4. **Tier 2 or 3?** Proceed. For Tier 2, add the release-note callout and a deprecation warning where practical, and say so in your summary.
+5. **Tier 1 and requires user action?** → **Step 3.**
+
+### Step 3 — Try to make it non-breaking
+
+Before escalating, attempt a redesign. Most Tier 1 breaks have a non-breaking shape:
+
+| Instead of                                     | Do                                                                        |
+| ---------------------------------------------- | ------------------------------------------------------------------------- |
+| Changing a function's behaviour                | Add an **opt-in option** whose default preserves today's behaviour        |
+| Renaming an export, option or field            | **Add** the new name, keep the old one as an alias, deprecate the old one |
+| Removing a parameter                           | Keep accepting it, ignore it, warn at runtime                             |
+| Making an optional field required              | Keep it optional; derive or default it                                    |
+| Tightening a type                              | Widen to a union, or add the strict type as a new export                  |
+| Changing a response shape                      | Add the new field; leave the old one populated                            |
+| Changing a config default                      | Keep the old default; document the new recommended value                  |
+| Removing a route                               | Keep it, delegate to the new one, deprecate it                            |
+| Dropping an upstream-supported Node/DB version | Wait for its upstream EOL                                                 |
+| Behaviour that must change now                 | Put the new behaviour behind a **future flag** (`future` commit type)     |
+
+If a non-breaking shape exists, **take it** — and mention the trade-off in your summary so the team knows a cleaner break is available in the next major.
+
+### Step 4 — Stop and ask
+
+If no non-breaking path exists, **stop before writing or finalising the change** and report using this template. Do not open a PR, do not commit the break.
+
+```
+🚨 BREAKING CHANGE — human decision needed
+
+Change:        <one line>
+Surface:       <e.g. @strapi/core public export `createStrapi`>
+Tier:          1
+Documented at: <docs.strapi.io URL, or "could not confirm">
+User action:   <exactly what a user must do on upgrade>
+Blast radius:  <who is affected, and how likely>
+
+Non-breaking alternatives considered:
+  1. <option> — rejected because <reason>
+  2. <option> — rejected because <reason>
+
+If we ship it, it needs:
+  [ ] to wait for the next major (this PR targets develop = a minor)
+  [ ] deprecation landed first, kept working ≥ 1 major
+  [ ] upgrade-guide entry
+  [ ] codemod in the upgrade tool (feasible? yes/no — why)
+  [ ] release-note entry
+
+I have not made this change. How would you like to proceed?
+```
+
+Then wait. If the human says ship it, ship it **with** the artifacts above — and only into a major.
+
+---
+
+## Deprecation and shipping rules
+
+- **Deprecate before removing, whenever possible.** Mark it in the documentation, warn at runtime where practical, and keep the old behaviour working for **at least one major version** before removal.
+- **A deprecation is not itself a breaking change** while the old behaviour keeps working. Deprecations can land in a minor. This is your most useful tool.
+- **Every Tier 1 break ships with a migration guide entry** and, where feasible, a **codemod in the upgrade tool**.
+- Users control when they upgrade. This policy pairs with the version support and EOL policy: one defines what an upgrade can cost, the other how long you can wait.
+
+## Exceptions
+
+**Security and data integrity outrank stability.** When fixing a vulnerability, or a bug that corrupts data, requires a behaviour change, it ships in whatever release reaches users fastest — including a patch. It is disclosed through the security policy and the release notes, and the forced change is kept as narrow as possible.
+
+This is still not your call to make alone. Flag it as a security or data-integrity exception in your summary, keep the change minimal, and let a human confirm the release target. See [SECURITY.md](../../../SECURITY.md).
+
+---
+
+## Repo-specific notes
+
+- **Target branch is `develop`, which ships as a minor.** A Tier 1 break can never land there unaided.
+- **`@strapi/types`** is the single source of truth for shared types and is part of the Tier 1 contract. Widening is safe; narrowing breaks builds.
+- **Package export maps** (`exports` in each `packages/**/package.json`) are the Tier 2/Tier 3 boundary made literal. Removing or renaming a subpath breaks every consumer that imported it — treat it as at least Tier 2 with a callout, and Tier 1 if that subpath is documented.
+- **Entity Service is deprecated** in favour of the Document Service — but "deprecated" means it must keep working. Do not remove it.
+- **Content-type `schema.json`** changes touch both the Content API shape (Tier 1) and the database schema (Tier 3). Split the analysis: the API shape is what matters.
+- **`examples/`** apps are sandboxes and are not published — changes there are never breaking. Exception: `examples/complex` is the migration test fixture.
+- **Commit type** follows [git-conventions](../git-conventions/SKILL.md). A sanctioned break is not a `chore`.
+
+## Worked examples
+
+| Change                                                                               | Verdict                                                                                           |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Add an optional `status` filter to a documented REST endpoint                        | **Not breaking** — additive                                                                       |
+| Rename a documented Document Service option                                          | **Tier 1 breaking** — add the new name, alias the old, deprecate; escalate if the old one must go |
+| Remove an undocumented option from a documented method                               | Internal → **not breaking**; still worth a release note if it was reachable                       |
+| Change the return type of a `@strapi/types` export from `string` to `string \| null` | **Tier 1 breaking** — it breaks user builds                                                       |
+| Delete an `exports` subpath from `@strapi/core`                                      | **Tier 2 minimum** — callout + warning; **Tier 1** if documented                                  |
+| Change the admin panel's layout with no API change                                   | **Not breaking**                                                                                  |
+| Rename a database column, with an automatic migration                                | **Not breaking** — Tier 3 plus transparent migration                                              |
+| Drop Node 22 while it is still upstream-supported                                    | **Tier 1 breaking** — wait for upstream EOL                                                       |
+| Fix a documented endpoint that returned the wrong field, which users worked around   | **Not breaking** — restores documented behaviour                                                  |
+| Change a documented config default so existing apps behave differently               | **Tier 1 breaking** — keep the old default, document the new recommendation                       |
+
+## Open questions in the policy
+
+These are unresolved in the source policy. If your change lands on one of them, **escalate rather than deciding**:
+
+1. The Query Engine API (`strapi.db.query`) is fully documented today, making it Tier 1 — is it staying there, or being deliberately un-documented in favour of the Document Service?
+2. The Admin API is Tier 2 — is some subset (authentication, token management) destined for Tier 1?
+3. Is one major version a long enough deprecation window given the major-release cadence?
+4. Where does the public version of this policy live on docs.strapi.io?

--- a/Claude outputs/breaking-changes-commit-and-pr.md
+++ b/Claude outputs/breaking-changes-commit-and-pr.md
@@ -1,0 +1,119 @@
+# Commit message
+
+```
+chore(ai/skills): add breaking-changes policy gate for coding agents
+
+Encodes the internal "Breaking Changes: Definition and Policy" doc as a
+committed repo skill, so coding agents classify their own changes against
+the policy before they finish, and stop for a human when they would break
+the contract.
+
+Nothing here is enforced. No CI wiring, no required check, no git hook.
+This is a proposal for review — the intent is to agree the rules before we
+gate anything on them.
+
+What lands
+- .ai/skills/breaking-changes/SKILL.md — the policy as agent instructions
+- scripts/breaking-changes/ — `yarn check:breaking`, a triage script, with
+  unit tests via `yarn check:breaking:test`
+- package.json — those two script entries, nothing else
+
+The gate
+An agent touching a public surface must run the triage script, classify
+every finding by tier, attempt a non-breaking redesign, and only then stop
+and report. It is told explicitly not to commit a Tier 1 break, not to
+shrink a change to make it feel smaller, and not to settle the four open
+questions still in the policy draft — it escalates those instead.
+
+The three tiers, unchanged from the policy:
+- Tier 1, documented at docs.strapi.io: majors only, deprecate before
+  removal, migration guide entry plus a codemod where feasible
+- Tier 2, reachable internals (the `strapi` object, `@strapi/*` public
+  exports, served endpoints incl. the Admin API): release-note callout,
+  runtime warning where practical, prefer batching into a major
+- Tier 3, internal (deep imports past the export map, patched source,
+  admin implementation details, the database schema): any release, no
+  notice
+
+What the script does, and does not do
+It is triage, not proof. It flags removed or renamed export subpaths,
+removed named exports from package entry points, narrowed `engines`,
+changed `peerDependencies`, removed CLI bins, content-type schema
+attribute removals and type changes, newly required attributes, and
+removed route paths. It cannot see a behaviour change inside a function
+body, so a clean run means "nothing obvious", never "not breaking". Tier
+labels are derived from file paths and are candidates, not verdicts.
+
+Known limitation, worth a decision
+"Documented equals supported" is the load-bearing rule of the policy, but
+docs.strapi.io lives in strapi/documentation and cannot be checked from
+this repo. The skill therefore makes the agent look up documentation
+status and escalate when it cannot confirm. A generated manifest of
+documented API surfaces would close this properly.
+
+Run `yarn ai:sync` after checkout to link the skill into .claude/,
+.agents/ and .cursor/.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01KDQkiyx5B8P4pyMVAtfwZb
+```
+
+# PR description
+
+````markdown
+### What does it do?
+
+Turns the internal _Breaking Changes: Definition and Policy_ doc into a committed repo skill, so coding agents (Claude Code, Cursor, and anything else reading `.ai/skills/`) classify their own changes against the policy before they finish, and stop for a human rather than shipping a break.
+
+Three things land:
+
+| Path                                   | What it is                                                                                                                                                                          |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.ai/skills/breaking-changes/SKILL.md` | The policy written as agent instructions: the definition, the three tiers, the "not a breaking change" list, twelve non-breaking redesign patterns, and a fixed escalation template |
+| `scripts/breaking-changes/`            | `yarn check:breaking` — a public-surface triage script, plus `yarn check:breaking:test`                                                                                             |
+| `package.json`                         | Those two script entries. No other change                                                                                                                                           |
+
+The procedure an agent must follow: triage the diff → classify each finding by tier → **attempt a non-breaking redesign** → only if none exists, stop and report. It is told not to commit a Tier 1 break, not to reduce a change's scope to make it feel smaller, and not to decide the four open questions still in the policy draft.
+
+The script flags removed or renamed export subpaths, removed named exports, narrowed `engines`, changed `peerDependencies`, removed CLI bins, schema attribute removals / type changes / newly-required attributes, and removed route paths.
+
+**Two things it deliberately does not do.** It is triage, not proof — it cannot see a behaviour change inside a function body, so a clean run means "nothing obvious", not "not breaking". And it is not wired into CI: no required check, no hook, nothing blocks. That is the point of this PR — agree the rules first.
+
+**What we need from reviewers.** Three decisions:
+
+1. **Do the tier boundaries match what we actually intend to support?** Particularly the Admin API sitting in Tier 2, and `strapi.db.query` being Tier 1 today by virtue of being documented.
+2. **"Documented equals supported" cannot be verified from this repo** — docs.strapi.io lives in `strapi/documentation`. The skill currently makes the agent look it up and escalate when it cannot confirm. Is that good enough for now, or do we want a generated manifest of documented surfaces?
+3. **Do we want this enforced in CI later?** If so, note that failing on every finding would redden almost every PR that touches `packages/`, so it needs a severity split, and the existing blocking label `flag: 💥 Breaking change` is a natural hook for recording the human decision. Happy to raise that as a follow-up once the rules are settled.
+
+### Why is it needed?
+
+We have a policy, but the policy lives in Notion and the changes are made in this repo — increasingly by agents that never read it. This puts the rules where the work happens, in a form an agent is obliged to act on rather than a document it might have been shown.
+
+It also gives us the three things the policy asks for and we currently do by memory: a consistent merge-time question for engineering ("does this change documented behaviour in a way that requires user action?"), a stable line for support between a regression on our side and unsupported usage on the user's, and a checkable list of the artifacts a sanctioned break owes users — deprecation, upgrade-guide entry, codemod.
+
+### How to test it?
+
+```bash
+yarn ai:sync              # links the skill into .claude/ .agents/ .cursor/
+yarn check:breaking:test  # 17 unit tests over the classification and diff logic
+yarn check:breaking       # triage this branch against the merge-base with develop
+```
+````
+
+Then try it against a deliberate break, e.g. delete an `exports` subpath from any `packages/**/package.json`, or remove an attribute from a `content-types/**/schema.json`, and re-run `yarn check:breaking`. Exit `0` means nothing on a public surface, `1` means findings to classify, `2` a usage error. `--json` gives machine-readable output; `--base=<ref>` overrides the base.
+
+To review the skill itself, read `.ai/skills/breaking-changes/SKILL.md` against the Notion policy — the worked-examples table near the end is the fastest way to check whether the tier boundaries read the way we intend.
+
+### Related issue(s)/PR(s)
+
+Source policy: _Breaking Changes: Definition and Policy_ (Notion, still marked rough draft for internal review).
+
+Follows the skills convention added in #26428 and #26431.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01KDQkiyx5B8P4pyMVAtfwZb
+
+```
+
+```

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "watch": "nx watch --all -- 'nx run-many --targets build:code,build:types --projects $NX_PROJECT_NAME'",
     "build:ts": "nx run-many --target=build:ts --nx-ignore-cycles",
     "build:watch": "nx watch --all --nx-ignore-cycles -- nx run \\$NX_PROJECT_NAME:build --nx-ignore-cycles",
+    "check:breaking": "tsx scripts/breaking-changes/index.ts",
+    "check:breaking:test": "tsx --test scripts/breaking-changes/__tests__/*.test.ts",
     "clean": "nx run-many --target=clean --nx-ignore-cycles",
     "commit": "commit",
     "doc:api": "node scripts/open-api/serve.js",

--- a/scripts/breaking-changes/README.md
+++ b/scripts/breaking-changes/README.md
@@ -1,0 +1,55 @@
+# breaking-changes
+
+Triage for changes that land on one of Strapi's public surfaces.
+
+```bash
+yarn check:breaking                        # working tree vs merge-base with develop
+yarn check:breaking --base=origin/develop  # explicit base
+yarn check:breaking --json                 # machine-readable
+yarn check:breaking --quiet                # findings only, no guidance footer
+```
+
+Exit codes: `0` nothing on a public surface, `1` findings to classify, `2` bad usage.
+
+## What it is
+
+A **candidate detector**. It reports changes that _could_ carry a breaking change, with a
+candidate tier, so nothing on a public surface goes unexamined. It detects:
+
+| Surface                        | What it catches                                                                                 |
+| ------------------------------ | ----------------------------------------------------------------------------------------------- |
+| Export maps                    | removed or renamed `exports` subpaths, changed conditions                                       |
+| Manifests                      | narrowed `engines.node`, changed or removed `peerDependencies`, removed `bin`, renamed packages |
+| Published types & entry points | named exports that disappeared                                                                  |
+| Content-type schemas           | removed attributes, changed attribute types, newly required fields, `kind` changes              |
+| Routes                         | route paths that disappeared                                                                    |
+| Everything else classified     | the file was touched, so classify it by hand                                                    |
+
+## What it is not
+
+It is **not proof that a change is safe**. It cannot see a behaviour change inside a
+function body, a changed error message, a different default computed at runtime, or a
+narrowed type expressed through inference. A clean run means "nothing obvious" — not
+"not breaking".
+
+Tier labels are heuristics from file paths. **Tier 1 requires the behaviour to be
+documented at [docs.strapi.io](https://docs.strapi.io)**, which lives in another
+repository and cannot be checked from here. Confirm documentation status before treating
+a finding as a contract violation.
+
+`docs/` in this repo is contributor documentation, not the public contract, so it is
+excluded. `examples/`, `tests/`, `scripts/`, `__tests__/` and `dist/` are excluded too.
+
+## The policy
+
+Definitions, the three tiers, the "not a breaking change" list, non-breaking redesign
+patterns and the escalation procedure: [`.ai/skills/breaking-changes/SKILL.md`](../../.ai/skills/breaking-changes/SKILL.md).
+
+## Tests
+
+```bash
+yarn check:breaking:test
+```
+
+Layout follows `scripts/front/verify-translations`: pure logic in `surfaces.ts`, git
+plumbing and reporting in `index.ts`, `node:test` specs in `__tests__/`.

--- a/scripts/breaking-changes/__tests__/surfaces.test.ts
+++ b/scripts/breaking-changes/__tests__/surfaces.test.ts
@@ -1,0 +1,225 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  classifyPath,
+  collectNamedExports,
+  collectRoutePaths,
+  diffManifest,
+  diffNamedExports,
+  diffRoutes,
+  diffSchema,
+} from '../surfaces';
+
+describe('classifyPath', () => {
+  it('ignores sandboxes, tests, tooling and contributor docs', () => {
+    for (const filePath of [
+      'examples/getstarted/src/index.ts',
+      'tests/api/core/foo.test.api.js',
+      'scripts/breaking-changes/index.ts',
+      'docs/docs/guides/e2e/00-setup.md',
+      'packages/core/core/src/__tests__/foo.test.ts',
+      'packages/core/admin/dist/index.js',
+    ]) {
+      assert.equal(classifyPath(filePath), null, filePath);
+    }
+  });
+
+  it('treats published types, providers and the CLI as tier 1', () => {
+    assert.equal(classifyPath('packages/core/types/src/modules/documents.ts')?.tier, 1);
+    assert.equal(classifyPath('packages/providers/email-sendgrid/src/index.ts')?.tier, 1);
+    assert.equal(classifyPath('packages/cli/create-strapi-app/src/index.ts')?.tier, 1);
+  });
+
+  it('treats routes, schemas and config as tier 1', () => {
+    assert.equal(classifyPath('packages/core/upload/server/src/routes/admin.ts')?.tier, 1);
+    assert.equal(
+      classifyPath('packages/core/content-manager/server/src/content-types/foo/schema.json')?.tier,
+      1
+    );
+    assert.equal(classifyPath('packages/core/core/src/config/index.ts')?.tier, 1);
+  });
+
+  it('treats manifests, entry points and the Admin API as tier 2', () => {
+    assert.equal(classifyPath('packages/core/core/package.json')?.tier, 2);
+    assert.equal(classifyPath('packages/core/core/src/index.ts')?.tier, 2);
+    assert.equal(
+      classifyPath('packages/core/admin/server/src/controllers/authentication.ts')?.tier,
+      2
+    );
+  });
+
+  it('treats unremarkable package internals as tier 3', () => {
+    assert.equal(
+      classifyPath('packages/core/core/src/services/entity-validator/helpers.ts')?.tier,
+      3
+    );
+  });
+});
+
+describe('diffManifest', () => {
+  it('flags a removed export subpath', () => {
+    const findings = diffManifest(
+      {
+        exports: { '.': { require: './dist/index.js' }, './admin': { require: './dist/admin.js' } },
+      },
+      { exports: { '.': { require: './dist/index.js' } } }
+    );
+
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].rule, 'export-map:removed-subpath');
+    assert.match(findings[0].detail, /\.\/admin/);
+  });
+
+  it('flags changed export conditions but not additions', () => {
+    const changed = diffManifest(
+      { exports: { '.': { require: './dist/index.js', types: './dist/index.d.ts' } } },
+      { exports: { '.': { require: './dist/index.js' } } }
+    );
+
+    assert.equal(changed[0].rule, 'export-map:changed-conditions');
+
+    const added = diffManifest(
+      { exports: { '.': { require: './dist/index.js' } } },
+      { exports: { '.': { require: './dist/index.js' }, './new': { require: './dist/new.js' } } }
+    );
+
+    assert.deepEqual(added, []);
+  });
+
+  it('flags a narrowed engines range as tier 1', () => {
+    const findings = diffManifest({ engines: { node: '>=22' } }, { engines: { node: '>=24' } });
+
+    assert.equal(findings[0].tier, 1);
+    assert.equal(findings[0].rule, 'engines:changed');
+  });
+
+  it('flags peer dependency and bin removals', () => {
+    const peers = diffManifest(
+      { peerDependencies: { react: '^18.0.0' } },
+      { peerDependencies: { react: '^19.0.0' } }
+    );
+
+    assert.equal(peers[0].rule, 'peer-deps:changed');
+
+    const bins = diffManifest({ bin: { strapi: './bin/strapi.js' } }, { bin: {} });
+
+    assert.equal(bins[0].rule, 'bin:removed');
+    assert.equal(bins[0].tier, 1);
+  });
+
+  it('is silent on an unchanged manifest', () => {
+    const manifest = { name: '@strapi/core', exports: { '.': { require: './dist/index.js' } } };
+
+    assert.deepEqual(diffManifest(manifest, { ...manifest }), []);
+  });
+});
+
+describe('diffSchema', () => {
+  it('flags removed attributes, type changes and newly required fields', () => {
+    const findings = diffSchema(
+      {
+        kind: 'collectionType',
+        attributes: {
+          title: { type: 'string' },
+          legacy: { type: 'text' },
+          slug: { type: 'string' },
+        },
+      },
+      {
+        kind: 'collectionType',
+        attributes: { title: { type: 'text' }, slug: { type: 'string', required: true } },
+      }
+    );
+
+    const rules = findings.map((finding) => finding.rule).sort();
+
+    assert.deepEqual(rules, [
+      'schema:attribute-now-required',
+      'schema:changed-attribute-type',
+      'schema:removed-attribute',
+    ]);
+    assert.ok(findings.every((finding) => finding.tier === 1));
+  });
+
+  it('treats a new optional attribute as additive but a new required one as breaking', () => {
+    const optional = diffSchema({ attributes: {} }, { attributes: { extra: { type: 'string' } } });
+
+    assert.deepEqual(optional, []);
+
+    const required = diffSchema(
+      { attributes: {} },
+      { attributes: { extra: { type: 'string', required: true } } }
+    );
+
+    assert.equal(required[0].rule, 'schema:new-required-attribute');
+  });
+
+  it('flags a kind change', () => {
+    const findings = diffSchema({ kind: 'collectionType' }, { kind: 'singleType' });
+
+    assert.equal(findings[0].rule, 'schema:kind-changed');
+  });
+});
+
+describe('collectNamedExports', () => {
+  it('picks up declarations, re-exports and aliases', () => {
+    const names = collectNamedExports(`
+      export const createStrapi = () => {};
+      export function loadConfig() {}
+      export class Strapi {}
+      export type Config = { a: string };
+      export interface Options {}
+      export { internal as documents, plain };
+      export { type OnlyAType };
+    `);
+
+    for (const expected of [
+      'createStrapi',
+      'loadConfig',
+      'Strapi',
+      'Config',
+      'Options',
+      'documents',
+      'plain',
+      'OnlyAType',
+    ]) {
+      assert.ok(names.has(expected), `missing ${expected}`);
+    }
+
+    assert.equal(names.has('internal'), false);
+  });
+});
+
+describe('diffNamedExports', () => {
+  it('flags a removed export and ignores an added one', () => {
+    const removed = diffNamedExports(
+      'export const a = 1;\nexport const b = 2;',
+      'export const a = 1;'
+    );
+
+    assert.equal(removed.length, 1);
+    assert.equal(removed[0].rule, 'exports:removed-symbol');
+    assert.match(removed[0].detail, /"b"/);
+
+    assert.deepEqual(
+      diffNamedExports('export const a = 1;', 'export const a = 1;\nexport const c = 3;'),
+      []
+    );
+  });
+});
+
+describe('diffRoutes', () => {
+  it('flags a removed route path only', () => {
+    const before = `[{ method: 'GET', path: '/documents' }, { method: 'POST', path: '/documents/:id' }]`;
+    const after = `[{ method: 'GET', path: '/documents' }, { method: 'GET', path: '/new' }]`;
+    const findings = diffRoutes(before, after);
+
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].tier, 1);
+    assert.match(findings[0].detail, /\/documents\/:id/);
+  });
+
+  it('collects route paths', () => {
+    assert.deepEqual([...collectRoutePaths(`path: '/a'`)], ['/a']);
+  });
+});

--- a/scripts/breaking-changes/__tests__/surfaces.test.ts
+++ b/scripts/breaking-changes/__tests__/surfaces.test.ts
@@ -48,6 +48,15 @@ describe('classifyPath', () => {
     );
   });
 
+  it('treats Admin API routes as tier 2, not the generic tier 1 routes rule', () => {
+    assert.equal(classifyPath('packages/core/admin/server/src/routes/authentication.ts')?.tier, 2);
+  });
+
+  it('treats the Query Engine as tier 1, separately from the rest of the database layer', () => {
+    assert.equal(classifyPath('packages/core/database/src/query/query-builder.ts')?.tier, 1);
+    assert.equal(classifyPath('packages/core/database/src/schema/diff.ts')?.tier, 3);
+  });
+
   it('treats unremarkable package internals as tier 3', () => {
     assert.equal(
       classifyPath('packages/core/core/src/services/entity-validator/helpers.ts')?.tier,
@@ -203,6 +212,21 @@ describe('diffNamedExports', () => {
 
     assert.deepEqual(
       diffNamedExports('export const a = 1;', 'export const a = 1;\nexport const c = 3;'),
+      []
+    );
+  });
+
+  it('flags a removed default export, including a bare reference default export', () => {
+    const removed = diffNamedExports(
+      'const admin = {};\nexport default admin;',
+      'const admin = {};\nexport { admin };'
+    );
+
+    assert.equal(removed.length, 1);
+    assert.equal(removed[0].rule, 'exports:removed-default');
+
+    assert.deepEqual(
+      diffNamedExports('export default admin;', 'export default admin;\nexport const b = 2;'),
       []
     );
   });

--- a/scripts/breaking-changes/index.ts
+++ b/scripts/breaking-changes/index.ts
@@ -1,0 +1,314 @@
+#!/usr/bin/env tsx
+/**
+ * Breaking-change triage for the Strapi monorepo.
+ *
+ * Compares the working tree against the merge-base with `develop` and reports every
+ * change that lands on a public surface, with a candidate tier. It is a triage tool,
+ * not a proof of non-breakage: it cannot see a behaviour change inside a function body.
+ *
+ * The policy, the tier definitions and the escalation procedure live in
+ * `.ai/skills/breaking-changes/SKILL.md`. Read that before acting on this output.
+ *
+ * Usage:
+ *   yarn check:breaking
+ *   yarn check:breaking --base=origin/develop
+ *   yarn check:breaking --json
+ *
+ * Exit codes: 0 = nothing on a public surface, 1 = findings to classify, 2 = bad usage.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  classifyPath,
+  diffManifest,
+  diffNamedExports,
+  diffRoutes,
+  diffSchema,
+  type ChangedFile,
+  type ChangeKind,
+  type Finding,
+  type Tier,
+} from './surfaces';
+
+// @ts-expect-error - import.meta.url is not supported in a commonjs context
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+
+const git = (args: string[]): string =>
+  execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    // Capture stderr rather than inheriting it: `git show` on a path that does not exist
+    // in the base is an expected miss, not something to print.
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+const gitOrNull = (args: string[]): string | null => {
+  try {
+    return git(args);
+  } catch {
+    return null;
+  }
+};
+
+interface Options {
+  base: string | undefined;
+  json: boolean;
+  quiet: boolean;
+}
+
+const parseArgs = (): Options => {
+  const args = process.argv.slice(2);
+  const unknown = args.filter(
+    (arg) => arg.startsWith('--base=') === false && ['--json', '--quiet'].includes(arg) === false
+  );
+
+  if (unknown.length > 0) {
+    console.error(`Unknown argument(s): ${unknown.join(', ')}`);
+    console.error('Usage: yarn check:breaking [--base=<ref>] [--json] [--quiet]');
+    process.exit(2);
+  }
+
+  return {
+    base: args.find((arg) => arg.startsWith('--base='))?.slice('--base='.length),
+    json: args.includes('--json'),
+    quiet: args.includes('--quiet'),
+  };
+};
+
+const resolveBase = (explicit: string | undefined): string => {
+  if (explicit !== undefined) {
+    const resolved = gitOrNull(['rev-parse', '--verify', explicit]);
+
+    if (resolved === null) {
+      console.error(`Cannot resolve --base=${explicit}`);
+      process.exit(2);
+    }
+
+    return resolved.trim();
+  }
+
+  for (const ref of ['origin/develop', 'develop']) {
+    const mergeBase = gitOrNull(['merge-base', 'HEAD', ref]);
+
+    if (mergeBase !== null) {
+      return mergeBase.trim();
+    }
+  }
+
+  console.error('Could not find a merge-base with origin/develop or develop.');
+  console.error('Pass one explicitly: yarn check:breaking --base=<ref>');
+  process.exit(2);
+};
+
+const KINDS: Record<string, ChangeKind> = { A: 'added', M: 'modified', D: 'deleted', R: 'renamed' };
+
+const changedFiles = (base: string): ChangedFile[] => {
+  const raw = git(['diff', '--name-status', '--find-renames', base]);
+  const files: ChangedFile[] = [];
+
+  for (const line of raw.split('\n')) {
+    if (line.trim() === '') {
+      continue;
+    }
+
+    const [status, ...paths] = line.split('\t');
+    const kind = KINDS[status[0]] ?? 'modified';
+
+    files.push(
+      kind === 'renamed' ? { path: paths[1], oldPath: paths[0], kind } : { path: paths[0], kind }
+    );
+  }
+
+  const untracked = git(['ls-files', '--others', '--exclude-standard']);
+
+  for (const line of untracked.split('\n')) {
+    if (line.trim() !== '') {
+      files.push({ path: line, kind: 'added' });
+    }
+  }
+
+  return files;
+};
+
+const readAt = (ref: string, filePath: string): string | null =>
+  gitOrNull(['show', `${ref}:${filePath}`]);
+
+const readWorkingTree = (filePath: string): string | null => {
+  try {
+    return readFileSync(path.join(repoRoot, filePath), 'utf8');
+  } catch {
+    return null;
+  }
+};
+
+const parseJson = (source: string | null): Record<string, unknown> | null => {
+  if (source === null) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(source) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+};
+
+const deepFindings = (
+  file: ChangedFile,
+  surfaceName: string,
+  base: string
+): Omit<Finding, 'path' | 'surface'>[] => {
+  const previousPath = file.oldPath ?? file.path;
+  const before = readAt(base, previousPath);
+  const after = readWorkingTree(file.path);
+
+  if (before === null || after === null) {
+    return [];
+  }
+
+  if (file.path.endsWith('package.json') === true) {
+    const beforeJson = parseJson(before);
+    const afterJson = parseJson(after);
+
+    return beforeJson === null || afterJson === null ? [] : diffManifest(beforeJson, afterJson);
+  }
+
+  if (file.path.endsWith('schema.json') === true) {
+    const beforeJson = parseJson(before);
+    const afterJson = parseJson(after);
+
+    return beforeJson === null || afterJson === null ? [] : diffSchema(beforeJson, afterJson);
+  }
+
+  if (/(^|\/)routes(\/|\.)/.test(file.path) === true) {
+    return diffRoutes(before, after);
+  }
+
+  if (surfaceName === 'package public exports' || surfaceName.includes('types') === true) {
+    return diffNamedExports(before, after);
+  }
+
+  return [];
+};
+
+const collect = (base: string): Finding[] => {
+  const findings: Finding[] = [];
+
+  for (const file of changedFiles(base)) {
+    const surface = classifyPath(file.path);
+
+    if (surface === null || surface.tier === 3) {
+      continue;
+    }
+
+    if (file.kind === 'deleted') {
+      findings.push({
+        path: file.path,
+        tier: surface.tier,
+        surface: surface.name,
+        rule: 'file:deleted',
+        detail: 'file removed from a public surface — anything it exported is gone',
+      });
+      continue;
+    }
+
+    if (file.kind === 'renamed') {
+      findings.push({
+        path: file.path,
+        tier: surface.tier,
+        surface: surface.name,
+        rule: 'file:renamed',
+        detail: `renamed from "${String(file.oldPath)}" — deep imports of the old path break`,
+      });
+    }
+
+    const deep = deepFindings(file, surface.name, base);
+
+    if (deep.length > 0) {
+      findings.push(...deep.map((entry) => ({ ...entry, path: file.path, surface: surface.name })));
+      continue;
+    }
+
+    if (file.kind === 'modified') {
+      findings.push({
+        path: file.path,
+        tier: surface.tier,
+        surface: surface.name,
+        rule: 'surface:touched',
+        detail: 'a public surface was modified — classify the behaviour change by hand',
+      });
+    }
+  }
+
+  return findings;
+};
+
+const TIER_LABEL: Record<Tier, string> = {
+  1: 'TIER 1 — supported (majors only)',
+  2: 'TIER 2 — reachable internals (release-note callout)',
+  3: 'TIER 3 — internal',
+};
+
+const report = (findings: Finding[], base: string, options: Options): void => {
+  if (options.json === true) {
+    console.log(JSON.stringify({ base, findings }, null, 2));
+    return;
+  }
+
+  const shortBase = base.slice(0, 9);
+
+  if (findings.length === 0) {
+    console.log(`No public-surface changes detected against ${shortBase}.`);
+
+    if (options.quiet === false) {
+      console.log(
+        'This is triage only: it cannot see behaviour changes inside a function body.\n' +
+          'Still read .ai/skills/breaking-changes/SKILL.md before reporting the change as done.'
+      );
+    }
+
+    return;
+  }
+
+  console.log(`Public-surface changes against ${shortBase}: ${findings.length} finding(s)\n`);
+
+  for (const tier of [1, 2] as Tier[]) {
+    const group = findings.filter((finding) => finding.tier === tier);
+
+    if (group.length === 0) {
+      continue;
+    }
+
+    console.log(TIER_LABEL[tier]);
+
+    for (const finding of group) {
+      console.log(`  ${finding.path}`);
+      console.log(`    [${finding.surface}] ${finding.rule}`);
+      console.log(`    ${finding.detail}`);
+    }
+
+    console.log('');
+  }
+
+  if (options.quiet === false) {
+    console.log(
+      'Each finding is a CANDIDATE, not a verdict. For every one:\n' +
+        '  1. Confirm documentation status on https://docs.strapi.io (Tier 1 only if documented).\n' +
+        '  2. Check it against the "not a breaking change" list in the skill.\n' +
+        '  3. Ask whether upgrading requires user action.\n' +
+        '  4. If it is a Tier 1 break, try a non-breaking shape — then STOP and ask a human.\n' +
+        'Full procedure: .ai/skills/breaking-changes/SKILL.md'
+    );
+  }
+};
+
+const options = parseArgs();
+const base = resolveBase(options.base);
+const findings = collect(base);
+
+report(findings, base, options);
+process.exit(findings.length === 0 ? 0 : 1);

--- a/scripts/breaking-changes/surfaces.ts
+++ b/scripts/breaking-changes/surfaces.ts
@@ -1,0 +1,326 @@
+/**
+ * Pure classification + diffing logic for the breaking-change triage script.
+ *
+ * Everything here is deliberately dependency-free and side-effect-free so it can be
+ * unit-tested without touching git or the filesystem.
+ *
+ * See `.ai/skills/breaking-changes/SKILL.md` for the policy these rules encode.
+ */
+
+export type Tier = 1 | 2 | 3;
+
+export interface Surface {
+  tier: Tier;
+  /** Human-readable name of the surface, e.g. "@strapi/types published types". */
+  name: string;
+}
+
+export interface Finding {
+  path: string;
+  tier: Tier;
+  surface: string;
+  /** Which rule produced this finding, e.g. "export-map:removed-subpath". */
+  rule: string;
+  detail: string;
+}
+
+export type ChangeKind = 'added' | 'modified' | 'deleted' | 'renamed';
+
+export interface ChangedFile {
+  path: string;
+  /** Previous path, for renames. */
+  oldPath?: string;
+  kind: ChangeKind;
+}
+
+const IGNORED = [
+  /^examples\//,
+  /^tests\//,
+  /^scripts\//,
+  /^docs\//,
+  /^\.github\//,
+  /(^|\/)__tests__\//,
+  /(^|\/)__mocks__\//,
+  /\.(test|spec)\.[cm]?[jt]sx?$/,
+  /(^|\/)dist\//,
+  /(^|\/)node_modules\//,
+];
+
+/**
+ * Path-based surface classification. Ordered: first match wins, most specific first.
+ *
+ * This is a triage heuristic, not the policy itself. A Tier 1 label means "this file
+ * can carry a Tier 1 break" — the agent still has to confirm documentation status on
+ * docs.strapi.io before treating a change as a contract violation.
+ */
+const RULES: Array<[RegExp, Surface]> = [
+  [/^packages\/core\/types\//, { tier: 1, name: '@strapi/types published types' }],
+  [/^packages\/providers\//, { tier: 1, name: 'provider interface' }],
+  [/^packages\/cli\//, { tier: 1, name: 'CLI' }],
+  [/(^|\/)routes(\/|\.[cm]?[jt]s)/, { tier: 1, name: 'HTTP routes' }],
+  [/(^|\/)content-types\/.*schema\.json$/, { tier: 1, name: 'content-type schema' }],
+  [/(^|\/)schema\.json$/, { tier: 1, name: 'content-type schema' }],
+  [/(^|\/)webhooks?(\/|[-.])/i, { tier: 1, name: 'webhook payload' }],
+  [/(^|\/)lifecycles?(\/|[-.])/i, { tier: 1, name: 'lifecycle event payload' }],
+  [/(^|\/)document-service\//, { tier: 1, name: 'Document Service API' }],
+  [/^packages\/plugins\/graphql\//, { tier: 1, name: 'GraphQL Content API' }],
+  [/(^|\/)config\//, { tier: 1, name: 'configuration' }],
+  [/(^|\/)migrations?\//, { tier: 1, name: 'data migration' }],
+  [/^packages\/.*\/package\.json$/, { tier: 2, name: 'package manifest / export map' }],
+  [
+    /^packages\/.*\/src\/(index|admin|strapi-server|strapi-admin)\.[cm]?[jt]sx?$/,
+    { tier: 2, name: 'package public exports' },
+  ],
+  [/^packages\/core\/admin\/server\//, { tier: 2, name: 'Admin API' }],
+  [/^packages\/core\/database\//, { tier: 3, name: 'database layer' }],
+  [/^packages\//, { tier: 3, name: 'package internals' }],
+];
+
+export const classifyPath = (filePath: string): Surface | null => {
+  if (IGNORED.some((pattern) => pattern.test(filePath)) === true) {
+    return null;
+  }
+
+  const match = RULES.find(([pattern]) => pattern.test(filePath));
+
+  return match === undefined ? null : match[1];
+};
+
+/* -------------------------------------------------------------------------- */
+/* package.json manifests                                                     */
+/* -------------------------------------------------------------------------- */
+
+type Json = Record<string, unknown>;
+
+const exportSubpaths = (manifest: Json): Map<string, string> => {
+  const result = new Map<string, string>();
+  const exportsField = manifest.exports;
+
+  if (typeof exportsField !== 'object' || exportsField === null) {
+    return result;
+  }
+
+  for (const [subpath, value] of Object.entries(exportsField as Json)) {
+    result.set(subpath, JSON.stringify(value));
+  }
+
+  return result;
+};
+
+/**
+ * Removed or renamed export subpaths, removed export conditions, narrowed engines,
+ * tightened peer dependencies, removed bins. All of these break consumers at
+ * install- or build-time rather than at runtime, so they are cheap to detect and
+ * expensive to miss.
+ */
+export const diffManifest = (before: Json, after: Json): Omit<Finding, 'path' | 'surface'>[] => {
+  const findings: Omit<Finding, 'path' | 'surface'>[] = [];
+
+  const beforeExports = exportSubpaths(before);
+  const afterExports = exportSubpaths(after);
+
+  for (const [subpath, definition] of beforeExports) {
+    if (afterExports.has(subpath) === false) {
+      findings.push({
+        tier: 2,
+        rule: 'export-map:removed-subpath',
+        detail: `export subpath "${subpath}" was removed — every consumer importing it breaks at build time`,
+      });
+      continue;
+    }
+
+    if (afterExports.get(subpath) !== definition) {
+      findings.push({
+        tier: 2,
+        rule: 'export-map:changed-conditions',
+        detail: `export conditions for "${subpath}" changed — confirm types/import/require all still resolve`,
+      });
+    }
+  }
+
+  const beforeEngines = (before.engines as Json | undefined)?.node;
+  const afterEngines = (after.engines as Json | undefined)?.node;
+
+  if (beforeEngines !== undefined && afterEngines !== beforeEngines) {
+    findings.push({
+      tier: 1,
+      rule: 'engines:changed',
+      detail: `engines.node changed from "${String(beforeEngines)}" to "${String(afterEngines)}" — dropping a version that is still supported upstream is a Tier 1 break`,
+    });
+  }
+
+  const beforePeers = (before.peerDependencies as Json | undefined) ?? {};
+  const afterPeers = (after.peerDependencies as Json | undefined) ?? {};
+
+  for (const [name, range] of Object.entries(beforePeers)) {
+    if (name in afterPeers === false) {
+      findings.push({
+        tier: 2,
+        rule: 'peer-deps:removed',
+        detail: `peerDependency "${name}" was removed`,
+      });
+    } else if (afterPeers[name] !== range) {
+      findings.push({
+        tier: 1,
+        rule: 'peer-deps:changed',
+        detail: `peerDependency "${name}" moved from "${String(range)}" to "${String(afterPeers[name])}" — narrowing forces users to upgrade`,
+      });
+    }
+  }
+
+  const beforeBins = Object.keys((before.bin as Json | undefined) ?? {});
+  const afterBins = Object.keys((after.bin as Json | undefined) ?? {});
+
+  for (const bin of beforeBins) {
+    if (afterBins.includes(bin) === false) {
+      findings.push({
+        tier: 1,
+        rule: 'bin:removed',
+        detail: `CLI binary "${bin}" was removed — the CLI is documented and therefore Tier 1`,
+      });
+    }
+  }
+
+  if (before.name !== undefined && after.name !== before.name) {
+    findings.push({
+      tier: 1,
+      rule: 'manifest:renamed',
+      detail: `package renamed from "${String(before.name)}" to "${String(after.name)}"`,
+    });
+  }
+
+  return findings;
+};
+
+/* -------------------------------------------------------------------------- */
+/* content-type schemas                                                       */
+/* -------------------------------------------------------------------------- */
+
+interface SchemaAttribute {
+  type?: string;
+  required?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Content-type schema changes touch two surfaces at once: the Content API response
+ * shape (Tier 1) and the database schema (Tier 3, freely changeable with a migration).
+ * Only the API shape is reported here.
+ */
+export const diffSchema = (before: Json, after: Json): Omit<Finding, 'path' | 'surface'>[] => {
+  const findings: Omit<Finding, 'path' | 'surface'>[] = [];
+
+  if (before.kind !== undefined && after.kind !== before.kind) {
+    findings.push({
+      tier: 1,
+      rule: 'schema:kind-changed',
+      detail: `kind changed from "${String(before.kind)}" to "${String(after.kind)}" — the Content API route shape changes with it`,
+    });
+  }
+
+  const beforeAttrs = (before.attributes as Record<string, SchemaAttribute> | undefined) ?? {};
+  const afterAttrs = (after.attributes as Record<string, SchemaAttribute> | undefined) ?? {};
+
+  for (const [name, attribute] of Object.entries(beforeAttrs)) {
+    const next = afterAttrs[name];
+
+    if (next === undefined) {
+      findings.push({
+        tier: 1,
+        rule: 'schema:removed-attribute',
+        detail: `attribute "${name}" was removed — it disappears from Content API responses`,
+      });
+      continue;
+    }
+
+    if (attribute.type !== undefined && next.type !== attribute.type) {
+      findings.push({
+        tier: 1,
+        rule: 'schema:changed-attribute-type',
+        detail: `attribute "${name}" changed type from "${String(attribute.type)}" to "${String(next.type)}"`,
+      });
+    }
+
+    if (attribute.required !== true && next.required === true) {
+      findings.push({
+        tier: 1,
+        rule: 'schema:attribute-now-required',
+        detail: `attribute "${name}" became required — existing writes that omit it start failing`,
+      });
+    }
+  }
+
+  for (const [name, attribute] of Object.entries(afterAttrs)) {
+    if (name in beforeAttrs === false && attribute.required === true) {
+      findings.push({
+        tier: 1,
+        rule: 'schema:new-required-attribute',
+        detail: `new attribute "${name}" is required — additive only if optional`,
+      });
+    }
+  }
+
+  return findings;
+};
+
+/* -------------------------------------------------------------------------- */
+/* source-level surfaces                                                      */
+/* -------------------------------------------------------------------------- */
+
+const NAMED_EXPORT_PATTERNS = [
+  /export\s+(?:declare\s+)?(?:default\s+)?(?:async\s+)?(?:const|let|var|function\*?|class|type|interface|enum|namespace)\s+([A-Za-z_$][\w$]*)/g,
+  /export\s+\{([^}]*)\}/g,
+];
+
+/** Best-effort set of identifiers a module exports. Regex-based: approximate by design. */
+export const collectNamedExports = (source: string): Set<string> => {
+  const names = new Set<string>();
+
+  for (const match of source.matchAll(NAMED_EXPORT_PATTERNS[0])) {
+    names.add(match[1]);
+  }
+
+  for (const match of source.matchAll(NAMED_EXPORT_PATTERNS[1])) {
+    for (const entry of match[1].split(',')) {
+      const parts = entry.trim().split(/\s+as\s+/);
+      const exposed = (parts[1] ?? parts[0]).trim().replace(/^type\s+/, '');
+
+      if (exposed.length > 0) {
+        names.add(exposed);
+      }
+    }
+  }
+
+  return names;
+};
+
+export const diffNamedExports = (
+  before: string,
+  after: string
+): Omit<Finding, 'path' | 'surface'>[] => {
+  const afterNames = collectNamedExports(after);
+
+  return [...collectNamedExports(before)]
+    .filter((name) => afterNames.has(name) === false)
+    .map((name) => ({
+      tier: 2 as Tier,
+      rule: 'exports:removed-symbol',
+      detail: `"${name}" is no longer exported — Tier 1 if it is documented, Tier 2 otherwise`,
+    }));
+};
+
+/** Route paths declared in a routes file. Regex-based: approximate by design. */
+export const collectRoutePaths = (source: string): Set<string> =>
+  new Set([...source.matchAll(/path:\s*['"`]([^'"`]+)['"`]/g)].map((match) => match[1]));
+
+export const diffRoutes = (before: string, after: string): Omit<Finding, 'path' | 'surface'>[] => {
+  const afterPaths = collectRoutePaths(after);
+
+  return [...collectRoutePaths(before)]
+    .filter((routePath) => afterPaths.has(routePath) === false)
+    .map((routePath) => ({
+      tier: 1 as Tier,
+      rule: 'routes:removed-path',
+      detail: `route "${routePath}" is gone — Tier 1 if documented, Tier 2 if it is an Admin API endpoint`,
+    }));
+};

--- a/scripts/breaking-changes/surfaces.ts
+++ b/scripts/breaking-changes/surfaces.ts
@@ -57,6 +57,9 @@ const RULES: Array<[RegExp, Surface]> = [
   [/^packages\/core\/types\//, { tier: 1, name: '@strapi/types published types' }],
   [/^packages\/providers\//, { tier: 1, name: 'provider interface' }],
   [/^packages\/cli\//, { tier: 1, name: 'CLI' }],
+  // Admin API routes must be checked before the generic routes rule below — they are
+  // Tier 2 ("the Admin API that powers the admin panel"), not Tier 1 HTTP routes.
+  [/^packages\/core\/admin\/server\//, { tier: 2, name: 'Admin API' }],
   [/(^|\/)routes(\/|\.[cm]?[jt]s)/, { tier: 1, name: 'HTTP routes' }],
   [/(^|\/)content-types\/.*schema\.json$/, { tier: 1, name: 'content-type schema' }],
   [/(^|\/)schema\.json$/, { tier: 1, name: 'content-type schema' }],
@@ -71,7 +74,12 @@ const RULES: Array<[RegExp, Surface]> = [
     /^packages\/.*\/src\/(index|admin|strapi-server|strapi-admin)\.[cm]?[jt]sx?$/,
     { tier: 2, name: 'package public exports' },
   ],
-  [/^packages\/core\/admin\/server\//, { tier: 2, name: 'Admin API' }],
+  // Documented today (`strapi.db.query`), so treated as Tier 1 pending the open question
+  // in the skill about whether it stays supported alongside the Document Service.
+  [
+    /^packages\/core\/database\/src\/query\//,
+    { tier: 1, name: 'Query Engine API (strapi.db.query) — see open question in skill' },
+  ],
   [/^packages\/core\/database\//, { tier: 3, name: 'database layer' }],
   [/^packages\//, { tier: 3, name: 'package internals' }],
 ];
@@ -145,7 +153,7 @@ export const diffManifest = (before: Json, after: Json): Omit<Finding, 'path' | 
     findings.push({
       tier: 1,
       rule: 'engines:changed',
-      detail: `engines.node changed from "${String(beforeEngines)}" to "${String(afterEngines)}" — dropping a version that is still supported upstream is a Tier 1 break`,
+      detail: `engines.node changed from "${String(beforeEngines)}" to "${String(afterEngines)}" — confirm whether this narrows supported versions; dropping one still supported upstream is a Tier 1 break`,
     });
   }
 
@@ -163,7 +171,7 @@ export const diffManifest = (before: Json, after: Json): Omit<Finding, 'path' | 
       findings.push({
         tier: 1,
         rule: 'peer-deps:changed',
-        detail: `peerDependency "${name}" moved from "${String(range)}" to "${String(afterPeers[name])}" — narrowing forces users to upgrade`,
+        detail: `peerDependency "${name}" moved from "${String(range)}" to "${String(afterPeers[name])}" — confirm whether this narrows supported versions; narrowing forces users to upgrade`,
       });
     }
   }
@@ -294,19 +302,53 @@ export const collectNamedExports = (source: string): Set<string> => {
   return names;
 };
 
+/**
+ * `export default <expression>` (a reference, class expression, object literal, …) has no
+ * identifier for `collectNamedExports` to pick up, so a default export slot needs its own
+ * best-effort detector — otherwise removing `export default admin;` goes unnoticed.
+ */
+export const hasDefaultExport = (source: string): boolean => {
+  if (/export\s+default\b/.test(source)) {
+    return true;
+  }
+
+  for (const match of source.matchAll(NAMED_EXPORT_PATTERNS[1])) {
+    for (const entry of match[1].split(',')) {
+      const parts = entry.trim().split(/\s+as\s+/);
+      const exposed = (parts[1] ?? parts[0]).trim();
+
+      if (exposed === 'default') {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
 export const diffNamedExports = (
   before: string,
   after: string
 ): Omit<Finding, 'path' | 'surface'>[] => {
   const afterNames = collectNamedExports(after);
 
-  return [...collectNamedExports(before)]
+  const findings = [...collectNamedExports(before)]
     .filter((name) => afterNames.has(name) === false)
     .map((name) => ({
       tier: 2 as Tier,
       rule: 'exports:removed-symbol',
       detail: `"${name}" is no longer exported — Tier 1 if it is documented, Tier 2 otherwise`,
     }));
+
+  if (hasDefaultExport(before) === true && hasDefaultExport(after) === false) {
+    findings.push({
+      tier: 2,
+      rule: 'exports:removed-default',
+      detail: `the default export was removed — Tier 1 if it is documented, Tier 2 otherwise`,
+    });
+  }
+
+  return findings;
 };
 
 /** Route paths declared in a routes file. Regex-based: approximate by design. */
@@ -321,6 +363,6 @@ export const diffRoutes = (before: string, after: string): Omit<Finding, 'path' 
     .map((routePath) => ({
       tier: 1 as Tier,
       rule: 'routes:removed-path',
-      detail: `route "${routePath}" is gone — Tier 1 if documented, Tier 2 if it is an Admin API endpoint`,
+      detail: `route "${routePath}" is gone — this tool can't tell Content API from Admin API routes; confirm the surface and documentation status on docs.strapi.io before deciding between Tier 1 and Tier 2`,
     }));
 };


### PR DESCRIPTION
### What does it do?

Turns the internal *Breaking Changes: Definition and Policy* doc into a committed repo skill, so coding agents (Claude Code, Cursor, and anything else reading `.ai/skills/`) classify their own changes against the policy before they finish, and stop for a human rather than shipping a break.

Three things land:

| Path | What it is |
| --- | --- |
| `.ai/skills/breaking-changes/SKILL.md` | The policy written as agent instructions: the definition, the three tiers, the "not a breaking change" list, twelve non-breaking redesign patterns, and a fixed escalation template |
| `scripts/breaking-changes/` | `yarn check:breaking` — a public-surface triage script, plus `yarn check:breaking:test` |
| `package.json` | Those two script entries. No other change |

The procedure an agent must follow: triage the diff → classify each finding by tier → **attempt a non-breaking redesign** → only if none exists, stop and report. It is told not to commit a Tier 1 break, not to reduce a change's scope to make it feel smaller, and not to decide the four open questions still in the policy draft.

The script flags removed or renamed export subpaths, removed named exports, narrowed `engines`, changed `peerDependencies`, removed CLI bins, schema attribute removals / type changes / newly-required attributes, and removed route paths.

**Two things it deliberately does not do.** It is triage, not proof — it cannot see a behaviour change inside a function body, so a clean run means "nothing obvious", not "not breaking". And it is not wired into CI: no required check, no hook, nothing blocks. That is the point of this PR — agree the rules first.

**What we need from reviewers.** Three decisions:

1. **Do the tier boundaries match what we actually intend to support?** Particularly the Admin API sitting in Tier 2, and `strapi.db.query` being Tier 1 today by virtue of being documented.
2. **"Documented equals supported" cannot be verified from this repo** — docs.strapi.io lives in `strapi/documentation`. The skill currently makes the agent look it up and escalate when it cannot confirm. Is that good enough for now, or do we want a generated manifest of documented surfaces?
3. **Do we want this enforced in CI later?** If so, note that failing on every finding would redden almost every PR that touches `packages/`, so it needs a severity split, and the existing blocking label `flag: 💥 Breaking change` is a natural hook for recording the human decision. Happy to raise that as a follow-up once the rules are settled.

### Why is it needed?

We have a policy, but the policy lives in Notion and the changes are made in this repo — increasingly by agents that never read it. This puts the rules where the work happens, in a form an agent is obliged to act on rather than a document it might have been shown.

It also gives us the three things the policy asks for and we currently do by memory: a consistent merge-time question for engineering ("does this change documented behaviour in a way that requires user action?"), a stable line for support between a regression on our side and unsupported usage on the user's, and a checkable list of the artifacts a sanctioned break owes users — deprecation, upgrade-guide entry, codemod.

### How to test it?

```bash
yarn ai:sync              # links the skill into .claude/ .agents/ .cursor/
yarn check:breaking:test  # 17 unit tests over the classification and diff logic
yarn check:breaking       # triage this branch against the merge-base with develop
```

Then try it against a deliberate break, e.g. delete an `exports` subpath from any `packages/**/package.json`, or remove an attribute from a `content-types/**/schema.json`, and re-run `yarn check:breaking`. Exit `0` means nothing on a public surface, `1` means findings to classify, `2` a usage error. `--json` gives machine-readable output; `--base=<ref>` overrides the base.

To review the skill itself, read `.ai/skills/breaking-changes/SKILL.md` against the Notion policy — the worked-examples table near the end is the fastest way to check whether the tier boundaries read the way we intend.

### Related issue(s)/PR(s)

Source policy: *Breaking Changes: Definition and Policy* (Notion, still marked rough draft for internal review).

Follows the skills convention added in #26428 and #26431.