### PR TITLE
fix(core/core): clone ignores media operation overrides

### DIFF
--- a/packages/core/core/src/services/document-service/utils/__tests__/clone-relations.test.ts
+++ b/packages/core/core/src/services/document-service/utils/__tests__/clone-relations.test.ts
@@ -1,0 +1,46 @@
+import { prepareCloneData } from '../clone-relations';
+
+const blockComponent = {
+  uid: 'basic.block',
+  modelType: 'component',
+  attributes: {
+    image: { type: 'media', multiple: false },
+  },
+} as any;
+
+const contentType = {
+  uid: 'api::article.article',
+  modelType: 'contentType',
+  attributes: {
+    cover: { type: 'media', multiple: false },
+    block: { type: 'component', component: 'basic.block', repeatable: false },
+  },
+} as any;
+
+const getModel = (uid: string) => (uid === 'basic.block' ? blockComponent : contentType);
+
+describe('clone-relations', () => {
+  describe('prepareCloneData', () => {
+    it('should replace the original media with a submitted media operation payload', async () => {
+      const { data } = await prepareCloneData(
+        { cover: { id: 1, documentId: 'file-a' } },
+        { cover: { set: [{ documentId: 'file-b' }] } },
+        contentType,
+        getModel
+      );
+
+      expect(data.cover).toEqual({ set: [{ documentId: 'file-b' }] });
+    });
+
+    it('should replace the original media of a component with a submitted media operation payload', async () => {
+      const { data } = await prepareCloneData(
+        { block: { id: 3, image: { id: 1, documentId: 'file-a' } } },
+        { block: { image: { connect: [{ documentId: 'file-b' }] } } },
+        contentType,
+        getModel
+      );
+
+      expect(data.block).toEqual({ id: 3, image: { connect: [{ documentId: 'file-b' }] } });
+    });
+  });
+});

--- a/packages/core/core/src/services/document-service/utils/clone-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/clone-relations.ts
@@ -69,7 +69,7 @@ const collectRelationOperationOverrides = async (
         overrides.set(path.rawWithIndices!, value);
       }
     },
-    { schema: contentType, getModel },
+    { schema: contentType, getModel, includeMedia: true },
     submittedData as TraversableData
   );
 


### PR DESCRIPTION
### What does it do?

Makes the clone helper collect media operation payloads (`set`, `connect`, `disconnect`) alongside relation ones, by passing `includeMedia: true` to the traversal in `collectRelationOperationOverrides`.

### Why is it needed?

Clone deep-merges the source entry into the submitted data, so a submitted `{ set: [...] }` ends up merged with the populated source value. Relation attributes are protected against that because their operation payloads are collected before the merge and written back afterwards, but the traversal only looked at relations. A media override was therefore merged into the source file and silently ignored, and the clone kept the original media. The same applies to media nested in components and dynamic zones.

### How to test it?

1. In `examples/getstarted`, add a single-media field `cover` to a collection type.
2. Upload two files, A and B, and create a document whose `cover` is A.
3. Clone it with `strapi.documents(<uid>).clone({ documentId, data: { cover: { set: [{ documentId: '<file-B-documentId>' }] } } })` and populate `cover`.
4. The clone now references B, and the source document still references A.

Unit tests: `yarn jest --config packages/core/core/jest.config.js --rootDir packages/core/core clone-relations`

### Related issue(s)/PR(s)

Fixes #27613.

Related context: #27557.
