### PR TITLE
fix(content-manager): flaky useKeyboardDragAndDrop test drops the move callback

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/tests/useKeyboardDragAndDrop.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useKeyboardDragAndDrop.test.ts
@@ -1,6 +1,6 @@
 import type { KeyboardEvent } from 'react';
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 
 import { useKeyboardDragAndDrop } from '../useKeyboardDragAndDrop';
 
@@ -18,7 +18,7 @@ describe('useKeyboardDragAndDrop', () => {
         useKeyboardDragAndDrop(true, 0, { onGrabItem, onMoveItem: jest.fn() })
       );
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Enter'));
       });
 
@@ -31,7 +31,7 @@ describe('useKeyboardDragAndDrop', () => {
         useKeyboardDragAndDrop(true, 0, { onGrabItem, onMoveItem: jest.fn() })
       );
 
-      await waitFor(() => {
+      act(() => {
         result.current(event(' '));
         result.current(event('Enter'));
       });
@@ -47,11 +47,11 @@ describe('useKeyboardDragAndDrop', () => {
         useKeyboardDragAndDrop(true, 0, { onDropItem, onMoveItem: jest.fn() })
       );
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Enter'));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Enter'));
       });
 
@@ -64,11 +64,11 @@ describe('useKeyboardDragAndDrop', () => {
         useKeyboardDragAndDrop(true, 0, { onDropItem, onMoveItem: jest.fn() })
       );
 
-      await waitFor(() => {
+      act(() => {
         result.current(event(' '));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event(' '));
       });
 
@@ -83,21 +83,21 @@ describe('useKeyboardDragAndDrop', () => {
         useKeyboardDragAndDrop(true, 0, { onCancel, onMoveItem: jest.fn() })
       );
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Enter'));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Escape'));
       });
 
       expect(onCancel).toHaveBeenCalledWith(0);
 
-      await waitFor(() => {
+      act(() => {
         result.current(event(' '));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Escape'));
       });
 
@@ -110,7 +110,7 @@ describe('useKeyboardDragAndDrop', () => {
         useKeyboardDragAndDrop(true, 0, { onCancel, onMoveItem: jest.fn() })
       );
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Escape'));
       });
 
@@ -123,11 +123,11 @@ describe('useKeyboardDragAndDrop', () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 0, { onMoveItem }));
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Enter'));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('ArrowDown'));
       });
 
@@ -138,11 +138,11 @@ describe('useKeyboardDragAndDrop', () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 0, { onMoveItem }));
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Enter'));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('ArrowRight'));
       });
 
@@ -153,11 +153,11 @@ describe('useKeyboardDragAndDrop', () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 0, { onMoveItem }));
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('ArrowDown'));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('ArrowRight'));
       });
 
@@ -168,11 +168,11 @@ describe('useKeyboardDragAndDrop', () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 1, { onMoveItem }));
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Enter'));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('ArrowUp'));
       });
 
@@ -183,11 +183,11 @@ describe('useKeyboardDragAndDrop', () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 1, { onMoveItem }));
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('Enter'));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('ArrowLeft'));
       });
 
@@ -198,11 +198,11 @@ describe('useKeyboardDragAndDrop', () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 1, { onMoveItem }));
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('ArrowUp'));
       });
 
-      await waitFor(() => {
+      act(() => {
         result.current(event('ArrowLeft'));
       });
 


### PR DESCRIPTION
### What does it do?

Replaces `await waitFor(() => { result.current(event(...)); })` with `act(() => { result.current(event(...)); })` throughout `useKeyboardDragAndDrop.test.ts`.

### Why is it needed?

`onMoveItem` for `useKeyboardDragAndDrop` intermittently failed on CI, e.g. in [#27614](https://github.com/strapi/strapi/pull/27614):

```
expect(jest.fn()).toHaveBeenCalledWith(...expected)
Expected: 0, 1
Number of calls: 0
> 179 | expect(onMoveItem).toHaveBeenCalledWith(0, 1);
```

Root cause: the test fired state-toggling key events (Enter/Space to grab or drop, arrow keys to move) inside `waitFor` callbacks. `waitFor` retries its callback via a `MutationObserver` + polling interval until it stops throwing; since these callbacks never throw, they normally resolve after a single call, but under CI's timing/load the callback can be invoked more than once before the promise settles — this is a documented testing-library anti-pattern (side effects inside `waitFor`).

I confirmed the exact mechanism with a throwaway reproduction: firing the "Enter" step across two separate flushes (grab → re-render → drop) toggles `isSelected` back to `false`, so the following arrow-key press silently no-ops — reproducing the CI failure exactly. `act()` flushes each key press exactly once per call, which structurally rules this out.

### How to test it?

`yarn test:front --testPathPattern useKeyboardDragAndDrop` — ran locally multiple times (including `--runInBand`), 12/12 passing. Opening this PR mainly to confirm it also passes reliably on CI's runners/load, where the original test was flaky.

### Related issue(s)/PR(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)