### PR TITLE
fix(admin): upsell banner controls overlap the sticky homepage header on scroll

### DIFF
--- a/packages/core/admin/admin/src/components/UpsellBanner.tsx
+++ b/packages/core/admin/admin/src/components/UpsellBanner.tsx
@@ -20,12 +20,16 @@ const BannerBackground = styled(Flex)`
   position: relative;
 `;
 
-const FixedButtonWrapper = styled(Box)`
-  position: fixed;
+const ReopenButtonWrapper = styled(Box)`
   display: flex;
-  flex-direction: column;
-  z-index: 11;
-  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 9px 16px;
+`;
+
+const CloseButtonWrapper = styled(Box)`
+  position: absolute;
+  display: flex;
+  z-index: 1;
   top: 9px;
   right: 16px;
 `;
@@ -114,19 +118,19 @@ const Banner = ({
             </LinkButton>
           </Box>
         </Flex>
+        <CloseButtonWrapper>
+          <IconButton
+            withTooltip={false}
+            label={formatMessage({
+              id: 'app.components.UpsellBanner.close',
+              defaultMessage: 'Close',
+            })}
+            onClick={onDismiss}
+          >
+            <Cross />
+          </IconButton>
+        </CloseButtonWrapper>
       </BannerBackground>
-      <FixedButtonWrapper>
-        <IconButton
-          withTooltip={false}
-          label={formatMessage({
-            id: 'app.components.UpsellBanner.close',
-            defaultMessage: 'Close',
-          })}
-          onClick={onDismiss}
-        >
-          <Cross />
-        </IconButton>
-      </FixedButtonWrapper>
     </>
   );
 };
@@ -188,7 +192,7 @@ const UpsellBanner = () => {
 
   if (isDismissed) {
     return (
-      <FixedButtonWrapper>
+      <ReopenButtonWrapper>
         <IconButton
           withTooltip={false}
           label={formatMessage({
@@ -199,7 +203,7 @@ const UpsellBanner = () => {
         >
           <ArrowsOut />
         </IconButton>
-      </FixedButtonWrapper>
+      </ReopenButtonWrapper>
     );
   }
 


### PR DESCRIPTION
### What does it do?

The upsell banner's close ("X") and reopen buttons were positioned with `position: fixed` relative to the viewport. This change:
- Makes the close button `position: absolute` inside the banner's own background container, so it scrolls away together with the banner.
- Renders the reopen button (shown once the banner is dismissed) in normal document flow instead of `position: fixed`.

### Why is it needed?

On the homepage, once the upsell banner scrolled out of view, its close/reopen button kept floating fixed at the top-right of the viewport. When the page's sticky header then engaged (`position: fixed; top: 0`), the orphaned banner button visually overlapped the header's primary action (e.g. "Add Widget"), instead of scrolling away with the banner it belonged to.

### How to test it?

1. Run the admin locally with a trial/EE license state that renders the upsell banner.
2. On the Homepage, scroll down until the page header becomes sticky.
3. Before: the banner's close button remains fixed on screen and overlaps the sticky header's "Add Widget" button.
4. After: the close button scrolls away with the banner and no longer overlaps the header. The same check applies to the reopen button after dismissing the banner.

Verified with the existing unit tests (`UpsellBanner.test.tsx`, 9/9 passing) and manually in the browser for the close-button scenario.

### Related issue(s)/PR(s)

Fix #27371

🤖 Generated with [Claude Code](https://claude.com/claude-code)