### PR TITLE
fix(content-manager): cannot re-assign a relation still present on the published version

### DIFF
--- a/packages/core/content-manager/server/src/controllers/__tests__/relations-find-available.test.ts
+++ b/packages/core/content-manager/server/src/controllers/__tests__/relations-find-available.test.ts
@@ -1,0 +1,139 @@
+// @ts-expect-error - types are not generated for this file
+// eslint-disable-next-line import/no-relative-packages
+import createContext from '../../../../../../../tests/helpers/create-context';
+import relations from '../relations';
+
+const SHOP_UID = 'api::shop.shop';
+const TAG_UID = 'api::tag.tag';
+
+const shopModel = {
+  uid: SHOP_UID,
+  modelType: 'contentType',
+  options: { draftAndPublish: true },
+  attributes: {
+    tags: { type: 'relation', target: TAG_UID },
+  },
+};
+
+const tagModel = {
+  uid: TAG_UID,
+  modelType: 'contentType',
+  options: { draftAndPublish: false },
+  attributes: {
+    name: { type: 'string' },
+  },
+};
+
+const createQueryBuilder = () => {
+  const qb: Record<string, any> = {};
+  qb.getAlias = jest.fn(() => 't1');
+  qb.where = jest.fn(() => qb);
+  qb.join = jest.fn(() => qb);
+  qb.select = jest.fn(() => qb);
+  qb.getKnexQuery = jest.fn(() => 'SUBQUERY');
+  return qb;
+};
+
+const setupStrapi = (queryBuilder: ReturnType<typeof createQueryBuilder>) => {
+  global.strapi = {
+    getModel: jest.fn((uid: string) => {
+      if (uid === SHOP_UID) {
+        return shopModel;
+      }
+      if (uid === TAG_UID) {
+        return tagModel;
+      }
+      return null;
+    }),
+    plugins: {
+      i18n: {
+        services: {
+          'content-types': {
+            isLocalizedContentType: jest.fn(() => false),
+          },
+        },
+      },
+      'content-manager': {
+        services: {
+          'permission-checker': {
+            create: jest.fn().mockReturnValue({
+              can: { read: jest.fn().mockReturnValue(true) },
+              cannot: { read: jest.fn().mockReturnValue(false) },
+              sanitizedQuery: { read: jest.fn().mockResolvedValue({}) },
+            }),
+          },
+          'populate-builder': () => ({
+            populateFromQuery: jest.fn().mockReturnThis(),
+            build: jest.fn().mockResolvedValue({}),
+          }),
+          'content-types': {
+            findConfiguration: jest.fn().mockResolvedValue({
+              metadatas: {
+                tags: {
+                  edit: {
+                    mainField: 'name',
+                  },
+                },
+              },
+            }),
+          },
+        },
+      },
+    },
+    db: {
+      query: jest.fn().mockReturnValue({
+        findOne: jest.fn().mockResolvedValue({ id: 10 }),
+        findPage: jest.fn().mockResolvedValue({ results: [], pagination: {} }),
+      }),
+      queryBuilder: jest.fn(() => queryBuilder),
+    },
+    get: jest.fn((name: string) => {
+      if (name === 'query-params') {
+        return { transform: jest.fn((_uid: string, params: unknown) => params) };
+      }
+      return undefined;
+    }),
+  } as any;
+};
+
+const createCtx = (query: Record<string, unknown>) => {
+  return createContext(
+    {
+      params: { model: SHOP_UID, targetField: 'tags' },
+      query,
+    },
+    { state: { userAbility: {} } }
+  );
+};
+
+describe('findAvailable source-row status filter', () => {
+  let queryBuilder: ReturnType<typeof createQueryBuilder>;
+
+  beforeEach(() => {
+    queryBuilder = createQueryBuilder();
+    setupStrapi(queryBuilder);
+  });
+
+  test('draft exclusion only matches the draft source row (issue #23743)', async () => {
+    await relations.findAvailable(createCtx({ id: 'shop-doc', status: 'draft' }));
+
+    expect(queryBuilder.where).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document_id: 'shop-doc',
+        published_at: { $null: true },
+      })
+    );
+    expect(queryBuilder.where.mock.calls[0][0]['t1.published_at']).toBeUndefined();
+  });
+
+  test('published exclusion only matches the published source row', async () => {
+    await relations.findAvailable(createCtx({ id: 'shop-doc', status: 'published' }));
+
+    expect(queryBuilder.where).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document_id: 'shop-doc',
+        published_at: { $notNull: true },
+      })
+    );
+  });
+});

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -352,6 +352,11 @@ export default {
        */
       if (sourceModelType === 'contentType') {
         where.document_id = id;
+
+        const sourcePublishedAt = getPublishedAtClause(status, sourceUid);
+        if (!isEmpty(sourcePublishedAt)) {
+          where.published_at = sourcePublishedAt;
+        }
       } else {
         where.id = id;
       }

--- a/tests/api/core/content-manager/api/relations-available-status.test.api.ts
+++ b/tests/api/core/content-manager/api/relations-available-status.test.api.ts
@@ -10,6 +10,7 @@ import { createAuthRequest } from 'api-tests/request';
  */
 const UID_PRODUCT = 'api::product.product';
 const UID_SHOP = 'api::shop.shop';
+const UID_TAG = 'api::tag.tag';
 
 const productModel = {
   attributes: {
@@ -35,11 +36,31 @@ const shopModel = {
       relation: 'oneToMany',
       target: UID_PRODUCT,
     },
+    tags_mm: {
+      type: 'relation',
+      relation: 'manyToMany',
+      target: UID_TAG,
+      targetAttribute: 'shops',
+    },
   },
   draftAndPublish: true,
   displayName: 'Shop',
   singularName: 'shop',
   pluralName: 'shops',
+  description: '',
+  collectionName: '',
+};
+
+const tagModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  draftAndPublish: false,
+  displayName: 'Tag',
+  singularName: 'tag',
+  pluralName: 'tags',
   description: '',
   collectionName: '',
 };
@@ -88,11 +109,26 @@ describe('CM API - Relations findAvailable status labels', () => {
     return res.body.data;
   };
 
-  const findAvailable = async (id: string, query: Record<string, any> = {}) => {
+  const findAvailable = async (
+    id: string,
+    query: Record<string, any> = {},
+    field = 'products_mw'
+  ) => {
     const res = await rq({
       method: 'GET',
-      url: `/content-manager/relations/${UID_SHOP}/products_mw`,
+      url: `/content-manager/relations/${UID_SHOP}/${field}`,
       qs: { id, pageSize: 50, ...query },
+    });
+
+    expect(res.statusCode).toBe(200);
+    return res.body;
+  };
+
+  const findExisting = async (id: string, query: Record<string, any> = {}, field = 'tags_mm') => {
+    const res = await rq({
+      method: 'GET',
+      url: `/content-manager/relations/${UID_SHOP}/${id}/${field}`,
+      qs: { pageSize: 50, ...query },
     });
 
     expect(res.statusCode).toBe(200);
@@ -113,7 +149,7 @@ describe('CM API - Relations findAvailable status labels', () => {
   };
 
   beforeAll(async () => {
-    await builder.addContentTypes([productModel, shopModel]).build();
+    await builder.addContentTypes([productModel, tagModel, shopModel]).build();
 
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
@@ -159,5 +195,62 @@ describe('CM API - Relations findAvailable status labels', () => {
   test('status=draft — no duplicates, correct status badges', async () => {
     const body = await findAvailable(shopDocId, { status: 'draft' });
     expectNoDuplicatesAndCorrectBadges(body);
+  });
+
+  test('draft can re-add a many-to-many relation still present on the published version', async () => {
+    const tagRes = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${UID_TAG}`,
+      body: { name: 'PageTag' },
+    });
+    expect(tagRes.statusCode).toBe(201);
+    const tagDocumentId = tagRes.body.data.documentId;
+
+    const shopRes = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${UID_SHOP}`,
+      body: { name: 'TaggedShop', tags_mm: [tagDocumentId] },
+    });
+    expect(shopRes.statusCode).toBe(201);
+    const taggedShopDocId = shopRes.body.data.documentId;
+
+    const publishRes = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${UID_SHOP}/${taggedShopDocId}/actions/publish`,
+    });
+    expect(publishRes.statusCode).toBe(200);
+
+    const availableWhileConnected = await findAvailable(
+      taggedShopDocId,
+      { status: 'draft' },
+      'tags_mm'
+    );
+    expect(availableWhileConnected.results.map((r: any) => r.documentId)).not.toContain(
+      tagDocumentId
+    );
+
+    const disconnectRes = await rq({
+      method: 'PUT',
+      url: `/content-manager/collection-types/${UID_SHOP}/${taggedShopDocId}`,
+      qs: { status: 'draft' },
+      body: { tags_mm: { disconnect: [tagDocumentId] } },
+    });
+    expect(disconnectRes.statusCode).toBe(200);
+
+    const existingDraft = await findExisting(taggedShopDocId, { status: 'draft' });
+    expect(existingDraft.results.map((r: any) => r.documentId)).not.toContain(tagDocumentId);
+
+    const existingPublished = await findExisting(taggedShopDocId, { status: 'published' });
+    expect(existingPublished.results.map((r: any) => r.documentId)).toContain(tagDocumentId);
+
+    const availableDraft = await findAvailable(taggedShopDocId, { status: 'draft' }, 'tags_mm');
+    expect(availableDraft.results.map((r: any) => r.documentId)).toContain(tagDocumentId);
+
+    const availablePublished = await findAvailable(
+      taggedShopDocId,
+      { status: 'published' },
+      'tags_mm'
+    );
+    expect(availablePublished.results.map((r: any) => r.documentId)).not.toContain(tagDocumentId);
   });
 });


### PR DESCRIPTION
### What does it do?

`findAvailable` now constrains the source row in the "already related" exclusion subquery with `getPublishedAtClause`, the same helper `findExisting` already uses for the source document.

A draft can again see (and pick) a many-to-many target that was disconnected from the draft but is still linked on the published version. The published picker still excludes that target.

No connect-path or publish-time validation was added.

The source-row filter uses `getPublishedAtClause` rather than switching the subquery to `entryId` from `extractAndValidateRequestInfo`. Both uniquely identify the draft or published source row. Reusing the helper keeps the production change to five lines and consistent with the target-alias filter in the same function.

### Why is it needed?

On a draft-and-publish entry, removing a many-to-many relation from the draft and saving left the published version unchanged. The relation picker then hid that target because the exclusion matched every version of the source document (`document_id` only), not just the draft row. Authors could not put the relation back without unpublishing.

### How to test it?

1. Two collection types: source with Draft & Publish on, target with Draft & Publish off, bidirectional many-to-many.
2. On the source, connect a target entry and publish.
3. In the draft, disconnect that target and save. The published tab still shows it.
4. Open the draft relation picker: the disconnected target is listed again.
5. Switch to the published tab picker: that target is still treated as connected (not listed as available).

Package unit tests (`packages/core/content-manager`):

    yarn test:unit --testPathPattern=relations-find-available

API tests are in `tests/api/core/content-manager/api/relations-available-status.test.api.ts` (needs `yarn test:api` on a generated test app).

### Related issue(s)/PR(s)

- Fixes #23743
- Write-path / publish-time uniqueness is not in this PR. That is the open scope question on the issue: whether a relation the picker now offers can still be rejected on save or publish (more relevant for xToOne than for this many-to-many).
