### PR TITLE
fix(content-manager): back after publishing a new entry returns to a pre-filled create form

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -943,10 +943,13 @@ const PublishAction: DocumentActionComponent = ({
          * TODO: refactor the router so we can just do `../${res.data.documentId}` instead of this.
          */
         if (idToPublish === 'create' && !fromRelationModal) {
-          navigate({
-            pathname: `../${collectionType}/${model}/${res.data.documentId}`,
-            search: rawQuery,
-          });
+          navigate(
+            {
+              pathname: `../${collectionType}/${model}/${res.data.documentId}`,
+              search: rawQuery,
+            },
+            { replace: true }
+          );
         } else if (fromRelationModal) {
           const newRelation = {
             documentId: res.data.documentId,

--- a/packages/core/content-manager/admin/src/pages/EditView/components/tests/DocumentActions.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/tests/DocumentActions.test.tsx
@@ -7,6 +7,9 @@ const mockPublish = jest.fn();
 const mockUpdateParent = jest.fn();
 const mockDispatch = jest.fn();
 const mockCountDraftRelations = jest.fn();
+const mockNavigate = jest.fn();
+const mockParams: { id?: string } = {};
+let mockIsRelationModalContext = true;
 let parentInitialFormValues: Record<string, unknown> | undefined;
 let currentDocumentSchema: { options: { draftAndPublish: boolean } } = {
   options: { draftAndPublish: true },
@@ -31,6 +34,12 @@ let relationModalState = {
     },
   ],
 };
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => mockParams,
+}));
 
 jest.mock('@strapi/admin/strapi-admin', () => ({
   ...jest.requireActual('@strapi/admin/strapi-admin'),
@@ -84,8 +93,12 @@ jest.mock('../../../../services/documents', () => ({
   useUpdateDocumentMutation: () => [mockUpdateParent],
 }));
 jest.mock('../FormInputs/Relations/RelationModal', () => ({
-  useRelationModal: (_name: string, selector: (state: Record<string, unknown>) => unknown) =>
-    selector({
+  useRelationModal: (_name: string, selector: (state: Record<string, unknown>) => unknown) => {
+    if (!mockIsRelationModalContext) {
+      return undefined;
+    }
+
+    return selector({
       dispatch: mockDispatch,
       currentDocument: { schema: { options: { draftAndPublish: true } } },
       rootDocumentMeta: {
@@ -97,7 +110,8 @@ jest.mock('../FormInputs/Relations/RelationModal', () => ({
       state: {
         ...relationModalState,
       },
-    }),
+    });
+  },
 }));
 
 import {
@@ -125,9 +139,55 @@ const ActionHarness = ({ Action, label }: { Action: typeof UpdateAction; label: 
   return <button onClick={() => action.onClick?.({} as React.SyntheticEvent)}>{label}</button>;
 };
 
+describe('PublishAction create navigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsRelationModalContext = false;
+    mockParams.id = 'create';
+    mockPublish.mockResolvedValue({ data: { documentId: 'published', locale: 'en' } });
+    mockCountDraftRelations.mockResolvedValue({
+      data: { unpublishedRelations: 0, draftM2mLinks: 0 },
+      error: undefined,
+    });
+  });
+
+  afterEach(() => {
+    mockIsRelationModalContext = true;
+    delete mockParams.id;
+  });
+
+  it('replaces the create route after publishing a new collection-type entry', async () => {
+    const { user } = render(<ActionHarness Action={PublishAction} label="Publish" />);
+
+    await user.click(screen.getByRole('button', { name: 'Publish' }));
+
+    await waitFor(() => expect(mockPublish).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(
+        {
+          pathname: '../collection-types/api::child.child/published',
+          search: '',
+        },
+        { replace: true }
+      )
+    );
+  });
+
+  it('does not navigate after publishing an existing collection-type entry', async () => {
+    mockParams.id = 'existing-entry';
+    const { user } = render(<ActionHarness Action={PublishAction} label="Publish" />);
+
+    await user.click(screen.getByRole('button', { name: 'Publish' }));
+
+    await waitFor(() => expect(mockPublish).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
 describe('relation parent updates', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRelationModalContext = true;
     parentInitialFormValues = undefined;
     relationModalState = {
       isModalOpen: true,


### PR DESCRIPTION
<!--
Hello. Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

When publishing a newly created collection-type entry, navigation to that entry's edit view now uses `replace: true`, so the `/create` route is replaced in history instead of pushed. Clicking Back (header link or browser) returns to the entries list.

This matches Save, which already replaces the create route.

No change to publish from the relation modal, or to publishing an already-saved entry.

Strapi support confirmed Back should go to the entries list, not stay on a create form with fields cleared. The original report asked for relation fields to be emptied on that create page; that would have been a different fix for a different product decision.

A `PublishAction` unit test covers `replace: true` (which `HistoryProvider` treats as `REPLACE_STATE`) rather than a new Playwright spec.

### Why is it needed?

After create then publish, Back returned to "Create an entry" with fields still populated (most visibly relations). That is leftover history pointing at the pre-publish create route, not a relation-reset bug.

Fixes #24326

Related: #27050 (closed unmerged, no review) made the same `replace: true` change on this `navigate`.

### How to test it?

1. Content Manager → a collection type → **Create new entry**.
2. Fill fields (including a relation) and click **Publish** (do not Save first).
3. Click **Back** in the header.
4. You should land on the **list view**, not a pre-filled create form.
5. Repeat with the browser Back button; same result.
6. **Save** a new entry, then Back: still the list. Publish an **existing** entry: stay on that entry; Back still goes to wherever you came from.

These steps were not run against a running admin.

### Related issue(s)/PR(s)

- Fix #24326
- #27050 (same gap; author-closed with no review)


---
Fixes CPR-472