### PR TITLE
docs: fix broken README logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://strapi.io/#gh-light-mode-only">
-    <img src="https://strapi.io/assets/strapi-logo-dark.svg" width="318px" alt="Strapi logo" />
+    <img src="docs/static/img/logo.svg" width="318px" alt="Strapi logo" />
   </a>
   <a href="https://strapi.io/#gh-dark-mode-only">
-    <img src="https://strapi.io/assets/strapi-logo-light.svg" width="318px" alt="Strapi logo" />
+    <img src="docs/static/img/logo_dark.svg" width="318px" alt="Strapi logo" />
   </a>
 </p>
 

--- a/packages/core/strapi/README.md
+++ b/packages/core/strapi/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://strapi.io/#gh-light-mode-only">
-    <img src="https://strapi.io/assets/strapi-logo-dark.svg" width="318px" alt="Strapi logo" />
+    <img src="../../../docs/static/img/logo.svg" width="318px" alt="Strapi logo" />
   </a>
   <a href="https://strapi.io/#gh-dark-mode-only">
-    <img src="https://strapi.io/assets/strapi-logo-light.svg" width="318px" alt="Strapi logo" />
+    <img src="../../../docs/static/img/logo_dark.svg" width="318px" alt="Strapi logo" />
   </a>
 </p>
 


### PR DESCRIPTION
### What does it do?

Replaces the two `strapi.io/assets` logo URLs in both repository READMEs with relative paths to the existing, versioned SVG assets under `docs/static/img`.

### Why is it needed?

Both remote logo URLs currently return HTTP 404, leaving the logo at the top of `README.md` and `packages/core/strapi/README.md` broken in GitHub light and dark modes. Keeping the assets in this repository prevents a marketing-site path change from breaking the repository README again.

The failing references were detected in the open [docrot dataset](https://codebyaurora.com/docrot/).

### How to test it?

- Confirm `docs/static/img/logo.svg` exists and is used for light mode.
- Confirm `docs/static/img/logo_dark.svg` exists and is used for dark mode.
- Resolve each relative path from each README location.
- Run `git diff --check`.

All four path resolutions and `git diff --check` pass locally. No runtime code changed.

### Related issue(s)/PR(s)

The original report was auto-closed by the issue-template bot: #27623. This PR contains the complete fix and verification.


---
Fixes CPR-473