### PR TITLE
fix(graphql): enum values named true prevent server from starting

### DIFF
--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/types.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/types.test.ts
@@ -369,6 +369,48 @@ describe('Type validators', () => {
     });
   });
 
+  describe('enumeration type', () => {
+    /**
+     * GraphQL forbids enum *names* `true` / `false` / `null`, but Strapi stores them as strings.
+     * The GraphQL plugin maps the identifier; schema validation must still allow the values.
+     * See strapi/strapi#23720.
+     */
+    test.each(['true', 'false', 'null'])(
+      'allows GraphQL reserved enum value %s as a string',
+      (value) => {
+        const attributes = {
+          status: {
+            type: 'enumeration',
+            enum: [value],
+          },
+        } satisfies Struct.SchemaAttributes;
+
+        const validator = getTypeValidator(attributes.status, {
+          types: ['enumeration'],
+          attributes,
+        });
+
+        expect(validator.isValidSync(attributes.status)).toBe(true);
+      }
+    );
+
+    test('allows mixed enum arrays that include a GraphQL reserved value', () => {
+      const attributes = {
+        status: {
+          type: 'enumeration',
+          enum: ['draft', 'true', 'false'],
+        },
+      } satisfies Struct.SchemaAttributes;
+
+      const validator = getTypeValidator(attributes.status, {
+        types: ['enumeration'],
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.status)).toBe(true);
+    });
+  });
+
   describe('media type', () => {
     test('Validates allowedTypes', () => {
       // @ts-expect-error - Silence the cast as Struct.SchemaAttributes since allowedTypes expects one of 'audios',

--- a/packages/plugins/graphql/server/src/services/builders/__tests__/enums.test.ts
+++ b/packages/plugins/graphql/server/src/services/builders/__tests__/enums.test.ts
@@ -1,0 +1,85 @@
+import { GraphQLEnumType } from 'graphql';
+import { makeSchema, objectType } from 'nexus';
+
+import createEnumBuilders from '../enums';
+
+const { buildEnumTypeDefinition } = createEnumBuilders();
+
+const membersOf = (definition: ReturnType<typeof buildEnumTypeDefinition>) =>
+  (definition as unknown as { config: { members: Record<string, string> } }).config.members;
+
+const graphqlEnumFrom = (name: string, members: string[]) => {
+  const definition = buildEnumTypeDefinition({ enum: members }, name);
+
+  return new GraphQLEnumType({
+    name,
+    values: Object.fromEntries(
+      Object.entries(membersOf(definition)).map(([graphqlName, value]) => [graphqlName, { value }])
+    ),
+  });
+};
+
+describe('buildEnumTypeDefinition', () => {
+  it.each(['true', 'false', 'null'])(
+    'maps GraphQL reserved enum name %s to a valid identifier while keeping the string value',
+    (value) => {
+      const graphqlEnum = graphqlEnumFrom('StatusEnum', [value]);
+
+      expect(graphqlEnum.getValue(`_${value}`)?.value).toBe(value);
+      expect(graphqlEnum.serialize(value)).toBe(`_${value}`);
+      expect(graphqlEnum.parseValue(`_${value}`)).toBe(value);
+    }
+  );
+
+  it('builds a GraphQL schema when an enumeration includes reserved names', () => {
+    const definition = buildEnumTypeDefinition(
+      { enum: ['true', 'false', 'null', 'draft'] },
+      'StatusEnum'
+    );
+
+    expect(() =>
+      makeSchema({
+        types: [
+          definition,
+          objectType({
+            name: 'Query',
+            definition(t) {
+              t.field('status', { type: 'StatusEnum' });
+            },
+          }),
+        ],
+        outputs: false,
+      })
+    ).not.toThrow();
+  });
+
+  it('does not rewrite names that are already valid GraphQL enum identifiers', () => {
+    const graphqlEnum = graphqlEnumFrom('StatusEnum', [
+      'draft',
+      'True',
+      'FALSE',
+      'Null',
+      'yes',
+      'no',
+      'on',
+      'off',
+    ]);
+
+    expect(graphqlEnum.serialize('draft')).toBe('draft');
+    expect(graphqlEnum.serialize('True')).toBe('True');
+    expect(graphqlEnum.serialize('FALSE')).toBe('FALSE');
+    expect(graphqlEnum.serialize('Null')).toBe('Null');
+    expect(graphqlEnum.serialize('yes')).toBe('yes');
+    expect(graphqlEnum.serialize('no')).toBe('no');
+    expect(graphqlEnum.serialize('on')).toBe('on');
+    expect(graphqlEnum.serialize('off')).toBe('off');
+  });
+
+  it('coerces boolean and null JSON values to the same string members as their literals', () => {
+    const graphqlEnum = graphqlEnumFrom('FlagEnum', [true, false, null] as unknown as string[]);
+
+    expect(graphqlEnum.serialize('true')).toBe('_true');
+    expect(graphqlEnum.serialize('false')).toBe('_false');
+    expect(graphqlEnum.serialize('null')).toBe('_null');
+  });
+});

--- a/packages/plugins/graphql/server/src/services/builders/enums.ts
+++ b/packages/plugins/graphql/server/src/services/builders/enums.ts
@@ -1,10 +1,25 @@
 import { enumType } from 'nexus';
-import { set } from 'lodash/fp';
 import { strings } from '@strapi/utils';
 
 interface Definition {
   enum: string[];
 }
+
+/**
+ * GraphQL forbids enum *names* that collide with language literals (`true`, `false`, `null`).
+ * Strapi stores those as ordinary strings (and JSON/YAML may coerce them to booleans/null).
+ * Keep the original string as the runtime value and only rename the GraphQL identifier.
+ *
+ * @see https://spec.graphql.org/October2021/#sec-Enum-Value
+ * @see https://github.com/strapi/strapi/issues/23720
+ */
+const GRAPHQL_RESERVED_ENUM_NAMES = new Set(['true', 'false', 'null']);
+
+const toGraphQLEnumName = (value: string) => {
+  const name = strings.toRegressedEnumValue(value);
+
+  return GRAPHQL_RESERVED_ENUM_NAMES.has(name) ? `_${name}` : name;
+};
 
 /**
  * Build a Nexus enum type from a Strapi enum attribute
@@ -16,10 +31,11 @@ interface Definition {
 const buildEnumTypeDefinition = (definition: Definition, name: string) => {
   return enumType({
     name,
-    members: definition.enum.reduce(
-      (acc, value) => set(strings.toRegressedEnumValue(value), value, acc),
-      {}
-    ),
+    members: definition.enum.reduce<Record<string, string>>((acc, value) => {
+      const original = String(value);
+      acc[toGraphQLEnumName(original)] = original;
+      return acc;
+    }, {}),
   });
 };
 


### PR DESCRIPTION
### What does it do?

When building GraphQL enum types from Strapi enumeration attributes, map the reserved GraphQL identifiers `true`, `false`, and `null` to `_true`, `_false`, and `_null`. The stored/runtime value stays the original string.

Content-type builder and schema validation still allow those string values.

### Why is it needed?

The CTB (and `GRAPHQL_ENUM_REGEX`) accept `"true"` / `"false"` / `"null"` because they match `/[_A-Za-z][_0-9A-Za-z]*/`. `graphql-js` then throws `Enum values cannot be named: true` during schema construction and the server never comes back up.

Fixing this in the GraphQL builder matches the preferred behaviour from #23720: treat them as string values and allow the schema to load. Rejecting them in the CTB would not recover an already-saved schema.

### How to test it?

- Unit: `yarn workspace @strapi/plugin-graphql test:unit`
- Unit: `yarn workspace @strapi/content-type-builder test:unit server/src/controllers/validation/__tests__/types.test.ts`
- Manual: enable the GraphQL plugin, create an enumeration field with values `true` and `false`, save, confirm the server restarts. GraphQL SDL should expose `_true` / `_false`; REST should still return `"true"` / `"false"`. GraphQL filters on enumerations remain `String` and should keep using `"true"`.

### Related issue(s)/PR(s)

Fix #23720

Supersedes the approach in #27010 (reject reserved values in the CTB).
