### PR TITLE
fix(core): openapi schema has empty dynamic zone items

### DIFF
--- a/packages/core/core/src/core-api/routes/validation/__tests__/attributes.test.ts
+++ b/packages/core/core/src/core-api/routes/validation/__tests__/attributes.test.ts
@@ -1,0 +1,124 @@
+import type { Core, Schema } from '@strapi/types';
+import * as z from 'zod/v4';
+
+import { createContentAPISchemaRegistry } from '../schema-registry';
+import { mapAttributeToSchema } from '../mappers';
+
+const toJsonSchemas = (strapi: Core.Strapi, schema: z.ZodType, id = 'Probe') => {
+  const registry = z.registry<{ id: string }>();
+
+  registry.add(schema, { id });
+
+  for (const [key, value] of strapi.contentAPISchemaRegistry.entries()) {
+    registry.add(value, { id: key });
+  }
+
+  return z.toJSONSchema(registry, {
+    target: 'draft-2020-12',
+    io: 'output',
+    uri: (schemaId: string) => `#/components/schemas/${schemaId}`,
+  }).schemas;
+};
+
+const createMockStrapi = (): Core.Strapi => {
+  const models: Record<string, { attributes: Record<string, Schema.Attribute.AnyAttribute> }> = {
+    'shared.hero': {
+      attributes: {
+        title: { type: 'string' },
+      },
+    },
+    'shared.quote': {
+      attributes: {
+        body: { type: 'string' },
+      },
+    },
+  };
+
+  return {
+    log: {
+      debug: jest.fn(),
+      error: jest.fn(),
+    },
+    contentAPISchemaRegistry: createContentAPISchemaRegistry(),
+    getModel: jest.fn((uid: string) => models[uid]),
+  } as unknown as Core.Strapi;
+};
+
+describe('mapAttributeToSchema dynamiczone', () => {
+  let strapi: Core.Strapi;
+
+  beforeEach(() => {
+    strapi = createMockStrapi();
+  });
+
+  it('emits anyOf component refs instead of empty items', () => {
+    const schema = mapAttributeToSchema(strapi, {
+      type: 'dynamiczone',
+      components: ['shared.hero', 'shared.quote'],
+    });
+
+    const schemas = toJsonSchemas(strapi, schema);
+
+    expect(schemas.Probe).toMatchObject({
+      type: 'array',
+      items: {
+        anyOf: [
+          { $ref: '#/components/schemas/SharedHeroEntry' },
+          { $ref: '#/components/schemas/SharedQuoteEntry' },
+        ],
+      },
+      description: 'A dynamic zone field',
+    });
+    expect(schemas.SharedHeroEntry).toMatchObject({
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+      },
+    });
+    expect(schemas.SharedQuoteEntry).toMatchObject({
+      type: 'object',
+      properties: {
+        body: { type: 'string' },
+      },
+    });
+  });
+
+  it('uses a single component $ref when the zone has one component', () => {
+    const schema = mapAttributeToSchema(strapi, {
+      type: 'dynamiczone',
+      components: ['shared.hero'],
+    });
+
+    const schemas = toJsonSchemas(strapi, schema);
+
+    expect(schemas.Probe).toMatchObject({
+      type: 'array',
+      items: { $ref: '#/components/schemas/SharedHeroEntry' },
+    });
+  });
+
+  it('reuses the same registered component schema as a component field', () => {
+    mapAttributeToSchema(strapi, {
+      type: 'component',
+      component: 'shared.hero',
+      repeatable: false,
+    });
+
+    const dynamicZoneSchema = mapAttributeToSchema(strapi, {
+      type: 'dynamiczone',
+      components: ['shared.hero', 'shared.quote'],
+    });
+
+    const schemas = toJsonSchemas(strapi, dynamicZoneSchema);
+
+    expect(schemas.Probe).toMatchObject({
+      items: {
+        anyOf: [
+          { $ref: '#/components/schemas/SharedHeroEntry' },
+          { $ref: '#/components/schemas/SharedQuoteEntry' },
+        ],
+      },
+    });
+    expect(strapi.contentAPISchemaRegistry.get('SharedHeroEntry')).toBeDefined();
+  });
+});

--- a/packages/core/core/src/core-api/routes/validation/attributes.ts
+++ b/packages/core/core/src/core-api/routes/validation/attributes.ts
@@ -155,13 +155,35 @@ export const decimalToSchema = (attribute: Schema.Attribute.Decimal): z.Schema =
  * @param attribute - The DynamicZone attribute object from the Strapi schema.
  * @returns A Zod schema representing the dynamic zone field.
  */
-export const dynamicZoneToSchema = (attribute: Schema.Attribute.DynamicZone): z.Schema => {
-  const { writable, required, min, max } = attribute;
+export const dynamicZoneToSchema = (
+  strapi: Core.Strapi,
+  attribute: Schema.Attribute.DynamicZone
+): z.Schema => {
+  const { writable, required, min, max, components } = attribute;
 
-  const baseSchema = z.array(z.any());
+  const componentSchemas = components.map(
+    (component) =>
+      safeSchemaCreation(
+        strapi,
+        component,
+        () => new CoreComponentRouteValidator(strapi, component).entry
+      ) as z.ZodType
+  );
+
+  let itemSchema: z.ZodType = z.any();
+
+  if (componentSchemas.length === 1) {
+    itemSchema = componentSchemas[0];
+  } else if (componentSchemas.length > 1) {
+    // z.union requires at least two options
+    itemSchema = z.union(componentSchemas as [z.ZodType, z.ZodType, ...z.ZodType[]]);
+  }
+
+  const baseSchema = z.array(itemSchema);
 
   const schema = augmentSchema(baseSchema, [
-    maybeWithMinMax(min, max),
+    (schema) => (min !== undefined && schema instanceof z.ZodArray ? schema.min(min) : schema),
+    (schema) => (max !== undefined && schema instanceof z.ZodArray ? schema.max(max) : schema),
     maybeRequired(required),
     maybeReadonly(writable),
   ]);

--- a/packages/core/core/src/core-api/routes/validation/mappers.ts
+++ b/packages/core/core/src/core-api/routes/validation/mappers.ts
@@ -120,7 +120,7 @@ export const mapAttributeToSchema = (
     case 'decimal':
       return attributes.decimalToSchema(attribute);
     case 'dynamiczone':
-      return attributes.dynamicZoneToSchema(attribute);
+      return attributes.dynamicZoneToSchema(strapi, attribute);
     case 'email':
       return attributes.emailToSchema(attribute);
     case 'enumeration':


### PR DESCRIPTION
### What does it do?

`strapi openapi generate` emits component `$ref`s (or `anyOf` of them) for dynamic-zone fields instead of `items: {}`, and registers those component schemas. Mapping goes through the same `safeSchemaCreation` + `CoreComponentRouteValidator` path a component field already uses.

Items with more than one component are `anyOf` of the registered `$ref`s (Zod `z.union` of the schemas `componentToSchema` already builds). That matches the existing component-field mapper and the documentation plugin's `$ref` list. The alternative on #24560 is `oneOf` plus a `__component` discriminator; `@strapi/plugin-documentation` uses `anyOf` + discriminator with `__component` inlined onto the component object. Attaching `__component` with `allOf` is invalid JSON Schema here because those component objects use `additionalProperties: false`. Inlining a discriminated union would drop the shared `$ref`s. Can switch to `oneOf` / `__component` / a discriminator if that is preferred.

Request bodies are unchanged: `dynamicZoneToInputSchema` is still `z.array(z.any())`, same as `componentToInputSchema`. Tightening the input schema would affect runtime input validation and is a separate change.

### Why is it needed?

`strapi openapi generate` describes every dynamic-zone field as an array of `{}` and does not export the allowed component schemas unless some other field happens to reference them. Frontend codegen from the spec has no types for dynamic-zone content.

### How to test it?

1. From `packages/core/core`: `yarn test:unit --testPathPattern=attributes.test.ts`
2. Optional: in an app with a dynamic zone (e.g. `examples/getstarted`), run `strapi openapi generate --output schema.json` and check that the dynamic-zone field's `items` is `anyOf` of `#/components/schemas/<Component>Entry` refs (or a single `$ref` when the zone has one component), and that those component schemas exist under `components.schemas`.

### Related issue(s)/PR(s)

- Fix #24560
- Separate from #26239 (optional OpenAPI HTTP route, already merged) and #24550 (documentation-plugin JSON route, closed). Those are about exposing the spec, not dynamic-zone item shape.
