### PR TITLE
fix(admin): hide native time picker on Time fields

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/DateTime.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/DateTime.tsx
@@ -11,7 +11,7 @@ import { InputProps } from './types';
 const MAX_DATE = new Date(2099, 11, 31);
 
 const DateTimeInput = forwardRef<HTMLInputElement, InputProps>(
-  ({ name, required, label, hint, labelAction, ...props }, ref) => {
+  ({ name, required, label, hint, labelAction, type: _type, ...props }, ref) => {
     const { formatMessage } = useIntl();
     const field = useField<string | null>(name);
     const fieldRef = useFocusInputField<HTMLInputElement>(name);

--- a/packages/core/admin/admin/src/components/FormInputs/Time.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Time.tsx
@@ -15,7 +15,7 @@ const formatTimeForTimePicker = (value: string | null | undefined): string => {
 };
 
 const TimeInput = forwardRef<HTMLInputElement, InputProps>(
-  ({ name, required, label, hint, labelAction, ...props }, ref) => {
+  ({ name, required, label, hint, labelAction, type: _type, ...props }, ref) => {
     const { formatMessage } = useIntl();
     const field = useField<string | null>(name);
     const fieldRef = useFocusInputField<HTMLInputElement>(name);

--- a/packages/core/admin/admin/src/components/FormInputs/tests/Time.test.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/tests/Time.test.tsx
@@ -33,6 +33,14 @@ describe('TimeInput Component', () => {
     expect(screen.getByText('Test Time')).toBeInTheDocument();
   });
 
+  it('should not use a native time input (avoids a second clock picker)', () => {
+    setupTest(null);
+    render(<TimeInput type="time" name="testTime" label="Test Time" />);
+
+    const input = screen.getByRole('combobox');
+    expect(input).not.toHaveAttribute('type', 'time');
+  });
+
   it('should strip seconds and milliseconds from display value', () => {
     setupTest('14:30:00.000');
     render(<TimeInput type="time" name="testTime" label="Test Time" />);


### PR DESCRIPTION
### What does it do?

Stop forwarding the form field `type` onto design-system `TimePicker` and `DateTimePicker`. `DateInput` already omitted `type`; Time and DateTime were leaking it onto the underlying combobox input.

Adds a TimeInput test that the combobox is not `type="time"`.

### Why is it needed?

Time fields showed two clocks: Strapi’s TimePicker and the browser’s native `input type="time"` icon. Clicking the native icon opened both UIs. The intended control is TimePicker only.

### How to test it?

1. Create a content type with a Time field (Date → Time).
2. Open an entry in the Content Manager edit view.
3. Confirm there is a single clock (Strapi TimePicker). Clicking the field opens only the Strapi picker, not a native browser time UI.

Frontend: `yarn test:front` in `@strapi/admin` for `admin/src/components/FormInputs/tests/Time.test.tsx`.

### Related issue(s)/PR(s)

Fixes #27630
Fixes CMS-1753
