### PR TITLE
fix(content-type-builder): experimental indexes removed when saving a content type

### DIFF
--- a/packages/core/content-type-builder/server/src/services/schema-builder/__tests__/schema-handler.vitest.test.ts
+++ b/packages/core/content-type-builder/server/src/services/schema-builder/__tests__/schema-handler.vitest.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fse from 'fs-extra';
+
+import createSchemaHandler from '../schema-handler';
+
+vi.mock('fs-extra', () => ({
+  default: {
+    ensureFile: vi.fn(() => Promise.resolve()),
+    writeJSON: vi.fn(() => Promise.resolve()),
+    remove: vi.fn(() => Promise.resolve()),
+    readdir: vi.fn(() => Promise.resolve([])),
+  },
+}));
+
+const indexes = [{ name: 'tests_slug_custom_idx', columns: ['slug'], type: null }];
+const foreignKeys = [{ name: 'tests_author_fk', columns: ['author_id'] }];
+
+const createTestHandler = (schemaOverrides: Record<string, unknown> = {}) =>
+  createSchemaHandler({
+    uid: 'api::test.test',
+    dir: '/tmp/api/test/content-types/test',
+    filename: 'schema.json',
+    schema: {
+      kind: 'collectionType',
+      collectionName: 'tests',
+      info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
+      options: { draftAndPublish: true },
+      pluginOptions: {},
+      attributes: {
+        test: { type: 'string' },
+        slug: { type: 'uid', targetField: 'test' },
+      },
+      ...schemaOverrides,
+    } as any,
+  });
+
+describe('schema-handler flush', () => {
+  beforeEach(() => {
+    vi.mocked(fse.ensureFile).mockClear();
+    vi.mocked(fse.writeJSON).mockClear();
+  });
+
+  it('writes experimental indexes and foreignKeys when saving an unrelated change', async () => {
+    const handler = createTestHandler({ indexes, foreignKeys });
+
+    handler.setAttribute('extra', { type: 'string' });
+    await handler.flush();
+
+    expect(fse.writeJSON).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fse.writeJSON).mock.calls[0][1]).toMatchObject({
+      collectionName: 'tests',
+      attributes: expect.objectContaining({ extra: { type: 'string' } }),
+      indexes,
+      foreignKeys,
+    });
+  });
+
+  it('does not invent indexes or foreignKeys when the schema has none', async () => {
+    const handler = createTestHandler();
+
+    handler.setAttribute('extra', { type: 'string' });
+    await handler.flush();
+
+    const written = vi.mocked(fse.writeJSON).mock.calls[0][1] as Record<string, unknown>;
+
+    expect(written.indexes).toBeUndefined();
+    expect(written.foreignKeys).toBeUndefined();
+  });
+});

--- a/packages/core/content-type-builder/server/src/services/schema-builder/schema-handler.ts
+++ b/packages/core/content-type-builder/server/src/services/schema-builder/schema-handler.ts
@@ -262,6 +262,8 @@ export default function createSchemaHandler(infos: Infos) {
             pluginOptions: state.schema.pluginOptions,
             attributes: state.schema.attributes,
             config: (state.schema as any).config,
+            indexes: (state.schema as Struct.ContentTypeSchema).indexes,
+            foreignKeys: (state.schema as Struct.ContentTypeSchema).foreignKeys,
           },
           { spaces: 2 }
         );

--- a/packages/core/core/src/domain/content-type/__tests__/validator.test.ts
+++ b/packages/core/core/src/domain/content-type/__tests__/validator.test.ts
@@ -100,3 +100,35 @@ describe('createContentType - draft and publish reserved attribute names', () =>
     expect(strapi.log.warn).not.toHaveBeenCalled();
   });
 });
+
+describe('createContentType - experimental schema keys', () => {
+  beforeEach(() => {
+    global.strapi = {
+      log: {
+        warn: jest.fn(),
+      },
+      config: {
+        get: jest.fn().mockReturnValue(false),
+      },
+    } as any;
+  });
+
+  it('keeps indexes and foreignKeys on __schema__ so the content-type builder can write them back', () => {
+    const indexes = [{ name: 'articles_slug_idx', columns: ['slug'] }];
+    const foreignKeys = [{ name: 'articles_author_fk', columns: ['author_id'] }];
+
+    const result = createContentType('api::article.article', {
+      schema: {
+        ...baseSchema,
+        collectionName: 'articles',
+        indexes,
+        foreignKeys,
+      } as any,
+      actions: {},
+      lifecycles: {},
+    }) as { __schema__: { indexes?: unknown; foreignKeys?: unknown } };
+
+    expect(result.__schema__.indexes).toEqual(indexes);
+    expect(result.__schema__.foreignKeys).toEqual(foreignKeys);
+  });
+});

--- a/packages/core/core/src/domain/content-type/index.ts
+++ b/packages/core/core/src/domain/content-type/index.ts
@@ -161,6 +161,8 @@ const pickSchema = (model: Schema.ContentType) => {
       'pluginOptions',
       'attributes',
       'kind',
+      'indexes',
+      'foreignKeys',
     ])
   );
 


### PR DESCRIPTION
### What does it do?

Keep experimental `indexes` and `foreignKeys` from `schema.json` when the Content-Type Builder saves.

`pickSchema` now copies those keys onto `__schema__` (the object the builder loads). `schema-handler` `flush()` writes them back with the rest of the file. `undefined` values are omitted by `writeJSON`, so content types without those keys are unchanged.

### Why is it needed?

Saving any unrelated change in the Content-Type Builder rewrote `schema.json` from a whitelist that omitted `indexes` / `foreignKeys`. User-defined experimental indexes disappeared. That is issue #22636.

### How to test it?

1. Create a collection type, then add an `indexes` array to its `schema.json` (see #22636).
2. Restart, open the Content-Type Builder, add an unrelated field, save.
3. Confirm `indexes` is still in `schema.json`.
4. Confirm a content type with no `indexes` still writes a schema without those keys.

Unit tests: `@strapi/core` `src/domain/content-type/__tests__/validator.test.ts`; `@strapi/content-type-builder` `server/src/services/schema-builder/__tests__/schema-handler.vitest.test.ts`.

### Related issue(s)/PR(s)

Fix #22636

Related (not fixed here): #21753 (`options.populateCreatorFields` is a different merge path).
