### PR TITLE
test(e2e): drive the home spec upload through the new media library

### DIFF
--- a/tests/e2e/tests/admin/home.spec.ts
+++ b/tests/e2e/tests/admin/home.spec.ts
@@ -5,6 +5,7 @@ import { resetFiles } from '../../../utils/file-reset';
 import { clickAndWait, findAndClose, navToHeader } from '../../../utils/shared';
 import { waitForRestart } from '../../../utils/restart';
 import { EDITOR_EMAIL_ADDRESS, EDITOR_PASSWORD } from '../../constants';
+import { AssetsPage } from '../media-library/future/page-objects/AssetsPage';
 
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
 
@@ -203,19 +204,22 @@ test.describe('Home as super admin — key statistics', () => {
       ]);
       await findAndClose(page, 'Saved document');
 
-      // Upload an asset
-      await navToHeader(page, ['Media Library'], 'Media Library');
-      await page.getByRole('button', { name: 'Add new assets' }).first().click();
-      await page
-        .getByLabel('Drag & Drop here or')
-        .setInputFiles('public/assets/administration_panel.png');
-      const uploadButton = page.getByRole('button', { name: 'Upload 1 asset to the library' });
-      try {
-        await uploadButton.waitFor({ state: 'visible', timeout: 5000 });
-        await uploadButton.click();
-      } catch {
-        await page.getByRole('button', { name: /^finish$/i }).click();
-      }
+      // Upload an asset, through the Media Library's page object rather than locators spelled
+      // out here — hardcoded panel copy is what broke this step when the new Media Library
+      // became the default.
+      //
+      // `navToHeader` cannot be used for the same reason: it asserts an exact heading, and the
+      // page is now titled after the folder you are in ("Home (3 items)" at the root). The menu
+      // link is unchanged, so only the readiness check moves — to `New`, which the upload opens
+      // anyway.
+      const assetsPage = new AssetsPage(page);
+      await clickAndWait(page, page.locator('role=link[name^="Media Library"]').last());
+      await expect(assetsPage.newButton).toBeVisible();
+
+      await assetsPage.uploadFilesWithFilePicker('public/assets/administration_panel.png');
+      await assetsPage.waitForUploadProgressSuccess();
+      // Dismissed before moving on: the dialog overlays the page the next steps navigate from.
+      await assetsPage.closeUploadProgressDialog();
 
       // Create a content type and a component
       await navToHeader(page, ['Content-Type Builder'], 'Content-Type Builder');


### PR DESCRIPTION
### What does it do?

Rewrites the upload step in `home.spec.ts` against the current Media Library, driving it through the Media Library's own page object instead of locators spelled out in the spec.

```ts
const assetsPage = new AssetsPage(page);
await assetsPage.uploadFilesWithFilePicker('public/assets/administration_panel.png');
await assetsPage.waitForUploadProgressSuccess();
await assetsPage.closeUploadProgressDialog();
```

Menu navigation stays as it was — reaching the Media Library through the header is part of what this smoke test exercises. The progress dialog is dismissed explicitly because it overlays the page the following steps navigate from.

The page object rather than local selectors is the point of the change, not incidental: hardcoded panel copy is exactly what broke here, so the coupling now points at the abstraction the Media Library owns and updates.

### Why is it needed?

The step drove the previous Media Library:

```ts
await page.getByRole('button', { name: 'Add new assets' }).first().click();
await page.getByLabel('Drag & Drop here or').setInputFiles(…);
await page.getByRole('button', { name: 'Upload 1 asset to the library' });
```

`Add new assets` (`header.actions.add-assets`) and `Drag & Drop here or` (`input.label`) exist only in the previous library's translations — neither appears anywhere under `admin/src/future/`. Since #27606 made the new Media Library the default, those locators match nothing and the test times out.

It fails on **shard 3/4 of every browser, both editions** — six jobs on every open pull request — because it is one deterministic spec failure rather than flake.

It went unnoticed because #27606 also left a stale job name in the `test_result` aggregator's `needs:` list, which made GitHub reject the whole workflow. No test ran between that merge and #27626 restoring it, so this surfaced on the first pull request to get a real run.

The upload has to genuinely land: the spec records the homepage statistics widget's asset count up front and asserts `initialAssetsCount + 1` at the end.

**Checked for siblings:** nothing else outside `tests/e2e/tests/media-library/` references the previous library's copy, and the settings smoke test only opens Settings → Media Library, which is unaffected. This spec was the only casualty.

### How to test it?

```bash
yarn test:e2e --setup --concurrency=1 --domains admin -- --project=chromium --grep "personalized homepage"
```

Passes locally against the new default (1 passed). On `develop` the same command fails at `Add new assets`.

The real confirmation is this pull request's own check list: the six red `shard: 3/4` jobs should go green.

### Related issue(s)/PR(s)

- Regression from #27606 (`feat(upload): make the new Media Library the default`).
- Surfaced once #27626 restored the Tests workflow.

**Known, not fixed here:** `tests/api/core/upload/admin/image-dimension.test.api.js` — "SVG uploads are rejected by the default security policy" — fails on `develop`, unrelated to this change. `tests/app-template/config/plugins.js` (from #27273) sets `upload.security.deniedTypes` so the upload journey has a type to reject, and configuring `security` at all replaces the default policy, under which a file whose detected type contradicts its declared one is refused. That template is shared with the api suite. Verified both ways: removing the config makes all 7 api tests pass, and also makes the e2e journey's rejection step fail — so the deny is needed, but only for e2e. Left for a separate pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
