### PR TITLE
fix(upload): media_update_asset reports the asset's real folder

### DIFF
--- a/packages/core/upload/server/src/mcp/__tests__/write-handlers.test.ts
+++ b/packages/core/upload/server/src/mcp/__tests__/write-handlers.test.ts
@@ -34,14 +34,17 @@ const STORED_ASSET = {
 const setupStrapi = (options: MockOptions = {}) => {
   const { isAllowed = true, canOnEntity = true, asset = STORED_ASSET } = options;
 
-  const findOne = jest.fn().mockResolvedValue(asset);
+  let stored = asset === null ? null : { ...asset };
+
+  const findOne = jest.fn().mockImplementation(async () => stored);
   const updateFileInfo = jest
     .fn()
-    .mockImplementation(async (id: number, fileInfo: Record<string, unknown>) => ({
-      ...STORED_ASSET,
-      ...fileInfo,
-      id,
-    }));
+    .mockImplementation(async (id: number, fileInfo: Record<string, unknown>) => {
+      stored = { ...(stored ?? STORED_ASSET), ...fileInfo, id };
+      const { folder: _folder, ...unpopulated } = stored;
+
+      return unpopulated;
+    });
 
   const createPermissionsManager = jest.fn(() => ({
     isAllowed,

--- a/packages/core/upload/server/src/mcp/handlers/write-handlers.ts
+++ b/packages/core/upload/server/src/mcp/handlers/write-handlers.ts
@@ -96,9 +96,11 @@ export const createMediaUpdateAssetHandler =
       throw error;
     }
 
-    const updated = await getService('upload', strapi).updateFileInfo(id, fileInfo, {
+    const written = await getService('upload', strapi).updateFileInfo(id, fileInfo, {
       user: context.user,
     });
 
-    return ok({ data: sanitizeMediaAsset(updated) });
+    const updated = await getService('upload', strapi).findOne(id, ['folder']);
+
+    return ok({ data: sanitizeMediaAsset(updated ?? written) });
   };

--- a/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
+++ b/tests/api/core/mcp/mcp-upload-rbac.test.api.ts
@@ -625,6 +625,41 @@ describe('MCP upload tools RBAC (api)', () => {
       });
     });
 
+    test('reports the containing folder in its own response after a rename', async () => {
+      const folder = await seeder.seedFolder('Reported');
+      const seeded = await seeder.seedAsset({ name: 'in-folder.jpg', folderId: folder.id });
+      const token = await createUpdateTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
+        id: seeded.id,
+        alternativeText: 'still in its folder',
+      });
+
+      expect(structured(response)).toMatchObject({
+        alternativeText: 'still in its folder',
+        folder: { id: folder.id, name: 'Reported' },
+      });
+
+      const row: any = await strapi.db
+        .query('plugin::upload.file')
+        .findOne({ where: { id: seeded.id }, populate: { folder: true } });
+
+      expect(row?.folder?.id).toBe(folder.id);
+      expect(row?.folderPath).toBe(folder.path);
+    });
+
+    test('reports null only for an asset genuinely at the media library root', async () => {
+      const seeded = await seeder.seedAsset({ name: 'at-root.jpg' });
+      const token = await createUpdateTokenSession();
+
+      const response = await mcp.callTool(token.accessKey, 'media_update_asset', {
+        id: seeded.id,
+        caption: 'root asset',
+      });
+
+      expect(structured(response)).toMatchObject({ caption: 'root asset', folder: null });
+    });
+
     test('returns the sanitized shape, with no provider secrets on the write path either', async () => {
       const seeded = await seeder.seedAsset({ name: 'sanitized.jpg' });
       const token = await createUpdateTokenSession();


### PR DESCRIPTION
### What does it do?

`media_update_asset` re-reads the asset after writing, instead of sanitizing the row `updateFileInfo` returns.

```ts
const written = await getService('upload', strapi).updateFileInfo(id, fileInfo, { user: context.user });
const updated = await getService('upload', strapi).findOne(id, ['folder']);

return ok({ data: sanitizeMediaAsset(updated ?? written) });
```

`?? written` because the write has already committed: a row that disappears underneath the re-read should not fail an update that succeeded.

**Beyond the ticket:** `update()` skips `signFileUrls` as well as `populate`, so this tool was also answering with an **unsigned url** on a private provider while `media_get_asset` answered with a signed one. `findOne` does both, so the same change closes that too.

The shared service is deliberately left alone. Both media libraries already refetch through the populating read path after a mutation, and public REST omits the key rather than asserting root — making `update()` populate would be broader churn with backward-compat risk for no gain on those paths. That call is the ticket's, restated here so it is visible in review rather than implied.

**Tests changed, not just added.** `write-handlers.test.ts` fabricated the relation: its `updateFileInfo` mock spread a fixture carrying `folder: { id: 2, name: 'Photos' }`, so the handler looked correct while reporting every asset as sitting at the root. The mock is now stateful — `updateFileInfo` persists the patch and resolves **without** `folder`, as the real service does; `findOne` answers with the stored row and its relation. That second half matters: a static mock returned pre-write values once the handler started reading back, which would have been mistaken for a regression.

### Why is it needed?

`media_update_asset` returned `folder: null` for every asset it touched, including assets inside a folder. `mediaAssetOutputSchema` documents that value as "the asset sits at the media library root", so an agent renaming an asset was told, affirmatively, that it had moved to the root — on the response this tool's own docblock says a client can trust instead of following up with `media_get_asset`.

The cause is that `updateFileInfo` ends in a bare `db.query().update()` with no `populate`, so the row carries the scalar `folderPath` but not the `folder` relation, and the sanitizer turns that absence into a positive claim.

The existing coverage could not catch it: the sibling api test confirms the folder through `media_get_asset`, whose read path populates the relation, so it stayed green throughout.

### How to test it?

**Automated**

```bash
yarn nx test:unit @strapi/upload -- --testPathPattern 'mcp/__tests__/write-handlers'   # 13 pass
yarn nx build @strapi/upload && yarn test:api --testPathPattern 'mcp-upload-rbac'       # 84 pass
```

Both bind to the fix — reverting the re-read fails `returns the asset through the read sanitizer` (unit) and `reports the containing folder in its own response after a rename` (api).

**Manual**, against an app with MCP enabled and an admin token holding `plugin::upload.read` + `plugin::upload.assets.update`:

1. Put an asset inside a folder in the Media Library.
2. Call `media_update_asset` with its id and a new `alternativeText`.
3. The response now carries `folder: { id, name }` for that folder. Before, it carried `folder: null`.
4. Repeat with an asset at the root — `folder: null`, which is now the only case that reports it.

### Related issue(s)/PR(s)

- fix CMS-1750
- Found while reviewing #27574 (`media_update_asset`), which is merged.
- **`media_move_assets` (#27578) checked**, per the ticket's last acceptance criterion. Its folder reporting is *not* affected — it sanitizes `{ ...updated, folder: destinationFolder }`, attaching the destination it already resolved. It does share the url-signing gap described above, since it sanitizes `updateFileInfo`'s row directly. Cheaper to fix there while that PR is still open than to follow up afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
