### PR TITLE
ci: add pr blast radius analyzer

### DIFF
--- a/.github/workflows/pr-blast-radius.yml
+++ b/.github/workflows/pr-blast-radius.yml
@@ -1,0 +1,56 @@
+name: PR blast radius (advisory)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, closed]
+
+concurrency:
+  group: pr-blast-radius-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  classify:
+    name: PR blast radius (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Monorepo install
+        uses: ./.github/actions/yarn-nm-install
+      - name: Classify pull request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RESULT_PATH: ${{ runner.temp }}/pr-blast-radius.json
+        run: |
+          set -euo pipefail
+          yarn tsx scripts/pr-blast-radius/index.ts "$PR_NUMBER" --json > "$RESULT_PATH"
+      - name: Validate classifier JSON
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/pr-blast-radius.json
+        run: |
+          node <<'NODE'
+          const { readFileSync } = require('node:fs');
+          const output = readFileSync(process.env.RESULT_PATH, 'utf8');
+          if (output.trim().length === 0) {
+            throw new Error('Classifier produced an empty JSON result.');
+          }
+          JSON.parse(output);
+          NODE
+      - name: Publish advisory job summary
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/pr-blast-radius.json
+        run: |
+          set -euo pipefail
+          yarn tsx scripts/pr-blast-radius/summary.ts "$RESULT_PATH" | tee -a "$GITHUB_STEP_SUMMARY"
+          test -s "$GITHUB_STEP_SUMMARY"

--- a/scripts/pr-blast-radius/__tests__/app.test.ts
+++ b/scripts/pr-blast-radius/__tests__/app.test.ts
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { run } from '../app';
+import type { CommandRunner } from '../types';
+const meta = {
+  number: 1,
+  state: 'open',
+  merged: false,
+  base: { ref: 'develop', sha: 'a'.repeat(40), repo: { full_name: 'strapi/strapi' } },
+  head: { sha: 'b'.repeat(40) },
+  additions: 0,
+  deletions: 0,
+  changed_files: 0,
+};
+test('json failure output is isolated', async () => {
+  let called = false;
+  const runner: CommandRunner = async () => {
+    called = true;
+    return { stdout: '', stderr: '' };
+  };
+  const value = await run(['0', '--json'], { runner });
+  assert.equal(value.exitCode, 2);
+  assert.equal(value.stdout, '');
+  assert.equal(called, false);
+});
+
+test('orchestrates a JSON success without diagnostic noise and uses only read-only commands', async () => {
+  const calls: Array<{ executable: string; args: readonly string[] }> = [];
+  const runner: CommandRunner = async (request) => {
+    calls.push(request);
+    const endpoint = request.args.at(-1);
+    if (request.executable === 'gh')
+      return { stdout: JSON.stringify(endpoint?.includes('/files?') ? [] : meta), stderr: '' };
+    if (request.executable === 'git') return { stdout: 'c'.repeat(40), stderr: '' };
+    return { stdout: request.args.includes('--affected') ? '[]' : '["root"]', stderr: '' };
+  };
+  const value = await run(['1', '--json'], { runner });
+  assert.equal(value.exitCode, 0);
+  assert.equal(value.stderr, '');
+  assert.equal(JSON.parse(value.stdout).radius, 'NON_RUNTIME');
+  assert.equal(
+    calls.every(
+      ({ executable, args }) =>
+        (executable === 'gh' && args[0] === 'api' && args.includes('GET')) ||
+        (executable === 'git' && args.join(' ') === 'rev-parse --verify HEAD^{commit}') ||
+        (executable === 'yarn' && args.slice(0, 3).join(' ') === 'nx show projects')
+    ),
+    true
+  );
+  assert.equal(
+    calls.some(({ args }) => args.includes('b'.repeat(40))),
+    false
+  );
+});
+
+test('preserves known exit categories with empty stdout', async () => {
+  const cases: Array<[number, CommandRunner]> = [
+    [
+      3,
+      async () => {
+        throw new Error('authentication failed');
+      },
+    ],
+    [4, async () => ({ stdout: '{}', stderr: '' })],
+    [
+      5,
+      async ({ executable, args }) =>
+        executable === 'gh'
+          ? {
+              stdout: JSON.stringify(String(args.at(-1)).includes('/files?') ? [] : meta),
+              stderr: '',
+            }
+          : { stdout: 'not json', stderr: '' },
+    ],
+    [
+      6,
+      async ({ executable, args }) => {
+        if (executable === 'gh')
+          return {
+            stdout: JSON.stringify(
+              String(args.at(-1)).includes('/files?')
+                ? [{ filename: 'unknown.ts', status: 'modified' }]
+                : { ...meta, changed_files: 1 }
+            ),
+            stderr: '',
+          };
+        if (executable === 'git') return { stdout: 'c'.repeat(40), stderr: '' };
+        return { stdout: args.includes('--affected') ? '[]' : '["root"]', stderr: '' };
+      },
+    ],
+  ];
+  for (const [exitCode, runner] of cases) {
+    const outcome = await run(['1', '--json'], { runner });
+    assert.equal(outcome.exitCode, exitCode);
+    assert.equal(outcome.stdout, '');
+    assert.notEqual(outcome.stderr, '');
+  }
+});
+
+test('uses the complete affected-project union and selects the greatest dependency reach', async () => {
+  const files = [
+    { filename: 'packages/a/src/a.ts', status: 'modified' },
+    { filename: 'packages/b/src/b.ts', status: 'modified' },
+  ];
+  const runner: CommandRunner = async ({ executable, args }) => {
+    if (executable === 'gh')
+      return {
+        stdout: JSON.stringify(
+          String(args.at(-1)).includes('/files?') ? files : { ...meta, changed_files: 2 }
+        ),
+        stderr: '',
+      };
+    if (executable === 'git') return { stdout: 'c'.repeat(40), stderr: '' };
+    if (!args.includes('--affected'))
+      return {
+        stdout: JSON.stringify(Array.from({ length: 10 }, (_, index) => `p${index}`)),
+        stderr: '',
+      };
+    return {
+      stdout: args.includes('--files=packages/a/src/a.ts')
+        ? '["p0","p1","p2"]'
+        : '["p3","p4","p5"]',
+      stderr: '',
+    };
+  };
+  const result = await run(['1', '--json'], { runner });
+  assert.equal(result.exitCode, 0);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.affectedProjectCount, 6);
+  assert.equal(output.radius, 'REPOSITORY');
+});
+
+test('maps an unclassified internal exception to exit 1 with no stdout', async () => {
+  const original = Array.prototype.flatMap;
+  Array.prototype.flatMap = (() => {
+    throw new Error('injected internal fault');
+  }) as typeof Array.prototype.flatMap;
+  try {
+    const outcome = await run(['1', '--json'], {
+      runner: async ({ args }) => ({
+        stdout: JSON.stringify(String(args.at(-1)).includes('/files?') ? [] : meta),
+        stderr: '',
+      }),
+    });
+    assert.equal(outcome.exitCode, 1);
+    assert.equal(outcome.stdout, '');
+    assert.match(outcome.stderr, /Unexpected blast-radius failure/);
+  } finally {
+    Array.prototype.flatMap = original;
+  }
+});
+
+test('Nx path reach for a Document Service path', async () => {
+  const calls: Array<{ executable: string; args: readonly string[] }> = [];
+  const roots = [
+    'packages/core/core',
+    'packages/core/content-manager',
+    'packages/core/content-releases',
+    'packages/core/review-workflows',
+    'packages/core/upload',
+    'packages/plugins/i18n',
+    'packages/plugins/graphql',
+    'packages/plugins/users-permissions',
+  ];
+  const nodes = Object.fromEntries(
+    roots.map((root) => {
+      const manifest = JSON.parse(readFileSync(`${root}/package.json`, 'utf8')) as {
+        name: string;
+        exports?: Record<string, { source?: string }>;
+      };
+      const source = manifest.exports?.['./strapi-server']?.source;
+      return [
+        manifest.name,
+        {
+          data: {
+            root,
+            metadata: { js: { packageExports: source ? { './strapi-server': { source } } : {} } },
+          },
+        },
+      ];
+    })
+  );
+  const projects = Object.keys(nodes).sort();
+  const activeMeta = { ...meta, changed_files: 1 };
+  const runner: CommandRunner = async (request) => {
+    const { executable, args } = request;
+    calls.push(request);
+    if (executable === 'gh')
+      return {
+        stdout: JSON.stringify(
+          String(args.at(-1)).includes('/files?')
+            ? [
+                {
+                  filename: 'packages/core/core/src/services/document-service/index.ts',
+                  status: 'modified',
+                },
+              ]
+            : activeMeta
+        ),
+        stderr: '',
+      };
+    if (executable === 'git') return { stdout: 'c'.repeat(40), stderr: '' };
+    if (args.includes('graph'))
+      return {
+        stdout: JSON.stringify({
+          graph: {
+            nodes,
+            dependencies: Object.fromEntries(projects.map((project) => [project, []])),
+          },
+        }),
+        stderr: '',
+      };
+    return {
+      stdout: args.includes('--affected')
+        ? JSON.stringify(['@strapi/core'])
+        : JSON.stringify(projects),
+      stderr: '',
+    };
+  };
+  const outcome = await run(['1', '--json'], { runner });
+  assert.equal(outcome.exitCode, 0);
+  const output = JSON.parse(outcome.stdout);
+  assert.deepEqual(output.affectedProjects, ['@strapi/core']);
+  assert.equal(output.affectedProjectCount, 1);
+  assert.equal(output.radius, 'LOCAL');
+  assert.equal('reachProvenance' in output, false);
+  assert.equal(
+    output.reasons.some((reason: string) => /Document Service runtime reach/.test(reason)),
+    false
+  );
+  assert.equal(
+    calls.some(({ executable, args }) => executable === 'yarn' && args.includes('graph')),
+    false
+  );
+});

--- a/scripts/pr-blast-radius/__tests__/classifier.test.ts
+++ b/scripts/pr-blast-radius/__tests__/classifier.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { classify } from '../classifier';
+const c = (n: number, total = 46, global = false) =>
+  classify({
+    affectedProjects: Array.from({ length: n }, (_, i) => `p${i}`),
+    totalProjects: total,
+    globalMatches: global
+      ? [{ category: 'workflow-definition', path: '.github/workflows/a.yml' }]
+      : [],
+    allPathsRecognizedNonRuntime: true,
+  });
+test('classifies tiers, boundaries and global precedence', () => {
+  assert.equal(c(0).radius, 'NON_RUNTIME');
+  assert.equal(c(1).radius, 'LOCAL');
+  assert.equal(c(2).radius, 'FEATURE');
+  assert.equal(c(5).radius, 'FEATURE');
+  assert.equal(c(6).radius, 'WIDE');
+  assert.equal(c(23).radius, 'REPOSITORY');
+  assert.equal(c(0, 46, true).radius, 'REPOSITORY');
+  assert.equal(c(1, 2).radius, 'REPOSITORY');
+});
+
+test('uses half thresholds for odd, even, and tiny workspaces independently of sensitivity', () => {
+  assert.equal(c(6, 13).radius, 'WIDE');
+  assert.equal(c(7, 13).radius, 'REPOSITORY');
+  assert.equal(c(3, 6).radius, 'REPOSITORY');
+  assert.equal(c(1, 1).radius, 'REPOSITORY');
+  assert.equal(c(0, 1).radius, 'NON_RUNTIME');
+  const withoutSignals = c(6, 13).radius;
+  // Sensitivity is deliberately absent from the classifier input type, so it cannot alter reach.
+  assert.equal(withoutSignals, 'WIDE');
+});

--- a/scripts/pr-blast-radius/__tests__/cli.test.ts
+++ b/scripts/pr-blast-radius/__tests__/cli.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseCliArgs } from '../cli';
+import { BlastRadiusError, ExitCode } from '../errors';
+
+test('parses numbers and canonical PR URL variants', () => {
+  for (const argv of [
+    ['00123'],
+    ['--json', '123'],
+    ['https://github.com/strapi/strapi/pull/123/'],
+    ['https://github.com/strapi/strapi/pull/123/?x=1#part', '--json'],
+  ]) {
+    assert.deepEqual(parseCliArgs(argv), {
+      repository: 'strapi/strapi',
+      pullRequest: 123,
+      json: argv.includes('--json'),
+    });
+  }
+});
+
+test('rejects unsafe and unexpected input as invalid CLI input', () => {
+  for (const argv of [
+    [],
+    ['0'],
+    ['1.2'],
+    ['https://github.com/other/repo/pull/1'],
+    ['http://github.com/strapi/strapi/pull/1'],
+    ['https://github.com/strapi/strapi/pulls/1'],
+    ['123', '456'],
+    ['--json', '--json', '1'],
+    ['--', '1'],
+  ]) {
+    assert.throws(
+      () => parseCliArgs(argv),
+      (error: unknown) =>
+        error instanceof BlastRadiusError && error.exitCode === ExitCode.InvalidInput
+    );
+  }
+});

--- a/scripts/pr-blast-radius/__tests__/command-runner.test.ts
+++ b/scripts/pr-blast-radius/__tests__/command-runner.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createCommandRunner } from '../command-runner';
+test('command runner is an injectable no-shell boundary', async () => {
+  let call: { file: string; args: readonly string[]; options: Record<string, unknown> } | undefined;
+  const fake = ((
+    file: string,
+    args: readonly string[],
+    options: Record<string, unknown>,
+    callback: Function
+  ) => {
+    call = { file, args, options };
+    callback(null, 'out', 'err');
+  }) as never;
+  const runner = createCommandRunner(fake);
+  const hostile = ['a b', '"quote"', 'line\nnext', ';|$()', '--looks-like-option'];
+  assert.deepEqual(
+    await runner({ executable: 'gh', args: hostile, cwd: '/safe', env: { TEST: 'yes' } }),
+    { stdout: 'out', stderr: 'err' }
+  );
+  assert.deepEqual(call?.args, hostile);
+  assert.equal(call?.file, 'gh');
+  assert.equal(call?.options.shell, false);
+  assert.equal(call?.options.encoding, 'utf8');
+  assert.equal(call?.options.maxBuffer, 1048576);
+});

--- a/scripts/pr-blast-radius/__tests__/entrypoint.test.ts
+++ b/scripts/pr-blast-radius/__tests__/entrypoint.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import test from 'node:test';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+
+const root = join(process.cwd(), 'package.json');
+test('direct entrypoints replace package aliases while retaining the thin process boundary', async () => {
+  const packageJson = JSON.parse(await readFile(root, 'utf8')) as {
+    scripts: Record<string, string>;
+  };
+  assert.equal(packageJson.scripts['pr:blast-radius'], undefined);
+  assert.equal(packageJson.scripts['pr:blast-radius:test'], undefined);
+
+  const directClassifier =
+    'yarn tsx scripts/pr-blast-radius/index.ts <number|https://github.com/strapi/strapi/pull/<number>> [--json]';
+  const directTests = 'yarn tsx --test scripts/pr-blast-radius/__tests__/*.test.ts';
+  assert.equal(
+    directClassifier,
+    'yarn tsx scripts/pr-blast-radius/index.ts <number|https://github.com/strapi/strapi/pull/<number>> [--json]'
+  );
+  assert.equal(directTests, 'yarn tsx --test scripts/pr-blast-radius/__tests__/*.test.ts');
+
+  const cli = await readFile(join(process.cwd(), 'scripts/pr-blast-radius/cli.ts'), 'utf8');
+  assert.match(cli, new RegExp(directClassifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.doesNotMatch(cli, /yarn pr:blast-radius/);
+
+  const source = await readFile(join(process.cwd(), 'scripts/pr-blast-radius/index.ts'), 'utf8');
+  assert.match(source, /createCommandRunner\(\)/);
+  assert.match(source, /run\(process\.argv\.slice\(2\)/);
+  assert.doesNotMatch(source, /retrievePullRequest|analyzeWorkspace|classify\(/);
+});
+test('direct usage is stderr-only for invalid input before external commands', async () => {
+  const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>(
+    (resolve) => {
+      const child = spawn('yarn', ['tsx', 'scripts/pr-blast-radius/index.ts', '0', '--json'], {
+        cwd: process.cwd(),
+        shell: false,
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => {
+        stdout += String(chunk);
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += String(chunk);
+      });
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    }
+  );
+  assert.equal(result.code, 2);
+  assert.equal(result.stdout, '');
+  assert.match(
+    result.stderr,
+    /Usage: yarn tsx scripts\/pr-blast-radius\/index\.ts <number\|https:\/\/github\.com\/strapi\/strapi\/pull\/<number>> \[--json\]/
+  );
+  assert.doesNotMatch(result.stderr, /yarn pr:blast-radius/);
+});
+test('static safety keeps shell execution and prohibited ref operations out of orchestration', async () => {
+  const sources = await Promise.all(
+    ['app.ts', 'github.ts', 'nx.ts', 'index.ts'].map((file) =>
+      readFile(join(process.cwd(), 'scripts/pr-blast-radius', file), 'utf8')
+    )
+  );
+  assert.doesNotMatch(sources.join('\n'), /\b(?:checkout|fetch|diff|reset)\b/);
+  const runner = await readFile(
+    join(process.cwd(), 'scripts/pr-blast-radius/command-runner.ts'),
+    'utf8'
+  );
+  assert.match(runner, /execFile/);
+  assert.match(runner, /shell:\s*false/);
+});
+
+test('no Document Service runtime analyzer ownership or references', async () => {
+  const directory = join(process.cwd(), 'scripts/pr-blast-radius');
+  await Promise.all(
+    ['document-service-reach.ts', 'source-analysis.ts'].map(async (file) =>
+      assert.rejects(access(join(directory, file)))
+    )
+  );
+  const productionFiles = [
+    'app.ts',
+    'classifier.ts',
+    'cli.ts',
+    'command-runner.ts',
+    'errors.ts',
+    'format.ts',
+    'github.ts',
+    'index.ts',
+    'nx.ts',
+    'paths.ts',
+    'types.ts',
+  ];
+  const sources = await Promise.all(
+    productionFiles.map((file) => readFile(join(directory, file), 'utf8'))
+  );
+  const forbidden = [
+    'document-service-reach',
+    'source-analysis',
+    'ReachProvenanceV2',
+    'BlastRadiusResultV2',
+    'reachProvenance',
+    'runtimeAnalysis',
+    'WorkspaceRuntimeGraph',
+    'parseWorkspaceRuntimeGraph',
+    'Runtime contracts',
+    'Document Service runtime reach',
+  ];
+  for (const value of forbidden) assert.doesNotMatch(sources.join('\n'), new RegExp(value));
+  assert.doesNotMatch(sources.join('\n'), /['"]nx['"],\s*['"]graph['"]/);
+});

--- a/scripts/pr-blast-radius/__tests__/format.test.ts
+++ b/scripts/pr-blast-radius/__tests__/format.test.ts
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createResult, renderHuman, renderJson, renderMarkdown } from '../format';
+test('renders stable JSON only', () => {
+  const text = renderJson({
+    schemaVersion: 2,
+    classifierVersion: 2,
+    repository: 'strapi/strapi',
+    radius: 'LOCAL',
+  });
+  assert.equal(
+    text,
+    '{"schemaVersion":2,"classifierVersion":2,"repository":"strapi/strapi","radius":"LOCAL"}\n'
+  );
+});
+
+test('version-1 output without runtime provenance', () => {
+  const result = createResult({
+    snapshot: {
+      number: 2,
+      state: 'closed',
+      merged: true,
+      base: { branch: 'develop', sha: 'A'.repeat(40) },
+      head: { sha: 'B'.repeat(40) },
+      additions: 3,
+      deletions: 1,
+      changedFiles: 2,
+      files: [
+        { path: 'z.ts', status: 'modified' },
+        { path: 'a.ts', previousPath: 'old.ts', status: 'renamed' },
+      ],
+    },
+    workspaceRevision: 'C'.repeat(40),
+    radius: 'LOCAL',
+    reasons: ['z', 'a'],
+    affectedProjects: ['z', 'a', 'a'],
+    totalProjects: 8,
+    sensitivitySignals: ['permissions', 'authentication'],
+  });
+  assert.deepEqual(Object.keys(result), [
+    'schemaVersion',
+    'classifierVersion',
+    'repository',
+    'pullRequest',
+    'prRevision',
+    'workspaceRevision',
+    'radius',
+    'radiusDefinition',
+    'changedFiles',
+    'additions',
+    'deletions',
+    'affectedProjectCount',
+    'totalProjectCount',
+    'affectedProjects',
+    'sensitivitySignals',
+    'reasons',
+    'warnings',
+  ]);
+  assert.equal(result.schemaVersion, 1);
+  assert.equal(result.classifierVersion, 1);
+  assert.equal('reachProvenance' in result, false);
+  assert.deepEqual(result.affectedProjects, ['a', 'z']);
+  assert.deepEqual(
+    result.changedFiles.map((file) => file.path),
+    ['a.ts', 'z.ts']
+  );
+  assert.equal(
+    renderJson(result),
+    renderJson(
+      createResult({
+        snapshot: {
+          ...result.pullRequest,
+          base: result.pullRequest.base,
+          head: result.pullRequest.head,
+          additions: 3,
+          deletions: 1,
+          changedFiles: 2,
+          files: result.changedFiles,
+        },
+        workspaceRevision: result.workspaceRevision,
+        radius: result.radius,
+        reasons: ['a', 'z'],
+        affectedProjects: ['a', 'z'],
+        totalProjects: 8,
+        sensitivitySignals: ['authentication', 'permissions'],
+      })
+    )
+  );
+  assert.equal(
+    renderHuman(result),
+    `PR strapi/strapi#2 — LOCAL\n\n2 of 8 projects affected\n2 files changed · +3 / -1\n\nAffected projects\n- a\n- z\n\nSensitivity signals\n- Authentication\n- Permissions\n\nWhy this tier\n- a\n- z\n\nAnalysis basis\n- GitHub PR revision: bbbbbbb\n- Current checkout Nx graph: ccccccc\n- Note: Uncommitted local graph-configuration changes are not represented by this hash.\n\nClassifier version: 1\n`
+  );
+  assert.doesNotMatch(renderJson(result), /reachProvenance|Document Service runtime reach/);
+  assert.doesNotMatch(renderHuman(result), /Runtime contracts|Document Service runtime reach/);
+  assert.deepEqual(result.warnings, [
+    "PR metadata and changed paths come from GitHub at bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; affected projects come from the current checkout's Nx graph at cccccccccccccccccccccccccccccccccccccccc.",
+    'Workspace revision identifies the checked-out commit; uncommitted local graph-configuration changes, if any, are not represented by that hash.',
+  ]);
+});
+
+test('renders deterministic injection-safe Markdown with readable labels', () => {
+  const result = createResult({
+    snapshot: {
+      number: 3,
+      state: 'open',
+      merged: false,
+      base: { branch: 'develop', sha: 'a'.repeat(40) },
+      head: { sha: 'b'.repeat(40) },
+      additions: 1,
+      deletions: 0,
+      changedFiles: 1,
+      files: [{ path: 'safe.ts', status: 'modified' }],
+    },
+    workspaceRevision: 'c'.repeat(40),
+    radius: 'LOCAL',
+    reasons: ['Why `this` <matters>'],
+    affectedProjects: ['<script>\n```\u0085\u202e\u2028\u2029', 'plain-project'],
+    totalProjects: 2,
+    sensitivitySignals: ['shared-test-infrastructure', 'future_signal'],
+  });
+
+  const markdown = renderMarkdown(result);
+  assert.equal(markdown, renderMarkdown(result));
+  assert.match(markdown, /^## PR strapi\/strapi#3 — LOCAL\n\n> Advisory only:/);
+  assert.match(markdown, /2 of 2 projects affected\n1 file changed · \+1 \/ -0/);
+  assert.match(markdown, /- &lt;script&gt;\\u000a&#96;&#96;&#96;/);
+  assert.match(markdown, /\\u0085\\u202e\\u2028\\u2029/);
+  assert.match(markdown, /- plain\\-project/);
+  assert.match(markdown, /- Shared test infrastructure/);
+  assert.match(markdown, /- Future Signal/);
+  assert.match(markdown, /Why this tier\n\n- Why &#96;this&#96; &lt;matters&gt;/);
+  assert.match(markdown, /Uncommitted local graph\\-configuration changes are not represented/);
+  assert.match(markdown, /Classifier version: 1/);
+  assert.doesNotMatch(markdown, /<script>|\n```|\u0085|\u202e|\u2028|\u2029/);
+});
+
+test('uses None for empty human and Markdown lists', () => {
+  const result = createResult({
+    snapshot: {
+      number: 4,
+      state: 'open',
+      merged: false,
+      base: { branch: 'develop', sha: 'a'.repeat(40) },
+      head: { sha: 'b'.repeat(40) },
+      additions: 0,
+      deletions: 0,
+      changedFiles: 0,
+      files: [],
+    },
+    workspaceRevision: 'c'.repeat(40),
+    radius: 'NON_RUNTIME',
+    reasons: [],
+    affectedProjects: [],
+    totalProjects: 2,
+    sensitivitySignals: [],
+  });
+
+  assert.match(
+    renderHuman(result),
+    /Affected projects\n- None\n\nSensitivity signals\n- None\n\nWhy this tier\n- None/
+  );
+  assert.match(
+    renderMarkdown(result),
+    /Affected projects\n\n- None\n\nSensitivity signals\n\n- None\n\nWhy this tier\n\n- None/
+  );
+});
+
+test('uses code-point changed-file ordering independent of input permutation', () => {
+  const input = (changedFiles: Array<{ path: string; status: 'modified' }>) =>
+    createResult({
+      snapshot: {
+        number: 1,
+        state: 'open',
+        merged: false,
+        base: { branch: 'develop', sha: 'a'.repeat(40) },
+        head: { sha: 'b'.repeat(40) },
+        additions: 0,
+        deletions: 0,
+        changedFiles: changedFiles.length,
+        files: changedFiles,
+      },
+      workspaceRevision: 'c'.repeat(40),
+      radius: 'NON_RUNTIME',
+      reasons: [],
+      affectedProjects: [],
+      totalProjects: 2,
+      sensitivitySignals: [],
+    });
+  const first = input([
+    { path: 'ä.ts', status: 'modified' },
+    { path: 'z.ts', status: 'modified' },
+  ]);
+  const second = input([
+    { path: 'z.ts', status: 'modified' },
+    { path: 'ä.ts', status: 'modified' },
+  ]);
+  assert.deepEqual(
+    first.changedFiles.map((file) => file.path),
+    ['z.ts', 'ä.ts']
+  );
+  assert.equal(renderJson(first), renderJson(second));
+});

--- a/scripts/pr-blast-radius/__tests__/github.test.ts
+++ b/scripts/pr-blast-radius/__tests__/github.test.ts
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { retrievePullRequest } from '../github';
+import { BlastRadiusError, ExitCode } from '../errors';
+import type { CommandRunner } from '../types';
+
+const sha = 'a'.repeat(40);
+const metadata = (overrides: Record<string, unknown> = {}) => ({
+  number: 12,
+  state: 'open',
+  merged: false,
+  base: { ref: 'develop', sha, repo: { full_name: 'strapi/strapi' } },
+  head: { sha: 'B'.repeat(40) },
+  additions: 3,
+  deletions: 1,
+  changed_files: 3,
+  ...overrides,
+});
+function transcript(
+  meta: unknown = metadata(),
+  files: unknown = [
+    { filename: 'src/a.ts', status: 'added' },
+    { filename: 'src/old.ts', status: 'removed' },
+    { filename: 'src/new.ts', previous_filename: 'src/previous.ts', status: 'renamed' },
+  ]
+) {
+  const calls: Array<{ executable: string; args: readonly string[] }> = [];
+  const runner: CommandRunner = async (request) => {
+    calls.push(request);
+    const endpoint = request.args.at(-1);
+    return { stdout: JSON.stringify(endpoint?.includes('/files?') ? files : meta), stderr: '' };
+  };
+  return { runner, calls };
+}
+
+test('retrieves complete open and fork-originated metadata with exact read-only gh arguments', async () => {
+  const { runner, calls } = transcript();
+  const result = await retrievePullRequest(runner, 12);
+  assert.equal(result.head.sha, 'b'.repeat(40));
+  assert.deepEqual(result.files[2], {
+    path: 'src/new.ts',
+    previousPath: 'src/previous.ts',
+    status: 'renamed',
+  });
+  assert.deepEqual(calls[0].args, [
+    'api',
+    '--method',
+    'GET',
+    '--header',
+    'Accept: application/vnd.github+json',
+    '--header',
+    'X-GitHub-Api-Version: 2022-11-28',
+    '/repos/strapi/strapi/pulls/12',
+  ]);
+  assert.equal(
+    calls.every((call) => call.executable === 'gh' && call.args.includes('GET')),
+    true
+  );
+});
+test('accepts closed merged and closed unmerged PR metadata', async () => {
+  for (const value of [
+    metadata({ state: 'closed', merged: true }),
+    metadata({ state: 'closed', merged: false }),
+  ])
+    assert.equal((await retrievePullRequest(transcript(value).runner, 12)).state, 'closed');
+});
+test('rejects malformed metadata, paths, statuses, duplicates, and command failure in distinct categories', async () => {
+  for (const [meta, files] of [
+    [metadata({ additions: '3' }), undefined],
+    [metadata(), [{ filename: '../bad.ts', status: 'added' }]],
+    [metadata(), [{ filename: 'a', status: 'copied' }]],
+    [
+      metadata({ changed_files: 2 }),
+      [
+        { filename: 'a', status: 'added' },
+        { filename: 'a', status: 'modified' },
+      ],
+    ],
+  ])
+    await assert.rejects(
+      () => retrievePullRequest(transcript(meta, files as never).runner, 12),
+      (error: unknown) =>
+        error instanceof BlastRadiusError && error.exitCode === ExitCode.IncompletePullRequest
+    );
+  const failing: CommandRunner = async () => {
+    throw new Error('authentication failed');
+  };
+  await assert.rejects(
+    () => retrievePullRequest(failing, 12),
+    (error: unknown) => error instanceof BlastRadiusError && error.exitCode === ExitCode.GitHub
+  );
+});
+test('pagination count limit snapshot and empty PR completeness', async () => {
+  const empty = metadata({ changed_files: 0 });
+  const emptyCalls: string[] = [];
+  await retrievePullRequest(async (request) => {
+    const endpoint = request.args.at(-1)!;
+    emptyCalls.push(endpoint);
+    return { stdout: JSON.stringify(endpoint.includes('/files?') ? [] : empty), stderr: '' };
+  }, 12);
+  assert.equal(emptyCalls.filter((endpoint) => endpoint.includes('/files?')).length, 1);
+  await assert.rejects(
+    () => retrievePullRequest(transcript(metadata({ changed_files: 3001 }), []).runner, 12),
+    (error: unknown) =>
+      error instanceof BlastRadiusError && error.exitCode === ExitCode.IncompletePullRequest
+  );
+  const malformed: CommandRunner = async () => ({ stdout: '{', stderr: '' });
+  await assert.rejects(
+    () => retrievePullRequest(malformed, 12),
+    (error: unknown) =>
+      error instanceof BlastRadiusError && error.exitCode === ExitCode.IncompletePullRequest
+  );
+});
+
+test('fetches every required page through the 3,000-file boundary and detects snapshot changes', async () => {
+  const records = Array.from({ length: 3000 }, (_, index) => ({
+    filename: `docs/${index}.md`,
+    status: 'modified',
+  }));
+  const calls: string[] = [];
+  await retrievePullRequest(async ({ args }) => {
+    const endpoint = String(args.at(-1));
+    calls.push(endpoint);
+    if (!endpoint.includes('/files?'))
+      return { stdout: JSON.stringify(metadata({ changed_files: 3000 })), stderr: '' };
+    const page = Number(new URL(`https://example.test${endpoint}`).searchParams.get('page'));
+    return { stdout: JSON.stringify(records.slice((page - 1) * 100, page * 100)), stderr: '' };
+  }, 12);
+  assert.equal(calls.filter((endpoint) => endpoint.includes('/files?')).length, 30);
+  let metadataCalls = 0;
+  await assert.rejects(
+    () =>
+      retrievePullRequest(async ({ args }) => {
+        const endpoint = String(args.at(-1));
+        if (endpoint.includes('/files?'))
+          return {
+            stdout: JSON.stringify([{ filename: 'docs/a.md', status: 'modified' }]),
+            stderr: '',
+          };
+        metadataCalls += 1;
+        return {
+          stdout: JSON.stringify(
+            metadata({ changed_files: 1, additions: metadataCalls === 1 ? 1 : 2 })
+          ),
+          stderr: '',
+        };
+      }, 12),
+    (error: unknown) =>
+      error instanceof BlastRadiusError && error.exitCode === ExitCode.IncompletePullRequest
+  );
+});
+
+test('requires exact two-page file transcripts and rejects malformed file evidence', async () => {
+  const twoPages = Array.from({ length: 101 }, (_, index) => ({
+    filename: `docs/${index}.md`,
+    status: 'modified',
+  }));
+  const calls: string[] = [];
+  await retrievePullRequest(async ({ args }) => {
+    const endpoint = String(args.at(-1));
+    calls.push(endpoint);
+    if (!endpoint.includes('/files?'))
+      return { stdout: JSON.stringify(metadata({ changed_files: 101 })), stderr: '' };
+    const page = Number(new URL(`https://example.test${endpoint}`).searchParams.get('page'));
+    return { stdout: JSON.stringify(twoPages.slice((page - 1) * 100, page * 100)), stderr: '' };
+  }, 12);
+  assert.deepEqual(
+    calls
+      .filter((value) => value.includes('/files?'))
+      .map((value) => value.slice(value.indexOf('?'))),
+    ['?per_page=100&page=1', '?per_page=100&page=2']
+  );
+  for (const files of [
+    twoPages.slice(0, 99),
+    [...twoPages, { filename: 'docs/extra.md', status: 'modified' }],
+  ]) {
+    await assert.rejects(
+      () => retrievePullRequest(transcript(metadata({ changed_files: 101 }), files).runner, 12),
+      (error: unknown) =>
+        error instanceof BlastRadiusError && error.exitCode === ExitCode.IncompletePullRequest
+    );
+  }
+  const malformedFiles: Array<[Record<string, unknown>, string]> = [
+    [{ filename: '/absolute.ts', status: 'added' }, 'invalid changed-file record'],
+    [{ filename: 'a.ts', status: 'copied' }, 'invalid changed-file record'],
+    [{ filename: 'a.ts', status: 'renamed' }, 'incomplete rename record'],
+    [
+      { filename: 'a.ts', status: 'renamed', previous_filename: '../old.ts' },
+      'incomplete rename record',
+    ],
+  ];
+  for (const [file, diagnostic] of malformedFiles) {
+    await assert.rejects(
+      () => retrievePullRequest(transcript(metadata({ changed_files: 1 }), [file]).runner, 12),
+      (error: unknown) =>
+        error instanceof BlastRadiusError &&
+        error.exitCode === ExitCode.IncompletePullRequest &&
+        error.message.includes(diagnostic)
+    );
+  }
+});

--- a/scripts/pr-blast-radius/__tests__/nx.test.ts
+++ b/scripts/pr-blast-radius/__tests__/nx.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { analyzeWorkspace } from '../nx';
+import type { CommandRunner } from '../types';
+import { BlastRadiusError, ExitCode } from '../errors';
+test('uses current workspace graph with per-path safe probes', async () => {
+  const calls: string[][] = [];
+  const runner: CommandRunner = async ({ executable, args }) => {
+    calls.push([executable, ...args]);
+    if (executable === 'git') return { stdout: 'a'.repeat(40), stderr: '' };
+    return { stdout: args.includes('--affected') ? '["p"]' : '["p","q"]', stderr: '' };
+  };
+  const result = await analyzeWorkspace(runner, ['a.ts']);
+  assert.deepEqual(result.affectedProjects, ['p']);
+  assert.equal(
+    calls.some((call) => call.includes('--files=a.ts')),
+    true
+  );
+});
+test('failure malformed unmapped comma and revision paths fail safely', async () => {
+  const runner: CommandRunner = async ({ executable, args }) =>
+    executable === 'git'
+      ? { stdout: 'a'.repeat(40), stderr: '' }
+      : { stdout: args.includes('--affected') ? '[]' : '["p"]', stderr: '' };
+  await assert.rejects(() => analyzeWorkspace(runner, ['packages/core/src/a.ts']));
+  await assert.rejects(() => analyzeWorkspace(runner, ['a,b.ts']));
+  const bad: CommandRunner = async ({ executable }) =>
+    executable === 'git' ? { stdout: 'not-a-revision', stderr: '' } : { stdout: '[]', stderr: '' };
+  await assert.rejects(() => analyzeWorkspace(bad, ['docs/a.md']));
+});
+
+test('uses isolated Nx environment and maps graph failures to exit 5 and unmapped paths to exit 6', async () => {
+  const calls: Array<{
+    executable: string;
+    args: readonly string[];
+    env?: Readonly<Record<string, string>>;
+  }> = [];
+  const runner: CommandRunner = async (request) => {
+    calls.push(request);
+    if (request.executable === 'git') return { stdout: 'a'.repeat(40), stderr: '' };
+    return { stdout: request.args.includes('--affected') ? '["p"]' : '["p","q"]', stderr: '' };
+  };
+  const value = await analyzeWorkspace(runner, ['z.ts', 'a.ts']);
+  assert.deepEqual(value.affectedProjects, ['p']);
+  for (const call of calls.filter((call) => call.executable === 'yarn')) {
+    assert.equal(call.env?.NX_DAEMON, 'false');
+    assert.equal(call.env?.NX_CACHE_PROJECT_GRAPH, 'false');
+    assert.match(String(call.env?.NX_WORKSPACE_DATA_DIRECTORY), /strapi-pr-blast-radius-/);
+  }
+  const invalid: CommandRunner = async ({ executable }) =>
+    executable === 'git' ? { stdout: 'a'.repeat(40), stderr: '' } : { stdout: '{}', stderr: '' };
+  await assert.rejects(
+    () => analyzeWorkspace(invalid, ['docs/a.md']),
+    (error: unknown) => error instanceof BlastRadiusError && error.exitCode === ExitCode.Nx
+  );
+  const subset: CommandRunner = async ({ executable, args }) =>
+    executable === 'git'
+      ? { stdout: 'a'.repeat(40), stderr: '' }
+      : { stdout: args.includes('--affected') ? '["outside"]' : '["p"]', stderr: '' };
+  await assert.rejects(
+    () => analyzeWorkspace(subset, ['docs/a.md']),
+    (error: unknown) => error instanceof BlastRadiusError && error.exitCode === ExitCode.Nx
+  );
+});
+
+test('maps temporary workspace setup and cleanup failures to Nx while preserving primary failures', async () => {
+  const runner: CommandRunner = async ({ executable, args }) =>
+    executable === 'git'
+      ? { stdout: 'a'.repeat(40), stderr: '' }
+      : { stdout: args.includes('--affected') ? '[]' : '["p"]', stderr: '' };
+  const setup = {
+    createTemp: async () => {
+      throw new Error('no tmp');
+    },
+    removeTemp: async () => undefined,
+  };
+  await assert.rejects(
+    () => analyzeWorkspace(runner, ['docs/a.md'], process.cwd(), setup),
+    (error: unknown) => error instanceof BlastRadiusError && error.exitCode === ExitCode.Nx
+  );
+  const removed: string[] = [];
+  const lifecycle = {
+    createTemp: async () => '/tmp/blast-radius-test',
+    removeTemp: async (path: string) => {
+      removed.push(path);
+    },
+  };
+  await analyzeWorkspace(runner, ['docs/a.md'], process.cwd(), lifecycle);
+  assert.deepEqual(removed, ['/tmp/blast-radius-test']);
+  const cleanupFails = {
+    createTemp: async () => '/tmp/blast-radius-test',
+    removeTemp: async () => {
+      throw new Error('cleanup');
+    },
+  };
+  await assert.rejects(
+    () => analyzeWorkspace(runner, ['docs/a.md'], process.cwd(), cleanupFails),
+    (error: unknown) => error instanceof BlastRadiusError && error.exitCode === ExitCode.Nx
+  );
+  await assert.rejects(
+    () => analyzeWorkspace(runner, ['unknown.ts'], process.cwd(), cleanupFails),
+    (error: unknown) =>
+      error instanceof BlastRadiusError && error.exitCode === ExitCode.UnrecognizedPath
+  );
+});
+
+test('uses one discrete probe for deletions and two sorted probes for renames, and rejects runner and revision races', async () => {
+  const calls: string[][] = [];
+  let gitCalls = 0;
+  const runner: CommandRunner = async ({ executable, args }) => {
+    calls.push([executable, ...args]);
+    if (executable === 'git') {
+      gitCalls += 1;
+      return { stdout: (gitCalls === 1 ? 'a' : 'b').repeat(40), stderr: '' };
+    }
+    return { stdout: args.includes('--affected') ? '["p"]' : '["p"]', stderr: '' };
+  };
+  await assert.rejects(
+    () => analyzeWorkspace(runner, ['new name;$(x).ts', 'old.ts']),
+    (error: unknown) => error instanceof BlastRadiusError && error.exitCode === ExitCode.Nx
+  );
+  assert.equal(
+    calls.some((call) => call.includes('--files=new name;$(x).ts')),
+    true
+  );
+  const failing: CommandRunner = async () => {
+    throw new Error('runner failure');
+  };
+  await assert.rejects(
+    () => analyzeWorkspace(failing, ['docs/a.md']),
+    (error: unknown) => error instanceof BlastRadiusError && error.exitCode === ExitCode.Nx
+  );
+});

--- a/scripts/pr-blast-radius/__tests__/paths.test.ts
+++ b/scripts/pr-blast-radius/__tests__/paths.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { analysisPaths, globalCategories, isNonRuntimePath, sensitivitySignals } from '../paths';
+test('expands rename paths and matches global and non-runtime categories without near misses', () => {
+  assert.deepEqual(analysisPaths([{ path: 'new.ts', previousPath: 'old.ts', status: 'renamed' }]), [
+    'new.ts',
+    'old.ts',
+  ]);
+  for (const path of [
+    'package.json',
+    'yarn.lock',
+    '.yarn/cache/a',
+    '.github/workflows/a.yml',
+    '.github/actions/run-build/a',
+    'packages/core/package.json',
+  ])
+    assert.notEqual(globalCategories(path).length, 0);
+  assert.equal(globalCategories('package-lock.json').length, 0);
+  for (const path of [
+    'docs/a.md',
+    'tests/a.ts',
+    'scripts/a.ts',
+    'examples/a.ts',
+    '.github/ISSUE_TEMPLATE/a.md',
+  ])
+    assert.equal(isNonRuntimePath(path), true);
+  assert.equal(isNonRuntimePath('packages/core/src/a.ts'), false);
+});
+test('emits each sensitivity signal exactly once from exact path evidence', () => {
+  assert.deepEqual(
+    sensitivitySignals([
+      'packages/plugins/users-permissions/auth.ts',
+      'packages/core/permissions/rbac.ts',
+      'tests/migration/a.ts',
+      'packages/core/database/a.sql',
+      'packages/core/types/a.ts',
+      '.changeset/a',
+      '.github/actions/run-api-tests/a',
+      '.github/workflows/release.yml',
+    ]),
+    [
+      'authentication',
+      'database-persistence',
+      'migrations',
+      'permissions',
+      'public-types',
+      'release-tooling',
+      'shared-test-infrastructure',
+      'workflow-changes',
+    ]
+  );
+  assert.deepEqual(sensitivitySignals(['authorization-code.ts']), []);
+});
+
+test('limits examples complex migration evidence to the approved fixture surface', () => {
+  assert.deepEqual(sensitivitySignals(['examples/complex/README.md']), []);
+  assert.deepEqual(
+    sensitivitySignals([
+      'examples/complex/config/database.ts',
+      'examples/complex/scripts/seed-v4.ts',
+      'examples/complex/src/index.ts',
+      'examples/complex/package.json',
+      'examples/complex/docker-compose.dev.yml',
+    ]),
+    ['database-persistence', 'migrations']
+  );
+});

--- a/scripts/pr-blast-radius/__tests__/summary.test.ts
+++ b/scripts/pr-blast-radius/__tests__/summary.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import test from 'node:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createResult, renderJson } from '../format';
+import { runSummary } from '../summary-app';
+
+const result = createResult({
+  snapshot: {
+    number: 3,
+    state: 'open',
+    merged: false,
+    base: { branch: 'develop', sha: 'a'.repeat(40) },
+    head: { sha: 'b'.repeat(40) },
+    additions: 1,
+    deletions: 0,
+    changedFiles: 1,
+    files: [{ path: 'safe.ts', status: 'modified' }],
+  },
+  workspaceRevision: 'c'.repeat(40),
+  radius: 'LOCAL',
+  reasons: [],
+  affectedProjects: ['plain-project'],
+  totalProjects: 2,
+  sensitivitySignals: [],
+});
+
+test('renders Markdown only from exactly one structurally valid JSON file', async () => {
+  const outcome = await runSummary(['result.json'], async (path) => {
+    assert.equal(path, 'result.json');
+    return renderJson(result);
+  });
+
+  assert.equal(outcome.exitCode, 0);
+  assert.equal(outcome.stderr, '');
+  assert.match(outcome.stdout, /^## PR strapi\/strapi#3 — LOCAL/);
+});
+
+test('accepts the 64-hex workspace revision emitted by Nx', async () => {
+  const outcome = await runSummary(['result.json'], async () =>
+    JSON.stringify({ ...result, workspaceRevision: 'c'.repeat(64) })
+  );
+
+  assert.equal(outcome.exitCode, 0);
+  assert.equal(outcome.stderr, '');
+  assert.match(outcome.stdout, /Current checkout Nx graph: ccccccc/);
+});
+
+test('runs the summary entrypoint as a real child process', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pr-blast-radius-summary-'));
+  const resultPath = join(directory, 'result.json');
+  await writeFile(resultPath, renderJson(result), 'utf8');
+
+  try {
+    const outcome = await new Promise<{ code: number | null; stdout: string; stderr: string }>(
+      (resolve) => {
+        const child = spawn('yarn', ['tsx', 'scripts/pr-blast-radius/summary.ts', resultPath], {
+          cwd: process.cwd(),
+          shell: false,
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (chunk) => {
+          stdout += String(chunk);
+        });
+        child.stderr.on('data', (chunk) => {
+          stderr += String(chunk);
+        });
+        child.on('close', (code) => resolve({ code, stdout, stderr }));
+      }
+    );
+    assert.equal(outcome.code, 0);
+    assert.equal(outcome.stderr, '');
+    assert.match(outcome.stdout, /^## PR strapi\/strapi#3 — LOCAL/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('rejects invalid arguments and malformed or unusable JSON without output', async () => {
+  const invalidArgs = await runSummary([], async () => renderJson(result));
+  assert.equal(invalidArgs.exitCode, 1);
+  assert.equal(invalidArgs.stdout, '');
+  assert.match(
+    invalidArgs.stderr,
+    /Usage: yarn tsx scripts\/pr-blast-radius\/summary.ts <result-json-path>/
+  );
+
+  const malformed = await runSummary(['result.json'], async () => '{');
+  assert.equal(malformed.exitCode, 1);
+  assert.equal(malformed.stdout, '');
+  assert.match(malformed.stderr, /valid JSON/);
+
+  const incomplete = await runSummary(['result.json'], async () =>
+    JSON.stringify({ schemaVersion: 1 })
+  );
+  assert.equal(incomplete.exitCode, 1);
+  assert.equal(incomplete.stdout, '');
+  assert.match(incomplete.stderr, /structurally usable/);
+});
+
+test('rejects mismatched counts and malformed changed-file records', async () => {
+  const invalidResults = [
+    { ...result, prRevision: 'B'.repeat(40) },
+    { ...result, workspaceRevision: 'c'.repeat(39) },
+    { ...result, totalProjectCount: 0 },
+    { ...result, affectedProjectCount: 3 },
+    { ...result, affectedProjects: ['plain-project', 'plain-project'], affectedProjectCount: 2 },
+    { ...result, affectedProjects: [''], affectedProjectCount: 1 },
+    { ...result, changedFiles: [{ path: '', status: 'modified' }] },
+    { ...result, changedFiles: [{ path: '../unsafe.ts', status: 'modified' }] },
+    { ...result, changedFiles: [{ path: 'unsafe\\path.ts', status: 'modified' }] },
+    { ...result, changedFiles: [{ path: 'safe.ts', status: 'unknown' }] },
+    {
+      ...result,
+      changedFiles: [],
+      pullRequest: { ...result.pullRequest, reportedChangedFileCount: 1 },
+    },
+    {
+      ...result,
+      changedFiles: [
+        { path: 'safe.ts', status: 'modified' },
+        { path: 'safe.ts', status: 'modified' },
+      ],
+      pullRequest: { ...result.pullRequest, reportedChangedFileCount: 2 },
+    },
+    { ...result, reasons: [1] },
+    { ...result, warnings: [1] },
+  ];
+
+  for (const invalidResult of invalidResults) {
+    const outcome = await runSummary(['result.json'], async () => JSON.stringify(invalidResult));
+    assert.equal(outcome.exitCode, 1);
+    assert.equal(outcome.stdout, '');
+    assert.match(outcome.stderr, /structurally usable/);
+  }
+});

--- a/scripts/pr-blast-radius/__tests__/workflow.test.ts
+++ b/scripts/pr-blast-radius/__tests__/workflow.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import { join } from 'node:path';
+
+const workflowPath = join(process.cwd(), '.github/workflows/pr-blast-radius.yml');
+const checkout = 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1';
+const setupNode = 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020';
+
+function escape(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function runBlocks(workflow: string): string[] {
+  return [...workflow.matchAll(/^        run: \|\n((?:          .*\n?)*)/gm)].map(
+    (match) => match[1]
+  );
+}
+
+function classifyJobHeader(workflow: string): string {
+  const match = workflow.match(/^  classify:\n([\s\S]*?)(?=^    steps:)/m);
+
+  assert.ok(match, 'the classify job header must end before its steps mapping');
+
+  return `  classify:\n${match[1]}`;
+}
+
+function assertNoRunnerContextInJobHeader(header: string): void {
+  assert.doesNotMatch(header, /\$\{\{\s*runner\.|runner\.temp/);
+}
+
+test('classify job header rejects runner context even with unrelated job environment keys', () => {
+  const invalidHeader = `  classify:\n    env:\n      CI: true\n      RESULT_PATH: \${{ runner.temp }}/pr-blast-radius.json\n`;
+
+  assert.throws(() => assertNoRunnerContextInJobHeader(invalidHeader));
+});
+
+test('advisory PR workflow has the approved read-only transport contract', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+
+  assert.match(
+    workflow,
+    /^on:\n  pull_request:\n    types: \[opened, synchronize, reopened, ready_for_review, closed\]$/m
+  );
+  assert.doesNotMatch(workflow, /^  pull_request_target:/m);
+  assert.match(
+    workflow,
+    /^concurrency:\n  group: pr-blast-radius-\$\{\{ github\.event\.pull_request\.number \}\}\n  cancel-in-progress: true$/m
+  );
+  assert.match(workflow, /^permissions:\n  contents: read\n  pull-requests: read$/m);
+  assert.doesNotMatch(workflow, /^\s+[\w-]+:\s*write\s*$/m);
+  assert.match(workflow, /^name: PR blast radius \(advisory\)$/m);
+  assert.match(
+    workflow,
+    /^  classify:\n    name: PR blast radius \(advisory\)\n    runs-on: ubuntu-latest\n    timeout-minutes: 15$/m
+  );
+  assertNoRunnerContextInJobHeader(classifyJobHeader(workflow));
+
+  const uses = [...workflow.matchAll(/^\s+-?(?: name: .*\n\s+)?\s*uses: (.+)$/gm)].map((match) =>
+    match[1].trim().replace(/\s+#.*$/, '')
+  );
+  assert.deepEqual(uses, [checkout, setupNode, './.github/actions/yarn-nm-install']);
+  for (const action of uses.filter((value) => !value.startsWith('./'))) {
+    assert.match(action, /@[a-f0-9]{40}$/);
+  }
+  assert.match(workflow, new RegExp(`${escape(checkout)} # v\\d+\\.\\d+\\.\\d+`));
+  assert.match(workflow, new RegExp(`${escape(setupNode)} # v\\d+\\.\\d+\\.\\d+`));
+  assert.doesNotMatch(
+    workflow,
+    /actions\/upload-artifact|name:\s*pr-blast-radius-pr-|if-no-files-found|retention-days/
+  );
+  const checkoutStep = workflow.match(
+    new RegExp(`- uses: ${escape(checkout)}(?:[^\\n]*\\n|$)([\\s\\S]*?)(?=^      - |^$)`, 'm')
+  );
+  assert.ok(checkoutStep, 'the pinned checkout step must exist');
+  assert.doesNotMatch(checkoutStep[0], /^\s+with:/m);
+  assert.doesNotMatch(checkoutStep[0], /^\s+(?:repository|ref|fetch-depth|persist-credentials):/m);
+  assert.match(
+    workflow,
+    new RegExp(
+      `uses: ${escape(setupNode)}(?: # [^\\n]+)?\\n        with:\\n          node-version: 22`
+    )
+  );
+  assert.doesNotMatch(workflow, /cache-prefix:\s*pr-blast-radius-trusted/);
+  assert.doesNotMatch(
+    workflow,
+    /head\.sha|github\.ref|refs\/pull|merge ref|\bgit (?:checkout|fetch)\b/i
+  );
+
+  assert.match(
+    workflow,
+    /name: Classify pull request\n        shell: bash\n        env:\n          GH_TOKEN: \$\{\{ github\.token \}\}\n          PR_NUMBER: \$\{\{ github\.event\.pull_request\.number \}\}\n          RESULT_PATH: \$\{\{ runner\.temp \}\}\/pr-blast-radius\.json\n        run: \|\n          set -euo pipefail\n          yarn tsx scripts\/pr-blast-radius\/index\.ts "\$PR_NUMBER" --json > "\$RESULT_PATH"/
+  );
+  assert.equal((workflow.match(/yarn tsx scripts\/pr-blast-radius\/index\.ts/g) ?? []).length, 1);
+  assert.doesNotMatch(workflow, /yarn pr:blast-radius/);
+
+  assert.match(
+    workflow,
+    /name: Validate classifier JSON\n        shell: bash\n        env:\n          RESULT_PATH: \$\{\{ runner\.temp \}\}\/pr-blast-radius\.json\n        run: \|\n          node <<'NODE'[\s\S]*readFileSync\(process\.env\.RESULT_PATH, 'utf8'\)[\s\S]*output\.trim\(\)\.length === 0[\s\S]*JSON\.parse\(output\);[\s\S]*NODE/
+  );
+  assert.doesNotMatch(workflow, /continue-on-error|\bcatch\b|\|\|\s*true|if:\s*always\(\)/);
+  assert.match(
+    workflow,
+    /name: Publish advisory job summary\n        shell: bash\n        env:\n          RESULT_PATH: \$\{\{ runner\.temp \}\}\/pr-blast-radius\.json\n        run: \|\n          set -euo pipefail\n          yarn tsx scripts\/pr-blast-radius\/summary\.ts "\$RESULT_PATH" \| tee -a "\$GITHUB_STEP_SUMMARY"\n          test -s "\$GITHUB_STEP_SUMMARY"/
+  );
+  assert.equal((workflow.match(/yarn tsx scripts\/pr-blast-radius\/summary\.ts/g) ?? []).length, 1);
+  const summary = workflow.slice(workflow.indexOf('name: Publish advisory job summary'));
+  assert.doesNotMatch(
+    summary,
+    /```|cat "\$RESULT_PATH"|sed 's\/\^\/    \/'|PR_NUMBER|RUN_ID|RUN_ATTEMPT/
+  );
+
+  for (const run of runBlocks(workflow)) {
+    assert.doesNotMatch(run, /github\.event\.|github\.token/);
+    assert.doesNotMatch(
+      run,
+      /\b(?:NON_RUNTIME|LOCAL|FEATURE|WIDE|REPOSITORY|UNKNOWN)\b|affectedProject|sensitivitySignals|gh api|yarn test/i
+    );
+  }
+});

--- a/scripts/pr-blast-radius/app.ts
+++ b/scripts/pr-blast-radius/app.ts
@@ -1,0 +1,50 @@
+import { parseCliArgs } from './cli';
+import { classify } from './classifier';
+import { BlastRadiusError, ExitCode } from './errors';
+import { createResult, renderHuman, renderJson } from './format';
+import { retrievePullRequest } from './github';
+import { analyzeWorkspace } from './nx';
+import { analysisPaths, globalCategories, isNonRuntimePath, sensitivitySignals } from './paths';
+import type { CommandRunner } from './types';
+
+export type AppOutcome = { exitCode: number; stdout: string; stderr: string };
+export async function run(
+  argv: readonly string[],
+  dependencies: { runner: CommandRunner }
+): Promise<AppOutcome> {
+  try {
+    const args = parseCliArgs(argv);
+    const snapshot = await retrievePullRequest(dependencies.runner, args.pullRequest);
+    const paths = analysisPaths(snapshot.files);
+    const workspace = await analyzeWorkspace(dependencies.runner, paths);
+    const globalMatches = paths.flatMap((path) =>
+      globalCategories(path).map((category) => ({ category, path }))
+    );
+    const classification = classify({
+      affectedProjects: workspace.affectedProjects,
+      totalProjects: workspace.allProjects.length,
+      globalMatches,
+      allPathsRecognizedNonRuntime: paths.every(isNonRuntimePath),
+    });
+    const result = createResult({
+      snapshot,
+      workspaceRevision: workspace.workspaceRevision,
+      radius: classification.radius,
+      reasons: classification.reasons,
+      affectedProjects: workspace.affectedProjects,
+      totalProjects: workspace.allProjects.length,
+      sensitivitySignals: sensitivitySignals(paths),
+    });
+    return {
+      exitCode: 0,
+      stdout: args.json ? renderJson(result) : renderHuman(result),
+      stderr: '',
+    };
+  } catch (error) {
+    const known =
+      error instanceof BlastRadiusError
+        ? error
+        : new BlastRadiusError(ExitCode.Internal, 'Unexpected blast-radius failure.');
+    return { exitCode: known.exitCode, stdout: '', stderr: `${known.message}\n` };
+  }
+}

--- a/scripts/pr-blast-radius/classifier.ts
+++ b/scripts/pr-blast-radius/classifier.ts
@@ -1,0 +1,47 @@
+export type Radius = 'NON_RUNTIME' | 'LOCAL' | 'FEATURE' | 'WIDE' | 'REPOSITORY';
+export function classify(input: {
+  affectedProjects: readonly string[];
+  totalProjects: number;
+  globalMatches: ReadonlyArray<{ category: string; path: string }>;
+  allPathsRecognizedNonRuntime: boolean;
+}) {
+  const count = input.affectedProjects.length;
+  if (input.globalMatches.length)
+    return {
+      radius: 'REPOSITORY' as Radius,
+      reasons: input.globalMatches
+        .map(
+          ({ category, path }) =>
+            `Repository-global category ${JSON.stringify(category)} matched ${JSON.stringify(path)}.`
+        )
+        .sort(),
+    };
+  if (count / input.totalProjects >= 0.5)
+    return {
+      radius: 'REPOSITORY' as Radius,
+      reasons: [
+        `${count} of ${input.totalProjects} workspace projects are affected, meeting the repository threshold of at least half.`,
+      ],
+    };
+  if (count === 0 && input.allPathsRecognizedNonRuntime)
+    return {
+      radius: 'NON_RUNTIME' as Radius,
+      reasons: [
+        'No workspace project is affected and all changed paths are recognized as non-runtime.',
+      ],
+    };
+  if (count === 1)
+    return {
+      radius: 'LOCAL' as Radius,
+      reasons: [`1 of ${input.totalProjects} workspace projects is affected.`],
+    };
+  if (count <= 5)
+    return {
+      radius: 'FEATURE' as Radius,
+      reasons: [`${count} of ${input.totalProjects} workspace projects are affected.`],
+    };
+  return {
+    radius: 'WIDE' as Radius,
+    reasons: [`${count} of ${input.totalProjects} workspace projects are affected.`],
+  };
+}

--- a/scripts/pr-blast-radius/cli.ts
+++ b/scripts/pr-blast-radius/cli.ts
@@ -1,0 +1,53 @@
+import { BlastRadiusError, ExitCode } from './errors';
+
+export const usage =
+  'Usage: yarn tsx scripts/pr-blast-radius/index.ts <number|https://github.com/strapi/strapi/pull/<number>> [--json]';
+
+export type CliArgs = { repository: 'strapi/strapi'; pullRequest: number; json: boolean };
+
+function numberFrom(value: string): number | undefined {
+  if (!/^\d+$/.test(value)) return undefined;
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number > 0 ? number : undefined;
+}
+
+function parseReference(value: string): number | undefined {
+  const bare = numberFrom(value);
+  if (bare !== undefined) return bare;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+  if (
+    url.protocol !== 'https:' ||
+    url.hostname.toLowerCase() !== 'github.com' ||
+    url.username ||
+    url.password ||
+    url.port
+  )
+    return undefined;
+  const match = /^\/strapi\/strapi\/pull\/(\d+)\/?$/.exec(url.pathname);
+  return match === null ? undefined : numberFrom(match[1]);
+}
+
+export function parseCliArgs(argv: readonly string[]): CliArgs {
+  const jsonCount = argv.filter((value) => value === '--json').length;
+  const positional = argv.filter((value) => value !== '--json');
+  if (
+    jsonCount > 1 ||
+    positional.length !== 1 ||
+    positional[0] === '--' ||
+    positional.some((value) => value.startsWith('-'))
+  ) {
+    throw new BlastRadiusError(ExitCode.InvalidInput, usage);
+  }
+  const pullRequest = parseReference(positional[0]);
+  if (pullRequest === undefined)
+    throw new BlastRadiusError(
+      ExitCode.InvalidInput,
+      `${usage}\nOnly strapi/strapi pull request numbers or canonical URLs are accepted.`
+    );
+  return { repository: 'strapi/strapi', pullRequest, json: jsonCount === 1 };
+}

--- a/scripts/pr-blast-radius/command-runner.ts
+++ b/scripts/pr-blast-radius/command-runner.ts
@@ -1,0 +1,25 @@
+import { execFile } from 'node:child_process';
+import type { CommandRunner } from './types';
+export type ExecFileImplementation = typeof execFile;
+export const createCommandRunner =
+  (execute: ExecFileImplementation = execFile): CommandRunner =>
+  async ({ executable, args, cwd, env }) => {
+    const value = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      execute(
+        executable,
+        [...args],
+        {
+          cwd,
+          env: { ...process.env, ...env },
+          encoding: 'utf8',
+          maxBuffer: 1048576,
+          shell: false,
+        },
+        (error, stdout, stderr) => {
+          if (error) reject(error);
+          else resolve({ stdout: String(stdout), stderr: String(stderr) });
+        }
+      );
+    });
+    return value;
+  };

--- a/scripts/pr-blast-radius/errors.ts
+++ b/scripts/pr-blast-radius/errors.ts
@@ -1,0 +1,18 @@
+export const ExitCode = {
+  Internal: 1,
+  InvalidInput: 2,
+  GitHub: 3,
+  IncompletePullRequest: 4,
+  Nx: 5,
+  UnrecognizedPath: 6,
+} as const;
+
+export class BlastRadiusError extends Error {
+  constructor(
+    public readonly exitCode: (typeof ExitCode)[keyof typeof ExitCode],
+    message: string
+  ) {
+    super(message);
+    this.name = 'BlastRadiusError';
+  }
+}

--- a/scripts/pr-blast-radius/format.ts
+++ b/scripts/pr-blast-radius/format.ts
@@ -1,0 +1,155 @@
+import type { BlastRadiusResultV1, ChangedFile, PullRequestSnapshot, Radius } from './types';
+
+const unique = (values: readonly string[]) => [...new Set(values)].sort();
+const compareCodePoints = (left: string, right: string) =>
+  left < right ? -1 : left > right ? 1 : 0;
+const files = (values: readonly ChangedFile[]) =>
+  [...values].sort(
+    (a, b) =>
+      compareCodePoints(a.path, b.path) ||
+      compareCodePoints(a.previousPath ?? '', b.previousPath ?? '') ||
+      compareCodePoints(a.status, b.status)
+  );
+export const radiusDefinition = {
+  metric: 'dependency-reach' as const,
+  description:
+    'Dependency reach only; excludes correctness, test coverage, security criticality, and AI confidence.',
+  tiers: {
+    NON_RUNTIME: { affectedProjects: 0, requiresRecognizedNonRuntimePaths: true },
+    LOCAL: { minAffectedProjects: 1, maxAffectedProjects: 1 },
+    FEATURE: { minAffectedProjects: 2, maxAffectedProjects: 5 },
+    WIDE: { minAffectedProjects: 6, maxAffectedFractionExclusive: 0.5 },
+    REPOSITORY: { minAffectedFractionInclusive: 0.5, repositoryGlobalPathForcesTier: true },
+    UNKNOWN: { successfulClassification: false },
+  },
+};
+export function createResult(input: {
+  snapshot: PullRequestSnapshot;
+  workspaceRevision: string;
+  radius: Radius;
+  reasons: readonly string[];
+  affectedProjects: readonly string[];
+  totalProjects: number;
+  sensitivitySignals: readonly string[];
+}): BlastRadiusResultV1 {
+  const prRevision = input.snapshot.head.sha.toLowerCase();
+  const workspaceRevision = input.workspaceRevision.toLowerCase();
+  const affectedProjects = unique(input.affectedProjects);
+  return {
+    schemaVersion: 1,
+    classifierVersion: 1,
+    repository: 'strapi/strapi',
+    pullRequest: {
+      number: input.snapshot.number,
+      state: input.snapshot.state,
+      merged: input.snapshot.merged,
+      base: { branch: input.snapshot.base.branch, sha: input.snapshot.base.sha.toLowerCase() },
+      head: { sha: prRevision },
+      reportedChangedFileCount: input.snapshot.changedFiles,
+    },
+    prRevision,
+    workspaceRevision,
+    radius: input.radius,
+    radiusDefinition,
+    changedFiles: files(input.snapshot.files),
+    additions: input.snapshot.additions,
+    deletions: input.snapshot.deletions,
+    affectedProjectCount: affectedProjects.length,
+    totalProjectCount: input.totalProjects,
+    affectedProjects,
+    sensitivitySignals: unique(input.sensitivitySignals),
+    reasons: unique(input.reasons),
+    warnings: unique([
+      `PR metadata and changed paths come from GitHub at ${prRevision}; affected projects come from the current checkout's Nx graph at ${workspaceRevision}.`,
+      'Workspace revision identifies the checked-out commit; uncommitted local graph-configuration changes, if any, are not represented by that hash.',
+    ]),
+  };
+}
+export const renderJson = (result: unknown) => `${JSON.stringify(result)}\n`;
+
+const signalLabels: Record<string, string> = {
+  authentication: 'Authentication',
+  permissions: 'Permissions',
+  migrations: 'Migrations',
+  'database-persistence': 'Database and persistence',
+  'public-types': 'Public types',
+  'release-tooling': 'Release tooling',
+  'shared-test-infrastructure': 'Shared test infrastructure',
+  'workflow-changes': 'Workflow changes',
+};
+
+const shortRevision = (revision: string) => revision.slice(0, 7);
+const plural = (count: number, singular: string) => `${count} ${singular}${count === 1 ? '' : 's'}`;
+const signalLabel = (signal: string) =>
+  signalLabels[signal] ??
+  signal
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1).toLowerCase()}`)
+    .join(' ');
+
+function displayText(value: string): string {
+  return [...value]
+    .map((character) => {
+      const codePoint = character.codePointAt(0);
+      if (
+        codePoint !== undefined &&
+        (/[\p{Cc}\p{Cf}]/u.test(character) || codePoint === 0x2028 || codePoint === 0x2029)
+      ) {
+        return `\\u${codePoint.toString(16).padStart(4, '0')}`;
+      }
+      return character;
+    })
+    .join('');
+}
+
+function markdownText(value: string): string {
+  return [...value]
+    .map((character) => {
+      const codePoint = character.codePointAt(0);
+      if (
+        codePoint !== undefined &&
+        (/[\p{Cc}\p{Cf}]/u.test(character) || codePoint === 0x2028 || codePoint === 0x2029)
+      ) {
+        return `\\u${codePoint.toString(16).padStart(4, '0')}`;
+      }
+      if (character === '&') return '&amp;';
+      if (character === '<') return '&lt;';
+      if (character === '>') return '&gt;';
+      if (character === '`') return '&#96;';
+      if ('\\!#()*+-.[\\]_{}|~'.includes(character)) return `\\${character}`;
+      return character;
+    })
+    .join('');
+}
+
+function renderList(
+  values: readonly string[],
+  transform: (value: string) => string = (value) => value
+) {
+  return values.length ? values.map((value) => `- ${transform(value)}`).join('\n') : '- None';
+}
+
+function overview(result: BlastRadiusResultV1): string {
+  return `${result.affectedProjectCount} of ${result.totalProjectCount} projects affected\n${plural(
+    result.changedFiles.length,
+    'file'
+  )} changed · +${result.additions} / -${result.deletions}`;
+}
+
+function analysisBasis(result: BlastRadiusResultV1): string {
+  return `- GitHub PR revision: ${shortRevision(result.prRevision)}\n- Current checkout Nx graph: ${shortRevision(result.workspaceRevision)}\n- Note: Uncommitted local graph-configuration changes are not represented by this hash.`;
+}
+
+export function renderHuman(result: BlastRadiusResultV1): string {
+  return `PR ${displayText(result.repository)}#${result.pullRequest.number} — ${displayText(result.radius)}\n\n${overview(result)}\n\nAffected projects\n${renderList(result.affectedProjects, displayText)}\n\nSensitivity signals\n${renderList(result.sensitivitySignals, (signal) => displayText(signalLabel(signal)))}\n\nWhy this tier\n${renderList(result.reasons, displayText)}\n\nAnalysis basis\n${analysisBasis(result)}\n\nClassifier version: ${result.classifierVersion}\n`;
+}
+
+export function renderMarkdown(result: BlastRadiusResultV1): string {
+  const projectList = renderList(result.affectedProjects, markdownText);
+  const sensitivityList = renderList(result.sensitivitySignals, (signal) =>
+    markdownText(signalLabel(signal))
+  );
+  const reasons = renderList(result.reasons, markdownText);
+  return `## PR ${markdownText(result.repository)}#${result.pullRequest.number} — ${markdownText(result.radius)}\n\n> Advisory only: generated by code from the pull request checkout. Do not use this result for permissions, merge eligibility, or privileged automation.\n\n${overview(result)}\n\nAffected projects\n\n${projectList}\n\nSensitivity signals\n\n${sensitivityList}\n\nWhy this tier\n\n${reasons}\n\nAnalysis basis\n\n- GitHub PR revision: ${markdownText(shortRevision(result.prRevision))}\n- Current checkout Nx graph: ${markdownText(shortRevision(result.workspaceRevision))}\n- Note: Uncommitted local graph\\-configuration changes are not represented by this hash.\n\nClassifier version: ${result.classifierVersion}\n`;
+}

--- a/scripts/pr-blast-radius/github.ts
+++ b/scripts/pr-blast-radius/github.ts
@@ -1,0 +1,177 @@
+import { BlastRadiusError, ExitCode } from './errors';
+import type { ChangedFile, CommandRunner, PullRequestSnapshot } from './types';
+export const GITHUB_MAX_PR_FILES = 3000;
+const headers = [
+  '--method',
+  'GET',
+  '--header',
+  'Accept: application/vnd.github+json',
+  '--header',
+  'X-GitHub-Api-Version: 2022-11-28',
+];
+const validPath = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  !value.startsWith('/') &&
+  !value.includes('\\') &&
+  !value.includes('\0') &&
+  value.split('/').every((segment) => segment && segment !== '.' && segment !== '..');
+const validSha = (value: unknown): string | undefined =>
+  typeof value === 'string' && /^[a-f\d]{40}$/i.test(value) ? value.toLowerCase() : undefined;
+const integer = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+async function request(runner: CommandRunner, endpoint: string) {
+  let stdout: string;
+  try {
+    ({ stdout } = await runner({
+      executable: 'gh',
+      args: ['api', ...headers, endpoint],
+      cwd: process.cwd(),
+    }));
+  } catch (error) {
+    throw new BlastRadiusError(
+      ExitCode.GitHub,
+      `gh api could not retrieve pull request data; check authentication and access (${error instanceof Error ? error.message.slice(0, 160) : 'command failure'}).`
+    );
+  }
+  try {
+    return JSON.parse(stdout) as unknown;
+  } catch {
+    throw new BlastRadiusError(
+      ExitCode.IncompletePullRequest,
+      'GitHub returned malformed JSON; retry the command.'
+    );
+  }
+}
+function parseMetadata(value: unknown, number: number): Omit<PullRequestSnapshot, 'files'> {
+  const data = value as Record<string, unknown>;
+  const base = data?.base as Record<string, unknown>;
+  const head = data?.head as Record<string, unknown>;
+  const repo = base?.repo as Record<string, unknown>;
+  const baseSha = validSha(base?.sha);
+  const headSha = validSha(head?.sha);
+  if (
+    !data ||
+    typeof data !== 'object' ||
+    data.number !== number ||
+    (data.state !== 'open' && data.state !== 'closed') ||
+    typeof data.merged !== 'boolean' ||
+    (data.merged && data.state !== 'closed') ||
+    typeof base?.ref !== 'string' ||
+    !base.ref ||
+    !baseSha ||
+    !headSha ||
+    typeof repo?.full_name !== 'string' ||
+    repo.full_name.toLowerCase() !== 'strapi/strapi' ||
+    !integer(data.additions) ||
+    !integer(data.deletions) ||
+    !integer(data.changed_files)
+  )
+    throw new BlastRadiusError(
+      ExitCode.IncompletePullRequest,
+      'GitHub returned malformed or incomplete pull request metadata.'
+    );
+  return {
+    number,
+    state: data.state,
+    merged: data.merged,
+    base: { branch: base.ref, sha: baseSha },
+    head: { sha: headSha },
+    additions: data.additions,
+    deletions: data.deletions,
+    changedFiles: data.changed_files,
+  };
+}
+function parseFile(value: unknown): ChangedFile {
+  const data = value as Record<string, unknown>;
+  if (
+    !data ||
+    typeof data !== 'object' ||
+    !validPath(data.filename) ||
+    !['added', 'removed', 'modified', 'renamed'].includes(data.status as string)
+  )
+    throw new BlastRadiusError(
+      ExitCode.IncompletePullRequest,
+      'GitHub returned an invalid changed-file record.'
+    );
+  if (data.status === 'renamed') {
+    if (!validPath(data.previous_filename) || data.previous_filename === data.filename)
+      throw new BlastRadiusError(
+        ExitCode.IncompletePullRequest,
+        'GitHub returned an incomplete rename record.'
+      );
+    return { path: data.filename, previousPath: data.previous_filename, status: 'renamed' };
+  }
+  if (data.previous_filename !== undefined)
+    throw new BlastRadiusError(
+      ExitCode.IncompletePullRequest,
+      'GitHub returned an unexpected previous filename.'
+    );
+  return { path: data.filename, status: data.status as ChangedFile['status'] };
+}
+export async function retrievePullRequest(
+  runner: CommandRunner,
+  number: number
+): Promise<PullRequestSnapshot> {
+  const endpoint = `/repos/strapi/strapi/pulls/${number}`;
+  let initial: Omit<PullRequestSnapshot, 'files'>;
+  try {
+    initial = parseMetadata(await request(runner, endpoint), number);
+  } catch (error) {
+    if (error instanceof BlastRadiusError) throw error;
+    throw new BlastRadiusError(
+      ExitCode.IncompletePullRequest,
+      'GitHub returned malformed pull request data.'
+    );
+  }
+  if (initial.changedFiles > GITHUB_MAX_PR_FILES)
+    throw new BlastRadiusError(
+      ExitCode.IncompletePullRequest,
+      `GitHub changed-file count exceeds ${GITHUB_MAX_PR_FILES}; completeness cannot be proven.`
+    );
+  const files: ChangedFile[] = [];
+  const pages = Math.max(1, Math.ceil(initial.changedFiles / 100));
+  for (let page = 1; page <= pages; page += 1) {
+    let values: unknown;
+    try {
+      values = await request(runner, `${endpoint}/files?per_page=100&page=${page}`);
+    } catch (error) {
+      if (error instanceof BlastRadiusError) throw error;
+      throw new BlastRadiusError(
+        ExitCode.IncompletePullRequest,
+        'GitHub returned malformed changed-file data.'
+      );
+    }
+    const expected = page === pages ? initial.changedFiles - (page - 1) * 100 : 100;
+    if (!Array.isArray(values) || values.length !== expected)
+      throw new BlastRadiusError(
+        ExitCode.IncompletePullRequest,
+        'GitHub changed-file pages are incomplete or truncated.'
+      );
+    files.push(...values.map(parseFile));
+  }
+  if (
+    files.length !== initial.changedFiles ||
+    new Set(files.map((file) => file.path)).size !== files.length
+  )
+    throw new BlastRadiusError(
+      ExitCode.IncompletePullRequest,
+      'GitHub changed-file records are incomplete or duplicated.'
+    );
+  let current: Omit<PullRequestSnapshot, 'files'>;
+  try {
+    current = parseMetadata(await request(runner, endpoint), number);
+  } catch (error) {
+    if (error instanceof BlastRadiusError) throw error;
+    throw new BlastRadiusError(
+      ExitCode.IncompletePullRequest,
+      'GitHub returned malformed pull request data.'
+    );
+  }
+  if (JSON.stringify(initial) !== JSON.stringify(current))
+    throw new BlastRadiusError(
+      ExitCode.IncompletePullRequest,
+      'Pull request changed during retrieval; retry the command.'
+    );
+  return { ...initial, files };
+}

--- a/scripts/pr-blast-radius/index.ts
+++ b/scripts/pr-blast-radius/index.ts
@@ -1,0 +1,8 @@
+import { run } from './app';
+import { createCommandRunner } from './command-runner';
+
+void run(process.argv.slice(2), { runner: createCommandRunner() }).then((outcome) => {
+  if (outcome.stdout) process.stdout.write(outcome.stdout);
+  if (outcome.stderr) process.stderr.write(outcome.stderr);
+  process.exitCode = outcome.exitCode;
+});

--- a/scripts/pr-blast-radius/nx.ts
+++ b/scripts/pr-blast-radius/nx.ts
@@ -1,0 +1,115 @@
+import { BlastRadiusError, ExitCode } from './errors';
+import { globalCategories, isNonRuntimePath } from './paths';
+import type { CommandRunner } from './types';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+const parse = (value: string) => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new BlastRadiusError(ExitCode.Nx, 'Nx returned malformed project JSON.');
+  }
+  if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== 'string' || !item))
+    throw new BlastRadiusError(ExitCode.Nx, 'Nx returned invalid projects.');
+  return [...new Set(parsed)].sort();
+};
+export type WorkspaceTempLifecycle = {
+  createTemp: () => Promise<string>;
+  removeTemp: (path: string) => Promise<void>;
+};
+const defaultTempLifecycle: WorkspaceTempLifecycle = {
+  createTemp: () => mkdtemp(join(tmpdir(), 'strapi-pr-blast-radius-')),
+  removeTemp: (path) => rm(path, { recursive: true, force: true }),
+};
+export async function analyzeWorkspace(
+  runner: CommandRunner,
+  paths: readonly string[],
+  cwd = process.cwd(),
+  lifecycle: WorkspaceTempLifecycle = defaultTempLifecycle
+) {
+  let workspaceData: string;
+  try {
+    workspaceData = await lifecycle.createTemp();
+  } catch {
+    throw new BlastRadiusError(ExitCode.Nx, 'Could not create isolated Nx workspace data.');
+  }
+  const call = async (executable: string, args: string[]) => {
+    try {
+      return await runner({
+        executable,
+        args,
+        cwd,
+        env:
+          executable === 'yarn'
+            ? {
+                NX_DAEMON: 'false',
+                NX_CACHE_PROJECT_GRAPH: 'false',
+                NX_WORKSPACE_DATA_DIRECTORY: workspaceData,
+              }
+            : undefined,
+      });
+    } catch {
+      throw new BlastRadiusError(ExitCode.Nx, 'Workspace graph command failed.');
+    }
+  };
+  let primaryError: unknown;
+  let result:
+    | { workspaceRevision: string; allProjects: string[]; affectedProjects: string[] }
+    | undefined;
+  try {
+    const before = (await call('git', ['rev-parse', '--verify', 'HEAD^{commit}'])).stdout
+      .trim()
+      .toLowerCase();
+    if (!/^[a-f\d]{40}(?:[a-f\d]{24})?$/.test(before))
+      throw new BlastRadiusError(ExitCode.Nx, 'Workspace revision is invalid.');
+    const allProjects = parse((await call('yarn', ['nx', 'show', 'projects', '--json'])).stdout);
+    if (!allProjects.length)
+      throw new BlastRadiusError(ExitCode.Nx, 'Nx returned no workspace projects.');
+    const affected = new Set<string>();
+    const unmapped: string[] = [];
+    const commaPaths: string[] = [];
+    for (const path of [...new Set(paths)].sort()) {
+      if (path.includes(',')) {
+        commaPaths.push(path);
+        continue;
+      }
+      const values = parse(
+        (await call('yarn', ['nx', 'show', 'projects', '--affected', `--files=${path}`, '--json']))
+          .stdout
+      );
+      if (!values.length && !isNonRuntimePath(path) && !globalCategories(path).length)
+        unmapped.push(path);
+      values.forEach((value) => affected.add(value));
+    }
+    const after = (await call('git', ['rev-parse', '--verify', 'HEAD^{commit}'])).stdout
+      .trim()
+      .toLowerCase();
+    if (after !== before)
+      throw new BlastRadiusError(ExitCode.Nx, 'Workspace revision changed during analysis.');
+    const affectedProjects = [...affected].sort();
+    if (affectedProjects.some((value) => !allProjects.includes(value)))
+      throw new BlastRadiusError(ExitCode.Nx, 'Affected project is not in workspace graph.');
+    if (unmapped.length || commaPaths.length)
+      throw new BlastRadiusError(
+        ExitCode.UnrecognizedPath,
+        `Nx could not safely map executable paths: ${[...unmapped, ...commaPaths]
+          .map((path) => JSON.stringify(path))
+          .join(', ')}`
+      );
+    result = { workspaceRevision: before, allProjects, affectedProjects };
+  } catch (error) {
+    primaryError = error;
+  }
+  let cleanupError: unknown;
+  try {
+    await lifecycle.removeTemp(workspaceData);
+  } catch (error) {
+    cleanupError = error;
+  }
+  if (primaryError) throw primaryError;
+  if (cleanupError)
+    throw new BlastRadiusError(ExitCode.Nx, 'Could not clean isolated Nx workspace data.');
+  return result!;
+}

--- a/scripts/pr-blast-radius/paths.ts
+++ b/scripts/pr-blast-radius/paths.ts
@@ -1,0 +1,114 @@
+import type { ChangedFile } from './types';
+export type SensitivitySignal =
+  | 'authentication'
+  | 'permissions'
+  | 'migrations'
+  | 'database-persistence'
+  | 'public-types'
+  | 'release-tooling'
+  | 'shared-test-infrastructure'
+  | 'workflow-changes';
+const global: Array<[string, RegExp]> = [
+  [
+    'root-package-metadata',
+    /^(package\.json|yarn\.lock|\.yarnrc\.yml|\.npmrc|\.nvmrc|\.syncpackrc\.json|lerna\.json)$/,
+  ],
+  ['workspace-package-manifest', /^packages\/.*\/package\.json$/],
+  ['workspace-build-graph', /^(nx\.json|\.nxignore|rollup\.utils\.mjs)$/],
+  ['workflow-definition', /^\.github\/(workflows\/.*|filters\.yaml)$/],
+  ['shared-install-build-action', /^\.github\/actions\/(yarn-nm-install|run-build)\//],
+  ['yarn-installation-data', /^\.yarn\//],
+];
+const nonRuntime = [
+  /^docs\//,
+  /\.mdx?$/,
+  /^LICENSE(?:\.|$)/,
+  /^\.github\//,
+  /^tests\//,
+  /\/__(tests|snapshots)__\//,
+  /\.(test|spec)\.(js|jsx|ts|tsx|mjs|cjs)$/,
+  /^examples\//,
+  /^scripts\//,
+  /^\.changeset\//,
+  /^(\.coderabbit\.yaml|\.commitlintrc\.ts|\.editorconfig|\.gitattributes|\.gitignore|\.prettierignore|\.prettierrc\.js|codecov\.yml|sonar-project\.properties|lint-staged\.(config|shared)\.mjs|fileTransformer\.js|jest(-preset|\.config\.).*\.js|playwright\.base\.config\.js|vitest\.config\.ts|docker-compose\.(test|dev)\.yml|jsconfig\.json)$/,
+];
+export const analysisPaths = (files: readonly ChangedFile[]) =>
+  [
+    ...new Set(
+      files.flatMap((file) => (file.previousPath ? [file.path, file.previousPath] : [file.path]))
+    ),
+  ].sort();
+export const globalCategories = (path: string) =>
+  global.filter(([, pattern]) => pattern.test(path)).map(([name]) => name);
+export const isNonRuntimePath = (path: string) =>
+  !globalCategories(path).length && nonRuntime.some((pattern) => pattern.test(path));
+const tokens = (path: string) =>
+  path
+    .split('/')
+    .flatMap((segment) => segment.split(/[._-]/))
+    .filter(Boolean)
+    .map((token) => token.toLowerCase());
+export function sensitivitySignals(paths: readonly string[]): SensitivitySignal[] {
+  const result = new Set<SensitivitySignal>();
+  const has = (path: string, allowed: string[]) =>
+    tokens(path).some((token) => allowed.includes(token));
+  for (const path of paths) {
+    if (
+      path.startsWith('packages/plugins/users-permissions/') ||
+      has(path, ['auth', 'authentication', 'jwt', 'oauth', 'sso', 'session', 'sessions'])
+    )
+      result.add('authentication');
+    if (
+      /^packages\/(core\/permissions|plugins\/users-permissions)\//.test(path) ||
+      has(path, ['permission', 'permissions', 'rbac'])
+    )
+      result.add('permissions');
+    if (
+      /^packages\/.*\/migrations\//.test(path) ||
+      path.startsWith('tests/migration/') ||
+      /^examples\/complex\/(docker-compose\.dev\.yml|package\.json|(?:config|scripts|src)\/)/.test(
+        path
+      ) ||
+      has(path, ['migration', 'migrations'])
+    )
+      result.add('migrations');
+    if (
+      path.startsWith('packages/core/database/') ||
+      path.endsWith('.sql') ||
+      has(path, [
+        'database',
+        'db',
+        'persistence',
+        'repository',
+        'repositories',
+        'transaction',
+        'transactions',
+      ])
+    )
+      result.add('database-persistence');
+    if (
+      path.startsWith('packages/core/types/') ||
+      /^packages\/.*\/(types\/|src\/types(?:\/|\.(ts|js)$)|shared\/types\.(ts|js)$)/.test(path) ||
+      /^packages\/.*\.d\.ts$/.test(path)
+    )
+      result.add('public-types');
+    if (
+      /^(\.changeset\/|scripts\/(release\.js|publish\.sh|pre-publish\.sh|remove-dist-tag\.sh)$|\.github\/workflows\/(publish-.*\.yml|.*release.*\.yml)$)/.test(
+        path
+      )
+    )
+      result.add('release-tooling');
+    if (
+      /^(tests\/|packages\/(admin-test-utils|utils\/(api-tests|vitest-config))\/|\.github\/actions\/run-.*-tests\/)/.test(
+        path
+      ) ||
+      /^(fileTransformer\.js|jest(-preset|\.config\.).*\.js|playwright\.base\.config\.js|vitest\.config\.ts|docker-compose\.test\.yml)$/.test(
+        path
+      )
+    )
+      result.add('shared-test-infrastructure');
+    if (/^\.github\/(workflows\/|actions\/|scripts\/|filters\.yaml$|dependabot\.yml$)/.test(path))
+      result.add('workflow-changes');
+  }
+  return [...result].sort();
+}

--- a/scripts/pr-blast-radius/summary-app.ts
+++ b/scripts/pr-blast-radius/summary-app.ts
@@ -1,0 +1,119 @@
+import { readFile } from 'node:fs/promises';
+import { renderMarkdown } from './format';
+import type { BlastRadiusResultV1, Radius } from './types';
+
+type ReadText = (path: string) => Promise<string>;
+type SummaryOutcome = { exitCode: number; stdout: string; stderr: string };
+
+const radii = new Set<Radius>(['NON_RUNTIME', 'LOCAL', 'FEATURE', 'WIDE', 'REPOSITORY']);
+const fileStatuses = new Set(['added', 'removed', 'modified', 'renamed']);
+const prRevisionPattern = /^[0-9a-f]{40}$/;
+const workspaceRevisionPattern = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
+const isRepositoryPath = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  !value.startsWith('/') &&
+  !value.includes('\\') &&
+  !value.includes('\0') &&
+  value.split('/').every((segment) => segment && segment !== '.' && segment !== '..');
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isUniqueNonemptyStringArray(value: unknown): value is string[] {
+  return (
+    isStringArray(value) &&
+    value.every((item) => item.length > 0) &&
+    new Set(value).size === value.length
+  );
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isChangedFile(value: unknown): value is BlastRadiusResultV1['changedFiles'][number] {
+  if (!isRecord(value) || !isRepositoryPath(value.path)) return false;
+  if (typeof value.status !== 'string' || !fileStatuses.has(value.status)) return false;
+  if (value.status === 'renamed')
+    return isRepositoryPath(value.previousPath) && value.previousPath !== value.path;
+  return value.previousPath === undefined;
+}
+
+function isUsableResult(value: unknown): value is BlastRadiusResultV1 {
+  if (!isRecord(value) || value.schemaVersion !== 1 || value.classifierVersion !== 1) return false;
+  if (value.repository !== 'strapi/strapi' || !isRecord(value.pullRequest)) return false;
+  if (!isNonNegativeInteger(value.pullRequest.number) || value.pullRequest.number === 0)
+    return false;
+  if (!isNonNegativeInteger(value.pullRequest.reportedChangedFileCount)) return false;
+  if (typeof value.prRevision !== 'string' || !prRevisionPattern.test(value.prRevision))
+    return false;
+  if (
+    typeof value.workspaceRevision !== 'string' ||
+    !workspaceRevisionPattern.test(value.workspaceRevision)
+  )
+    return false;
+  if (typeof value.radius !== 'string' || !radii.has(value.radius as Radius)) return false;
+  if (!Array.isArray(value.changedFiles) || !value.changedFiles.every(isChangedFile)) return false;
+  if (value.changedFiles.length !== value.pullRequest.reportedChangedFileCount) return false;
+  if (new Set(value.changedFiles.map((file) => file.path)).size !== value.changedFiles.length)
+    return false;
+  if (!isNonNegativeInteger(value.additions) || !isNonNegativeInteger(value.deletions))
+    return false;
+  if (
+    !isNonNegativeInteger(value.affectedProjectCount) ||
+    !isNonNegativeInteger(value.totalProjectCount)
+  )
+    return false;
+  if (value.totalProjectCount === 0 || value.affectedProjectCount > value.totalProjectCount)
+    return false;
+  if (!isUniqueNonemptyStringArray(value.affectedProjects)) return false;
+  if (value.affectedProjectCount !== value.affectedProjects.length) return false;
+  return (
+    isStringArray(value.sensitivitySignals) &&
+    isStringArray(value.reasons) &&
+    isStringArray(value.warnings)
+  );
+}
+
+export async function runSummary(
+  argv: readonly string[],
+  readText: ReadText = (path) => readFile(path, 'utf8')
+): Promise<SummaryOutcome> {
+  if (argv.length !== 1 || argv[0].length === 0) {
+    return {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'Usage: yarn tsx scripts/pr-blast-radius/summary.ts <result-json-path>\n',
+    };
+  }
+
+  let text: string;
+  try {
+    text = await readText(argv[0]);
+  } catch {
+    return { exitCode: 1, stdout: '', stderr: 'Unable to read classifier JSON result.\n' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { exitCode: 1, stdout: '', stderr: 'Classifier result must be valid JSON.\n' };
+  }
+
+  if (!isUsableResult(parsed)) {
+    return {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'Classifier result is not structurally usable version-1 output.\n',
+    };
+  }
+
+  return { exitCode: 0, stdout: renderMarkdown(parsed), stderr: '' };
+}

--- a/scripts/pr-blast-radius/summary.ts
+++ b/scripts/pr-blast-radius/summary.ts
@@ -1,0 +1,7 @@
+import { runSummary } from './summary-app';
+
+void runSummary(process.argv.slice(2)).then((outcome) => {
+  if (outcome.stdout) process.stdout.write(outcome.stdout);
+  if (outcome.stderr) process.stderr.write(outcome.stderr);
+  process.exitCode = outcome.exitCode;
+});

--- a/scripts/pr-blast-radius/tsconfig.json
+++ b/scripts/pr-blast-radius/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/scripts/pr-blast-radius/types.ts
+++ b/scripts/pr-blast-radius/types.ts
@@ -1,0 +1,52 @@
+export type FileStatus = 'added' | 'removed' | 'modified' | 'renamed';
+export type ChangedFile = { path: string; status: FileStatus; previousPath?: string };
+export type CommandRequest = {
+  executable: string;
+  args: readonly string[];
+  cwd: string;
+  env?: Readonly<Record<string, string>>;
+};
+export type CommandResult = { stdout: string; stderr: string };
+export type CommandRunner = (request: CommandRequest) => Promise<CommandResult>;
+export type PullRequestSnapshot = {
+  number: number;
+  state: 'open' | 'closed';
+  merged: boolean;
+  base: { branch: string; sha: string };
+  head: { sha: string };
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  files: ChangedFile[];
+};
+export type Radius = 'NON_RUNTIME' | 'LOCAL' | 'FEATURE' | 'WIDE' | 'REPOSITORY';
+export type BlastRadiusResultV1 = {
+  schemaVersion: 1;
+  classifierVersion: 1;
+  repository: 'strapi/strapi';
+  pullRequest: {
+    number: number;
+    state: 'open' | 'closed';
+    merged: boolean;
+    base: { branch: string; sha: string };
+    head: { sha: string };
+    reportedChangedFileCount: number;
+  };
+  prRevision: string;
+  workspaceRevision: string;
+  radius: Radius;
+  radiusDefinition: {
+    metric: 'dependency-reach';
+    description: string;
+    tiers: Record<string, object>;
+  };
+  changedFiles: ChangedFile[];
+  additions: number;
+  deletions: number;
+  affectedProjectCount: number;
+  totalProjectCount: number;
+  affectedProjects: string[];
+  sensitivitySignals: string[];
+  reasons: string[];
+  warnings: string[];
+};


### PR DESCRIPTION
### What does it do?

Adds an advisory PR blast-radius check using GitHub changed files and the current Nx project graph.
It publishes a readable job summary and uploads the exact JSON result as an artifact.

### Why is it needed?

It helps reviewers quickly understand the potential scope of a change. The classification and
formatting stay in a tested script instead of being duplicated in workflow YAML

### How to test it?

After creating the PR, confirm the advisory check runs and provides both a readable summary and a
downloadable JSON artifact.
