### PR TITLE
fix(admin): derive the auth cookie path from admin.url

### DIFF
--- a/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
+++ b/packages/core/admin/shared/utils/__tests__/session-auth.test.ts
@@ -62,6 +62,32 @@ describe('getAccessCookiePath', () => {
 
     expect(getAccessCookiePath()).toBe('/strapi-de/admin');
   });
+
+  test('falls back to admin.path so a custom admin.url stays readable', () => {
+    global.strapi.config.get = jest.fn((key: string) =>
+      key === 'admin.path' ? '/dashboard' : undefined
+    ) as any;
+
+    expect(getAccessCookiePath()).toBe('/dashboard');
+  });
+
+  test('prefers admin.auth.cookie.path over admin.path', () => {
+    global.strapi.config.get = jest.fn((key: string) => {
+      if (key === 'admin.auth.cookie.path') return '/strapi-de/admin';
+      if (key === 'admin.path') return '/dashboard';
+      return undefined;
+    }) as any;
+
+    expect(getAccessCookiePath()).toBe('/strapi-de/admin');
+  });
+
+  test('still defaults to /admin when admin.path is the default admin path', () => {
+    global.strapi.config.get = jest.fn((key: string) =>
+      key === 'admin.path' ? DEFAULT_AUTH_COOKIE_PATH : undefined
+    ) as any;
+
+    expect(getAccessCookiePath()).toBe(DEFAULT_AUTH_COOKIE_PATH);
+  });
 });
 
 describe('getAccessCookieDomain', () => {

--- a/packages/core/admin/shared/utils/session-auth.ts
+++ b/packages/core/admin/shared/utils/session-auth.ts
@@ -26,7 +26,10 @@ export const getAccessCookieName = (): string => {
 
 export const getAccessCookiePath = (): string => {
   const configured: string | undefined = strapi.config.get('admin.auth.cookie.path');
-  return resolveAuthCookiePath(configured, warnViaStrapiLog);
+  // Fall back to the path the admin panel is served from, so a custom
+  // `admin.url` keeps the cookie readable by the panel without extra config.
+  const adminPath: string | undefined = strapi.config.get('admin.path');
+  return resolveAuthCookiePath(configured || adminPath, warnViaStrapiLog);
 };
 
 export const getAccessCookieDomain = (): string | undefined => {

--- a/packages/core/strapi/src/node/__tests__/create-build-context.test.ts
+++ b/packages/core/strapi/src/node/__tests__/create-build-context.test.ts
@@ -132,12 +132,26 @@ describe('createBuildContext', () => {
     expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_PATH).toBe('/strapi-de/admin');
   });
 
-  it('sets an empty STRAPI_ADMIN_AUTH_COOKIE_PATH when config is unset', async () => {
+  it('falls back to admin.path when admin.auth.cookie.path is unset', async () => {
     const strapi = buildStrapiMock(undefined, undefined);
 
     const ctx = await createBuildContext(buildArgs(strapi));
 
-    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_PATH).toBe('');
+    // The mock serves the admin panel from the default '/admin'.
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_PATH).toBe('/admin');
+  });
+
+  it('follows a custom admin.path so the panel can read its own cookie', async () => {
+    const strapi = buildStrapiMock(undefined, undefined);
+    const get = strapi.config.get as jest.Mock;
+    const original = get.getMockImplementation()!;
+    get.mockImplementation((key: string, def?: unknown) =>
+      key === 'admin.path' ? '/dashboard' : original(key, def)
+    );
+
+    const ctx = await createBuildContext(buildArgs(strapi));
+
+    expect(ctx.env.STRAPI_ADMIN_AUTH_COOKIE_PATH).toBe('/dashboard');
   });
 
   it('overrides ambient STRAPI_ADMIN_AUTH_COOKIE_PATH from process.env with config', async () => {

--- a/packages/core/strapi/src/node/create-build-context.ts
+++ b/packages/core/strapi/src/node/create-build-context.ts
@@ -105,7 +105,9 @@ const createBuildContext = async ({
   env.STRAPI_ADMIN_AUTH_COOKIE_NAME =
     strapiInstance.config.get<string | undefined>('admin.auth.cookie.name') || '';
   env.STRAPI_ADMIN_AUTH_COOKIE_PATH =
-    strapiInstance.config.get<string | undefined>('admin.auth.cookie.path') || '';
+    strapiInstance.config.get<string | undefined>('admin.auth.cookie.path') ||
+    strapiInstance.config.get<string | undefined>('admin.path') ||
+    '';
   env.STRAPI_ADMIN_AUTH_COOKIE_DOMAIN =
     strapiInstance.config.get<string | undefined>('admin.auth.cookie.domain') ||
     strapiInstance.config.get<string | undefined>('admin.auth.domain') ||


### PR DESCRIPTION
### What does it do?

Defaults the admin auth cookie path to the path the admin panel is actually served from, instead of a hardcoded `/admin`.

`resolveAuthCookiePath` stays a pure browser-shared validator with `/admin` as its last resort. The fallback is added at the two places that can read Strapi config:

- `packages/core/admin/shared/utils/session-auth.ts` — `getAccessCookiePath()` now falls back to `admin.path`
- `packages/core/strapi/src/node/create-build-context.ts` — `STRAPI_ADMIN_AUTH_COOKIE_PATH` now falls back to `admin.path` before the empty string

`admin.path` is already resolved in `packages/core/core/src/configuration/index.ts`, so nothing new is computed. An explicit `admin.auth.cookie.path` still takes precedence, so the multi-instance case the option was added for (for example `/strapi-de/admin`) is unchanged, and a default install still resolves to `/admin`.

### Why is it needed?

With a custom `admin.url`, logging into the admin panel is currently impossible.

The access cookie is written at `Path=/admin`, but the panel reads it client side through `document.cookie` (`packages/core/admin/admin/src/utils/cookies.ts`), and the browser only exposes cookies whose path matches the current page. Served from `/dashboard`, the panel cannot see its own cookie, so it never sends an Authorization header:

```
POST /admin/login               -> 200 OK
POST /admin/access-token        -> 200 OK
GET  /admin/users/me            -> 401
GET  /admin/users/me/permissions -> 401
POST /admin/logout              -> 401   (the panel gives up and logs out)
```

The user lands back on the login form with no error, and repeats.

This was a regression rather than an intended change. Before the cookie path became configurable, the client wrote the access cookie at `Path=/`, which the browser sends for every path, so a custom `admin.url` worked with no extra configuration. The leftover `LEGACY_AUTH_COOKIE_PATHS = ['/']` in `cookies.ts` is what remains of that. Narrowing the default to `/admin` silently broke those installs.

### How to test it?

On a fresh Strapi 5 application, set a custom admin path and leave the cookie options untouched:

```js
// config/admin.js
module.exports = ({ env }) => ({
  url: '/dashboard',
  // no auth.cookie.path
});
```

Then `NODE_ENV=production yarn build && yarn start`, register an administrator, and log in at `http://localhost:1337/dashboard`.

- Before: the login request returns 200, every following admin request returns 401, and the panel returns to the login form. `document.cookie` is empty on the page.
- After: login succeeds and the panel loads. `document.cookie` contains `jwtToken`, and the login response sets `path=/dashboard`.

Reproduced and verified against 5.53.0.

Unit tests: `packages/core/admin/shared/utils/__tests__/session-auth.test.ts` and `packages/core/strapi/src/node/__tests__/create-build-context.test.ts`.

One pre-existing assertion changed rather than being added to: `create-build-context.test.ts` asserted that `STRAPI_ADMIN_AUTH_COOKIE_PATH` is an empty string when the option is unset. It now asserts the `admin.path` fallback. The rendered result for a default install is identical, because the empty string previously fell through to the same `/admin` default inside `resolveAuthCookiePath`; only a custom `admin.path` behaves differently. Worth a close look during review.

### Related issue(s)/PR(s)

Regression from #27100, released in 5.51.0.

Once this ships, the `admin-url-cookie-path` snippet in strapi/documentation should be updated, since the extra configuration step it documents is no longer required.
