### PR TITLE
[EE] [AI] Authorize custom providers registration in AI admin service

### DIFF
--- a/packages/core/admin/server/src/ai/services/__tests__/ai.test.ts
+++ b/packages/core/admin/server/src/ai/services/__tests__/ai.test.ts
@@ -47,6 +47,7 @@ describe('AI Container', () => {
       },
       log: {
         info: jest.fn(),
+        warn: jest.fn(),
         error: jest.fn(),
         http: jest.fn(),
       },
@@ -533,6 +534,79 @@ describe('AI Container', () => {
       licensedFeatures.length = 0;
 
       expect(aiContainer.isStrapiManagedAiEnabled()).toBe(false);
+    });
+  });
+
+  describe('authorizeCustomProvider', () => {
+    const createStrapi = ({ configEnabled = true, licensedFeatures = [] as string[] } = {}) =>
+      ({
+        config: {
+          get: jest.fn((key: string, defaultValue?: unknown) => {
+            if (key === 'admin.ai.enabled') return configEnabled ? (defaultValue ?? true) : false;
+            return defaultValue;
+          }),
+        },
+        ee: {
+          isEE: true,
+          features: { isEnabled: jest.fn((name: string) => licensedFeatures.includes(name)) },
+        },
+        log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), http: jest.fn() },
+      }) as any;
+
+    test('returns true and does not log when the cms-byok-ai feature is present', () => {
+      const strapi = createStrapi({ licensedFeatures: ['cms-byok-ai'] });
+      const aiContainer = createAiAdminService({ strapi });
+
+      expect(aiContainer.authorizeCustomProvider()).toBe(true);
+      expect(strapi.log.warn).not.toHaveBeenCalled();
+      expect(strapi.log.info).not.toHaveBeenCalled();
+    });
+
+    test('returns false and calls log.warn once with a message containing cms-byok-ai when the feature is missing', () => {
+      const strapi = createStrapi();
+      const aiContainer = createAiAdminService({ strapi });
+
+      expect(aiContainer.authorizeCustomProvider()).toBe(false);
+      expect(strapi.log.warn).toHaveBeenCalledTimes(1);
+      expect(strapi.log.warn).toHaveBeenCalledWith(expect.stringContaining('cms-byok-ai'));
+    });
+
+    test('after one rejection, isAvailable and isStrapiManagedAiEnabled return false, even when features.isEnabled later returns true', () => {
+      const strapi = createStrapi();
+      const aiContainer = createAiAdminService({ strapi });
+
+      expect(aiContainer.authorizeCustomProvider()).toBe(false);
+
+      strapi.ee.features.isEnabled.mockReturnValue(true);
+
+      expect(aiContainer.isAvailable()).toBe(false);
+      expect(aiContainer.isStrapiManagedAiEnabled()).toBe(false);
+    });
+
+    test('returns false, logs info, does not warn, and does not block when admin.ai.enabled is false', () => {
+      let enabled = false;
+      const strapi = {
+        config: {
+          get: jest.fn((key: string, defaultValue?: unknown) => {
+            if (key === 'admin.ai.enabled') return enabled;
+            return defaultValue;
+          }),
+        },
+        ee: {
+          isEE: true,
+          features: { isEnabled: jest.fn().mockReturnValue(true) },
+        },
+        log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), http: jest.fn() },
+      } as any;
+      const aiContainer = createAiAdminService({ strapi });
+
+      expect(aiContainer.authorizeCustomProvider()).toBe(false);
+      expect(strapi.log.info).toHaveBeenCalledTimes(1);
+      expect(strapi.log.warn).not.toHaveBeenCalled();
+
+      enabled = true;
+
+      expect(aiContainer.isStrapiManagedAiEnabled()).toBe(true);
     });
   });
 

--- a/packages/core/admin/server/src/ai/services/ai.ts
+++ b/packages/core/admin/server/src/ai/services/ai.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { AdminUser } from '../../../../shared/contracts/shared';
 
 const STRAPI_MANAGED_AI_LICENSE_FEATURE = 'cms-ai';
+const CUSTOM_AI_PROVIDER_LICENSE_FEATURE = 'cms-byok-ai';
 
 const createAiAdminService = ({ strapi }: { strapi: Core.Strapi }) => {
   /**
@@ -20,12 +21,36 @@ const createAiAdminService = ({ strapi }: { strapi: Core.Strapi }) => {
     }
   >();
 
+  let isCustomProviderRejected = false;
+
   const isConfigEnabled = (): boolean => strapi.config.get('admin.ai.enabled', true) === true;
 
-  const isAvailable = (): boolean => isConfigEnabled() && strapi.ee?.isEE === true;
+  const isAvailable = (): boolean =>
+    isConfigEnabled() && strapi.ee?.isEE === true && !isCustomProviderRejected;
 
   const isStrapiManagedAiEnabled = (): boolean =>
-    isConfigEnabled() && strapi.ee?.features?.isEnabled(STRAPI_MANAGED_AI_LICENSE_FEATURE) === true;
+    isConfigEnabled() &&
+    !isCustomProviderRejected &&
+    strapi.ee?.features?.isEnabled(STRAPI_MANAGED_AI_LICENSE_FEATURE) === true;
+
+  const authorizeCustomProvider = (): boolean => {
+    if (!isConfigEnabled()) {
+      strapi.log.info(
+        'A custom AI provider was ignored: AI is disabled by the "admin.ai.enabled" config.'
+      );
+      return false;
+    }
+
+    if (strapi.ee?.features?.isEnabled(CUSTOM_AI_PROVIDER_LICENSE_FEATURE) === true) {
+      return true;
+    }
+
+    isCustomProviderRejected = true;
+    strapi.log.warn(
+      `A custom AI provider was rejected: the Strapi license does not include the "${CUSTOM_AI_PROVIDER_LICENSE_FEATURE}" feature. All AI features are disabled.`
+    );
+    return false;
+  };
 
   const isPluginAiFeatureConfigured = async (plugin: string, service: string): Promise<boolean> => {
     const aiService = strapi.plugin(plugin)?.service(service) as
@@ -303,6 +328,7 @@ const createAiAdminService = ({ strapi }: { strapi: Core.Strapi }) => {
          This boolean is needed while all AI features are being ported to providers architecture.
          Once all compatibility has been tested, this flag will most likely be deprecated. */
     isStrapiManagedAiEnabled,
+    authorizeCustomProvider,
     /* Returns one flag per feature, each saying if it has a
      *   usable provider:
      *     - With Strapi-managed, every feature says yes.

--- a/packages/core/types/src/modules/ai.ts
+++ b/packages/core/types/src/modules/ai.ts
@@ -11,6 +11,7 @@ export type AiProvider = {
 export type AiAdminService = {
   isAvailable(): boolean;
   isStrapiManagedAiEnabled(): boolean;
+  authorizeCustomProvider(): boolean;
   getAiToken(): Promise<{ token: string; expiresAt?: string }>;
   getAiUsage(): Promise<{
     cmsAiCreditsUsed: number;

--- a/packages/plugins/i18n/server/src/bootstrap.ts
+++ b/packages/plugins/i18n/server/src/bootstrap.ts
@@ -1,7 +1,6 @@
 import type { Schema } from '@strapi/types';
 import { isEqual } from 'lodash/fp';
 import { getService } from './utils';
-import { createStrapiManagedAiTranslationsProvider } from './services/ai-translations-strapi-managed';
 
 const registerModelsHooks = () => {
   strapi.db.lifecycles.subscribe({
@@ -107,9 +106,7 @@ export default async () => {
     const aiTranslations = getService('ai-translations');
 
     if (!aiTranslations.hasProvider() && strapi.ai.admin.isStrapiManagedAiEnabled()) {
-      aiTranslations.registerProvider({
-        provider: createStrapiManagedAiTranslationsProvider({ strapi }),
-      });
+      aiTranslations.registerStrapiManagedProvider();
     }
 
     getService('ai-localizations').setupMiddleware();

--- a/packages/plugins/i18n/server/src/services/__tests__/ai-translations.test.ts
+++ b/packages/plugins/i18n/server/src/services/__tests__/ai-translations.test.ts
@@ -1,11 +1,11 @@
 import { createAITranslationsService, type AiTranslationsProvider } from '../ai-translations';
-import { createStrapiManagedAiTranslationsProvider } from '../ai-translations-strapi-managed';
 
-const createMockStrapi = ({ isAvailable = true } = {}) =>
+const createMockStrapi = ({ isAvailable = true, authorizeCustomProvider = true } = {}) =>
   ({
     ai: {
       admin: {
         isAvailable: jest.fn(() => isAvailable),
+        authorizeCustomProvider: jest.fn(() => authorizeCustomProvider),
         getAiToken: jest.fn().mockResolvedValue({ token: 'test-token' }),
       },
     },
@@ -41,7 +41,7 @@ describe('ai-translations service', () => {
     );
   });
 
-  test('the Strapi-managed provider registers like any other provider', async () => {
+  test('registerStrapiManagedProvider installs the Strapi-managed provider', async () => {
     const strapi = createMockStrapi();
     const service = createAITranslationsService({ strapi });
     const fetchMock = jest.fn().mockResolvedValue({
@@ -50,7 +50,7 @@ describe('ai-translations service', () => {
     });
     (global as any).fetch = fetchMock;
 
-    service.registerProvider({ provider: createStrapiManagedAiTranslationsProvider({ strapi }) });
+    service.registerStrapiManagedProvider();
 
     expect(service.hasProvider()).toBe(true);
 
@@ -62,35 +62,29 @@ describe('ai-translations service', () => {
     );
   });
 
-  test('ignores a provider registered while AI is unavailable', async () => {
-    const strapi = createMockStrapi({ isAvailable: false });
+  test('registerProvider asks core to authorize a custom provider', () => {
+    const strapi = createMockStrapi();
+    const service = createAITranslationsService({ strapi });
+
+    service.registerProvider({ provider: createProvider() });
+
+    expect(strapi.ai.admin.authorizeCustomProvider).toHaveBeenCalledTimes(1);
+    expect(service.hasProvider()).toBe(true);
+  });
+
+  test('a rejected provider is not registered', async () => {
+    const strapi = createMockStrapi({ authorizeCustomProvider: false });
     const service = createAITranslationsService({ strapi });
     const provider = createProvider();
 
     service.registerProvider({ provider });
 
-    expect(strapi.log.warn).toHaveBeenCalledWith(
-      'The AI translations provider "byok" was ignored: AI features require an Enterprise license and "admin.ai.enabled" to be true.'
-    );
     expect(service.hasProvider()).toBe(false);
     await expect(service.generateTranslations(PARAMS)).rejects.toThrow(
       'No AI translations provider is registered.'
     );
     expect(provider.generateTranslations).not.toHaveBeenCalled();
-  });
-
-  test('an ignored provider does not block a later registration', () => {
-    const strapi = createMockStrapi({ isAvailable: false });
-    const service = createAITranslationsService({ strapi });
-
-    service.registerProvider({ provider: createProvider() });
-
-    strapi.ai.admin.isAvailable.mockReturnValue(true);
-
-    expect(() =>
-      service.registerProvider({ provider: createProvider({ name: 'other-byok' }) })
-    ).not.toThrow();
-    expect(service.hasProvider()).toBe(true);
+    expect(strapi.log.warn).not.toHaveBeenCalled();
   });
 
   test('a registered provider follows the AI availability switch at runtime', async () => {
@@ -118,6 +112,31 @@ describe('ai-translations service', () => {
       service.registerProvider({ provider: createProvider({ name: 'other-byok' }) })
     ).toThrow(
       'The AI translations provider "byok" is already registered, "other-byok" cannot replace it.'
+    );
+  });
+
+  test('a custom provider replaces the Strapi-managed one', async () => {
+    const strapi = createMockStrapi();
+    const service = createAITranslationsService({ strapi });
+    const provider = createProvider();
+
+    service.registerStrapiManagedProvider();
+    service.registerProvider({ provider });
+
+    await service.generateTranslations(PARAMS);
+
+    expect(provider.generateTranslations).toHaveBeenCalledWith(PARAMS);
+    expect((global as any).fetch).toBeUndefined();
+  });
+
+  test('registerStrapiManagedProvider throws when a custom provider is already registered', () => {
+    const strapi = createMockStrapi();
+    const service = createAITranslationsService({ strapi });
+
+    service.registerProvider({ provider: createProvider() });
+
+    expect(() => service.registerStrapiManagedProvider()).toThrow(
+      'The AI translations provider "byok" is already registered, "strapi-managed" cannot replace it.'
     );
   });
 });

--- a/packages/plugins/i18n/server/src/services/ai-translations.ts
+++ b/packages/plugins/i18n/server/src/services/ai-translations.ts
@@ -1,4 +1,5 @@
 import type { Core, Modules } from '@strapi/types';
+import { createStrapiManagedAiTranslationsProvider } from './ai-translations-strapi-managed';
 
 export type GenerateTranslationsParams = {
   sourceLocale: string;
@@ -18,6 +19,7 @@ export type AiTranslationsProvider = Modules.AI.AiProvider & {
 export interface AiTranslationsService {
   hasProvider(): boolean;
   registerProvider(params: { provider: AiTranslationsProvider }): void;
+  registerStrapiManagedProvider(): void;
   generateTranslations(params: GenerateTranslationsParams): Promise<GenerateTranslationsResult>;
 }
 
@@ -27,6 +29,7 @@ const createAITranslationsService = ({
   strapi: Core.Strapi;
 }): AiTranslationsService => {
   let registeredProvider: AiTranslationsProvider | null = null;
+  let strapiManagedProvider: AiTranslationsProvider | null = null;
 
   const resolveProvider = (): AiTranslationsProvider | null => {
     if (!strapi.ai.admin.isAvailable()) {
@@ -42,12 +45,21 @@ const createAITranslationsService = ({
     },
 
     registerProvider({ provider }: { provider: AiTranslationsProvider }) {
-      if (!strapi.ai.admin.isAvailable()) {
-        strapi.log.warn(
-          `The AI translations provider "${provider.name}" was ignored: AI features require an Enterprise license and "admin.ai.enabled" to be true.`
-        );
+      if (!strapi.ai.admin.authorizeCustomProvider()) {
         return;
       }
+
+      if (registeredProvider !== null && registeredProvider !== strapiManagedProvider) {
+        throw new Error(
+          `The AI translations provider "${registeredProvider.name}" is already registered, "${provider.name}" cannot replace it.`
+        );
+      }
+
+      registeredProvider = provider;
+    },
+
+    registerStrapiManagedProvider() {
+      const provider = createStrapiManagedAiTranslationsProvider({ strapi });
 
       if (registeredProvider !== null) {
         throw new Error(
@@ -55,6 +67,7 @@ const createAITranslationsService = ({
         );
       }
 
+      strapiManagedProvider = provider;
       registeredProvider = provider;
     },
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

-->

> [!NOTE]
> This PR is a POC into trying to refactor the new registration logic of the AI providers.

### Related issue(s)/PR(s)

- [EE-154](https://linear.app/strapi/issue/EE-154/byok-add-the-ai-mode-and-provider-api-to-strapi)
- [EE-160](https://linear.app/strapi/issue/EE-160/byok-support-ai-translation-in-strapi)