### PR TITLE
feat(upload): make the new Media Library the default

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -8,9 +8,12 @@ inputs:
   domains:
     description: 'Restrict the run to these test domains (space separated). Defaults to every domain.'
     default: ''
-  betaMediaLibrary:
-    description: 'Serve the beta Media Library instead of the legacy one. Only the dedicated beta job sets this.'
+  useLegacyMediaLibrary:
+    description: 'Serve the previous Media Library instead of the current one. Only the dedicated legacy job sets this.'
     default: 'false'
+  mediaLibrarySuite:
+    description: 'Which Media Library specs to run: current, legacy, or neither. Only the dedicated jobs set this, so the shared matrix is unaffected by either suite.'
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -20,5 +23,6 @@ runs:
         JEST_OPTIONS: ${{ inputs.jestOptions }}
         DOMAINS: ${{ inputs.domains }}
         STRAPI_FEATURES_UNSTABLE_PREVIEW_SIDE_EDITOR: true
-        BETA_MEDIA_LIBRARY: ${{ inputs.betaMediaLibrary }}
+        USE_LEGACY_MEDIA_LIBRARY: ${{ inputs.useLegacyMediaLibrary }}
+        E2E_MEDIA_LIBRARY: ${{ inputs.mediaLibrarySuite }}
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -306,48 +306,30 @@ jobs:
           org-slug: strapi
           token: ${{ secrets.TRUNK_API_TOKEN }}
         continue-on-error: true
-
-  # The beta Media Library only exists behind `betaMediaLibrary`, so its specs are
-  # skipped by every other e2e job. This one turns the flag on for the media-library
-  # domain alone, which keeps the blast radius off the legacy suite.
+  # The Media Library specs run in dedicated jobs rather than the shared matrix, and each
+  # job picks its suite explicitly with `mediaLibrarySuite`. Nothing about the product
+  # default decides what runs here: the shared matrix sets neither suite, so it is
+  # unaffected by both, and the two suites cannot collide in one app.
   #
-  # Chromium only, for two different reasons.
+  # Chromium only, for two different reasons — this is the constraint to lift first if
+  # the Media Library suite should join the shared matrix.
   #
-  # WebKit is a hard limitation: the drag-and-drop helper builds a DataTransfer,
+  # WebKit is a hard limitation: the upload drag-and-drop helper builds a DataTransfer,
   # which WebKit does not implement.
   #
-  # Firefox is simply unknown. It has never been run against this suite: locally
-  # the admin login does not go through under Firefox, so every test drives a
-  # logged-out app and fails on the first click — which says nothing about the
-  # Media Library itself. CI does run Firefox for the rest of the e2e suite, so
-  # login works there. Adding `firefox` to a matrix here is the way to find out;
-  # it was left out of this PR so an unknown result would not block the review.
+  # Firefox is simply unknown. It has never been run against this suite: locally the
+  # admin login does not go through under Firefox, so every test drives a logged-out app
+  # and fails on the first click — which says nothing about the Media Library itself. CI
+  # does run Firefox for the rest of the e2e suite, so login works there.
   #
-  # The two folder-move specs are skipped for now. They simulate a pointer drag
-  # through dnd-kit and the move never fires; they fail independently of this flag.
-  #
-  # The filter names their describe blocks (`Drag and Drop Deep` / `Shallow`) rather
-  # than just `Drag and Drop`: the looser pattern also caught the upload journey's
-  # own drag-and-drop step, which works and has nothing to do with the folder-move
-  # problem.
-  #
-  # This is a bigger gap than a broken helper. Nothing else in the e2e suite tests
-  # a pointer drag: the one reordering test we have
-  # (content-manager/relations-ui-management.spec.ts) drives the keyboard
-  # affordance instead, and the Media Library deliberately ships no
-  # `KeyboardSensor` — `AssetsDndProvider` states that pointer drag is a mouse-only
-  # enhancement and `BulkMoveDialog` is the accessible path. So the Content
-  # Manager's workaround does not transfer here.
-  #
-  # Skipping these costs the gesture, not the feature: moving assets between
-  # folders is already covered through the bulk-move dialog in
-  # `bulk-move.spec.ts`, which passes. Drop the filter once someone finds a
-  # pointer-drag simulation that dnd-kit accepts.
-  e2e_media_library_beta:
+  # The folder drag & drop specs are skipped in the specs themselves rather than filtered
+  # out here — see `RUN_FOLDER_DRAG_SPECS` in `drag-drop-deep.spec.ts`. A grep filter only
+  # protects this job, and those specs must stay parked wherever they are run from.
+  e2e_media_library:
     if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true' || needs.conditions.outputs.e2e == 'true'
     timeout-minutes: 45
     needs: [conditions, build]
-    name: '[CE] e2e beta media library (browser: chromium)'
+    name: '[CE] e2e media library (browser: chromium)'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -365,18 +347,19 @@ jobs:
       - name: Monorepo build
         uses: ./.github/actions/run-build
 
-      - name: Run [CE] beta Media Library E2E tests
+      - name: Run [CE] e2e media library E2E tests
         uses: ./.github/actions/run-e2e-tests
         with:
           runEE: false
-          betaMediaLibrary: true
+          useLegacyMediaLibrary: false
+          mediaLibrarySuite: current
           domains: media-library
-          jestOptions: '--project=chromium --grep-invert=Drag.and.Drop.(Deep|Shallow)'
+          jestOptions: '--project=chromium'
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
-          name: ce-beta-media-library--playwright-trace-${{ github.run_id }}-${{ github.job }}
+          name: ce-media-library-playwright-trace-${{ github.run_id }}-${{ github.job }}
           path: test-apps/e2e/test-results/**/trace.zip
           retention-days: 1
 
@@ -389,6 +372,52 @@ jobs:
           token: ${{ secrets.TRUNK_API_TOKEN }}
         continue-on-error: true
 
+  e2e_media_library_legacy:
+    if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true' || needs.conditions.outputs.e2e == 'true'
+    timeout-minutes: 45
+    needs: [conditions, build]
+    name: '[CE] e2e media library (legacy) (browser: chromium)'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Monorepo install
+        uses: ./.github/actions/yarn-nm-install
+
+      - name: Install Playwright Browsers
+        run: node_modules/.bin/playwright install --with-deps chromium
+
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
+
+      - name: Run [CE] e2e media library (legacy) E2E tests
+        uses: ./.github/actions/run-e2e-tests
+        with:
+          runEE: false
+          useLegacyMediaLibrary: true
+          mediaLibrarySuite: legacy
+          domains: media-library
+          jestOptions: '--project=chromium'
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: failure()
+        with:
+          name: ce-media-library-legacy-playwright-trace-${{ github.run_id }}-${{ github.job }}
+          path: test-apps/e2e/test-results/**/trace.zip
+          retention-days: 1
+
+      - name: Upload results to trunk
+        if: '!cancelled()'
+        uses: trunk-io/analytics-uploader@1198efcc0976501147b10a7e343c3fa069527526 # v2.0.9
+        with:
+          junit-paths: test-apps/junit-reports/*.xml
+          org-slug: strapi
+          token: ${{ secrets.TRUNK_API_TOKEN }}
+        continue-on-error: true
   e2e_ee:
     if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true' || needs.conditions.outputs.e2e == 'true'
     timeout-minutes: 60

--- a/examples/getstarted/config/features.js
+++ b/examples/getstarted/config/features.js
@@ -1,5 +1,3 @@
 module.exports = ({ env }) => ({
-  future: {
-    betaMediaLibrary: env.bool('BETA_MEDIA_LIBRARY', false),
-  },
+  useLegacyMediaLibrary: env.bool('USE_LEGACY_MEDIA_LIBRARY', false),
 });

--- a/packages/admin-test-utils/custom.d.ts
+++ b/packages/admin-test-utils/custom.d.ts
@@ -12,6 +12,9 @@ declare global {
       future: {
         isEnabled: (name: string) => boolean;
       };
+      featureFlags: {
+        isEnabled: (name: string) => boolean;
+      };
       projectType: string;
       telemetryDisabled: boolean;
       flags: {

--- a/packages/admin-test-utils/src/setup.ts
+++ b/packages/admin-test-utils/src/setup.ts
@@ -118,6 +118,11 @@ window.strapi = {
   future: {
     isEnabled: () => false,
   },
+  // Defaults to false, so tests see the shipped configuration: no flag set, which
+  // at GA means the current Media Library rather than the legacy one.
+  featureFlags: {
+    isEnabled: () => false,
+  },
   projectType: 'Community',
   telemetryDisabled: true,
   flags: {

--- a/packages/core/admin/admin/custom.d.ts
+++ b/packages/core/admin/admin/custom.d.ts
@@ -14,6 +14,13 @@ interface BrowserStrapi {
   future: {
     isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
   };
+  /**
+   * Permanent config flags from the project's `features` file. Separate from `features`
+   * below, which carries EE licence feature names rather than configuration.
+   */
+  featureFlags: {
+    isEnabled: (name: keyof Omit<Modules.Features.FeaturesConfig, 'future'>) => boolean;
+  };
   features: {
     SSO: 'sso';
     AUDIT_LOGS: 'audit-logs';

--- a/packages/core/admin/admin/src/App.tsx
+++ b/packages/core/admin/admin/src/App.tsx
@@ -45,7 +45,7 @@ const App = ({ strapi, store }: AppProps) => {
     <Providers strapi={strapi} store={store}>
       <Suspense fallback={<Page.Loading />}>
         <GlobalNotifications />
-        {window.strapi.future.isEnabled('betaMediaLibrary') &&
+        {!window.strapi.featureFlags.isEnabled('useLegacyMediaLibrary') &&
           globalComponents.map(({ name, Component }) => <Component key={name} />)}
         <Outlet />
       </Suspense>

--- a/packages/core/admin/admin/src/render.ts
+++ b/packages/core/admin/admin/src/render.ts
@@ -42,6 +42,11 @@ const renderAdmin = async (
         return features?.future?.[name] === true;
       },
     },
+    featureFlags: {
+      isEnabled: (name: keyof Omit<Modules.Features.FeaturesConfig, 'future'>) => {
+        return features?.[name] === true;
+      },
+    },
     // eslint-disable-next-line
     // @ts-ignore – there's pollution from the global scope of Node. Cannot use @ts-expect-error because of build:code and build:types context collision. Cannot use @ts-expect-error because of build:code and build:types context collision.
     features: {

--- a/packages/core/admin/ee/admin/custom.d.ts
+++ b/packages/core/admin/ee/admin/custom.d.ts
@@ -17,6 +17,9 @@ declare global {
       future: {
         isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
       };
+      featureFlags: {
+        isEnabled: (name: keyof Omit<Modules.Features.FeaturesConfig, 'future'>) => boolean;
+      };
       features: {
         SSO: 'sso';
         AUDIT_LOGS: 'audit-logs';

--- a/packages/core/core/src/services/features.ts
+++ b/packages/core/core/src/services/features.ts
@@ -18,6 +18,9 @@ const createFeaturesService = (strapi: Core.Strapi): Modules.Features.FeaturesSe
         return service.config?.future?.[futureFlagName as FeatureName] === true;
       },
     },
+    isEnabled(flagName): boolean {
+      return service.config?.[flagName] === true;
+    },
   };
 
   return service;

--- a/packages/core/types/src/core/config/features.ts
+++ b/packages/core/types/src/core/config/features.ts
@@ -4,11 +4,19 @@
  * @see docs/docs/docs/06-future-flags.md
  */
 export interface FeaturesFutureFlags {
-  betaMediaLibrary?: boolean;
   experimental_firstPublishedAt?: boolean;
   [futureFlagName: string]: boolean | undefined;
 }
 
 export interface Features {
   future?: FeaturesFutureFlags;
+  /**
+   * Restores the previous Media Library.
+   *
+   * Flat rather than under `future`, which means "unstable, may be removed": this flag
+   * is a supported opt-out that outlives the feature's release. It reads as an opt-out
+   * because the new Media Library is the default from 5.53 — see the removal version in
+   * the Media Library documentation.
+   */
+  useLegacyMediaLibrary?: boolean;
 }

--- a/packages/core/types/src/modules/features.ts
+++ b/packages/core/types/src/modules/features.ts
@@ -10,4 +10,10 @@ export interface FeaturesService {
   future: {
     isEnabled: (futureFlagName: string) => boolean;
   };
+  /**
+   * Permanent flags, read straight off `features`. Unlike `future.*` these are supported
+   * configuration rather than opt-in previews, so they are named for what they do rather
+   * than gathered under a bucket that promises removal.
+   */
+  isEnabled: (flagName: keyof Omit<FeaturesConfig, 'future'>) => boolean;
 }

--- a/packages/core/upload/admin/custom.d.ts
+++ b/packages/core/upload/admin/custom.d.ts
@@ -7,6 +7,9 @@ declare global {
       future: {
         isEnabled: (name: keyof NonNullable<Modules.Features.FeaturesConfig['future']>) => boolean;
       };
+      featureFlags: {
+        isEnabled: (name: keyof Omit<Modules.Features.FeaturesConfig, 'future'>) => boolean;
+      };
     };
   }
   module '*?raw';

--- a/packages/core/upload/admin/src/index.ts
+++ b/packages/core/upload/admin/src/index.ts
@@ -20,11 +20,12 @@ const name = pluginPkg.strapi.name;
 const admin: Plugin.Config.AdminInput = {
   register(app: StrapiApp) {
     /**
-     * The beta Media Library owns `plugins/upload` outright when the flag is on:
-     * the legacy app is not registered at all, so there is exactly one Media
-     * Library entry in the menu and no route to rename at GA.
+     * Whichever Media Library is selected owns `plugins/upload` outright: the other is
+     * not registered at all, so there is exactly one Media Library entry in the menu.
+     *
+     * The new one is the default; `useLegacyMediaLibrary` opts back out.
      */
-    const isBetaMediaLibrary = window.strapi.future.isEnabled('betaMediaLibrary');
+    const isLegacyMediaLibrary = window.strapi.featureFlags.isEnabled('useLegacyMediaLibrary');
 
     app.addMenuLink({
       to: `plugins/${pluginId}`,
@@ -34,19 +35,19 @@ const admin: Plugin.Config.AdminInput = {
         defaultMessage: 'Media Library',
       },
       permissions: PERMISSIONS.main,
-      Component: isBetaMediaLibrary
+      Component: isLegacyMediaLibrary
         ? () => {
+            return import('./pages/App/App').then((mod) => ({ default: mod.Upload }));
+          }
+        : () => {
             return import('./future/App').then((mod) => ({
               default: mod.BetaMediaLibrary,
             }));
-          }
-        : () => {
-            return import('./pages/App/App').then((mod) => ({ default: mod.Upload }));
           },
       position: 4,
     });
 
-    if (isBetaMediaLibrary) {
+    if (!isLegacyMediaLibrary) {
       app.addReducers({ uploadProgress: uploadProgressReducer });
 
       app.addComponents([

--- a/packages/core/upload/server/src/__tests__/media-library-default-notice.test.ts
+++ b/packages/core/upload/server/src/__tests__/media-library-default-notice.test.ts
@@ -1,0 +1,55 @@
+import { notifyMediaLibraryDefault } from '../media-library-default-notice';
+
+const createStrapi = ({ optOut }: { optOut?: boolean | undefined }) => {
+  const store = { get: jest.fn(async () => null), set: jest.fn(async () => {}) };
+
+  return {
+    strapi: {
+      config: { get: jest.fn(() => optOut) },
+      log: { info: jest.fn() },
+      store: jest.fn(() => store),
+    } as any,
+    store,
+  };
+};
+
+describe('Media Library default notice', () => {
+  test('tells an upgrading app that took the new default', async () => {
+    const { strapi, store } = createStrapi({ optOut: undefined });
+
+    await notifyMediaLibraryDefault({ strapi, isExistingApp: true });
+
+    expect(strapi.log.info).toHaveBeenCalledTimes(1);
+    expect(strapi.log.info.mock.calls[0][0]).toContain('useLegacyMediaLibrary');
+    // Persisted rather than remembered, so a restart does not repeat it.
+    expect(store.set).toHaveBeenCalledWith({ value: { shown: true } });
+  });
+
+  test('stays quiet on a fresh install, which has no Media Library to lose', async () => {
+    const { strapi, store } = createStrapi({ optOut: undefined });
+
+    await notifyMediaLibraryDefault({ strapi, isExistingApp: false });
+
+    expect(strapi.log.info).not.toHaveBeenCalled();
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  test.each([true, false])('stays quiet when the flag is set to %s', async (optOut) => {
+    const { strapi } = createStrapi({ optOut });
+
+    await notifyMediaLibraryDefault({ strapi, isExistingApp: true });
+
+    // `false` is an app saying it knows and wants the new one, so it is not a surprise.
+    expect(strapi.log.info).not.toHaveBeenCalled();
+  });
+
+  test('does not repeat itself once shown', async () => {
+    const { strapi, store } = createStrapi({ optOut: undefined });
+    store.get.mockResolvedValueOnce({ shown: true } as any);
+
+    await notifyMediaLibraryDefault({ strapi, isExistingApp: true });
+
+    expect(strapi.log.info).not.toHaveBeenCalled();
+    expect(store.set).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/upload/server/src/bootstrap.ts
+++ b/packages/core/upload/server/src/bootstrap.ts
@@ -2,6 +2,7 @@ import type { Core } from '@strapi/types';
 
 import { getService } from './utils';
 import { ALLOWED_SORT_STRINGS, ALLOWED_WEBHOOK_EVENTS } from './constants';
+import { notifyMediaLibraryDefault } from './media-library-default-notice';
 
 export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
   const defaultConfig = {
@@ -17,11 +18,19 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
     },
   };
 
+  // Whether this plugin has stored settings from an earlier boot, which is what separates
+  // an upgrading app from a fresh install for the Media Library default notice below.
+  let isExistingApp = false;
+
   for (const [key, defaultValue] of Object.entries(defaultConfig)) {
     // set plugin store
     const configurator = strapi.store!({ type: 'plugin', name: 'upload', key });
 
     const config = await configurator.get({});
+
+    if (config) {
+      isExistingApp = true;
+    }
     if (
       config &&
       Object.keys(defaultValue).every((key) => Object.prototype.hasOwnProperty.call(config, key))
@@ -36,6 +45,8 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
       value: Object.assign(defaultValue, config || {}),
     });
   }
+
+  await notifyMediaLibraryDefault({ strapi, isExistingApp });
 
   await registerPermissionActions();
   await registerWebhookEvents();

--- a/packages/core/upload/server/src/media-library-default-notice.ts
+++ b/packages/core/upload/server/src/media-library-default-notice.ts
@@ -1,0 +1,44 @@
+import type { Core } from '@strapi/types';
+
+const NOTICE_STORE_KEY = 'media_library_default_notice';
+
+const NOTICE = [
+  'The Media Library has been redesigned and is now the default.',
+  'To keep the previous one, set `useLegacyMediaLibrary: true` in config/features.',
+].join(' ');
+
+/**
+ * Tells an upgrading app, once, that its Media Library changed.
+ *
+ * At GA every existing app changes behaviour with nothing in its config to hint at it,
+ * because nobody has a flag set. Three conditions keep this from becoming noise:
+ *
+ * - only when the flag is absent — setting it either way is a deliberate choice, and
+ *   `false` is how an app says "I know, I want the new one"
+ * - only for an app that has booted this plugin before, so a fresh install (which has
+ *   no previous Media Library to lose) stays quiet
+ * - only once, tracked in the plugin store rather than in memory, so restarts and
+ *   multi-instance deployments do not repeat it
+ */
+export const notifyMediaLibraryDefault = async ({
+  strapi,
+  isExistingApp,
+}: {
+  strapi: Core.Strapi;
+  isExistingApp: boolean;
+}) => {
+  const optOut = strapi.config.get('features.useLegacyMediaLibrary');
+
+  if (optOut !== undefined || !isExistingApp) {
+    return;
+  }
+
+  const store = strapi.store!({ type: 'plugin', name: 'upload', key: NOTICE_STORE_KEY });
+
+  if ((await store.get({})) !== null) {
+    return;
+  }
+
+  strapi.log.info(NOTICE);
+  await store.set({ value: { shown: true } });
+};

--- a/tests/app-template/config/features.js
+++ b/tests/app-template/config/features.js
@@ -1,5 +1,3 @@
 module.exports = ({ env }) => ({
-  future: {
-    betaMediaLibrary: env.bool('BETA_MEDIA_LIBRARY', false),
-  },
+  useLegacyMediaLibrary: env.bool('USE_LEGACY_MEDIA_LIBRARY', false),
 });

--- a/tests/e2e/tests/media-library/cancel-deletion.spec.ts
+++ b/tests/e2e/tests/media-library/cancel-deletion.spec.ts
@@ -6,8 +6,8 @@ import { resetFiles } from '../../../utils/file-reset';
 import { login } from '../../../utils/login';
 import { describeOnCondition, navToHeader } from '../../../utils/shared';
 
-// With `betaMediaLibrary` on, `plugins/upload` serves the beta Media Library
-// instead of this one, so the legacy suite only applies when the flag is off.
+// The legacy Media Library renders only with `useLegacyMediaLibrary: true`, so this suite
+// runs in the `legacy` e2e job alone.
 describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'legacy')('Media Library', () => {
   test.beforeEach(async ({ page }) => {
     await resetDatabaseAndImportDataFromPath('with-admin');

--- a/tests/e2e/tests/media-library/cancel-deletion.spec.ts
+++ b/tests/e2e/tests/media-library/cancel-deletion.spec.ts
@@ -8,7 +8,7 @@ import { describeOnCondition, navToHeader } from '../../../utils/shared';
 
 // With `betaMediaLibrary` on, `plugins/upload` serves the beta Media Library
 // instead of this one, so the legacy suite only applies when the flag is off.
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY !== 'true')('Media Library', () => {
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'legacy')('Media Library', () => {
   test.beforeEach(async ({ page }) => {
     await resetDatabaseAndImportDataFromPath('with-admin');
     await resetFiles();

--- a/tests/e2e/tests/media-library/future/asset-crop.spec.ts
+++ b/tests/e2e/tests/media-library/future/asset-crop.spec.ts
@@ -6,7 +6,7 @@ import { describeOnCondition } from '../../../../utils/shared';
 
 import { AssetsPage } from './page-objects/AssetsPage';
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')('Media Library - Crop', () => {
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')('Media Library - Crop', () => {
   test.beforeEach(async ({ page }) => {
     await resetDatabaseAndImportDataFromPath('with-admin');
     await page.goto('/admin');

--- a/tests/e2e/tests/media-library/future/asset-details.spec.ts
+++ b/tests/e2e/tests/media-library/future/asset-details.spec.ts
@@ -7,7 +7,7 @@ import { describeOnCondition } from '../../../../utils/shared';
 
 import { AssetsPage } from './page-objects/AssetsPage';
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')(
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')(
   'Media Library - Asset Details Drawer',
   () => {
     test.beforeEach(async ({ page }) => {

--- a/tests/e2e/tests/media-library/future/bulk-delete.spec.ts
+++ b/tests/e2e/tests/media-library/future/bulk-delete.spec.ts
@@ -10,7 +10,7 @@ import { AssetsPage } from './page-objects/AssetsPage';
 const FIXTURE_IMAGE_1 = path.join(__dirname, '../../../data/uploads/test-image-1.jpg');
 const FIXTURE_IMAGE_2 = path.join(__dirname, '../../../data/uploads/test-image-2.jpg');
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')(
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')(
   'Media Library - Bulk delete',
   () => {
     test.beforeEach(async ({ page }) => {

--- a/tests/e2e/tests/media-library/future/bulk-move.spec.ts
+++ b/tests/e2e/tests/media-library/future/bulk-move.spec.ts
@@ -10,82 +10,85 @@ import { AssetsPage } from './page-objects/AssetsPage';
 const FIXTURE_IMAGE_1 = path.join(__dirname, '../../../data/uploads/test-image-1.jpg');
 const FIXTURE_IMAGE_2 = path.join(__dirname, '../../../data/uploads/test-image-2.jpg');
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')('Media Library - Bulk move', () => {
-  test.beforeEach(async ({ page }) => {
-    await resetDatabaseAndImportDataFromPath('with-admin');
-    await page.goto('/admin');
-    await login({ page });
-  });
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')(
+  'Media Library - Bulk move',
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await resetDatabaseAndImportDataFromPath('with-admin');
+      await page.goto('/admin');
+      await login({ page });
+    });
 
-  test('moves the selected assets into a folder from the bulk action bar', async ({ page }) => {
-    const assetsPage = new AssetsPage(page);
-    await assetsPage.goto();
+    test('moves the selected assets into a folder from the bulk action bar', async ({ page }) => {
+      const assetsPage = new AssetsPage(page);
+      await assetsPage.goto();
 
-    await assetsPage.createFolder('Marketing team');
-    await assetsPage.uploadFilesWithFilePicker([FIXTURE_IMAGE_1, FIXTURE_IMAGE_2]);
-    await assetsPage.completeUpload();
+      await assetsPage.createFolder('Marketing team');
+      await assetsPage.uploadFilesWithFilePicker([FIXTURE_IMAGE_1, FIXTURE_IMAGE_2]);
+      await assetsPage.completeUpload();
 
-    await assetsPage.switchToTableView();
-    await assetsPage.selectAsset('test-image-1.jpg');
-    await assetsPage.selectAsset('test-image-2.jpg');
+      await assetsPage.switchToTableView();
+      await assetsPage.selectAsset('test-image-1.jpg');
+      await assetsPage.selectAsset('test-image-2.jpg');
 
-    await expect(assetsPage.getBulkActionsBar()).toContainText('2 items selected');
+      await expect(assetsPage.getBulkActionsBar()).toContainText('2 items selected');
 
-    await assetsPage.bulkMoveSelectionTo('Marketing team');
+      await assetsPage.bulkMoveSelectionTo('Marketing team');
 
-    await expect(
-      page.getByText('2 elements have been moved from Media Library to Marketing team')
-    ).toBeVisible();
+      await expect(
+        page.getByText('2 elements have been moved from Media Library to Marketing team')
+      ).toBeVisible();
 
-    // Assets left the current (root) list, selection cleared → bar hidden.
-    await expect(assetsPage.getAssetRow('test-image-1.jpg')).not.toBeVisible();
-    await expect(assetsPage.getAssetRow('test-image-2.jpg')).not.toBeVisible();
-    await expect(assetsPage.getBulkActionsBar()).not.toBeVisible();
+      // Assets left the current (root) list, selection cleared → bar hidden.
+      await expect(assetsPage.getAssetRow('test-image-1.jpg')).not.toBeVisible();
+      await expect(assetsPage.getAssetRow('test-image-2.jpg')).not.toBeVisible();
+      await expect(assetsPage.getBulkActionsBar()).not.toBeVisible();
 
-    // The assets are inside the destination folder.
-    await assetsPage.navigateIntoFolder('Marketing team');
-    await expect(assetsPage.getAssetRow('test-image-1.jpg')).toBeVisible();
-    await expect(assetsPage.getAssetRow('test-image-2.jpg')).toBeVisible();
-  });
+      // The assets are inside the destination folder.
+      await assetsPage.navigateIntoFolder('Marketing team');
+      await expect(assetsPage.getAssetRow('test-image-1.jpg')).toBeVisible();
+      await expect(assetsPage.getAssetRow('test-image-2.jpg')).toBeVisible();
+    });
 
-  test('moves a selected folder and updates the sidebar folder tree', async ({ page }) => {
-    const assetsPage = new AssetsPage(page);
-    await assetsPage.goto();
+    test('moves a selected folder and updates the sidebar folder tree', async ({ page }) => {
+      const assetsPage = new AssetsPage(page);
+      await assetsPage.goto();
 
-    await assetsPage.createFolder('Destination');
-    await assetsPage.createFolder('Nomad');
+      await assetsPage.createFolder('Destination');
+      await assetsPage.createFolder('Nomad');
 
-    await assetsPage.switchToTableView();
-    await assetsPage.selectAsset('Nomad');
+      await assetsPage.switchToTableView();
+      await assetsPage.selectAsset('Nomad');
 
-    await assetsPage.bulkMoveSelectionTo('Destination');
+      await assetsPage.bulkMoveSelectionTo('Destination');
 
-    // The folder left the root list.
-    await expect(assetsPage.getFolderRow('Nomad')).not.toBeVisible();
+      // The folder left the root list.
+      await expect(assetsPage.getFolderRow('Nomad')).not.toBeVisible();
 
-    // The sidebar tree reflects the new hierarchy: Nomad nests under Destination.
-    const sidebar = page.getByRole('navigation', { name: 'Media library folders' });
-    await sidebar.getByRole('button', { name: 'Expand Destination' }).click();
-    await expect(sidebar.getByRole('button', { name: 'Nomad', exact: true })).toBeVisible();
-  });
+      // The sidebar tree reflects the new hierarchy: Nomad nests under Destination.
+      const sidebar = page.getByRole('navigation', { name: 'Media library folders' });
+      await sidebar.getByRole('button', { name: 'Expand Destination' }).click();
+      await expect(sidebar.getByRole('button', { name: 'Nomad', exact: true })).toBeVisible();
+    });
 
-  test('cancelling the move dialog keeps the assets and the selection', async ({ page }) => {
-    const assetsPage = new AssetsPage(page);
-    await assetsPage.goto();
+    test('cancelling the move dialog keeps the assets and the selection', async ({ page }) => {
+      const assetsPage = new AssetsPage(page);
+      await assetsPage.goto();
 
-    await assetsPage.uploadFilesWithFilePicker(FIXTURE_IMAGE_1);
-    await assetsPage.completeUpload();
+      await assetsPage.uploadFilesWithFilePicker(FIXTURE_IMAGE_1);
+      await assetsPage.completeUpload();
 
-    await assetsPage.switchToTableView();
-    await assetsPage.selectAsset('test-image-1.jpg');
+      await assetsPage.switchToTableView();
+      await assetsPage.selectAsset('test-image-1.jpg');
 
-    await assetsPage.getBulkActionsBar().getByRole('button', { name: 'Move' }).click();
-    await expect(page.getByRole('dialog', { name: 'Move elements to' })).toBeVisible();
+      await assetsPage.getBulkActionsBar().getByRole('button', { name: 'Move' }).click();
+      await expect(page.getByRole('dialog', { name: 'Move elements to' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Cancel' }).click();
+      await page.getByRole('button', { name: 'Cancel' }).click();
 
-    await expect(page.getByRole('dialog', { name: 'Move elements to' })).not.toBeVisible();
-    await expect(assetsPage.getAssetRow('test-image-1.jpg')).toBeVisible();
-    await expect(assetsPage.getBulkActionsBar()).toBeVisible();
-  });
-});
+      await expect(page.getByRole('dialog', { name: 'Move elements to' })).not.toBeVisible();
+      await expect(assetsPage.getAssetRow('test-image-1.jpg')).toBeVisible();
+      await expect(assetsPage.getBulkActionsBar()).toBeVisible();
+    });
+  }
+);

--- a/tests/e2e/tests/media-library/future/drag-drop-deep.spec.ts
+++ b/tests/e2e/tests/media-library/future/drag-drop-deep.spec.ts
@@ -9,7 +9,21 @@ import { AssetsPage } from './page-objects/AssetsPage';
 
 const FIXTURE_IMAGE = path.join(__dirname, '../../../data/uploads/test-image.jpg');
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')(
+/**
+ * Folder drag & drop is parked, so these are skipped everywhere rather than filtered out
+ * in CI: with the new Media Library on by default they would otherwise run in the main
+ * e2e jobs, which carry no grep filter.
+ *
+ * The gesture itself simulates correctly — a trace shows dnd-kit announcing
+ * "Picked up <file>. Drop on a folder to move." What fails is the expected copy: this
+ * page object waits for "Elements have been moved successfully" (the legacy string)
+ * while the provider emits "N element(s) has/have been moved from X to Y". Uploads are
+ * the same shape of problem — they emit no toast at all. Fixing those assertions is a
+ * follow-up; flip this to `true` with them.
+ */
+const RUN_FOLDER_DRAG_SPECS = false;
+
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current' && RUN_FOLDER_DRAG_SPECS)(
   'Media Library - Drag and Drop Deep',
   () => {
     test.beforeEach(async ({ page }) => {

--- a/tests/e2e/tests/media-library/future/drag-drop-shallow.spec.ts
+++ b/tests/e2e/tests/media-library/future/drag-drop-shallow.spec.ts
@@ -12,7 +12,23 @@ const FIXTURE_IMAGE = path.join(__dirname, '../../../data/uploads/test-image.jpg
 // Sub-pixel layout rounding only — the modifier centres the chip exactly.
 const CHIP_CENTRE_TOLERANCE_PX = 1;
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')(
+/**
+ * Folder drag & drop is parked, so these are skipped everywhere rather than filtered out in
+ * CI: with the new Media Library on by default they would otherwise run in the main e2e
+ * jobs, which carry no grep filter.
+ *
+ * The gesture itself simulates correctly — a trace shows dnd-kit announcing
+ * "Picked up <file>. Drop on a folder to move." What fails is the expected copy: this page
+ * object waits for "Elements have been moved successfully" (the legacy string) while the
+ * provider emits "N element(s) has/have been moved from X to Y". Fixing those assertions is
+ * a follow-up; flip this to `true` with them.
+ *
+ * The drag-preview tests below are deliberately in their own describe: they pass, so parking
+ * the folder moves must not take them with it.
+ */
+const RUN_FOLDER_DRAG_SPECS = false;
+
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current' && RUN_FOLDER_DRAG_SPECS)(
   'Media Library - Drag and Drop Shallow',
   () => {
     test.beforeEach(async ({ page }) => {
@@ -100,6 +116,33 @@ describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')(
       await expect(assetsPage.getMoveSuccessNotification()).not.toBeVisible();
     });
 
+    test('shows success toast and removes item from current view after drop', async ({ page }) => {
+      const assetsPage = new AssetsPage(page);
+      await assetsPage.goto();
+
+      await assetsPage.createFolder('Toast Target');
+      await assetsPage.waitForNotification();
+      await assetsPage.uploadFilesWithFilePicker(FIXTURE_IMAGE);
+      await assetsPage.completeUpload();
+
+      await assetsPage.switchToGridView();
+      await assetsPage.dragItemToFolder('test-image.jpg', 'Toast Target', 'grid');
+
+      await expect(assetsPage.getMoveSuccessNotification()).toBeVisible();
+      await expect(assetsPage.getAssetCard('test-image.jpg')).not.toBeVisible();
+    });
+  }
+);
+
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')(
+  'Media Library - Drag preview',
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await resetDatabaseAndImportDataFromPath('with-admin');
+      await page.goto('/admin');
+      await login({ page });
+    });
+
     for (const view of ['grid', 'table'] as const) {
       test(`keeps the drag preview under the cursor in ${view} view`, async ({ page }) => {
         const assetsPage = new AssetsPage(page);
@@ -138,21 +181,5 @@ describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')(
         await page.mouse.up();
       });
     }
-
-    test('shows success toast and removes item from current view after drop', async ({ page }) => {
-      const assetsPage = new AssetsPage(page);
-      await assetsPage.goto();
-
-      await assetsPage.createFolder('Toast Target');
-      await assetsPage.waitForNotification();
-      await assetsPage.uploadFilesWithFilePicker(FIXTURE_IMAGE);
-      await assetsPage.completeUpload();
-
-      await assetsPage.switchToGridView();
-      await assetsPage.dragItemToFolder('test-image.jpg', 'Toast Target', 'grid');
-
-      await expect(assetsPage.getMoveSuccessNotification()).toBeVisible();
-      await expect(assetsPage.getAssetCard('test-image.jpg')).not.toBeVisible();
-    });
   }
 );

--- a/tests/e2e/tests/media-library/future/empty-state.spec.ts
+++ b/tests/e2e/tests/media-library/future/empty-state.spec.ts
@@ -36,7 +36,7 @@ const clearMediaLibrary = async (request: APIRequestContext) => {
 
 const FIXTURE_IMAGE = path.join(__dirname, '../../../data/uploads/test-image.jpg');
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')(
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')(
   'Media Library - Empty state',
   () => {
     test.beforeEach(async ({ page }) => {

--- a/tests/e2e/tests/media-library/future/filters.spec.ts
+++ b/tests/e2e/tests/media-library/future/filters.spec.ts
@@ -9,7 +9,7 @@ import { AssetsPage } from './page-objects/AssetsPage';
 
 const FIXTURE_IMAGE_1 = path.join(__dirname, '../../../data/uploads/test-image-1.jpg');
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')('Media Library - Filters', () => {
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')('Media Library - Filters', () => {
   test.beforeEach(async ({ page }) => {
     await resetDatabaseAndImportDataFromPath('with-admin');
     await page.goto('/admin');

--- a/tests/e2e/tests/media-library/future/folder-creation.spec.ts
+++ b/tests/e2e/tests/media-library/future/folder-creation.spec.ts
@@ -4,7 +4,7 @@ import { resetDatabaseAndImportDataFromPath } from '../../../../utils/dts-import
 import { AssetsPage } from './page-objects/AssetsPage';
 import { describeOnCondition } from '../../../../utils/shared';
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')(
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')(
   'Media Library - Folder Creation',
   () => {
     test.beforeEach(async ({ page }) => {

--- a/tests/e2e/tests/media-library/future/grid-view.spec.ts
+++ b/tests/e2e/tests/media-library/future/grid-view.spec.ts
@@ -5,82 +5,85 @@ import { AssetsPage } from './page-objects/AssetsPage';
 import path from 'path';
 import { describeOnCondition } from '../../../../utils/shared';
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')('Media Library - Grid View', () => {
-  test.beforeEach(async ({ page }) => {
-    await resetDatabaseAndImportDataFromPath('with-admin');
-    await page.goto('/admin');
-    await login({ page });
-  });
-
-  test.describe('View Toggle', () => {
-    test('should switch between grid and table views', async ({ page }) => {
-      const assetsPage = new AssetsPage(page);
-      await assetsPage.goto();
-
-      // Switch to table view
-      await assetsPage.switchToTableView();
-      expect(await assetsPage.isGridViewActive()).toBe(false);
-
-      // Switch back to grid view
-      await assetsPage.switchToGridView();
-      expect(await assetsPage.isGridViewActive()).toBe(true);
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')(
+  'Media Library - Grid View',
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await resetDatabaseAndImportDataFromPath('with-admin');
+      await page.goto('/admin');
+      await login({ page });
     });
 
-    test('should persist view preference', async ({ page }) => {
-      const assetsPage = new AssetsPage(page);
-      await assetsPage.goto();
+    test.describe('View Toggle', () => {
+      test('should switch between grid and table views', async ({ page }) => {
+        const assetsPage = new AssetsPage(page);
+        await assetsPage.goto();
 
-      // Switch to table view
-      await assetsPage.switchToTableView();
+        // Switch to table view
+        await assetsPage.switchToTableView();
+        expect(await assetsPage.isGridViewActive()).toBe(false);
 
-      // Reload page
-      await page.reload();
-      await page.waitForLoadState('networkidle');
+        // Switch back to grid view
+        await assetsPage.switchToGridView();
+        expect(await assetsPage.isGridViewActive()).toBe(true);
+      });
 
-      // Should still be in table view
-      expect(await assetsPage.isGridViewActive()).toBe(false);
+      test('should persist view preference', async ({ page }) => {
+        const assetsPage = new AssetsPage(page);
+        await assetsPage.goto();
+
+        // Switch to table view
+        await assetsPage.switchToTableView();
+
+        // Reload page
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+
+        // Should still be in table view
+        expect(await assetsPage.isGridViewActive()).toBe(false);
+      });
+
+      test('should keep the selection when switching views', async ({ page }) => {
+        const assetsPage = new AssetsPage(page);
+        await assetsPage.goto();
+
+        const testImagePath = path.join(__dirname, '../../../data/uploads/test-image.jpg');
+        await assetsPage.uploadFilesWithFilePicker(testImagePath);
+        await assetsPage.completeUpload();
+
+        await assetsPage.switchToTableView();
+        await assetsPage.selectAsset('test-image.jpg');
+        await expect(assetsPage.getBulkActionsBar()).toContainText('1 item selected');
+
+        // Both views render the same list, so the view is deliberately kept out
+        // of the fingerprint that clears the selection (see getListQueryKey).
+        await assetsPage.switchToGridView();
+        await expect(assetsPage.getBulkActionsBar()).toContainText('1 item selected');
+        await expect(assetsPage.getSelectionCheckbox('test-image.jpg')).toBeChecked();
+
+        await assetsPage.switchToTableView();
+        await expect(assetsPage.getBulkActionsBar()).toContainText('1 item selected');
+        await expect(assetsPage.getSelectionCheckbox('test-image.jpg')).toBeChecked();
+      });
     });
 
-    test('should keep the selection when switching views', async ({ page }) => {
-      const assetsPage = new AssetsPage(page);
-      await assetsPage.goto();
+    test.describe('Grid Display', () => {
+      test('should display uploaded file as card in grid view', async ({ page }) => {
+        const assetsPage = new AssetsPage(page);
+        await assetsPage.goto();
 
-      const testImagePath = path.join(__dirname, '../../../data/uploads/test-image.jpg');
-      await assetsPage.uploadFilesWithFilePicker(testImagePath);
-      await assetsPage.completeUpload();
+        // Ensure we're in grid view
+        await assetsPage.switchToGridView();
+        expect(await assetsPage.isGridViewActive()).toBe(true);
 
-      await assetsPage.switchToTableView();
-      await assetsPage.selectAsset('test-image.jpg');
-      await expect(assetsPage.getBulkActionsBar()).toContainText('1 item selected');
+        const testImagePath = path.join(__dirname, '../../../data/uploads/test-image.jpg');
+        await assetsPage.uploadFilesWithFilePicker(testImagePath);
+        await assetsPage.completeUpload();
 
-      // Both views render the same list, so the view is deliberately kept out
-      // of the fingerprint that clears the selection (see getListQueryKey).
-      await assetsPage.switchToGridView();
-      await expect(assetsPage.getBulkActionsBar()).toContainText('1 item selected');
-      await expect(assetsPage.getSelectionCheckbox('test-image.jpg')).toBeChecked();
-
-      await assetsPage.switchToTableView();
-      await expect(assetsPage.getBulkActionsBar()).toContainText('1 item selected');
-      await expect(assetsPage.getSelectionCheckbox('test-image.jpg')).toBeChecked();
+        // Verify asset appears as card
+        const assetCard = assetsPage.getAssetCard('test-image');
+        await expect(assetCard).toBeVisible();
+      });
     });
-  });
-
-  test.describe('Grid Display', () => {
-    test('should display uploaded file as card in grid view', async ({ page }) => {
-      const assetsPage = new AssetsPage(page);
-      await assetsPage.goto();
-
-      // Ensure we're in grid view
-      await assetsPage.switchToGridView();
-      expect(await assetsPage.isGridViewActive()).toBe(true);
-
-      const testImagePath = path.join(__dirname, '../../../data/uploads/test-image.jpg');
-      await assetsPage.uploadFilesWithFilePicker(testImagePath);
-      await assetsPage.completeUpload();
-
-      // Verify asset appears as card
-      const assetCard = assetsPage.getAssetCard('test-image');
-      await expect(assetCard).toBeVisible();
-    });
-  });
-});
+  }
+);

--- a/tests/e2e/tests/media-library/future/media-library-upload.spec.ts
+++ b/tests/e2e/tests/media-library/future/media-library-upload.spec.ts
@@ -91,7 +91,7 @@ const countAssets = async (request: APIRequestContext) => {
   return (await listed.json())?.pagination?.total ?? 0;
 };
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')(
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')(
   'Media Library - Journey 1: Upload my assets',
   () => {
     test.describe.configure({ timeout: 600_000 });

--- a/tests/e2e/tests/media-library/future/sort.spec.ts
+++ b/tests/e2e/tests/media-library/future/sort.spec.ts
@@ -14,7 +14,7 @@ const ownItems = (names: string[]) => names.filter((name) => name.startsWith('te
 const FIXTURE_IMAGE_1 = path.join(__dirname, '../../../data/uploads/test-image-1.jpg');
 const FIXTURE_IMAGE_2 = path.join(__dirname, '../../../data/uploads/test-image-2.jpg');
 
-describeOnCondition(process.env.BETA_MEDIA_LIBRARY === 'true')('Media Library - Sort', () => {
+describeOnCondition(process.env.E2E_MEDIA_LIBRARY === 'current')('Media Library - Sort', () => {
   test.beforeEach(async ({ page }) => {
     await resetDatabaseAndImportDataFromPath('with-admin');
     await page.goto('/admin');


### PR DESCRIPTION
### What does it do?

Makes the new Media Library the default and replaces the opt-**in** beta flag with an opt-**out** escape hatch.

- **`useLegacyMediaLibrary`** (default `false`) replaces `betaMediaLibrary`, which is removed. Setting it to `true` restores the previous Media Library in full.
- The flag sits **flat under `features`**, not under `future.*`. `future.*` means "unstable, may be removed", which fitted the beta flag but not a supported opt-out that outlives the release. This is the first non-`future` config flag, so it sets the precedent: permanent flags flat under `features`, previews nested under `future`.

  ```js
  // config/features.js
  module.exports = {
    useLegacyMediaLibrary: true, // opt out at GA
  };
  ```

- Accessors either side of the wire: `strapi.features.isEnabled('useLegacyMediaLibrary')` on the server, `window.strapi.featureFlags.isEnabled(…)` in the admin. The client needed its own namespace because `window.strapi.features` already carries EE licence feature names (`SSO`, `AUDIT_LOGS`…) rather than configuration.
- Whichever Media Library is selected still owns `plugins/upload` outright — the other is never registered, so there is exactly one entry in the menu.
- **One-time upgrade notice.** At GA every existing app changes behaviour with nothing in its config to hint at it, so `bootstrap` logs the change once. Three conditions keep it from becoming noise: only when the flag is absent (setting it either way is a deliberate choice), only for an app that has booted this plugin before (fresh installs have no Media Library to lose), and only once — tracked in the plugin store, so restarts and multi-instance deployments do not repeat it.

**Beyond the ticket, and worth a look in review:** the e2e specs are gated on a new `E2E_MEDIA_LIBRARY=current|legacy` variable rather than on the product flag, and the folder drag & drop specs are now parked in the specs themselves (`RUN_FOLDER_DRAG_SPECS`) rather than by a CI grep filter.

Following the product default would have pushed the whole Media Library suite into the shared e2e matrix, which runs **WebKit** — no `DataTransfer`, which the upload drag helper builds — and **Firefox**, which has never run this suite. So the CI topology is unchanged in shape: `e2e_media_library_beta` becomes `e2e_media_library`, and it gains a `e2e_media_library_legacy` twin that sets the opt-out so the legacy spec keeps coverage. Letting the suite join the shared matrix is a separate follow-up, and lifting the Chromium-only constraint is the first step of it.

A grep filter also only protects the job that carries it, which is why the parked drag specs moved into the code.

### Why is it needed?

The new Media Library shipped behind an opt-in beta flag. At GA it becomes the default for everyone, and the flag has to reverse: opt *in* to a beta, opt *out* at GA. A single `useLegacyMediaLibrary` across both phases would have meant setting it to `false` to try the new Media Library — a double negative exactly when easy opt-in mattered.

`grid-view.spec.ts` shows a large diff for a one-line change: the longer `describeOnCondition(…)` call wraps, so Prettier re-indented the describe body. No logic changed there.

### How to test it?

**Default on**

1. `cd examples/getstarted && yarn develop`
2. Open **Media Library** — the new one, with nothing set in `config/features.js`.

**Opt back out**

3. Add `useLegacyMediaLibrary: true` to `examples/getstarted/config/features.js` (or `USE_LEGACY_MEDIA_LIBRARY=true`), restart, and confirm the previous Media Library is back — one menu entry, legacy routes, no upload progress dialog.

**Upgrade notice**

4. On an app that has run the upload plugin before, with no flag set, the startup log carries: *"The Media Library has been redesigned and is now the default. To keep the previous one, set `useLegacyMediaLibrary: true` in config/features."*
5. Restart — it does not appear again. Set the flag either way and it stays quiet.

**Automated**

```bash
yarn nx test:unit @strapi/upload                    # 340 pass, incl. 5 notice tests
yarn nx run-many --target=test:front --projects=@strapi/admin,@strapi/upload
yarn build                                          # code + types, 37 projects
yarn test:e2e --domains media-library                # E2E_MEDIA_LIBRARY=current via tests/e2e/.env
E2E_MEDIA_LIBRARY=legacy USE_LEGACY_MEDIA_LIBRARY=true yarn test:e2e --domains media-library
```

### Related issue(s)/PR(s)

- fix CMS-1576
- Follows #27273 (the beta Media Library e2e suite this re-gates)

**Not in this PR**, from the ticket's scope:

- **Documentation** — a hard gate for GA, tracked separately.
- **A removal version for the legacy trees.** The ticket offers "delete them or name a removal version", but deleting them now would leave `useLegacyMediaLibrary: true` with nothing to restore, which is its own acceptance criterion. So only a version can be named, and it needs a product decision (6.0?) to state in the docs from day one.
- **Moving the frozen trees into `legacy/` and promoting `future/`** — a separate PR, deliberately: ~200 renamed files would bury this behaviour change, and reviewers cannot tell a move from an edit in that diff.
- Changelog / upgrade note, and the media field picker gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
